### PR TITLE
Make rpm version arg option for check_install_rpm

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -95,15 +95,21 @@ fi
 
 function check_install_rpm {
     local this_rpm=$1
-    local this_version=$2
+    if [ ! -z "$2" ]; then
+    	local this_version="-$2"
+    else
+	local this_version=""
+    fi
+
     rpm_status=`rpm --query $this_rpm`
     if echo $rpm_status | grep -q "is not installed"; then
-	yum --debuglevel=0 install -y $this_rpm-$this_version > $pbench_log 2>&1
+	echo attempting to install ${this_rpm}$this_version
+	yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1
 	rc=$?
     else
 	local installed_rpm_version=`echo $rpm_status | awk -F- '{print $2"-"$3}'`
 	if [ "$this_version" != "$installed_rpm_version" ]; then
-	    yum --debuglevel=0 install -y $this_rpm-$this_version > $pbench_log 2>&1
+	    yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1
 	    rc=$?
 	else
 	    debug_log "$this_rpm has already been installed"


### PR DESCRIPTION
This makes the rpm version for check_install_rpm function
optional. There are cases where we may not know which version of the
package we want to install. This happens when we are requesting
packages that pbench does not build/maintain. An example of this is
systemtap.