### PR TITLE
make sosreport collect logs for 1 day

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -90,7 +90,7 @@ function collect_sos {
 	fi
 	sosreport -o general -o kernel -o filesys -o devicemapper -o system -o memory \
 	      -o hardware -o networking -o lsbrelease ${block} ${processor} ${tuned} \
-	      --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
+	      -o logs log_days 1 --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
 	if [[ -f "sosreport-$name-*.tar.xz" ]]; then
 		debug_log "[$script_name]done collecting sosreport"
 	else


### PR DESCRIPTION
sosreport doesn't collect any logs.  We did this because it takes time and space.
Maybe we can handle that now.

See https://github.com/distributed-system-analysis/pbench/issues/179#issuecomment-194050340