### PR TITLE
append '-o collectd' plugin while running sosreport

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -66,11 +66,17 @@ function collect_block {
 function collect_sos {
 	name=$(hostname -f)-pbench
 	debug_log "[$script_name]collecting sosreport"
-	sos_ver=`rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $1}'`
-	if [[ "$sos_ver" == "3" ]]; then
+	read sos_ver sos_ver_minor <<< `rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $1" "$2}'`
+	if [[ "$sos_ver" -ge 3 ]]; then
 		quiet="--quiet"
 		block="-o block"
 		processor="-o processor"
+		# ref for plugin collectd: https://github.com/sosreport/sos/pull/866
+		if [[ "$sos_ver_minor" -ge 4 ]]; then
+		    collectd="-o collectd"
+		else
+		    collectd=""
+		fi
 		sos_ver=`rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $2}'`
 		if [[ "$sos_ver" == "0" ]]; then
 		    # No tuned plug-in in sosreport v3.0
@@ -84,10 +90,11 @@ function collect_sos {
 		block=""
 		processor=""
 		tuned=""
+		collectd=""
 	fi
 	sosreport -o general -o kernel -o filesys -o devicemapper -o system -o memory \
 	      -o hardware -o networking -o lsbrelease ${block} ${processor} ${tuned} \
-	      --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
+	      ${collectd} --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
 	if [[ -f "sosreport-$name-*.tar.xz" ]]; then
 		debug_log "[$script_name]done collecting sosreport"
 	else


### PR DESCRIPTION
For collecting information about collectd on a system, enable collectd plugin (ref: https://github.com/sosreport/sos/pull/866). 

This is a WIP and Fixes #322.

TODO: 

 * add option for indexing the added infomation on pbench server side using toc_extra option as introduced under https://github.com/distributed-system-analysis/pbench/pull/176/commits/056fea00d5de380687391719ebc0a7c5d79b87c4#diff-5421c653bebed8a25579ee626ce4088fR899
 * add check in sos_version and if needed, fork the new sosversion under DSA and install that on clients, as a workaround until collectd plugin PR gets accepted
