### PR TITLE
Update the jschart legend rectangle outlining code to work with Firefox and vector zooming

### DIFF
--- a/web-server/v0.3/css/jschart.css
+++ b/web-server/v0.3/css/jschart.css
@@ -20,7 +20,8 @@ line.points { stroke-width: 1.5px; cursor: crosshair; pointer-events: none; }
 .titlebox { fill: #033E6B; }
 .legendlabel { }
 .area { opacity: 0.9; cursor: crosshair; pointer-events: none; }
-.legendrect { outline-style: solid; outline-offset: 1px; outline-width: 2px; opacity: 0.9; }
+.legendrect { opacity: 0.9; }
+.legendrectoutline { stroke-width: 2px; fill-opacity: 0; }
 rect.pane { cursor: crosshair; fill: none; pointer-events: all; }
 .actionlabel { cursor: pointer; fill: blue; }
 .actionlabel:hover { text-decoration: underline; font-weight: bold; fill: red; }

--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -947,14 +947,20 @@ function complete_chart(charts_index) {
         .attr("transform", function(d, i) { return "translate(" + (-margin.left + 5 + (i % charts[charts_index].legend_columns) * (total_width / charts[charts_index].legend_columns)) + "," + (height + legend_properties.margin.top + (Math.floor(i / charts[charts_index].legend_columns) * legend_properties.row_height)) + ")"; });
 
     charts[charts_index].chart.legend.append("rect")
+	.attr("class", "legendrectoutline")
+	.attr("width", 16)
+	.attr("height", 16)
+	.style("stroke", function(d) { return mycolors(d.index); } );
+
+    charts[charts_index].chart.legend.append("rect")
 	.attr("class", function(d) { d.dom.legend.rect = d3.select(this); return "legendrect"; })
 	.on("click", toggle_hide_click_event)
 	.on("mouseover", mouseover_highlight_function)
 	.on("mouseout", mouseout_highlight_function)
-	.attr("width", 16)
-	.attr("height", 16)
+	.attr("width", 12)
+	.attr("height", 12)
+	.attr("transform", "translate(2, 2)")
 	.style("opacity", function(d) { if (d.hidden) { return hidden_opacity; } else { return default_opacity; } })
-	.style("outline-color", function(d) { return mycolors(d.index); } )
 	.style("fill", function(d) { return mycolors(d.index); } );
 
     var legend_label_offset = 25;


### PR DESCRIPTION
- Orginally I used the CSS outline-* properties to construct the
  permanent outlines around the legend rectangle that are not modified
  by event actions such as mouse overs and dataset hiding and this
  worked fine in Chrome.  It turns out that these properties are
  ignored by Firefox in the SVG context and even in Chrome if the page
  is zoomed they do not scale properly since they are not actual
  vector objects.

- This bug fix replaces the CSS outline-* properties with a secondary
  vector element that is independently controlled.  Visually the
  primary vector element (which responds to mouse events) is located
  inside the secondary element (which ignores mouse events).  In order
  to distinguish between the two elements the secondary element has a
  visible stroke and an invisible fill.