### PR TITLE
Using turbostat in a VM is just a warning

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -105,7 +105,8 @@ function check_install_rpm {
 	local this_version=""
     fi
 
-    rpm_status=`rpm --query ${this_rpm}$this_version`
+    local rpm_status=`rpm --query ${this_rpm}$this_version`
+    local rc=0
     if echo $rpm_status | grep -q "is not installed"; then
 	debug_log "[check_install_rpm] attempting to install ${this_rpm}$this_version"
 	yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1

--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -306,6 +306,7 @@ case "$mode" in
 		# no version is provided here because we rely on a 
 		# distribution provided package and we take whatever we can get
 		check_install_rpm trace-cmd
+		rc=$?
 		;;
 		turbostat)
 		release=$(awk '{x=$7; split(x, a, "."); print a[1];}' /etc/redhat-release)
@@ -318,9 +319,9 @@ case "$mode" in
 			;;
 		esac
 		check_install_rpm $pkg
+		rc=$?
 		if grep -q KVM /sys/devices/virtual/dmi/id/product_name ; then
-			error_log "pbench is running inside a KVM guest.  Disabling turbostat."
-			exit 1
+			warn_log "pbench is running inside a KVM guest.  Disabling turbostat."
 		fi
 		;;
 		dm-cache)

--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -43,36 +43,36 @@ if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
 	printf "The following options are available: \n\n"
-	printf -- "\t--install,			install this perf tool\n"
+	printf -- "\t--install,                install this perf tool\n"
 	printf "\n"
-	printf -- "\t--start|stop|postprocess	start/stop/postprocess the data collection\n"
-	printf -- "\t--iteration=int 		the iteration (required)\n"
-	printf -- "\t--group=str		the perftool group (required)\n"
-	printf -- "\t--dir=str			directory to store data collection (required)\n"
-	printf -- "\t--interval=int		number of seconds between each data collection\n"
+	printf -- "\t--start|stop|postprocess  start/stop/postprocess the data collection\n"
+	printf -- "\t--iteration=int           the iteration (required)\n"
+	printf -- "\t--group=str               the perftool group (required)\n"
+	printf -- "\t--dir=str                 directory to store data collection (required)\n"
+	printf -- "\t--interval=int            number of seconds between each data collection\n"
 	if [ "$script_name" == "sysfs" ]; then
-		printf -- "\t--pattern=str		a pattern passed to -name option of find command to filter files\n"
-		printf -- "\t--path=str			a path (beyond the /sysfs prefix) passed to -name option of find command to filter files\n"
-		printf -- "\t--maxdepth=int		a maxdepth passed to -name option of find command to filter files\n"
+		printf -- "\t--pattern=str             a pattern passed to -name option of find command to filter files\n"
+		printf -- "\t--path=str                a path (beyond the /sysfs prefix) passed to -name option of find command to filter files\n"
+		printf -- "\t--maxdepth=int            a maxdepth passed to -name option of find command to filter files\n"
 	fi
 	if [ "$script_name" == "virsh-migrate" ]; then
-		printf -- "\t--vm=str			the name of the VM being migrated\n"
+		printf -- "\t--vm=str                  the name of the VM being migrated\n"
 	fi
 	if [ "$script_name" == "blktrace" ]; then
-		printf -- "\t--devices=str,[str]	the list of block devices to trace\n"
+		printf -- "\t--devices=str,[str]       the list of block devices to trace\n"
 	fi
 	if [ "$script_name" == "kvmtrace" ]; then
-		printf -- "\t--vm=str			the hostname of the vm running (to get kallsyms)\n"
-		printf -- "\t--timeout=int		how long the trace will run (default is 1 second).  If 0 is used, the trace will not stop until stop-tools is called\n"
-		printf -- "\t--start-delay=int		sleep this many seconds before starting the trace\n"
+		printf -- "\t--vm=str                  the hostname of the vm running (to get kallsyms)\n"
+		printf -- "\t--timeout=int             how long the trace will run (default is 1 second).  If 0 is used, the trace will not stop until stop-tools is called\n"
+		printf -- "\t--start-delay=int         sleep this many seconds before starting the trace\n"
 	fi
 	if [ "$script_name" == "tcpdump" ]; then
