### PR TITLE
Add mail notification to pbench-backup-tarballs

### DIFF
--- a/server/pbench/bin/gold/test-2.txt
+++ b/server/pbench/bin/gold/test-2.txt
@@ -35,3 +35,6 @@ pbench-index: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-
 /var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log:pbench-edit-prefixes: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-3.txt
+++ b/server/pbench/bin/gold/test-3.txt
@@ -41,3 +41,6 @@ pbench-backup-tarballs: Missing target backup directory argument
 /var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log:run-1900-01-01T00:00:00-UTC: ending at 1900-01-01T00:00:00-UTC, indexed 0 (skipped 0) results, 0 errors
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad INCOMING=/var/tmp/pbench-test-server/pbench/public_html/incoming
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-4.txt
+++ b/server/pbench/bin/gold/test-4.txt
@@ -44,3 +44,6 @@ pbench-backup-tarballs: Missing target backup directory argument
 /var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log:run-1900-01-01T00:00:00-UTC: ending at 1900-01-01T00:00:00-UTC, indexed 0 (skipped 0) results, 0 errors
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad RESULTS=/var/tmp/pbench-test-server/pbench/public_html/results
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -46,3 +46,6 @@ pbench-backup-tarballs: Missing target backup directory argument
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:run-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:run-1900-01-01T00:00:00-UTC: Processed 0 tarballs
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -15,10 +15,27 @@
 --- pbench tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:sending incremental file list
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:./
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:sent ### bytes  received ### bytes  ###.## bytes/sec
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:total size is 0  speedup is 0.00
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench.backup
+/var/tmp/pbench-test-server/test-execution.log:
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of deleted files: 0
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of regular files transferred: 0
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total file size: 0 bytes
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total transferred file size: 0 bytes
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Literal data: 0 bytes
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Matched data: 0 bytes
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list size: 0
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list generation time: 0.001 seconds
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list transfer time: 0.000 seconds
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total bytes sent: 54
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total bytes received: 19
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:sent ### bytes  received ### bytes  ###.## bytes/sec
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:total size is 0  speedup is 0.00
+/var/tmp/pbench-test-server/test-execution.log:
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/mailx -s pbench-backup-tarballs - run-1900-01-01T00:00:00-UTC
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-6a.txt
+++ b/server/pbench/bin/gold/test-6a.txt
@@ -17,3 +17,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:pbench-backup-tarballs: The ARCHIVE directory does not resolve to a real location, /var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-6b.txt
+++ b/server/pbench/bin/gold/test-6b.txt
@@ -17,3 +17,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:pbench-backup-tarballs: The ARCHIVE directory does not resolve to a directory, /var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-6c.txt
+++ b/server/pbench/bin/gold/test-6c.txt
@@ -17,3 +17,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:pbench-backup-tarballs: Specified backup directory does not resolve to a real location, /var/tmp/pbench-test-server/foo/pbench.backup
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-6d.txt
+++ b/server/pbench/bin/gold/test-6d.txt
@@ -17,3 +17,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:pbench-backup-tarballs: Specified backup directory does not resolve to a directory, /var/tmp/pbench-test-server/pbench.backup
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.1.txt
+++ b/server/pbench/bin/gold/test-7.1.txt
@@ -6,3 +6,6 @@ Bad Date:  /var/tmp/pbench-test-server/test-7.1.tar.xz
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.2.txt
+++ b/server/pbench/bin/gold/test-7.2.txt
@@ -6,3 +6,6 @@ Unsupported Tarball Format - no metadata.log:  /var/tmp/pbench-test-server/test-
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.3.txt
+++ b/server/pbench/bin/gold/test-7.3.txt
@@ -26,3 +26,6 @@ Exception: 'end_run'
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.4.txt
+++ b/server/pbench/bin/gold/test-7.4.txt
@@ -21,3 +21,6 @@ Exception: The sosreport did not collect a hostname other than 'localhost'
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.5.txt
+++ b/server/pbench/bin/gold/test-7.5.txt
@@ -21,3 +21,6 @@ Exception: The sosreport did not collect a hostname other than 'localhost'
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -65,3 +65,6 @@
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -65,3 +65,6 @@
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -28,3 +28,6 @@ chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
++++ test-execution.log file contents
+grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+--- test-execution.log file contents

