### PR TITLE
reduce sampling interval for perf to 100Hz

### DIFF
--- a/agent/tool-scripts/perf
+++ b/agent/tool-scripts/perf
@@ -22,7 +22,7 @@ dir="/tmp"
 mode=""
 iteration="1"
 options="none"
-record_opts="record -a"
+record_opts="record -a -freq=100"
 report_opts="report --show-nr-samples -I"
 
 # Process options and arguments


### PR DESCRIPTION
We found some cases where when a longer run (1hour) was run on a system with 32GB of RAM, that the post-processing step of the perf data would be OOM-killed by the kernel.  When post-processing fails, the system is left in an awkward state that needs to be cleaned up, and it also may prevent the collection of remotely-registered data recordings.

We already set the perf recording frequency to 100Hz when we enable callgraphs.  This patch sets the perf frequency to 100Hz by default to reduce the sampling size.  In my experience this won't cause a loss of fidelity in trace data.