### PR TITLE
Upstream turbostat removed c-state information for default turbostat …

### DIFF
--- a/agent/tool-scripts/datalog/turbostat-datalog
+++ b/agent/tool-scripts/datalog/turbostat-datalog
@@ -3,4 +3,4 @@
 interval=$1
 file=$2
 
-/usr/bin/turbostat -i $interval | log-timestamp $file
+/usr/bin/turbostat --debug -i $interval | log-timestamp $file


### PR DESCRIPTION
…output.

--debug gets it back, and --debug works on all versions of turbostat, for both RHEL6 and 7.
--debug gets us some interesting hardware information up front as well.

So, use --debug by default.

See https://bugzilla.redhat.com/show_bug.cgi?id=1247740