### PR TITLE
Fix several problems with systemtap script

### DIFF
--- a/agent/tool-scripts/systemtap
+++ b/agent/tool-scripts/systemtap
@@ -18,14 +18,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 tool=$script_name
 tool_bin=staprun
-ver=10.2.1
-tool_url="http://pagesperso-orange.fr/sebastien.godard/sysstat-$ver.tar.bz2"
 group=default
 dir="/tmp"
-mode=""
-interval="10"
-iteration="1"
-options="none"
 
 # Process options and arguments
 opts=$(getopt -q -o idp --longoptions "dir:,script:,group:,iteration:,options:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
@@ -86,9 +80,10 @@ while true; do
 		--script)
 		shift;
 		if [ -n "$1" ]; then
-			script="$1"
+			script=`echo $1 | sed 's/^"\(.*\)"$/\1/'`
 			shift
-			echo script is $script
+		else
+			echo "you did not provide a script"
 		fi
 		;;
 		-o|--options)
@@ -115,6 +110,9 @@ case "$mode" in
 	install)
 	# the installation for systemtap includes compiling the kernel module from the stap script
 	# this is done to avoid extra overhead when the workload is running
+	check_install_rpm systemtap-client
+	check_install_rpm systemtap-devel
+	check_install_rpm kernel-devel
 	pushd $pbench_tmp >/dev/null
 	install_cmd="stap -v -m pbench_systemtap -p4 $script"
 	printf "%s\n" $script
@@ -123,6 +121,7 @@ case "$mode" in
 	popd >/dev/null
         ;;
 	start)
+	mkdir -p $tool_output_dir
 	if [ -e $tool_output_file ]; then
 		/bin/rm $tool_output_file
 	fi


### PR DESCRIPTION
There were several problems with the systemtap script in pbench:
  1) unused variables (script was probably copied from sar)
  2) the $script var must have the leading and trailing quotes
     removed. We embed these quotes for tool options in register-tool
     and start-tools to avoid white-space issues, but for some reason
     the stap command does not like dealing with quotes in its
     arguments (all other tools seem unaffected).
  3) No required packages were installed (like systemtap!)
  4) The directory where systemtap output is collected was not
     created.

Note that while this changeset should apply cleanly without two other
pull requests:
  https://github.com/distributed-system-analysis/pbench/pull/41
  https://github.com/distributed-system-analysis/pbench/pull/42
This changeset does require those 2 to function properly.