### PR TITLE
Sort the list of tarballs by size before processing.

### DIFF
--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -35,6 +35,7 @@ pbench-backup-tarballs: Missing target backup directory argument
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
+/var/tmp/pbench-test-server/pbench/tmp/pbench-unpack-tarballs.NNNN
 --- pbench tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log:run-1900-01-01T00:00:00-UTC: starting at 1900-01-01T00:00:00-UTC

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -79,15 +79,16 @@ linkdest=TO-COPY-SOS
 
 echo $TS
 
-# get the list of files we'll be operating on
-list=$(ls $ARCHIVE/*/$linksrc/*.tar.xz 2>/dev/null)
+# get the list of files we'll be operating on - sort them by size
+list=$TMP/pbench-unpack-tarballs.$$
+find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' -printf "%s\t%p\n" 2>/dev/null | grep -v DUPLICATE | sort -n > $list
 
 typeset -i ntb=0
 typeset -i ntotal=0
 typeset -i nerrs=0
 typeset -i ndups=0
 
-for result in $list ;do
+while read size result ;do
     ntotal=$ntotal+1
 
     link=$(readlink -e $result)
@@ -255,7 +256,7 @@ for result in $list ;do
     # log the success
     echo "$TS: $hostname/$resultname: success"
     ntb=$ntb+1
-done
+done < $list
 
 echo "$TS: Processed $ntb tarballs"
 

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -58,7 +58,8 @@ function _run_allscripts {
 function _save_tree {
     # Save state of the tree
     echo "+++ pbench tree state" >> $_testout
-    find $_testdir | sort >> $_testout
+    find $_testdir | sort |
+        sed 's;tmp/pbench-unpack-tarballs.[0-9]*$;tmp/pbench-unpack-tarballs.NNNN;' >> $_testout
     echo "--- pbench tree state" >> $_testout
 }
 function _dump_logs {


### PR DESCRIPTION
This is only a half-measure (or less): if there are multiple tarballs waiting
to be processed, it will process them in increasing size order, so
the short ones will finish sooner. But once a long one is encountered,
everything will be queued behind it, until it is finished. But it's a simple
change, already implemented and tested in pbench-index.

It also takes care of the (unlikely) event of long command lines.