### PR TITLE
Check for the existence of the hash element rather than it having a

### DIFF
--- a/agent/bench-scripts/postprocess/BenchPostprocess.pm
+++ b/agent/bench-scripts/postprocess/BenchPostprocess.pm
@@ -82,7 +82,7 @@ sub get_uid {
 	while ( $uid && $uid =~ s/^([^%]*)%([^%]+)%// ) {
 		my $before_uid_marker = $1;
 		my $uid_marker = $2;
-		if ( $$uid_sources_ref{$uid_marker} ) {
+		if ( exists $$uid_sources_ref{$uid_marker} ) {
 			$mapped_uid = $mapped_uid . $before_uid_marker . $$uid_sources_ref{$uid_marker};
 		} else {
 			$mapped_uid = $mapped_uid . $before_uid_marker . "%" . $uid_marker . "%";


### PR DESCRIPTION
non-zero value when doing substitution in BenchPostprocess::get_uid

- It is possible that the value of the hash element is zero in which
  case checking it's value will fail the if statement.  By checking
  for the elements existence it's value is irrelevant, as it should
  be.

- Result output from pbench-moongen has port IDs of zero which where
  not being substituted into the uid because of this bug.