### PR TITLE
Adjust ownership/mode of "activation" files.

### DIFF
--- a/agent/util-scripts/activate-local-installation
+++ b/agent/util-scripts/activate-local-installation
@@ -11,11 +11,22 @@
 
 configfile=$1
 keyfile=$2
+user=$(getconf.py -C $configfile pbench_user pbench-agent)
+group=$(getconf.py -C $configfile pbench_group pbench-agent)
+
+# fallbacks assume the existence of user/group pbench
+if [ -z "$user" ] ;then
+    user=pbench
+fi
+if [ -z "$group" ] ;then
+    group=pbench
+fi
 
 if [ -f $configfile ] ;then
     pbenchdir=$(getconf.py -C $configfile pbench_install_dir pbench-agent)
     if [ ! -z "$pbenchdir" -a -d $pbenchdir -a -d $pbenchdir/config ] ;then
         cp $configfile $pbenchdir/config/pbench-agent.conf
+        chown ${user}.${group} $pbenchdir/config/pbench-agent.conf
     else
         exit 1
     fi
@@ -26,6 +37,8 @@ fi
 # if we have not exited, then $pbenchdir is good.
 if [ -f $keyfile ] ;then
     cp $keyfile $pbenchdir/id_rsa
+    chown $user.$group $pbenchdir/id_rsa
+    chmod 640 $pbenchdir/id_rsa
 else
     exit 3
 fi

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -26,6 +26,9 @@ push-results:	results.html
 push-test-rpms:	test-rpms.html
 	rsync -ave ssh $< ${dest}/test-repo/$<
 
+push-relnotes: RELEASE-NOTES.html
+	rsync -ave ssh $< ${dest}/doc/$<
+
 .PHONY: clean veryclean
 clean:
 	rm -f *~ *.fdb_latexmk *.fls *.toc *.aux *.log *.out

--- a/doc/pbench-agent.org
+++ b/doc/pbench-agent.org
@@ -27,7 +27,9 @@ Convenience links for some places of interest (N.B. The results directory has ch
 [[*Accessing results on the web][Accessing results on the web]] for the details):
 
 - [[http://pbench.example.com/results/][Results directory]].
-- [[http://pbench.example.com/repo][pbench RPM repo]].
+- [[http://pbench.example.com/repo][pbench RPM repo]]
+- [[http://pbench.example.com/doc/RELEASE-NOTES.html][Release notes]]
+
 
 [2015-01-23 Fri] In preparation for moving the incoming directory to bigger storage,
 older directories in the pbench incoming area were archived (tarred/compressed/moved


### PR DESCRIPTION
Change ownership to pbench.pbench (or whatever is specified
in the config file - pbench.pbench is the default).
Change mode of id_rsa file to 640 - that allows anybody in
the pbench group to call move/copy-results successfully.