### PR TITLE
Define results_host_info_url in config file.

### DIFF
--- a/agent/config/pbench-agent.conf.example
+++ b/agent/config/pbench-agent.conf.example
@@ -4,15 +4,17 @@ pbench_results_redirector = pbench.results.example.com
 pbench_web_server = pbench.example.com
 
 [pbench-agent]
+pbench_user = pbench
 pbench_run = /var/lib/pbench-agent
 pbench_log = %(pbench_run)s/pbench.log
 
 [results]
 user = pbench
 host_path = http://%(pbench_result_redirector)s/pbench-archive-host
-dir = /pbench/public_html/incoming
 ssh_opts = -o StrictHostKeyChecking=no
 webserver = %(pbench_web_server)s
+host_info_url = http://%swebserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
+dir = /pbench/public_html/incoming
 
 [pbench/tools]
 default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat

--- a/agent/util-scripts/move-results
+++ b/agent/util-scripts/move-results
@@ -69,7 +69,7 @@ fi
 # User-Agent HTTP header: <pbench-agent-ver-rel>:<FQDN>:<$USER>:<full path of this script>""
 user_agent="pbench-agent-$ver-$rel:$(hostname -f):$USER:$0"
 
-results_host_info_url="http://$results_webserver/pbench-results-host-info.versioned/pbench-results-host-info.URL001"
+results_host_info_url=$(getconf.py host_info_url results)
 results_host_info=$(curl -s -A "$user_agent" -L "$results_host_info_url")
 if [ -z "$results_host_info" ]; then
     error_log "ERROR: unable to determine results host info from $results_host_info_url"


### PR DESCRIPTION
Replace the explicit value in move-results with a getconf of
the value in the config file.