### PR TITLE
Templating prototype for pbench-fio

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -14,6 +14,8 @@ benchmark="fio"
 benchmark_bin=/usr/local/bin/$benchmark
 ver=2.2.11
 
+job_file="${script_path}/templates/fio.job"
+
 # Every bench-script follows a similar sequence:
 # 1) process bench script arguments
 # 2) ensure the right version of the benchmark is installed
@@ -42,14 +44,14 @@ block_sizes="4,64,1024"
 targets="/tmp/fio"
 directory=""
 numjobs=""
-runtime=30
-ramptime=5
-iodepth=32
-ioengine="libaio"
+runtime=""
+ramptime=""
+iodepth=""
+ioengine=""
 job_mode="concurrent" # serial or concurrent
-file_size="4096M"
-direct=1 # don't cache IO's by default
-sync=0 # don't sync IO's by default
+file_size=""
+direct="" # don't cache IO's by default
+sync="" # don't sync IO's by default
 clients="" # A list of hostnames (hosta,hostb,hostc) where you want fio to run.  Note: if you use this, pbench must be installed on these systems already.
 tool_label_pattern="fio-"
 tool_group="default"
@@ -80,9 +82,9 @@ function fio_usage() {
 		printf -- "\t-b int[,int] --block-sizes=str[,str] (default is $block_sizes)\n"
 		printf "\t\tone or more block sizes in KiB (default is $block_sizes)\n"
 		printf "\n"
-                printf -- "\t-s int[,int] --file-size=str[,str] (default is $file_size)\n"
-                printf "\t\tfile sizes in MiB: %s\n"
-                printf "\n"
+		printf -- "\t-s int[,int] --file-size=str[,str] (default is $file_size)\n"
+		printf "\t\tfile sizes in MiB: %s\n"
+		printf "\n"
 		printf -- "\t-d str[,str] --targets=str[,str]\n"
 		printf "\t\tone or more directories or block devices (default is $targets)\n"
 		printf "\t\t(persistent names for devices highly recommended)\n"
@@ -106,12 +108,14 @@ function fio_usage() {
 		printf "\t\tprovide the path to an existing directory where fio operations will be performed\n"
 		printf -- "\t--numjobs=<int>\n"
 		printf "\t\tnumber of jobs to run, if not given then fio default of numjobs=1 will be used\n"
+		printf -- "\t--job-file=<path>\n"
+		printf "\t\tprovide the path of a fio job config file, (default is $job_file)\n"
 		printf -- "\t--samples=<int>\n"
 		printf "\t\tnumber of samples to use per test iteration (default is $nr_sanples)\n"
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,noinstall:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,noinstall:" -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -177,13 +181,13 @@ function fio_process_options() {
 				shift;
 			fi
 			;;
-                        -s|--file-size)
-                        shift;
-                        if [ -n "$1" ]; then
-                                file_size="$1"
-                                shift;
-                        fi
-                        ;;
+			-s|--file-size)
+			shift;
+			if [ -n "$1" ]; then
+				file_size="$1"
+				shift;
+			fi
+			;;
 			--ramptime)
 			shift;
 			if [ -n "$1" ]; then
@@ -294,13 +298,20 @@ function fio_process_options() {
 				shift;
 			fi 
 			;;
+			--job-file)
+			shift;
+			if [ -n "$1" ]; then
+				job_file="$1"
+				shift;
+			fi
+			;; 
 			--noinstall)
 				shift;
 				if [ -n "$1" ]; then 
 					noinstall="$1"
 					shift;
 				fi
-			;; 
+			;;
 			--)
 			shift;
 			break;
