### PR TITLE
Add --client-file option to specify a list of clients

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -93,6 +93,7 @@ function fio_usage() {
 		printf "\n"
 		printf -- "\t--clients=str[,str]      str= one or more remote systems to run fio\n"
 		printf -- "\t                         If no clients are specified, fio is run locally\n"
+		printf -- "\t--client-file=str        str= file (with absolute path) which contains 1 client per line\n"
 		printf -- "\t--tool-group=str\n"
 		printf "\n"
 		printf -- "\t--postprocess_only=[y|n]\n"
@@ -110,7 +111,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,noinstall:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,noinstall:" -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -208,6 +209,18 @@ function fio_process_options() {
 			shift;
 			if [ -n "$1" ]; then
 				clients="$1"
+				shift;
+			fi
+			;;
+			--client-file)
+			shift;
+			if [ -n "$1" ]; then
+				if [ -e $1 ]; then
+					while read line; do
+						clients="$clients,$line"
+					done <$1
+					clients=`echo $clients | sed -e 's/^,//'`
+				fi
 				shift;
 			fi
 			;;


### PR DESCRIPTION
fixes issue #333, providing an option to specify a file containing a list of clients