### PR TITLE
pbench tool to collect pprof data for Openshift

### DIFF
--- a/agent/tool-scripts/datalog/pprof-datalog
+++ b/agent/tool-scripts/datalog/pprof-datalog
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+
+openshift_conf="/etc/sysconfig/atomic-openshift-master"
+
+profile="$1"
+osecomponent="$2"
+
+ose_pprof() {
+    case "$osecomponent" in
+        master)
+            case  "$profile" in
+                cpu)
+                    echo "OPENSHIFT_PROFILE=cpu" >> /etc/sysconfig/atomic-openshift-master
+                    systemctl restart atomic-openshift-master.service
+                 ;;
+                mem)
+                    echo "OPENSHIFT_PROFILE=mem" >> /etc/sysconfig/atomic-openshift-master
+                    systemctl restart atomic-openshift-master.service
+                ;;
+            esac
+        ;;
+        node)
+            case "$profile" in
+                cpu)
+                    echo "OPENSHIFT_PROFILE=cpu" >> /etc/sysconfig/atomic-openshift-node
+                    systemctl restart atomic-openshift-node.service
+                 ;;
+                mem)
+                    echo "OPENSHIFT_PROFILE=mem" >> /etc/sysconfig/atomic-openshift-node
+                    systemctl restart atomic-openshift-node.service
+                ;;
+            esac
+        ;;
+    esac
+}
+ose_pprof
+
+
+

--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -21,14 +21,20 @@ mode=""
 interval="10"
 iteration="1"
 options="none"
+
 if [ "$script_name" == "sysfs" ]; then
 	pattern='*'
 	maxdepth=4
 	path=""
 fi
 
+if [ "$script_name" == "pprof" ]; then
+    profile="cpu"
+    osecomponent="master"
+fi
+
 # Process options and arguments
-opts=$(getopt -q -o idp --longoptions "path:,maxdepth:,pattern:,vm:,dir:,group:,iteration:,interval:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o idp --longoptions "path:,maxdepth:,pattern:,vm:,dir:,group:,iteration:,interval:,profile:,osecomponent:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
@@ -40,6 +46,8 @@ if [ $? -ne 0 ]; then
 	printf -- "\t--group=str		the perftool group (required)\n"
 	printf -- "\t--dir=str			directory to store data collection (required)\n"
 	printf -- "\t--interval=int		number of seconds between each data collection\n"
+	printf -- "\t--profile=str pprof profile to use : supported are mem or cpu profile - default is cpu profile\n"
+	printf -- "\t-osecomponent=str Openshift component to profile : supported are node or master - default is master\n"
 	if [ "$script_name" == "sysfs" ]; then
 		printf -- "\t--pattern=str		a pattern passed to -name option of find command to filter files\n"
 		printf -- "\t--path=str			a path (beyond the /sysfs prefix) passed to -name option of find command to filter files\n"
@@ -125,6 +133,20 @@ while true; do
 			shift
 		fi
 		;;
+		--profile)
+		shift;
+		if [ -n "$1" ]; then
+		    profile="$1"
+		    shift
+		fi
+		;;
+		--osecomponent)
+		shift;
+		if [ -n "$1" ]; then
+		    osecomponent="$1"
+		    shift
+		fi
+	    ;;
 		--)
 		shift;
 		break;
@@ -150,6 +172,12 @@ case "$tool" in
 	numastat)
 	tool_cmd="$script_path/datalog/$tool-datalog $interval $tool_output_file $pattern"
 	;;
+	pprof)
+	tool_cmd="$script_path/datalog/$tool-datalog $profile $osecomponent"
+	;;
+	# oc is Openshift Developer and Administrator Client
+	oc)
+	tool_cmd="$script_path/datalog/$tool-datalog $interval $tool_output_dir"
 esac
 case "$mode" in
 	install)

--- a/agent/tool-scripts/postprocess/pprof-postprocess
+++ b/agent/tool-scripts/postprocess/pprof-postprocess
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+
+script_path=`dirname $0`
+if [ "$script_path" = "." ]
+then
+    script_path=$PWD
+fi
+script_name=`basename $0`
+pbench_bin="`cd ${script_path}/..; /bin/pwd`"
+
+# Defaults
+tool_output_dir="$1"
+tool=pprof
+tool_bin=/usr/bin/go
+origin_dir="/var/lib/origin"
+openshift_bin="/usr/bin/openshift"
+
+# generate report
+for profile in mem cpu; do
+    # it can be either cpu or mem profile
+    if [ -e $origin_dir/$profile.pprof ] && [ -s $origin_dir/$profile.pprof ] ; then
+        $tool_bin tool $tool -cum -text -output $tool_output_dir/$profile-pprof-output $openshift_bin $origin_dir/$profile.pprof
+    else
+        printf "$origin_dir/$profile.pprof is zero bytes in size ... so no profile data were generated\n"
+    fi
+done

--- a/agent/tool-scripts/pprof
+++ b/agent/tool-scripts/pprof
@@ -1,0 +1,1 @@
+kvm-spinlock


### PR DESCRIPTION
pprof will collect profile data for OSE master ( atomic-openshift-master  )  or OSE node ( atomic-openshift-node ) 

By default will collect data for atomic-openshift-master in case started with 
register-tool --name=pprof

To profile atomic-openshift-node start pbench tools with 
register-tool --name=pprof --  --profile=cpu --osecomponent=node

profile can be: cpu or mem
osecomponent can be : master or node, default is master 

--- --- this is limitation of pprof ---- 
not possible to run both profiles at same time, so either cpu or mem 
not possible to profile master and node at same time if both ran on same machine 
--- ---- -----------------------------------------------------------

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>