### PR TITLE
add rpm -q option to sosreport

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -89,7 +89,7 @@ function collect_sos {
 		tuned=""
 	fi
 	sosreport -o general -o kernel -o filesys -o devicemapper -o system -o memory \
-	      -o hardware -o networking -o lsbrelease ${block} ${processor} ${tuned} \
+	      -o hardware -o networking -o lsbrelease -o rpm rpm.rpmq on ${block} ${processor} ${tuned} \
 	      --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
 	if [[ -f "sosreport-$name-*.tar.xz" ]]; then
 		debug_log "[$script_name]done collecting sosreport"


### PR DESCRIPTION
This adds about 5 seconds and 1MB to sosreport

We're not enabling the rpm -q plugin. This means we're not capturing the package versions installed during the test, which is definitely and oversight as it's one of the main reasons to run sosreport at all.
