### PR TITLE
Rsync tarballs from satellite servers to a production server.

### DIFF
--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -30,7 +30,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/backup
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -19,7 +19,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/backup
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -60,7 +60,7 @@ fi
 mail_recipients=$(getconf.py mailto pbench-server)
 
 # make all the state directories for the pipeline and any others needed
-LINKDIRS="TODO TO-COPY-SOS TO-INDEX INDEXED WONT-INDEX DONE"
+LINKDIRS="TODO TO-COPY-SOS TO-INDEX INDEXED WONT-INDEX DONE BAD-MD5"
 
 function mk_dirs {
     hostname=$1

--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -89,6 +89,12 @@ for host in $hosts ;do
     fi
     # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
     mk_dirs $prefix::$host
+    # check md5
+    md5sum -c *.md5 > $logdir/$prefix-host/md5-checks.txt
+    # delete all that check
+    for x in $(sed '/OK$/s/: OK//' $logdir/$prefix-host/md5-checks.txt) ;do
+        echo $x $x.md5
+    done | ssh $remotehost "cd $remotearchive/$host; xargs rm"
     popd > /dev/null
 done
 

--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -1,0 +1,123 @@
+#! /bin/bash
+
+# This script rsyncs the archive of pbench tarballs of a satellite server
+# to the archive of the internal production server. In the process, it
+# renames the local copy of each remote host directory by prepending a prefix.
+# That way, hosts associated with the satellite are disambiguated and distinguished from
+# every other host (internal or from another satellite).
+
+# Any newly downloaded tarballs are then linked into the TODO directory of the host,
+# just as if pbench-move-results had moved the tarball here.
+
+# The tarballs will be sorted by size and any tarball bigger than 100MB will be
+# tagged for future handling, in order to prevent delays to current data sets.
+
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)
+        PROG=$(basename $0)
+        ;;
+esac
+
+case $# in
+    4|5)
+        :
+        ;;
+    *)
+        echo "Usage: $PROG <prefix> <remotehost> <remotearchive> <TOP> [<TOP_LOCAL>]"
+        exit 1
+        ;;
+esac
+
+prefix=$1
+remotehost=$2
+remotearchive=$3
+
+shift 3
+
+TOP=$1
+TOP_LOCAL=$2
+. $dir/pbench-base.sh
+
+# for testing, limit it to a few hosts and stay away from the largest tarballs
+# hosts=$(ssh $remotehost "cd $remotearchive; ls | grep -v 300 | sed 4q")
+hosts=$(ssh $remotehost "cd $remotearchive; ls")
+
+tmp=$TMP/$PROG.$$
+
+trap "rm -rf $tmp" EXIT
+
+mkdir -p $tmp
+
+exclude=$tmp/exclude
+cat <<EOF > $exclude
+TODO
+TO-INDEX
+TO-COPY-SOS
+INDEXED
+DONE
+WONT-INDEX*
+EOF
+
+log_init $(basename $0)
+logdir=$LOGSDIR/$(basename $0)
+
+let start_time=$(date +%s)
+echo "run-$TS: start - $(date +%Y-%m-%dT%H:%M:%S)"
+let failures=0
+for host in $hosts ;do
+    localdir=$ARCHIVE/$prefix::$host
+    if [ ! -d $localdir ] ;then
+        mkdir -p $localdir || exit 1
+    fi
+    pushd $localdir 2>/dev/null || exit 2
+    if [ ! -d $logdir/$prefix-$host ] ;then
+        mkdir -p $logdir/$prefix-$host
+    fi
+    echo "rsync -av --exclude-from=$exclude --log-file=$logdir/$prefix-$ost/rsync.$TS $remotehost:$remotearchive/$host/ ."
+    rsync -av --exclude-from=$exclude --log-file=$logdir/$prefix-$host/rsync.$TS $remotehost:$remotearchive/$host/ .
+    rc=$?
+    if [[ $rc != 0 ]] ;then
+        echo "FAILED:    rsync -av $remotehost:$remotearchive/$host/ ."
+        let failures=failures+1
+    fi
+    # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
+    mk_dirs $prefix::$host
+    popd > /dev/null
+done
+
+# generate a list of downloaded files in the form "<prefix>::<host>/<file>" from the rsync log files
+list=$tmp/tb.list
+for host in $hosts ;do
+    rsync_log=$logdir/$prefix-$host/rsync.$TS
+    cat $rsync_log | grep '>f' | awk -v prefix=$prefix -v host=$host '{printf("%s::%s/%s\n", prefix, host, $5);}'
+done | sort > $list
+
+# decorate the list with the sizes and sort by size
+cd $ARCHIVE
+for host in $hosts ;do
+    find $prefix::$host -type f -name '*.tar.xz' -printf "%p\t%s\n" 
+done | sort | join - $list | sort -k 2 -n > $logdir/$PROG.$TS.wq
+
+# we now have a work queue - we add a link to the TODO directory for each tarball that we want
+# processed and we let pbench-unpack-tarballs take care of the rest.
+$dir/pbench-rsync-satellite-process-work-queue --archive=$ARCHIVE $logdir/$PROG.$TS.wq
+rc=$?
+if [[ $rc == 1 ]] ;then
+    echo "pbench-rsync-satellite-process-work-queue exited with status 1"
+    echo "Check $logdir/$PROG.$TS.wq.todo and $logdir/$PROG.$TS.wq.files"
+else
+    echo "pbench-rsync-satellite-process-work-queue exited with non-zero status $rc - why?"
+fi
+let end_time=$(date +%s)
+let duration=end_time-start_time
+echo "run-$TS: end - $(date +%Y-%m-%dT%H:%M:%S)"
+echo "run-$TS: duration (secs): $duration"
+
+exit $failures

