### PR TITLE
Need to run apt-get update for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ perl:
  - "5.16"
  - "5.10"
 install:
+ - sudo apt-get update
  - sudo apt-get install python python-pip bc libjson-perl realpath
  - sudo pip install configtools elasticsearch
  - sudo apt-get install python-software-properties


### PR DESCRIPTION
Not sure why it was not required on the old infrastructure, but
it seems to be necessary on the new one.