### PR TITLE
Make metadata-log create the directory if necessary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ install:
 script:
  - ./agent/bench-scripts/unittests
  - ./agent/tool-scripts/postprocess/unittests
+ - ./agent/util-scripts/unittests
  - ./bgtasks/pbench/bin/unittests
  - ./agent/util-scripts/unittests

--- a/agent/util-scripts/metadata-log
+++ b/agent/util-scripts/metadata-log
@@ -199,6 +199,7 @@ function metadata_log_end {
     echo "end_run: $(TZ=UTC date '+%F_%H:%M:%S.%N')" >> $log
 }
 
+mkdir -p $dir
 case $1 in
     beg)
         metadata_log_start $dir


### PR DESCRIPTION
This emulates the behavior of collect-sysinfo, which
is a good thing.