--- a/server/pbench/bin/pbench-rsync-satellite-process-work-queue
+++ b/server/pbench/bin/pbench-rsync-satellite-process-work-queue
@@ -1,0 +1,142 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+process the work queue: it consists of pairs (filename, size).
+
+The work list is processed in size order (smallest to largest).
+We bite off a chunk and send it for processing, then we sleep,
+waking up occasionally to check if the last of the chunk is done.
+If not, sleep some more; if yes, submit the next chunk. 
+
+We limit the size of each chunk to the number of files whose sizes
+sum to less than some limit (the limit is supposed to make sure that
+the processing does not take inordinately long). Files bigger than
+the limit are *not* processed: the list is mailed to a human, who
+can then inject them into the processing queue by hand, at whatever
+time it is deemed convenient to minimize the chance of inconveniencing
+current users.
+
+"""
+import os, sys, time
+from optparse import OptionParser
+
+# global wq file - absolute path
+workq = None
+
+class tball(object):
+    archive = None
+    
+    def __init__(self, name, size):
+        self.name = name
+        self.size = size
+        self.link_name = os.path.join(os.path.dirname(name), "TODO", os.path.basename(name))
+        
+    def __repr__(self):
+        return "{}: {} ({})".format(os.path.join(self.archive, self.name), self.size, self.link_name)
+
+
+def totalsize(files, maxsize):
+    """
+    Return a portion of the files list whose total size does not exceed
+    maxsize. Actually, the first n-1 do not exceed maxsize, but adding
+    the nth will. If n > 1, return n-1 to stay within the limitation,
+    but otherwise return 1.  That guarantees that at least one file
+    will be dealt with, so we will continue to make progress through
+    the list, albeit slowly.
+
+    """
+    total = 0
+    n = 0
+    while total < maxsize and n < len(files):
+        total += files[n].size
+        n += 1
+    if n > 1:
+        return n-1
+    else:
+        return 1
+
+def process(todo, options):
+    for x in todo:
+        if options.verbose:
+            print("os.symlink({}, {})".format(os.path.join(x.archive, x.name), x.link_name))
+        if not options.dryrun:
+            os.symlink(os.path.join(x.archive, x.name), x.link_name)
+
+def processed(f, options):
+    import stat
+
+    # this just checks a single symlink (the caller passes it the last symlink
+    # in the todo list.
+
+    if options.verbose:
+        print(f)
+    if options.dryrun:
+        return True
+    try:
+        # if it exists, it'd better be a link, in which case we are *NOT* done yet.
+        return not stat.S_ISLNK(os.lstat(f.link_name).st_mode)
+    except OSError:
+        # no link found - we are done
+        return True
+
+def dump(tag, files):
+    dumpf = open("{}.{}".format(workq, tag), "w")
+    for f in files:
+        dumpf.write("{}\t{}\n".format(f.name, f.size))
+    dumpf.close()
+    
+def main(options, args):
+    # print(options)
+    if options.archive:
+        os.chdir(options.archive)
+        tball.archive = options.archive
+    else:
+        sys.exit(9)
+        
+    workq = args[0]
+    files = [tball(x.split()[0], int(x.split()[1]))  for x in open(args[0]).readlines() if x.find("TO-COPY") == -1]
+
+    maxsize = 50*1024*1024
+    while files:
+        # get n files whose total size is roughly maxsize
+        n = totalsize(files, maxsize)
+        todo = files[0:n]
+        files = files[n:]
+
+        process(todo, options)
+        if options.verbose:
+            print(len(todo), len(files))
+        nsleep = 0
+        while True:
+            if not options.dryrun:
+                time.sleep(60)
+            nsleep += 1
+            # check the last one: if that is done, all the others are too.
+            if processed(todo[n-1], options):
+                break
+            elif nsleep % 10 == 0:
+                if options.verbose:
+                    print("Not done yet: {} minutes".format(nsleep))
+            elif nsleep > 30:
+                if options.verbose:
+                    print("Process taking more than 30 minutes - dumping the work queue for manual processing")
+                dump("todo", todo)
+                dump("files", files)
+                return 1
+    return 0
+
+if __name__ == '__main__':
+    parser = OptionParser()
+    parser.add_option("-a", "--archive", dest="archive",
+                      help="Archive location (absolute pathname)", metavar="FILE")
+    parser.add_option("-v", "--verbose",
+                      action="store_true", dest="verbose", default=False,
+                      help="print status messages to stdout")
+    parser.add_option("-n", "--dry-run",
+                      action="store_true", dest="dryrun", default=False,
+                      help="don't process tarballs or wait for them to be processed")
+
+    (options, args) = parser.parse_args()
+    status = main(options, args)
+    sys.exit(status)

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -94,7 +94,7 @@ while read size result ;do
     ntotal=$ntotal+1
 
     link=$(readlink -e $result)
-    if [ ! -f $link ] ;then
+    if [ ! -f "$link" ] ;then
         echo "$TS: $link does not exist" >&4
         nerrs=$nerrs+1
         continue
@@ -161,10 +161,13 @@ while read size result ;do
     md5tar=$(md5sum $link 2> /dev/null | cut -d' ' -f1)
     if [ "$md5" != "$md5tar" ] ;then
         echo "$TS: MD5 check failed on $link" >&4
+        # move the link so that the script does not report the error continuously
+        mv $result $(echo $result | sed 's/TODO/BAD-MD5/')
         nerrs=$nerrs+1
         continue
     fi
 
+    let start_time=$(date +%s)
     # unpack the tarball into a temp area
     pushd $TMP/$PROG/$hostname > /dev/null 2>&1
     tar --extract --no-same-owner --no-overwrite-dir --touch --file="$result"
@@ -254,9 +257,10 @@ while read size result ;do
         nerrs=$nerrs+1
         continue
     fi
-
+    let end_time=$(date +%s)
+    let duration=end_time-start_time
     # log the success
-    echo "$TS: $hostname/$resultname: success"
+    echo "$TS: $hostname/$resultname: success - elapsed time (secs): $duration - size (bytes): $size"
     ntb=$ntb+1
 done < $list
 


### PR DESCRIPTION
This addresses issue #277. The code has been tested in production, with the exception of the tarball/md5 deletion from the satellite. The files ranged from 1MB to almost 4GB in size, with typically a few thousand small files and a handful of big ones: no problems were found. It has not been added to the crontab in production, but that's ready to go at a moment's notice. The default frequency is nightly.
