### PR TITLE
Fixes to fully handle epoch time

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -375,7 +375,7 @@ function print_iteration {
 	# printing a iteration assumes this must be a new row, so include \n first
 	printf "\n%28s" "$1" >>$benchmark_summary_txt_file
 	printf "\n%s" "$1" >>$benchmark_summary_csv_file
-	hist_interval=`cat $iteration_dir/reference-result/fio.job | grep "^log_hist_msec" | cut -f2 -d= | head -n1 | xargs echo -n`
+	hists=`cat $iteration_dir/reference-result/fio.job | grep "^log_hist_msec"`
 	if [ $1 == "iteration" ]; then
 		# this is just a label, so no links here
 		if [ ! -z "$hist_interval" ]; then
@@ -648,15 +648,20 @@ function fio_run_benchmark() {
 						done
 						if [ $sample_failed -eq 0 ]; then
 
-							hist_interval=`cat $iteration_dir/sample1/fio.job | grep "^log_hist_msec" | cut -f2 -d= | head -n1 | xargs echo -n`
-							if [ ! -z "$hist_interval" ]; then
+							hists=`cat $iteration_dir/sample1/fio.job | grep "^log_hist_msec"`
+							if [ ! -z "$hists" ]; then
 								hist_results=$iteration_dir/hist
 								mkdir -p $hist_results
 								# Use sample1 here, since all of the samples have the same log_hist_msec value
 								# NOTE: If --log_unix_epoch gets enabled in fio.job, then fiologparser_hist.py will not merge
 								# histograms into an "average" across the samples.
-								fiologparser_hist.py -i $hist_interval $iteration_dir/sample*/clients/*/*_clat_hist.* > $hist_results/hist.csv
-								$script_path/postprocess/$benchmark-postprocess-viz.py $hist_results
+								fiologparser_hist.py \
+									--job-file=$iteration_dir/sample1/fio.job \
+									$iteration_dir/sample*/clients/*/*_clat_hist.* \
+									> $hist_results/hist.csv
+								$script_path/postprocess/$benchmark-postprocess-viz.py \
+									--job-file=$iteration_dir/sample1/fio.job \
+									$hist_results
 							fi
 
 							# find the keys that we will compute avg & stddev

--- a/agent/bench-scripts/postprocess/fio-postprocess
+++ b/agent/bench-scripts/postprocess/fio-postprocess
@@ -11,11 +11,11 @@ my $js_str;
 
 # Determine histogram interval based on value used in job file. Should really make
 # this an option, but perfectly reasonable default.
-my $interval = `cat $dir/fio.job | grep "^log_hist_msec" | cut -f2 -d= | head -n1 | xargs echo -n`;
+my $interval = `cat $dir/fio.job | grep "^log_hist_msec"`;
 if ( ! $interval =~ /^\s*$/ ) {
 	system("mkdir -p $dir/hist");
-	system("fiologparser_hist.py -i $interval $dir/clients/*/*_clat_hist.* > $dir/hist/hist.csv");
-	system(abs_path($0) . "-viz.py $dir/hist");
+	system("fiologparser_hist.py --job-file=$dir/fio.job $dir/clients/*/*_clat_hist.* > $dir/hist/hist.csv");
+	system(abs_path($0) . "-viz.py --job-file=$dir/fio.job $dir/hist");
 }
 
 open( JS, "<$dir/fio-result.txt" ) or die "Can't open $dir/fio-result.txt: $!";

--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -59,12 +59,12 @@ except AttributeError:
     SafeConfigParser.read_dict = _read_dict
 
 def parse_config(filename):
-    cp = SafeConfigParser()
+    cp = SafeConfigParser(allow_no_value=True)
     cp.read(filename)
     return cp._sections
 
 def write_config(dictionary, out=sys.stdout):
-    cp = SafeConfigParser()
+    cp = SafeConfigParser(allow_no_value=True)
     cp.read_dict(dictionary)
     cp.write(out)
 
@@ -75,7 +75,7 @@ def replace_all(dct, old, new):
     for k in keys:
         if isinstance(dct[k], dict):
             dct[k] = replace_all(dct[k], old, new)
-        else:
+        elif dct[k] is not None:
             old_val = dct[k]
             del dct[k]
             k = k.replace(old, new)
@@ -90,7 +90,7 @@ def replace_val(dct, magic, delta):
         if isinstance(dct[k], dict):
             dct[k] = replace_val(dct[k], delta)
         else:
-            if magic in dct[k]:
+            if (dct[k] is not None) and magic in dct[k]:
                 dct[k] = dct[k].replace(magic, delta[k])
 
 # Other arguments that can override those given in the job file:


### PR DESCRIPTION
Implements all the fixes I mentioned in Issue #313. Works for me with both configparser and ConfigParser, and latest upstream fio (which has a new option added to fiologparser_hist.py to take in the fio job file).