### PR TITLE
Get the bench-scrips unit-tests working

### DIFF
--- a/agent/bench-scripts/gold/pbench_uperf/test-00.txt
+++ b/agent/bench-scripts/gold/pbench_uperf/test-00.txt
@@ -43,6 +43,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01_00:00:00/summary-result.txt
 --- pbench tree state
 +++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench_uperf]processing options
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench_uperf]uperf is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on server 127.0.0.1
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Starting iteration  (1 of 2)
@@ -65,7 +66,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 127.0.0.1 pbench_uperf --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/systemctl stop firewalld

--- a/agent/bench-scripts/gold/pbench_uperf/test-01.txt
+++ b/agent/bench-scripts/gold/pbench_uperf/test-01.txt
@@ -75,6 +75,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/uperf_test-01_1900-01-01_00:00:00/summary-result.txt
 --- pbench tree state
 +++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench_uperf]processing options
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench_uperf]uperf is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on client c1
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on client c2
@@ -118,7 +119,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no c1 pbench_uperf --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no c2 pbench_uperf --install

--- a/agent/bench-scripts/pbench_uperf
+++ b/agent/bench-scripts/pbench_uperf
@@ -198,7 +198,7 @@ function print_header {
 
 
 # Process options and arguments
-opts=$(getopt -q -o i:c:t:r:m:p:M:S:C: --longoptions "server-node:,server-nodes:,client-node:,client-nodes:,client-label:,server-label:,tool-label-pattern:,install,start-iteration-num:,config:,instances:,test-types:,runtime:,message-sizes:,protocols:,samples:,client:,clients:,servers:,server:,max-stddev:,max-failures:,kvm-host:,log-response-times:,postprocess-only:,run-dir:,tool-group:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o i:c:t:r:m:p:M:S:C: --longoptions "server-node:,server-nodes:,client-node:,client-nodes:,client-label:,server-label:,tool-label-pattern:,install,start-iteration-num:,config:,instances:,test-types:,runtime:,message-sizes:,protocols:,samples:,client:,clients:,servers:,server:,max-stddev:,max-failures:,kvm-host:,log-response-times:,postprocess-only:,run-dir:,tool-group:" -n "getopt.sh" -- "$@")
 if [ $? -ne 0 ]; then
 	printf -- "$*\n"
 	printf "\n"
@@ -249,176 +249,176 @@ if [ $? -ne 0 ]; then
 	printf    "\t\t                                        the prefix pattern to use for CPU information.\n"
 	exit 1
 fi
-eval set -- "$opts";
+eval set -- "$opts"
 debug_log "[$script_name]processing options"
 while true; do
 	case "$1" in
 		--install)
-		shift;
+		shift
 		install_uperf
 		exit
 		;;
 		--client-label)
-		shift;
+		shift
 		if [ -n "$1" ]; then
-			shift;
+			shift
 		fi
 		warn_log "The --client-label option is deprecated, please use --tool-label-pattern"
 		;;
 		--server-label)
-		shift;
+		shift
 		if [ -n "$1" ]; then
-			shift;
+			shift
 		fi
 		warn_log "The --server-label option is deprecated, please use --tool-label-pattern"
 		;;
 		--tool-label-pattern)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			tool_label_pattern="$1"
-			shift;
+			shift
 		fi
 		;;
 		--postprocess-only)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			postprocess_only="$1"
-			shift;
+			shift
 		fi
 		;;
 		--run-dir)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			benchmark_run_dir="$1"
-			shift;
+			shift
 		fi
 		;;
 		--max-stddev)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			maxstddevpct="$1"
-			shift;
+			shift
 		fi
 		;;
 		--max-failures)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			max_failures="$1"
-			shift;
+			shift
 		fi
 		;;
 		--samples)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			nr_samples="$1"
-			shift;
+			shift
 		fi
 		;;
 		-i|--instances)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			instances="$1"
-			shift;
+			shift
 		fi
 		;;
 		-t|--test-types)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			test_types="$1"
