### PR TITLE
use correct benchmark name

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -325,7 +325,7 @@ function fio_install() {
 		debug_log "verifying clients have fio installed"
 		echo "verifying clients have fio installed"
 		for client in `echo $clients | sed -e s/,/" "/g`; do
-			ssh $ssh_opts $client ${pbench_install_dir}/bench-scripts/pbench_fio --install &
+			ssh $ssh_opts $client ${pbench_install_dir}/bench-scripts/$script_name --install &
 		done
 		wait
 	elif [ ! -z "$clients" ] && [ "$noinstall" == "y" ]; then 


### PR DESCRIPTION
When I tried running pbench-fio in distributed mode with --client= syntax, I got this:

    # pbench-fio -t write --clients=10.0.11.179 -b 4 -s 1024m -d /srv/fio/foo --ioengine sync --direct=0
    verifying clients have fio installed
    bash: /opt/pbench-agent/bench-scripts/pbench_fio: No such file or directory

So I suspect it used to be called pbench_fio and then this changed, but it didn't get changed here.  Rather than changing it to pbench-fio, I used **$script_name** so it won't happen again.  Does this happen to any other benchmarking tools with --client option?