### PR TITLE
disable turbostat when running inside a KVM guest

### DIFF
--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -260,6 +260,10 @@ case "$mode" in
         		;;
 		esac
 		check_install_rpm $pkg
+		if grep -q KVM /sys/devices/virtual/dmi/id/product_name ; then
+			echo "pbench is running inside a KVM guest.  Disabling turbostat."
+		exit 1
+		fi
 		;;
 		dm-cache)
 		kmod=dm_cache


### PR DESCRIPTION
turbostat doesn't work inside a KVM guest, so do not allow it to be registered as a tool.  This lets us keep the same default tool-set but special-case when pbench is being run inside kvm.

Strangely enough, turbostat works OK on EC2 but I'm not sure I trust the data.

Tested like so:

```
# rpm -q pbench-agent
pbench-agent-0.36-5g439ab75.noarch (plus this PR)

# cat /sys/devices/virtual/dmi/id/product_name
KVM

# pbench-list-tools | wc -l
0

# pbench-register-tool --name=turbostat
pbench is running inside a KVM guest.  Disabling turbostat.
For some reason this tool could not be installed
# pbench-list-tools | wc -l
0
```