### PR TITLE
Fix the calls to check_installed_rpm in all the benchmarks.

### DIFF
--- a/agent/bench-scripts/gold/pbench-uperf/test-00.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-00.txt
@@ -46,7 +46,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench tree state
 +++ pbench.log file contents
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]processing options
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]uperf is installed
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]pbench-uperf is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on server 127.0.0.1
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Starting iteration  (1 of 2)
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] test sample 1 of 2 
@@ -68,8 +68,8 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf-1.0.4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y uperf-1.0.4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query pbench-uperf-1.0.4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y pbench-uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 127.0.0.1 pbench-uperf --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01_00:00:00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 127.0.0.1 mkdir -p /var/tmp/pbench-test-bench/pbench/uperf_test-00_1900-01-01_00:00:00/1-tcp_rr-64B-1i/sample1

--- a/agent/bench-scripts/gold/pbench-uperf/test-01.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-01.txt
@@ -66,7 +66,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench tree state
 +++ pbench.log file contents
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]processing options
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]uperf is installed
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-uperf]pbench-uperf is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on client c1
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on client c2
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking for uperf on client c3
@@ -109,8 +109,8 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query uperf-1.0.4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y uperf-1.0.4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query pbench-uperf-1.0.4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/yum --debuglevel=0 install -y pbench-uperf-1.0.4
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no c1 pbench-uperf --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no c2 pbench-uperf --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no c3 pbench-uperf --install

--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -13,7 +13,6 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 . "$pbench_bin"/base
 
 benchmark="cyclictest"
-benchmark_bin=/usr/bin/$benchmark
 benchmark_rpm=rt-tests
 ver=0.87
 

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -18,6 +18,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="dbench"
 if [[ -z "$benchmark_bin" ]]; then
     benchmark_bin=/usr/local/bin/$benchmark
@@ -55,10 +56,10 @@ thread_counts=`cat /proc/cpuinfo | grep processor | wc -l`
 client_nodes=""
 
 function install_dbench {
-	if check_install_rpm $benchmark $ver; then
-		debug_log "[$script_name]$benchmark is installed"
+	if check_install_rpm $benchmark_rpm $ver; then
+		debug_log "[$script_name]$benchmark_rpm is installed"
 	else
-		error_log "[$script_name]$benchmark installation failed, exiting"
+		error_log "[$script_name]$benchmark_rpm installation failed, exiting"
 		exit 1
 	fi
 }

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -9,6 +9,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="fio"
 benchmark_bin=/usr/local/bin/$benchmark
 ver=2.2.5
@@ -313,10 +314,10 @@ function fio_process_options() {
 # Ensure the right version of the benchmark is installed
 function fio_install() {
 	if [ "$postprocess_only" == "n" ]; then
-		if check_install_rpm $benchmark $ver; then
-			debug_log "[$script_name]$benchmark is installed"
+		if check_install_rpm $benchmark_rpm $ver; then
+			debug_log "[$script_name]$benchmark_rpm is installed"
 		else
-			debug_log "[$script_name]$benchmark installation failed, exiting"
+			debug_log "[$script_name]$benchmark_rpm installation failed, exiting"
 			exit 1
 		fi 
 	fi

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -19,6 +19,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="iozone"
 benchmark_bin=/usr/local/bin/$benchmark
 ver=3.429
@@ -62,10 +63,10 @@ tool_group=default
 
 ## Ensure the right version of the benchmark is installed
 
-if check_install_rpm $benchmark $ver; then
-	debug_log "[$script_name]$benchmark is installed"
+if check_install_rpm $benchmark_rpm $ver; then
+	debug_log "[$script_name]$benchmark_rpm is installed"
 else
-	debug_log "[$script_name]$benchmark installation failed, exiting"
+	debug_log "[$script_name]$benchmark_rpm installation failed, exiting"
 	exit 1
 fi
 

--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -15,6 +15,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="linpack"
 ver=11.1.3
 benchmark_bin=/usr/local/linpack_$ver/benchmarks/linpack/xlinpack_xeon64
@@ -98,7 +99,12 @@ done
 verify_tool_group $tool_group
 
 ## Ensure the right version of the benchmark is installed
-check_install_rpm $benchmark $ver
+if check_install_rpm $benchmark_rpm $ver; then
+    debug_log "[$script_name]$benchmark_rpm is installed"
+else
+    error_log "[$script_name]$benchmark_rpm installation failed, exiting"
+    exit 1
+fi
 
 benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -22,6 +22,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="migrate"
 ver=1.0
 

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -33,6 +33,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="netperf"
 benchmark_bin=/usr/bin/$benchmark
 ver=2.6.0
@@ -116,10 +117,10 @@ function start_server {
 }
 
 function install_netperf {
-	if check_install_rpm $benchmark $ver; then
-		debug_log "[$script_name]$benchmark is installed"
+	if check_install_rpm $benchmark_rpm $ver; then
+		debug_log "[$script_name]$benchmark_rpm is installed"
 	else
-		error_log "[$script_name]$benchmark installation failed, exiting"
+		error_log "[$script_name]$benchmark_rpm installation failed, exiting"
 		exit 1
 	fi
 }

--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -18,6 +18,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="specjbb2005"
 
 # Every bench-script follows a similar sequence:

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -22,6 +22,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+benchmark_rpm=$script_name
 benchmark="uperf"
 if [[ -z "$benchmark_bin" ]]; then
     benchmark_bin=/usr/local/bin/$benchmark
@@ -167,10 +168,10 @@ function stop_server {
 }
 
 function install_uperf {
-	if check_install_rpm $benchmark $ver; then
-		debug_log "[$script_name]$benchmark is installed"
+	if check_install_rpm $benchmark_rpm $ver; then
+		debug_log "[$script_name]$benchmark_rpm is installed"
 	else
-		error_log "[$script_name]$benchmark installation failed, exiting"
+		error_log "[$script_name]$benchmark_rpm installation failed, exiting"
 		exit 1
 	fi
 }


### PR DESCRIPTION
The RPMs have been renamed to pbench-* but the RPM check was
still using the unadorned name.

Fix unit tests.