--- a/server/pbench/bin/pbench-backup-tarballs
+++ b/server/pbench/bin/pbench-backup-tarballs
@@ -30,6 +30,10 @@ TOP_LOCAL="$3"
 
 . $dir/pbench-base.sh
 
+stats=$TMP/${PROG}.$$
+
+trap "rm -f $stats" EXIT INT QUIT
+                 
 log_init $(basename $0)
 
 echo "start-$(timestamp)"
@@ -54,8 +58,12 @@ if [[ ! -d "$rlb" ]]; then
     log_finish; exit 1
 fi
 
+# exclude the subdirs of symlinks
+exclude="--exclude=$(echo $LINKDIRS | sed 's/  */ --exclude=/g')"
+
 # N.B The trailing slash is important
-/usr/bin/rsync -va $rla/ $rlb
+rsync -va --stats $exclude $rla/ $rlb | tee -a $stats
+
 rsync_sts=$?
 if [[ $rsync_sts -ne 0 ]]; then
     echo "$PROG: rsync failed with code: $rsync_sts, $BDIR"
@@ -64,5 +72,9 @@ fi
 echo "end-$(timestamp)"
 
 log_finish
+
+# Back up some way and find the empty line separating the list of files
+# from the stats.
+tail -n 20 $stats | sed -n '/^$/,$p' | mailx -s "$PROG - $TS" $mail_recipients 
 
 exit 0

--- a/server/pbench/bin/test-bin/mailx
+++ b/server/pbench/bin/test-bin/mailx
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "$0 $*" >> $_testlog
+cat >> $_testlog
+

--- a/server/pbench/bin/test-bin/rsync
+++ b/server/pbench/bin/test-bin/rsync
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "$0 $*" >> $_testlog
+echo "
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of deleted files: 0
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of regular files transferred: 0
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total file size: 0 bytes
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total transferred file size: 0 bytes
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Literal data: 0 bytes
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Matched data: 0 bytes
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list size: 0
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list generation time: 0.001 seconds
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:File list transfer time: 0.000 seconds
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total bytes sent: 54
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Total bytes received: 19
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:sent ### bytes  received ### bytes  ###.## bytes/sec
+/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:total size is 0  speedup is 0.00
+" >> $_testlog

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -15,6 +15,7 @@ if [[ $? -gt 0 ]]; then
     exit 1
 fi
 _testout=$_testroot/output.txt
+export _testlog=$_testroot/test-execution.log
 _testdir=$_testroot/pbench
 mkdir -p $_testdir
 if [[ ! -d $_testdir ]]; then
@@ -24,10 +25,17 @@ fi
 
 # Fixed timestamp output
 export _PBENCH_SERVER_TEST=1
-res=0
 
-# mock out some stuff
-PATH=$_tdir/test-bin:$PATH
+# execution environment
+_testopt=$_testroot/opt/pbench-agent
+res=0
+mkdir -p $_testopt/unittest-scripts/
+let res=res+$?
+cp $_tdir/test-bin/* $_testopt/unittest-scripts/
+let res=res+$?
+
+export PATH=$_testopt/unittest-scripts:$_tconfigtoolsbin:$PATH
+res=0
 
 function _run {
     tname=$1
@@ -86,6 +94,11 @@ function _dump_logs {
             done
     fi
     echo "--- pbench log file contents" >> $_testout
+    echo "+++ test-execution.log file contents" >> $_testout
+    grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log >> $_testout 2>&1
+    echo "--- test-execution.log file contents" >> $_testout
+    rm -f $_testroot/test-execution.log
+
 }
 function _verify_output {
     res=$1


### PR DESCRIPTION
Make rsync produce some stats (in addition to the list of files)
and send the stats as notification mail.

Also exclude the TODO/TO-INDEX/etcf directories from the backup: they
cause permissions problems (but I think the underlying reason is that
we have different UIDs for pbench on the two systems involved).