### PR TITLE
Make debug_log deal with all its arguments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,3 @@ script:
  - ./agent/tool-scripts/postprocess/unittests
  - ./agent/util-scripts/unittests
  - ./server/pbench/bin/unittests
- - ./agent/util-scripts/unittests

--- a/agent/base
+++ b/agent/base
@@ -70,9 +70,9 @@ function error_log {
 function debug_log {
     debug_date=$(timestamp)
     if [ "$PBENCH_debug_mode" != "0" ]; then
-        echo "[debug][$debug_date] $1"
+        echo "[debug][$debug_date] $*"
     fi
-    echo "[debug][$debug_date] $1" >> $pbench_log
+    echo "[debug][$debug_date] $*" >> $pbench_log
 }
 
 


### PR DESCRIPTION
It only output the first one, but it is called with "$@",
which expands to multiple arguments.

Opportunistically, delete duplicate run of util-scripts unittests
from .travis.yml.