### PR TITLE
Make sure that metadata.log is complete.

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -42,7 +42,7 @@ export pbench_install_dir pbench_tspp_dir pbench_bspp_dir pbench_run
 
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     function timestamp {
-        echo "$(date +'%Y%m%d_%H:%M:%S.%N')"
+        echo "$(date --utc +'%Y%m%d_%H:%M:%S.%N')"
     }
 else
     function timestamp {
@@ -79,7 +79,7 @@ function debug_log {
 # Some standard global vars - try the config file first and fall back on hardwired defaults
 # which are valid today.
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
-    date=`date "+%F_%H:%M:%S"`
+    date=`date --utc "+%F_%H:%M:%S"`
     hostname=`hostname -s`
     full_hostname=`hostname`
 else

--- a/agent/bench-scripts/user-benchmark
+++ b/agent/bench-scripts/user-benchmark
@@ -92,6 +92,9 @@ export benchmark_results_dir=$benchmark_results_dir
 export benchmark config
 metadata-log --group=$tool_group --dir=$benchmark_run_dir beg
 
+# on abnormal exit, make sure that the metadata log exists and is complete.
+trap "metadata-log --group=$tool_group --dir=$benchmark_run_dir int" INT QUIT
+
 start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"

--- a/agent/util-scripts/metadata-log
+++ b/agent/util-scripts/metadata-log
@@ -173,8 +173,12 @@ EOF
 
 function metadata_log_start {
     dir=$1
+    ts=$2
     log=$dir/metadata.log
 
+    if [ -z "$ts" ] ;then
+        ts=$(date --utc '+%F_%H:%M:%S.%N')
+    fi
     cat > $log <<EOF
 [pbench]
 name: $(basename $dir)
@@ -188,15 +192,30 @@ EOF
     cat >> $log <<EOF
 [run]
 controller: $full_hostname
-start_run: $(TZ=UTC date '+%F_%H:%M:%S.%N')
+start_run: $ts
 EOF
 }
 
 function metadata_log_end {
     dir=$1
+    int=$2
     log=$dir/metadata.log
 
-    echo "end_run: $(TZ=UTC date '+%F_%H:%M:%S.%N')" >> $log
+    if [ ! -f $log ] ;then
+        # Somehow, metadata_log_start was never called !?!?
+        # Call it explicitly.
+        # Manufacture a start_run timestamp and pass it
+        # explicitly. The manufactured stamp is the date that
+        # the base file calculates (now in UTC).
+        start_ts=$date
+        metadata_log_start $dir $start_ts
+    fi
+    if ! grep -q end_run $log ;then
+        echo "end_run: $(date --utc '+%F_%H:%M:%S.%N')" >> $log
+    fi
+    if [ "$int" == "int" ] ;then
+        echo "run_interrupted: true" >> $log
+    fi
 }
 
 mkdir -p $dir
@@ -206,6 +225,9 @@ case $1 in
         ;;
     end)
         metadata_log_end $dir
+        ;;
+    int)
+        metadata_log_end $dir int
         ;;
     *)
         usage


### PR DESCRIPTION
metadata-log is supposed to be called at the beginning of a run (with
a "beg" argument) and again at the end of the run (with an "end"
argument). Most bench scripts call it through collect-sysinfo.
user-benchmark is an exception: it calls it explicitly at the
beginning and through collect-sysinfo at the end. User scripts are a
problem (as usual).

Make metadata-log "end" check for the existence of the metadata.log
file and if not, make it call metadata_log_start explicitly to write
the file. Since the timestamp cannot be obtained from the date command
at that point, we make it use the $date variable that the base script
sets. That should make sure that we have a reasonable metadata.log file
if metadata-log "end" is called.

Since we use UTC for all other timestamps, make all timestamps be UTC
in the base script.

There are distressingly many instances of tarballs (mostly
user_benchmark) that don't have an end_run timestamp in
metadata.log. On the theory that that's caused by keyboard interrupts,
add a trap to user_benchmark that will catch INT and QUIT and run
metadata-log "end" to complete the metadata.log file.

Assuming that the above implementation is correct, plan on adding
the trap code to all the bench-scripts (TBD).