### PR TITLE
must specify openflow version

### DIFF
--- a/agent/tool-scripts/datalog/openvswitch-datalog
+++ b/agent/tool-scripts/datalog/openvswitch-datalog
@@ -10,7 +10,7 @@ if [ ! -z "$bridges" ]; then
 		echo "timestamp: `date +%s.%N`" >>$file
 		for b in $bridges; do
 			echo bridge: $b >>$file
-			ovs-ofctl dump-ports $b >>$file
+			ovs-ofctl dump-ports --protocols OpenFlow13 $b >>$file
 			echo >>$file
 		done
 		sleep $interval


### PR DESCRIPTION
```
# rpm -q openvswitch
openvswitch-2.4.0-1.el7.x86_64
# ovs-ofctl dump-ports br0
2016-01-14T18:42:12Z|00001|vconn|WARN|unix:/var/run/openvswitch/br0.mgmt: version negotiation failed (we support version 0x01, peer supports version 0x04)
ovs-ofctl: br0: failed to connect to socket (Broken pipe)
root@dell-r620-01: ~ # ovs-ofctl dump-ports --protocols OpenFlow13 br0
OFPST_PORT reply (OF1.3) (xid=0x2): 4 ports
  port LOCAL: rx pkts=0, bytes=0, drop=0, errs=0, frame=0, over=0, crc=0
           tx pkts=0, bytes=0, drop=3, errs=0, coll=0
           duration=21638.994s
  port  1: rx pkts=0, bytes=0, drop=0, errs=0, frame=0, over=0, crc=0
           tx pkts=0, bytes=0, drop=0, errs=0, coll=0
           duration=21638.984s
  port  2: rx pkts=10, bytes=732, drop=0, errs=0, frame=0, over=0, crc=0
           tx pkts=1, bytes=42, drop=0, errs=0, coll=0
           duration=21638.893s
  port  3: rx pkts=15, bytes=1158, drop=0, errs=0, frame=0, over=0, crc=0
           tx pkts=10, bytes=732, drop=0, errs=0, coll=0
           duration=21638.824s

```