### PR TITLE
Add generic script to activate local installation.

### DIFF
--- a/agent/util-scripts/activate-local-installation
+++ b/agent/util-scripts/activate-local-installation
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+# Usage: activate-local-installation </path/to/local/config/pbench.conf> <path/to/local/private/key>
+
+# This script installs the local config file that is used by the
+# scripts to discover local settings. One of these is the results
+# server that move-results uses to copy results to. The move-results
+# script uses scp to do that under the user id "pbench". The private
+# key for that user, as given by the second argument to this script,
+# is copied to the place where move-results expects it.
+
+configfile=$1
+keyfile=$2
+
+if [ -f $configfile ] ;then
+    pbenchdir=$(getconf.py -C $configfile pbench_install_dir pbench-agent)
+    if [ ! -z "$pbenchdir" -a -d $pbenchdir -a -d $pbenchdir/config ] ;then
+        cp $configfile $pbenchdir/config/pbench-agent.conf
+    else
+        exit 1
+    fi
+else
+    exit 2
+fi
+
+# if we have not exited, then $pbenchdir is good.
+if [ -f $keyfile ] ;then
+    cp $keyfile $pbenchdir/id_rsa
+else
+    exit 3
+fi
+
+exit 0
+
+    


### PR DESCRIPTION
Add script to copy the local config file and pbench keyfile
to their proper places.

The idea is that the generic pieces (pbench-agent and configtools)
will exist as packages based on upstream code.

The local bits (the local config file and the keyfile) will exist in
an internal package only: this package will have dependencies on the other
two, so when installed or updated, it will pull in those two if
necessary. Then it will stash the local bits in some place and call
this script in the post-install phase to copy them to their final
resting place.