### PR TITLE
Remove random output of dbench unittests

### DIFF
--- a/agent/bench-scripts/pbench_dbench
+++ b/agent/bench-scripts/pbench_dbench
@@ -368,9 +368,14 @@ for thread_count in `echo $thread_counts | sed -e s/,/" "/g`; do
 						echo "client[$client_nr-$client]${client_nodeinfo}threads[$thread_count]"
 
 						if [ "$client" == "127.0.0.1" ]; then
-							$benchmark_client_cmd_file >$result_file &
+							final_cmd_file="$benchmark_client_cmd_file"
 						else # using remote clients
-							ssh $ssh_opts $client "$benchmark_client_cmd_file" >$result_file &
+							final_cmd_file="ssh $ssh_opts $client \"$benchmark_client_cmd_file\""
+						fi
+						if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
+							$final_cmd_file >$result_file &
+						else
+							$final_cmd_file >$result_file
 						fi
 						((client_nr++))
 					done


### PR DESCRIPTION
The unit test for dbench will mostly pass, but fails every once in a
while due to the random order in which the dbench commands are run,
since it is putting them in the background and waiting for them all to
finish in parallel. For unit tests, it is sufficient to have
sequential behavior for now.

This is a bit of a hack, as we have to enable the dbench command with
knowledge of the presence of unit test execution.