### PR TITLE
Make permisssions on unpacked files/directories more liberal.

### DIFF
--- a/bgtasks/pbench/bin/pbench-unpack-tarballs
+++ b/bgtasks/pbench/bin/pbench-unpack-tarballs
@@ -175,12 +175,31 @@ for result in $list ;do
     pushd $TMP/$hostname > /dev/null 2>&1
     tar --extract --no-same-owner --no-overwrite-dir --touch --file="$result"
     status=$?
-    popd > /dev/null 2>&1
     if [[ $status -ne 0 ]] ;then
         echo "$TS: tar -xf $result failed: code $status" >&4
         nerrs=$nerrs+1
+        popd > /dev/null 2>&1
         continue
     fi
+    # chmod directories to at least 555
+    find . -type d -print0 | xargs -0 chmod ugo+rx
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: chmod go+rx of subdirs failed: code $status" >&4
+        nerrs=$nerrs+1
+        popd > /dev/null 2>&1
+        continue
+    fi
+    # chmod files to at least 444
+    chmod -R ugo+r .
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: ``chmod -R +r .'' failed: code $status" >&4
+        nerrs=$nerrs+1
+        popd > /dev/null 2>&1
+        continue
+    fi
+    popd > /dev/null 2>&1
 
     # move the tarball contents to INCOMING
     rm $incoming/index.html


### PR DESCRIPTION
Make pbench-unpack-tarballs chmod directories to at least 555
and files to at least 444.

Rationale: sometimes, results directories are moved into the pbench
results directory, before move-results is called to copy the whole
thing over. There have been cases where perms on those directories
were tight enough that the results were not visible on the web. The
above modes should be enough to alleviate that problem.