### PR TITLE
Wrong link for pbench-kill-tools.

### DIFF
--- a/agent/util-scripts/pbench-kill-tools
+++ b/agent/util-scripts/pbench-kill-tools
@@ -1,1 +1,1 @@
-postprocess-tools
+pbench-postprocess-tools


### PR DESCRIPTION
It pointed to the old name.