### PR TITLE
Revert "Elevated container privs required for dev names"

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -132,22 +132,3 @@ function verify_tool_group {
 	fi
 	return 0
 }
-
-function container_sanity_check_perf {
-if [ "$container" = "docker" ]; then
-	if egrep -qv ^\-1 /proc/sys/kernel/perf_event_paranoid; then
-		warn_log "As an unpriv user (i.e. in a container) perf record -a requires \"echo -1 > /proc/sys/kernel/perf_event_paranoid\" or --privileged."
-		warn_log "Continuing anyway, perf data will NOT be collected."
-	fi
-fi
-}
-
-function container_sanity_check_iostat {
-if [ "$container" = "docker" ]; then
-	if [ ! -e /dev/mapper ]; then
-		warn_log "The iostat tool requires /dev/mapper be volume mounted in to resolve device names."
-		warn_log "Add \"-v /dev/mapper:/dev/mapper\" or --privileged to the docker run command."
-		warn_log "Continuing anyway, iostat data will still be collected, but device names may be unclear"
-	fi
-fi
-}

--- a/agent/tool-scripts/perf
+++ b/agent/tool-scripts/perf
@@ -119,7 +119,6 @@ tool_pid_file=$pbench_tmp/$group.$iteration.$tool.pid
 tool_output_file=$tool_output_dir/$tool.txt
 case "$mode" in
 	install)
-	container_sanity_check_perf
         ;;
 	start)
 	if ! cat /proc/mounts | grep -q debugfs; then

--- a/agent/tool-scripts/sar
+++ b/agent/tool-scripts/sar
@@ -153,7 +153,6 @@ case "$mode" in
 	else
 		echo $script_name is installed
 	fi
-	container_sanity_check_iostat
         ;;
 	start)
 	mkdir -p $tool_output_dir


### PR DESCRIPTION
Reverts distributed-system-analysis/pbench#25

Backing this out temporarily while we finish verifying that we have properly open-sourced the first round of code.