@@ -345,11 +356,11 @@ function fio_install() {
 		wait
 	elif [ ! -z "$clients" ] && [ "$noinstall" == "y" ]; then 
 		debug_log "verifying clients have fio installed" 
-                echo "verifying clients have fio installed"
+		echo "verifying clients have fio installed"
 		for client in `echo $clients | sed -e s/,/" "/g`; do
 			if ( ssh $ssh_opts $clients "[ ! -e $benchmark_bin ]" ); then
 				debug_log "[$script_name]$benchmark is not installed on $client and option noinstall specified. Cannot proceed, remove noinstall or install $benchmark manually"
-                                echo "$script_name $benchmark is not installed on $client and option noinstall specified. Cannot proceed, remove noinstall or install $benchmark manually"
+				echo "$script_name $benchmark is not installed on $client and option noinstall specified. Cannot proceed, remove noinstall or install $benchmark manually"
 				exit 0 
 		
 			fi 
@@ -420,54 +431,20 @@ function fio_device_check() {
 }
 
 function fio_create_jobfile() {
-	local test_type="$1"
-	local ioengine="$2"
-	local block_size="$3"
-	local iodepth="$4"
-	local direct="$5"
-	local sync="$6"
-	local runtime="$7"
-	local ramptime="$8"
-	local size="$9"
-	local rate_iops="${10}"
-	local targets="${11}"
 	local fio_job_file="${12}"
-	local job_num=1
-	local job_dir=`dirname "$fio_job_file"`
-	local target
 
-	mkdir -p $job_dir
-	printf "[global]\n"		 >$fio_job_file
-	printf "bs=%sk\n" $block_size	>>$fio_job_file
-	printf "ioengine=$ioengine\n"	>>$fio_job_file
-	printf "iodepth=$iodepth\n"	>>$fio_job_file
-	printf "direct=$direct\n"	>>$fio_job_file
-	printf "sync=$sync\n"		>>$fio_job_file
-	printf "time_based=1\n"		>>$fio_job_file
-	printf "runtime=$runtime\n"	>>$fio_job_file
-	printf "clocksource=gettimeofday\n" >>$fio_job_file 
-	printf "ramp_time=$ramptime\n" >>$fio_job_file 
-	for target in `echo $targets | sed -e s/,/" "/g`; do
-		printf "[job%d]\n" $job_num	>>$fio_job_file
-		printf "rw=%s\n" $test_type	>>$fio_job_file
-		printf "size=%s\n" "$size"	>>$fio_job_file # only used if actual file is used
-		printf "write_bw_log=fio\n"	>>$fio_job_file
-		printf "write_iops_log=fio\n"	>>$fio_job_file
-		printf "write_lat_log=fio\n"	>>$fio_job_file
-		printf "log_avg_msec=1000\n"	>>$fio_job_file
-		if [ ! -z "$rate_iops" ]; then
-			printf "rate_iops=$rate_iops\n"	>>$fio_job_file
-		fi
-		if [ ! -z "$directory" ]; then 
-			printf "directory=$directory\n" >>$fio_job_file
-		else
-			printf "filename=%s\n" $target  >>$fio_job_file
-		fi 
-		if [ ! -z "$numjobs" ]; then 
-			printf "numjobs=$numjobs\n"	>>$fio_job_file
-		fi 
-		let job_num=$job_num+1
-	done
+	mkdir -p "`dirname \"$fio_job_file\"`"
+	"${script_path}/templates/make-fio-jobfile.py" -j $job_file \
+		-bs="`printf \"%sk\" $3`" -rw="$1" \
+		-ioengine="$2" \
+		-iodepth="$4" \
+		-direct="$5" \
+		-sync="$6" \
+		-runtime="$7" \
+		-ramptime="$8" \
+		-size="$9" \
+		-rate_iops="${10}" \
+		-targets `echo "${11}" | sed -e s/,/" "/g` > $fio_job_file
 
 	echo "The following jobfile was created: $fio_job_file"
 	cat $fio_job_file

--- a/agent/bench-scripts/templates/fio.job
+++ b/agent/bench-scripts/templates/fio.job
@@ -1,0 +1,33 @@
+# Syntax:
+#   $target : expands to the fio target file
+#   $@ : expands to the value of the option as passed to
+#        pbench-fio
+
+[global]
+	bs = $@
+	runtime = 30
+	ioengine = libaio
+	iodepth = 32
+	direct = 1
+	sync = 0
+	time_based = 1
+	clocksource = gettimeofday
+	ramp_time = 5
+
+[job-$target]
+	filename = $target
+	rw = $@
+	size = 4096M
+	write_bw_log = fio
+	write_iops_log = fio
+	write_lat_log = fio
+	log_avg_msec = 1000
+
+	write_hist_log = fio
+	log_hist_msec = 10000
+	log_hist_coarseness = 4 # 76 bins
+
+	#rate_iops=10
+	#directory=/tmp/fio
+	#numjobs=4
+

--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python2.7
+""" Constructs an fio job file with the following precedence
+    from high to low:
+
+        - Common options, given on command line (-bs, -rw, ...)
+        - Job file, given with '-j'.
+
+    Fio job files may contain references to:
+    
+        - '$target', which is replaced sequentially with each instance of the
+          targets specified with '-targets'.
+        - '$@', which is replaced by the command line parameter to this
+          program by the same name.
+    
+"""
+import sys
+import configparser
+from collections import OrderedDict
+
+def parse_config(filename):
+    cp = configparser.ConfigParser()
+    cp.read(filename)
+    return cp._sections
+
+def write_config(dictionary, out=sys.stdout):
+    cp = configparser.ConfigParser()
+    cp.read_dict(dictionary)
+    cp.write(out, False)
+
+def replace_all(dct, old, new):
+    """ Replace all instances of string 'old' with string 'new' in
+        both keys and values of the (possibly nested) dictionary """
+    for k in dct.keys():
+        if isinstance(dct[k], dict):
+            dct[k] = replace_all(dct[k], old, new)
+        else:
+            old_val = dct[k]
+            del dct[k]
+            k = k.replace(old, new)
+            dct[k] = old_val.replace(old, new)
+
+def replace_val(dct, magic, delta):
+    """ Replace all values of string 'magic' with the new value
+        given by the same key in dict 'delta', in the possibly nested
+        dictionary dct """
+    for k in dct.keys():
+        if isinstance(dct[k], dict):
+            dct[k] = replace_val(dct[k], delta)
+        else:
+            if magic in dct[k]:
+                if delta[k] is None: import pdb; pdb.set_trace()
+                dct[k] = dct[k].replace(magic, delta[k])
+
+# Other arguments that can override those given in the job file:
+other_args = \
+    ['bs', 'rw', 'ioengine', 'iodepth', 'direct', 'sync',
+     'runtime', 'ramptime', 'size', 'rate_iops']
+
+def main(ctx):
+
+    cfg       = parse_config(ctx.job_file)
+
+    _delta = {
+        'bs' : ctx.bs,
+        'rw' : ctx.rw,
+    }
+
+    # Expand targets for each job file section with '$target' in the name:
+    jobfile = OrderedDict()
+    for target in ctx.targets:
+        for k,v in cfg.items():
+            if '$target' in k:
+                key = k.replace('$target', target)
+            else:
+                key = k
+            jobfile[key] = cfg[k].copy()
+            replace_val(jobfile[key], '$@', _delta)
+            replace_all(jobfile[key], '$target', target)
+    
+    # Override job file options with command line options:
+    for a in other_args:
+        val = ctx.__dict__[a]
+        if not (val is None or val is ""):
+            for k in jobfile.keys():
+                if jobfile[k].has_key(a):
+                        jobfile[k][a] = val
+
+    write_config(jobfile)
+
+if __name__ == '__main__':
+    import argparse
+    p = argparse.ArgumentParser()
+    arg = p.add_argument
+    arg('-j', '--job_file', required=False,
+        default=None,
+        help='Fio job file options. Defaults to agent/bench-scripts/templates/fio.defaults.')
+    arg('-targets', required=True, help='fio target device', nargs='+')
+    for a in other_args:
+        arg('-%s' % a, required=False, default=None, help=a)
+main(p.parse_args())
+


### PR DESCRIPTION
This is by no means a complete template infrastructure but it works for the default `pbench-fio` options, and for a few sample configuration files I tried out. I've included fio's new histogram options in the default config file.

Commit message starts here:

Templating prototype for `pbench-fio`, using config files to specify
fio parameters. The order of precedence used is as follows: (from high
to low)

- Command line options already given to pbench-fio
- Fio job file given with `--job-file`

The defaults in agent/bench-scripts/templates/fio.job match the existing
defaults Additionally the template currently has the following two special
semantics:

- '$target' gets replaced with each of the specified targets, ultimately
making a copy of each of the job file sections with '$target' in
their name for each target.

- '$@' gets replaced with whatever was given on the command line of
make-fio-jobfile.py. For now this only works for 'bs' and 'rw', so that
I didn't have to make substantial changes to pbench-fio - namely
reconstruct the for-loops which iterate over the targets, test_types,
and block_sizes.

The next thing(s) templating could handle are:

- Arbitrary replacement of '$' variables, as either environment
variables or options to pbench-fio.
- Benchmark agnostic - abstract away the fio-specific details of
make-fio-jobfile.