### PR TITLE
pbench_fio to support <load_generator_ip>.filename format 

### DIFF
--- a/agent/bench-scripts/pbench_fio
+++ b/agent/bench-scripts/pbench_fio
@@ -100,7 +100,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:" -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -173,7 +173,7 @@ function fio_process_options() {
                                 shift;
                         fi
                         ;;
-			-r|--ramptime)
+			--ramptime)
 			shift;
 			if [ -n "$1" ]; then
 				ramptime="$1"

--- a/agent/bench-scripts/pbench_fio
+++ b/agent/bench-scripts/pbench_fio
@@ -38,6 +38,7 @@ rate_iops=""
 test_types="read,randread"		# default is -non- destructive
 block_sizes="4,64,1024"
 targets="/tmp/fio"
+directory=""
 runtime=30
 ramptime=5
 iodepth=32
@@ -97,10 +98,13 @@ function fio_usage() {
 		printf "\n"
 		printf -- "\t--run-dir=<path>\n"
 		printf "\t\tprovide the path of an existig result (typically somewhere in $pbench_run\n"
+		printf -- "\t--directory=<path>\n"
+		printf "\t\tprovide the path to an existing directory where fio operations will be performed\n"
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions
+	"help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:" -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -257,6 +261,13 @@ function fio_process_options() {
 				shift;
 			fi
 			;;
+			--directory)
+			shift;
+			if [ -n "$1" ]; then 
+				directory="$1"
+				shift;
+			fi
+			;;
 			--)
 			shift;
 			break;
@@ -395,7 +406,6 @@ function fio_create_jobfile() {
 	for target in `echo $targets | sed -e s/,/" "/g`; do
 		printf "[job%d]\n" $job_num	>>$fio_job_file
 		printf "rw=%s\n" $test_type	>>$fio_job_file
-		printf "filename=%s\n" $target	>>$fio_job_file
 		printf "size=%s\n" "$size"	>>$fio_job_file # only used if actual file is used
 		printf "write_bw_log=fio\n"	>>$fio_job_file
 		printf "write_iops_log=fio\n"	>>$fio_job_file
@@ -404,6 +414,11 @@ function fio_create_jobfile() {
 		if [ ! -z "$rate_iops" ]; then
 			printf "rate_iops=$rate_iops\n"	>>$fio_job_file
 		fi
+		if [ ! -z "$directory" ]; then 
+			printf "directory=$directory\n" >>$fio_job_file
+		else
+			printf "filename=%s\n" $target  >>$fio_job_file
+		fi 
 		let job_num=$job_num+1
 	done
 


### PR DESCRIPTION
fio supports <load_generator_ip>.filename file format  in case only --directory is passed ( instead of -d|--target )
Updated pbench_fio to accept --directory option which will leave it up to fio to create filenames at --directory location 
Original state where fio filename was predefined ( with -d|--target ) is preserved 
