### PR TITLE
Store cron job script logs in the local file system.

### DIFF
--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -36,7 +36,7 @@ else
 fi
 
 ARCHIVE=${TOP}/archive/fs-version-001
-LOGSDIR=${TOP}/logs
+LOGSDIR=${TOP_LOCAL}/logs
 INCOMING=${TOP}/public_html/incoming
 # this is where the symlink forest is going to go
 RESULTS=${TOP}/public_html/results


### PR DESCRIPTION
This is in the spirit of keeping everything that is
not necessary for primary storage or visualization off
the distributed file system.