-		printf -- "\t--interface=str		the network interface to monitor\n"
-		printf -- "\t--packets=	int		the number of packets to monitor before exiting\n"
+		printf -- "\t--interface=str           the network interface to monitor\n"
+		printf -- "\t--packets=	int            the number of packets to monitor before exiting\n"
 	fi
 	if [ "$script_name" == "rabbit" ]; then
-		printf -- "\t--username=str         rabbit user name (default is "$username")\n"
-		printf -- "\t--password=int         rabbit password (default is "$password")\n"
+		printf -- "\t--username=str            rabbit user name (default is "$username")\n"
+		printf -- "\t--password=int            rabbit password (default is "$password")\n"
 	fi
 	exit 1
 fi
@@ -310,26 +310,26 @@ case "$mode" in
 		turbostat)
 		release=$(awk '{x=$7; split(x, a, "."); print a[1];}' /etc/redhat-release)
 		case $release in
-    			6)
-        		pkg=cpupowerutils
-        		;;
-    			*)
-        		pkg=kernel-tools
-        		;;
+			6)
+			pkg=cpupowerutils
+			;;
+			*)
+			pkg=kernel-tools
+			;;
 		esac
 		check_install_rpm $pkg
 		if grep -q KVM /sys/devices/virtual/dmi/id/product_name ; then
 			echo "pbench is running inside a KVM guest.  Disabling turbostat."
-		exit 1
+			exit 1
 		fi
 		;;
 		dm-cache)
 		kmod=dm_cache
 		if ! grep -q $kmod /proc/modules ; then
-            		echo "$kmod not loaded, exiting"
-            	exit 1
+			echo "$kmod not loaded, exiting"
+			exit 1
 		fi
-        	;;
+		;;
 		rabbit)
 		tool_bin="/usr/bin/rabbitmqadmin"
 		if [ ! -e $tool_bin ]; then
@@ -338,7 +338,7 @@ case "$mode" in
 		fi
 		;;
 	esac
-        ;;
+	;;
 	start)
 	if [ "$tool" == "kvmtrace" ]; then
 		if [ ! -z "$start_delay" ]; then

--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -299,7 +299,7 @@ case "$mode" in
 		kvmtrace)
 		# ensure debugfs is mounted
 		if cat /proc/mounts | grep -q debugfs; then
-			echo "debugfs is already mounted"
+			log "debugfs is already mounted"
 		else
 			mount -t debugfs none /sys/kernel/debug
 		fi
@@ -319,21 +319,21 @@ case "$mode" in
 		esac
 		check_install_rpm $pkg
 		if grep -q KVM /sys/devices/virtual/dmi/id/product_name ; then
-			echo "pbench is running inside a KVM guest.  Disabling turbostat."
+			error_log "pbench is running inside a KVM guest.  Disabling turbostat."
 			exit 1
 		fi
 		;;
 		dm-cache)
 		kmod=dm_cache
 		if ! grep -q $kmod /proc/modules ; then
-			echo "$kmod not loaded, exiting"
+			error_log "$kmod not loaded, exiting"
 			exit 1
 		fi
 		;;
 		rabbit)
 		tool_bin="/usr/bin/rabbitmqadmin"
 		if [ ! -e $tool_bin ]; then
-			echo "$tool_bin not installed, exiting"
+			error_log "$tool_bin not installed, exiting"
 			exit 1
 		fi
 		;;


### PR DESCRIPTION
Also be sure we don't leak the `rc` variable value out of the
`check_install_rpm` function, and be sure we capture its return value for
`kvm-spinlock`'s exit status.

We also address some whitespace formatting issues with `kvm-spinlock`, and use proper pbench logging methods where applicable.

Enhances #286.