### PR TITLE
Clean up the list file.

### DIFF
--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -35,7 +35,6 @@ pbench-backup-tarballs: Missing target backup directory argument
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/tmp/pbench-unpack-tarballs.NNNN
 --- pbench tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log:run-1900-01-01T00:00:00-UTC: starting at 1900-01-01T00:00:00-UTC

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -83,6 +83,8 @@ echo $TS
 list=$TMP/pbench-unpack-tarballs.$$
 find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' -printf "%s\t%p\n" 2>/dev/null | grep -v DUPLICATE | sort -n > $list
 
+trap 'rm -f $list' EXIT INT QUIT
+
 typeset -i ntb=0
 typeset -i ntotal=0
 typeset -i nerrs=0


### PR DESCRIPTION
pbench-unpack-tarballs creates a list file of tarballs it
is going to process in this run, sorts it and then goes
through it, but it does not delete it.

Add a trap to remove it.