### PR TITLE
remove exit 1 from when registering turbostat inside a kvm guest

### DIFF
--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -320,7 +320,6 @@ case "$mode" in
 		check_install_rpm $pkg
 		if grep -q KVM /sys/devices/virtual/dmi/id/product_name ; then
 			echo "pbench is running inside a KVM guest.  Disabling turbostat."
-		exit 1
 		fi
 		;;
 		dm-cache)


### PR DESCRIPTION
This isn't actually an error, so remove the exit 1.