### PR TITLE
Respect GOROOT env var if set

### DIFF
--- a/agent/tool-scripts/pprof
+++ b/agent/tool-scripts/pprof
@@ -15,7 +15,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 
 # Defaults
 tool=pprof
-tool_bin=/usr/bin/go
+tool_bin=${GOROOT:-/usr}/bin/go
 tool_package=golang
 group=default
 dir="/tmp"


### PR DESCRIPTION
go is often installed under /usr/local or /usr/local/go.   If the standard GOROOT env var (https://golang.org/doc/install#tarball_non_standard) is set, the pprof tool should respect it and not assume /usr/bin/go.

@ekuric PTAL