### PR TITLE
Use configuration file for sosreport dest

### DIFF
--- a/bgtasks/config/run.conf.example
+++ b/bgtasks/config/run.conf.example
@@ -1,0 +1,7 @@
+[sosreports]
+sosreportdest-user = user
+sosreportdest-host = sosreport.host.example.com
+sosreportdest-dir = /example/reception/pbench.d/
+
+[mail]
+mailto = pbench-admins@example.com

--- a/bgtasks/pbench/bin/pbench-backup-tarballs
+++ b/bgtasks/pbench/bin/pbench-backup-tarballs
@@ -1,8 +1,7 @@
 #! /bin/bash
 
-# Runs on perf44 as a cron job for user pbench, pulling tarballs from the
-# GlusterFS pbench mount point ARCHIVE, copying them to the configured
-# backup directory.
+# Cron job for user pbench, pulling tarballs from the pbench ARCHIVE and
+# copying them to the configured backup directory.
 
 # load common things
 opts=$SHELLOPTS

--- a/bgtasks/pbench/bin/pbench-base.sh
+++ b/bgtasks/pbench/bin/pbench-base.sh
@@ -35,9 +35,7 @@ if [ "$TS" = "" ]; then
     TS="run-$(timestamp)"
 fi
 
-SOSREPORTDEST=sosreport@example.com:VoS/reception/pbench.d/
-
-mail_recipients="pbench-admins@example.com"
+mail_recipients=$(getconf.py mailto mail)
 
 # make all the state directories for the pipeline and any others needed
 function mk_dirs {

--- a/bgtasks/pbench/bin/pbench-copy-sosreports
+++ b/bgtasks/pbench/bin/pbench-copy-sosreports
@@ -26,8 +26,7 @@
 
 # assumptions:
 
-# - this script runs as a cron job on perf42 (eventually to be moved
-#    to the gluster servers) - for now it runs once an hour.
+# - this script runs as a cron job, recommended to run once an hour.
 
 # - tarballs and md5 sums are uploaded by move/copy-results to
 #    $ARCHIVE/$(hostname -s) area.
@@ -74,7 +73,12 @@ test -d $INCOMING || doexit "Bad INCOMING=$INCOMING"
 linksrc=TO-COPY-SOS
 linkdest=TO-INDEX
 
-DEST=$SOSREPORTDEST
+if [ "$SOSREPORTDEST" == "" ]; then
+    _sosrpt_user=$(getconf.py sosreportdest-user sosreports)
+    _sosrpt_host=$(getconf.py sosreportdest-host sosreports)
+    _sosrpt_dir=$(getconf.py sosreportdest-dir sosreports)
+    SOSREPORTDEST=$_sosrpt_user@$_sosrpt_host:$_sosrpt_dir/
+fi
 
 echo "$TS: starting at $(timestamp)"
 
@@ -151,7 +155,7 @@ for result in $list ;do
         echo "$TS: No sosreports found for $result"
     else
         pushd $incoming > /dev/null
-        cmd="/usr/bin/rsync -av $TMPDIR/ $DEST"
+        cmd="/usr/bin/rsync -av $TMPDIR/ $SOSREPORTDEST"
         echo "$TS: $cmd"
         $cmd
         sts=$?

--- a/bgtasks/pbench/bin/pbench-edit-prefixes
+++ b/bgtasks/pbench/bin/pbench-edit-prefixes
@@ -8,8 +8,7 @@
 # correspond to the link. Each request moves a link from one place to
 # another in the results/ hierarchy.
 
-# - this script runs as a cron job on perf42 (eventually to be moved
-#    to the gluster servers) - for now it runs once a minute.
+# - this script runs as a cron job, recommended once a minute
 
 # - tarballs and md5 sums are uploaded by move/copy-results to
 #    $ARCHIVE/$(hostname -s) area.

--- a/bgtasks/pbench/bin/pbench-index
+++ b/bgtasks/pbench/bin/pbench-index
@@ -25,15 +25,16 @@
 #               the TO-INDEX subdir to the DONE subdir.
 
 # assumptions:
-# - this script runs as a cron job on perf42 (eventually to be moved to the gluster servers)
-# - tarballs and md5 sums are uploaded by move/copy-results to $ARCHIVE/$(hostname -s) area.
-# - move/copy-results also makes a symlink to each tarball it uploads in $ARCHIVE/TODO.
+# - this script runs as a cron job
+# - tarballs and md5 sums are uploaded by move/copy-results to
+#   the $ARCHIVE/$(hostname -s) area.
+# - move/copy-results also makes a symlink to each tarball it uploads
+#   in $ARCHIVE/TODO.
 
-# this script loops over the contents of $archive/<hostname>/TO-INDEX, extracts
-# the information from the tarball and calls an indexing script to
-# index the results into ES. If everything works, it then moves the
-# symlink from $ARCHIVE/<hostname>/TO-INDEX to
-# $ARCHIVE/<hostname>/DONE.
+# This script loops over the contents of $archive/<hostname>/TO-INDEX,
+# extracts the information from the tarball and calls an indexing script
+# to index the results into ES. If everything works, it then moves the
+# symlink from $ARCHIVE/<hostname>/TO-INDEX to $ARCHIVE/<hostname>/DONE.
 
 ###########################################################################
 # load common things

--- a/bgtasks/pbench/bin/pbench-unpack-tarballs
+++ b/bgtasks/pbench/bin/pbench-unpack-tarballs
@@ -25,13 +25,16 @@
 #               the TO-INDEX subdir to the DONE subdir.
 
 # assumptions:
-# - this script runs as a cron job on perf42 (eventually to be moved to the gluster servers)
-# - tarballs and md5 sums are uploaded by move/copy-results to $ARCHIVE/$(hostname -s) area.
-# - move/copy-results also makes a symlink to each tarball it uploads in $ARCHIVE/TODO.
+# - this script runs as a cron job
+# - tarballs and md5 sums are uploaded by move/copy-results to
+#   $ARCHIVE/$(hostname -s) area.
+# - move/copy-results also makes a symlink to each tarball it uploads
+#   in $ARCHIVE/TODO.
 
-# this script loops over the contents of $archive/TODO, verifies the md5 sum of each
-# tarball, and if correct, it unpacks the tarball into .../incoming/$(hostname -s)/.
-# If everything works, it then moves the symlink from $ARCHIVE/TODO to $ARCHIVE/TO-COPY-SOS.
+# This script loops over the contents of $archive/TODO, verifies the md5
+# sum of each tarball, and if correct, it unpacks the tarball into
+# .../incoming/$(hostname -s)/.  If everything works, it then moves the
+# symlink from $ARCHIVE/TODO to $ARCHIVE/TO-COPY-SOS.
 
 
 ###########################################################################

--- a/bgtasks/pbench/bin/unittests
+++ b/bgtasks/pbench/bin/unittests
@@ -21,6 +21,8 @@ if [[ ! -d $_testdir ]]; then
     exit 1
 fi
 
+export CONFIG=../../config/run.conf
+
 # Fixed timestamp output
 export _PBENCH_BGTASKS_TEST=1
 


### PR DESCRIPTION
We now use a configuration file for the sosreport user/host/dir rather
than just leaving it as an example of the reader, and also clean
various comments in the scripts.