-			shift;
+			shift
 		fi
 		;;
 		--kvm-host)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			kvm_host="$1"
-			shift;
+			shift
 		fi
 		;;
 		--tool-group)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			tool_group="$1"
-			shift;
+			shift
 		fi
 		;;
 		-m|--message-sizes)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			message_sizes="$1"
-			shift;
+			shift
 		fi
 		;;
 		-r|--runtime)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			runtime="$1"
-			shift;
+			shift
 		fi
 		;;
 		--log-response-times)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			log_response_times="$1"
-			shift;
+			shift
 		fi
 		;;
 		-p|--protocols)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			protocols="$1"
-			shift;
+			shift
 		fi
 		;;
 		-C|--client|--clients)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			clients="$1"
-			shift;
+			shift
 		fi
 		;;
 		-S|--server|--servers)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			servers="$1"
-			shift;
+			shift
 		fi
 		;;
 		-c|--config)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			config="$1"
-			shift;
+			shift
 		fi
 		;;
 		--start-iteration-num)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			start_iteration_num=$1
-			shift;
+			shift
 		fi
 		;;
 		--client-node|--client-nodes)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			client_nodes="$1"
-			shift;
+			shift
 		fi
 		;;
 		--server-node|--server-nodes)
-		shift;
+		shift
 		if [ -n "$1" ]; then
 			server_nodes="$1"
-			shift;
+			shift
 		fi
 		;;
-		*)
-		debug_log "[$script_name]what happened? [$1]"
-		break;
-		;;
 		--)
-		shift;
-		break;
+		shift
+		break
+		;;
+		*)
+		error_log "[$script_name] bad option, \"$1 $2\""
+		break
 		;;
 	esac
 done

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -2,15 +2,6 @@
 
 _tdir=$(dirname $0)
 
-_tconfigtoolsdir=$_tdir/../../configtools
-(cd $_tconfigtoolsdir; make)
-if [[ $? -gt 0 ]]; then
-    echo "ERROR: failed to make configtools" >&2
-    exit 1
-fi
-_tconfigtoolsbin=$_tconfigtoolsdir/build/bin
-export PYTHONPATH=$_tconfigtoolsdir/build/lib
-
 _testroot=/var/tmp/pbench-test-bench
 mkdir -p $_testroot
 if [[ ! -d $_testroot ]]; then
@@ -139,7 +130,7 @@ _reset_state
 # 2. Verify uperf numa opts
 #
 _setup_state
-_run test-01 pbench_uperf  --config=test-01  --test-types=rr,stream  --message-sizes=64  --instances=1  --protocols=tcp  --runtime=20  --samples=2 --servers=s1,s2,s3 --clients=c1,c2,c3 --server-node=0,-1,2 --client-node=1,-1,3
+_run test-01 pbench_uperf  --config=test-01  --test-types=rr,stream  --message-sizes=64  --instances=1  --protocols=tcp  --runtime=20  --samples=2  --servers=s1,s2,s3  --clients=c1,c2,c3  --server-node=0,-1,2  --client-node=1,-1,3
 res=$?
 _save_tree
 _dump_logs
@@ -151,7 +142,7 @@ _reset_state
 # 3. Verify dbench
 #
 _setup_state
-_run test-00 pbench_dbench --threads=24,48 --client-nodes=0,1 --clients=127.0.0.1,127.0.0.1 --max-stddev=10
+_run test-00 pbench_dbench --threads=24,48  --client-nodes=0,1  --clients=127.0.0.1,127.0.0.1  --max-stddev=10
 res=$?
 _save_tree
 _dump_logs


### PR DESCRIPTION
We had removed configtools from the pbench report and moved it to its
own repository, so now we just require it to be installed and available
for the unit tests.  As a result, we just needed to remove the in-tree
build of configtools performed by the unit test script.

And fix the pbench_uperf option processing which was emitting a debug
message for "--" instead of just recognizing the termination of the
options.