### PR TITLE
Adopt the latest jschart features

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess-viz.py
+++ b/agent/bench-scripts/postprocess/fio-postprocess-viz.py
@@ -20,7 +20,7 @@ html = \
 <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
 <div id='jschart_latency'>
   <script>
-    create_graph(0, "%s", "jschart_latency", "Percentiles", "Time (s)", "Latency (s)",
+    create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (s)", "Latency (s)",
         { plotfiles: [ "avg.log", "median.log", "p90.log",
                        "p99.log", "min.log", "max.log" ],
           sort_datasets: false, x_log_scale: false

--- a/agent/tool-scripts/postprocess/GenData.pm
+++ b/agent/tool-scripts/postprocess/GenData.pm
@@ -252,7 +252,7 @@ sub gen_data {
 					$threshold = ", threshold: " . $thresholds{$htmlpage}{$chart};
 				}
 
-				printf TOOL_HTML "        create_graph(\"%s\", \"%s\", \"%s\", \"%s\", null, null, { csvfiles: [ \"csv/%s.csv\" ]%s });\n", $this_graph_type, "timeseries", "chart_" . $chartnum, $chart, $htmlpage . '_' . $chart, $threshold;
+				printf TOOL_HTML "        create_jschart(\"%s\", \"%s\", \"%s\", \"%s\", null, null, { csvfiles: [ \"csv/%s.csv\" ]%s });\n", $this_graph_type, "timeseries", "chart_" . $chartnum, $chart, $htmlpage . '_' . $chart, $threshold;
 
 				printf TOOL_HTML "      </script>\n";
 				printf TOOL_HTML "    </div>\n";

--- a/agent/tool-scripts/postprocess/gold/cpuacct/cgroup_cpuacct.html
+++ b/agent/tool-scripts/postprocess/gold/cpuacct/cgroup_cpuacct.html
@@ -12,367 +12,367 @@
     <center><h2>cpuacct - cgroup_cpuacct</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "machine.slice", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "machine.slice", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "machine.slice_machine-qemu-vm1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "machine.slice_machine-qemu-vm1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "machine.slice_machine-qemu-vm10", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "machine.slice_machine-qemu-vm10", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "machine.slice_machine-qemu-vm10_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "machine.slice_machine-qemu-vm10_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "machine.slice_machine-qemu-vm10_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "machine.slice_machine-qemu-vm10_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "machine.slice_machine-qemu-vm10_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_6", "machine.slice_machine-qemu-vm10_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "machine.slice_machine-qemu-vm10_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_7", "machine.slice_machine-qemu-vm10_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("lineChart", "timeseries", "chart_8", "machine.slice_machine-qemu-vm10_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_8", "machine.slice_machine-qemu-vm10_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm10_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_9">
       <script>
-        create_graph("lineChart", "timeseries", "chart_9", "machine.slice_machine-qemu-vm11", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_9", "machine.slice_machine-qemu-vm11", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11.csv" ] });
       </script>
     </div>
     <div id="chart_10">
       <script>
-        create_graph("lineChart", "timeseries", "chart_10", "machine.slice_machine-qemu-vm11_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_10", "machine.slice_machine-qemu-vm11_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_11">
       <script>
-        create_graph("lineChart", "timeseries", "chart_11", "machine.slice_machine-qemu-vm11_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_11", "machine.slice_machine-qemu-vm11_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_12">
       <script>
-        create_graph("lineChart", "timeseries", "chart_12", "machine.slice_machine-qemu-vm11_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_12", "machine.slice_machine-qemu-vm11_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_13">
       <script>
-        create_graph("lineChart", "timeseries", "chart_13", "machine.slice_machine-qemu-vm11_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_13", "machine.slice_machine-qemu-vm11_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_14">
       <script>
-        create_graph("lineChart", "timeseries", "chart_14", "machine.slice_machine-qemu-vm11_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_14", "machine.slice_machine-qemu-vm11_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm11_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_15">
       <script>
-        create_graph("lineChart", "timeseries", "chart_15", "machine.slice_machine-qemu-vm12", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_15", "machine.slice_machine-qemu-vm12", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12.csv" ] });
       </script>
     </div>
     <div id="chart_16">
       <script>
-        create_graph("lineChart", "timeseries", "chart_16", "machine.slice_machine-qemu-vm12_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_16", "machine.slice_machine-qemu-vm12_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_17">
       <script>
-        create_graph("lineChart", "timeseries", "chart_17", "machine.slice_machine-qemu-vm12_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_17", "machine.slice_machine-qemu-vm12_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_18">
       <script>
-        create_graph("lineChart", "timeseries", "chart_18", "machine.slice_machine-qemu-vm12_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_18", "machine.slice_machine-qemu-vm12_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_19">
       <script>
-        create_graph("lineChart", "timeseries", "chart_19", "machine.slice_machine-qemu-vm12_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_19", "machine.slice_machine-qemu-vm12_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_20">
       <script>
-        create_graph("lineChart", "timeseries", "chart_20", "machine.slice_machine-qemu-vm12_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_20", "machine.slice_machine-qemu-vm12_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm12_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_21">
       <script>
-        create_graph("lineChart", "timeseries", "chart_21", "machine.slice_machine-qemu-vm1_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_21", "machine.slice_machine-qemu-vm1_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_22">
       <script>
-        create_graph("lineChart", "timeseries", "chart_22", "machine.slice_machine-qemu-vm1_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_22", "machine.slice_machine-qemu-vm1_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_23">
       <script>
-        create_graph("lineChart", "timeseries", "chart_23", "machine.slice_machine-qemu-vm1_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_23", "machine.slice_machine-qemu-vm1_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_24">
       <script>
-        create_graph("lineChart", "timeseries", "chart_24", "machine.slice_machine-qemu-vm1_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_24", "machine.slice_machine-qemu-vm1_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_25">
       <script>
-        create_graph("lineChart", "timeseries", "chart_25", "machine.slice_machine-qemu-vm1_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_25", "machine.slice_machine-qemu-vm1_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm1_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_26">
       <script>
-        create_graph("lineChart", "timeseries", "chart_26", "machine.slice_machine-qemu-vm2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_26", "machine.slice_machine-qemu-vm2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2.csv" ] });
       </script>
     </div>
     <div id="chart_27">
       <script>
-        create_graph("lineChart", "timeseries", "chart_27", "machine.slice_machine-qemu-vm2_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_27", "machine.slice_machine-qemu-vm2_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_28">
       <script>
-        create_graph("lineChart", "timeseries", "chart_28", "machine.slice_machine-qemu-vm2_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_28", "machine.slice_machine-qemu-vm2_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_29">
       <script>
-        create_graph("lineChart", "timeseries", "chart_29", "machine.slice_machine-qemu-vm2_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_29", "machine.slice_machine-qemu-vm2_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_30">
       <script>
-        create_graph("lineChart", "timeseries", "chart_30", "machine.slice_machine-qemu-vm2_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_30", "machine.slice_machine-qemu-vm2_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_31">
       <script>
-        create_graph("lineChart", "timeseries", "chart_31", "machine.slice_machine-qemu-vm2_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_31", "machine.slice_machine-qemu-vm2_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm2_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_32">
       <script>
-        create_graph("lineChart", "timeseries", "chart_32", "machine.slice_machine-qemu-vm3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_32", "machine.slice_machine-qemu-vm3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3.csv" ] });
       </script>
     </div>
     <div id="chart_33">
       <script>
-        create_graph("lineChart", "timeseries", "chart_33", "machine.slice_machine-qemu-vm3_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_33", "machine.slice_machine-qemu-vm3_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_34">
       <script>
-        create_graph("lineChart", "timeseries", "chart_34", "machine.slice_machine-qemu-vm3_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_34", "machine.slice_machine-qemu-vm3_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_35">
       <script>
-        create_graph("lineChart", "timeseries", "chart_35", "machine.slice_machine-qemu-vm3_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_35", "machine.slice_machine-qemu-vm3_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_36">
       <script>
-        create_graph("lineChart", "timeseries", "chart_36", "machine.slice_machine-qemu-vm3_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_36", "machine.slice_machine-qemu-vm3_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_37">
       <script>
-        create_graph("lineChart", "timeseries", "chart_37", "machine.slice_machine-qemu-vm3_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_37", "machine.slice_machine-qemu-vm3_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm3_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_38">
       <script>
-        create_graph("lineChart", "timeseries", "chart_38", "machine.slice_machine-qemu-vm4", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_38", "machine.slice_machine-qemu-vm4", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4.csv" ] });
       </script>
     </div>
     <div id="chart_39">
       <script>
-        create_graph("lineChart", "timeseries", "chart_39", "machine.slice_machine-qemu-vm4_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_39", "machine.slice_machine-qemu-vm4_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_40">
       <script>
-        create_graph("lineChart", "timeseries", "chart_40", "machine.slice_machine-qemu-vm4_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_40", "machine.slice_machine-qemu-vm4_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_41">
       <script>
-        create_graph("lineChart", "timeseries", "chart_41", "machine.slice_machine-qemu-vm4_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_41", "machine.slice_machine-qemu-vm4_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_42">
       <script>
-        create_graph("lineChart", "timeseries", "chart_42", "machine.slice_machine-qemu-vm4_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_42", "machine.slice_machine-qemu-vm4_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_43">
       <script>
-        create_graph("lineChart", "timeseries", "chart_43", "machine.slice_machine-qemu-vm4_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_43", "machine.slice_machine-qemu-vm4_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm4_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_44">
       <script>
-        create_graph("lineChart", "timeseries", "chart_44", "machine.slice_machine-qemu-vm5", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_44", "machine.slice_machine-qemu-vm5", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5.csv" ] });
       </script>
     </div>
     <div id="chart_45">
       <script>
-        create_graph("lineChart", "timeseries", "chart_45", "machine.slice_machine-qemu-vm5_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_45", "machine.slice_machine-qemu-vm5_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_46">
       <script>
-        create_graph("lineChart", "timeseries", "chart_46", "machine.slice_machine-qemu-vm5_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_46", "machine.slice_machine-qemu-vm5_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_47">
       <script>
-        create_graph("lineChart", "timeseries", "chart_47", "machine.slice_machine-qemu-vm5_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_47", "machine.slice_machine-qemu-vm5_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_48">
       <script>
-        create_graph("lineChart", "timeseries", "chart_48", "machine.slice_machine-qemu-vm5_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_48", "machine.slice_machine-qemu-vm5_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_49">
       <script>
-        create_graph("lineChart", "timeseries", "chart_49", "machine.slice_machine-qemu-vm5_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_49", "machine.slice_machine-qemu-vm5_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm5_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_50">
       <script>
-        create_graph("lineChart", "timeseries", "chart_50", "machine.slice_machine-qemu-vm6", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_50", "machine.slice_machine-qemu-vm6", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6.csv" ] });
       </script>
     </div>
     <div id="chart_51">
       <script>
-        create_graph("lineChart", "timeseries", "chart_51", "machine.slice_machine-qemu-vm6_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_51", "machine.slice_machine-qemu-vm6_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_52">
       <script>
-        create_graph("lineChart", "timeseries", "chart_52", "machine.slice_machine-qemu-vm6_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_52", "machine.slice_machine-qemu-vm6_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_53">
       <script>
-        create_graph("lineChart", "timeseries", "chart_53", "machine.slice_machine-qemu-vm6_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_53", "machine.slice_machine-qemu-vm6_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_54">
       <script>
-        create_graph("lineChart", "timeseries", "chart_54", "machine.slice_machine-qemu-vm6_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_54", "machine.slice_machine-qemu-vm6_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_55">
       <script>
-        create_graph("lineChart", "timeseries", "chart_55", "machine.slice_machine-qemu-vm6_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_55", "machine.slice_machine-qemu-vm6_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm6_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_56">
       <script>
-        create_graph("lineChart", "timeseries", "chart_56", "machine.slice_machine-qemu-vm7", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_56", "machine.slice_machine-qemu-vm7", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7.csv" ] });
       </script>
     </div>
     <div id="chart_57">
       <script>
-        create_graph("lineChart", "timeseries", "chart_57", "machine.slice_machine-qemu-vm7_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_57", "machine.slice_machine-qemu-vm7_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_58">
       <script>
-        create_graph("lineChart", "timeseries", "chart_58", "machine.slice_machine-qemu-vm7_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_58", "machine.slice_machine-qemu-vm7_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_59">
       <script>
-        create_graph("lineChart", "timeseries", "chart_59", "machine.slice_machine-qemu-vm7_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_59", "machine.slice_machine-qemu-vm7_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_60">
       <script>
-        create_graph("lineChart", "timeseries", "chart_60", "machine.slice_machine-qemu-vm7_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_60", "machine.slice_machine-qemu-vm7_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_61">
       <script>
-        create_graph("lineChart", "timeseries", "chart_61", "machine.slice_machine-qemu-vm7_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_61", "machine.slice_machine-qemu-vm7_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm7_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_62">
       <script>
-        create_graph("lineChart", "timeseries", "chart_62", "machine.slice_machine-qemu-vm8", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_62", "machine.slice_machine-qemu-vm8", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8.csv" ] });
       </script>
     </div>
     <div id="chart_63">
       <script>
-        create_graph("lineChart", "timeseries", "chart_63", "machine.slice_machine-qemu-vm8_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_63", "machine.slice_machine-qemu-vm8_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_64">
       <script>
-        create_graph("lineChart", "timeseries", "chart_64", "machine.slice_machine-qemu-vm8_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_64", "machine.slice_machine-qemu-vm8_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_65">
       <script>
-        create_graph("lineChart", "timeseries", "chart_65", "machine.slice_machine-qemu-vm8_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_65", "machine.slice_machine-qemu-vm8_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_66">
       <script>
-        create_graph("lineChart", "timeseries", "chart_66", "machine.slice_machine-qemu-vm8_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_66", "machine.slice_machine-qemu-vm8_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_67">
       <script>
-        create_graph("lineChart", "timeseries", "chart_67", "machine.slice_machine-qemu-vm8_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_67", "machine.slice_machine-qemu-vm8_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm8_vcpu3.csv" ] });
       </script>
     </div>
     <div id="chart_68">
       <script>
-        create_graph("lineChart", "timeseries", "chart_68", "machine.slice_machine-qemu-vm9", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_68", "machine.slice_machine-qemu-vm9", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9.csv" ] });
       </script>
     </div>
     <div id="chart_69">
       <script>
-        create_graph("lineChart", "timeseries", "chart_69", "machine.slice_machine-qemu-vm9_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_emulator.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_69", "machine.slice_machine-qemu-vm9_emulator", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_emulator.csv" ] });
       </script>
     </div>
     <div id="chart_70">
       <script>
-        create_graph("lineChart", "timeseries", "chart_70", "machine.slice_machine-qemu-vm9_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu0.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_70", "machine.slice_machine-qemu-vm9_vcpu0", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu0.csv" ] });
       </script>
     </div>
     <div id="chart_71">
       <script>
-        create_graph("lineChart", "timeseries", "chart_71", "machine.slice_machine-qemu-vm9_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu1.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_71", "machine.slice_machine-qemu-vm9_vcpu1", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu1.csv" ] });
       </script>
     </div>
     <div id="chart_72">
       <script>
-        create_graph("lineChart", "timeseries", "chart_72", "machine.slice_machine-qemu-vm9_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu2.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_72", "machine.slice_machine-qemu-vm9_vcpu2", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu2.csv" ] });
       </script>
     </div>
     <div id="chart_73">
       <script>
-        create_graph("lineChart", "timeseries", "chart_73", "machine.slice_machine-qemu-vm9_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu3.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_73", "machine.slice_machine-qemu-vm9_vcpu3", null, null, { csvfiles: [ "csv/cgroup_cpuacct_machine.slice_machine-qemu-vm9_vcpu3.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/docker/docker.html
+++ b/agent/tool-scripts/postprocess/gold/docker/docker.html
@@ -12,7 +12,7 @@
     <center><h2>docker - docker</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "containers", null, null, { csvfiles: [ "csv/docker_containers.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "containers", null, null, { csvfiles: [ "csv/docker_containers.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/iostat-1/disk.html
+++ b/agent/tool-scripts/postprocess/gold/iostat-1/disk.html
@@ -12,37 +12,37 @@
     <center><h2>iostat-1 - disk</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "Queue_Size", null, null, { csvfiles: [ "csv/disk_Queue_Size.csv" ], threshold: 0.01 });
+        create_jschart("lineChart", "timeseries", "chart_2", "Queue_Size", null, null, { csvfiles: [ "csv/disk_Queue_Size.csv" ], threshold: 0.01 });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_3", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_4", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "Throughput", null, null, { csvfiles: [ "csv/disk_Throughput.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_5", "Throughput", null, null, { csvfiles: [ "csv/disk_Throughput.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "Utilization", null, null, { csvfiles: [ "csv/disk_Utilization.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_6", "Utilization", null, null, { csvfiles: [ "csv/disk_Utilization.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_7", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/iostat-2/disk.html
+++ b/agent/tool-scripts/postprocess/gold/iostat-2/disk.html
@@ -12,22 +12,22 @@
     <center><h2>iostat-2 - disk</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_2", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_3", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_4", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/iostat-3/disk.html
+++ b/agent/tool-scripts/postprocess/gold/iostat-3/disk.html
@@ -12,37 +12,37 @@
     <center><h2>iostat-3 - disk</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_1", "IOPS", null, null, { csvfiles: [ "csv/disk_IOPS.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "Queue_Size", null, null, { csvfiles: [ "csv/disk_Queue_Size.csv" ], threshold: 0.01 });
+        create_jschart("lineChart", "timeseries", "chart_2", "Queue_Size", null, null, { csvfiles: [ "csv/disk_Queue_Size.csv" ], threshold: 0.01 });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_3", "Request_Merges", null, null, { csvfiles: [ "csv/disk_Request_Merges.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_4", "Request_Size", null, null, { csvfiles: [ "csv/disk_Request_Size.csv" ], threshold: 0.1 });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "Throughput", null, null, { csvfiles: [ "csv/disk_Throughput.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_5", "Throughput", null, null, { csvfiles: [ "csv/disk_Throughput.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "Utilization", null, null, { csvfiles: [ "csv/disk_Utilization.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_6", "Utilization", null, null, { csvfiles: [ "csv/disk_Utilization.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
+        create_jschart("lineChart", "timeseries", "chart_7", "Wait_Time", null, null, { csvfiles: [ "csv/disk_Wait_Time.csv" ], threshold: 0.1 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/kvmstat/kvmstat.html
+++ b/agent/tool-scripts/postprocess/gold/kvmstat/kvmstat.html
@@ -12,7 +12,7 @@
     <center><h2>kvmstat - kvmstat</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "kvm_exits", null, null, { csvfiles: [ "csv/kvmstat_kvm_exits.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "kvm_exits", null, null, { csvfiles: [ "csv/kvmstat_kvm_exits.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu0.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu0.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu0</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu0", null, null, { csvfiles: [ "csv/cpu0_cpu0.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu0", null, null, { csvfiles: [ "csv/cpu0_cpu0.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu1.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu1.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu1</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu1", null, null, { csvfiles: [ "csv/cpu1_cpu1.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu1", null, null, { csvfiles: [ "csv/cpu1_cpu1.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu2.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu2.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu2</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu2", null, null, { csvfiles: [ "csv/cpu2_cpu2.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu2", null, null, { csvfiles: [ "csv/cpu2_cpu2.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu3.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu3.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu3</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu3", null, null, { csvfiles: [ "csv/cpu3_cpu3.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu3", null, null, { csvfiles: [ "csv/cpu3_cpu3.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu4.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu4.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu4</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu4", null, null, { csvfiles: [ "csv/cpu4_cpu4.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu4", null, null, { csvfiles: [ "csv/cpu4_cpu4.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu5.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu5.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu5</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu5", null, null, { csvfiles: [ "csv/cpu5_cpu5.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu5", null, null, { csvfiles: [ "csv/cpu5_cpu5.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu6.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu6.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu6</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu6", null, null, { csvfiles: [ "csv/cpu6_cpu6.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu6", null, null, { csvfiles: [ "csv/cpu6_cpu6.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpu7.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpu7.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpu7</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu7", null, null, { csvfiles: [ "csv/cpu7_cpu7.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu7", null, null, { csvfiles: [ "csv/cpu7_cpu7.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat-0/cpuall.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat-0/cpuall.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat-0 - cpuall</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpuall", null, null, { csvfiles: [ "csv/cpuall_cpuall.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpuall", null, null, { csvfiles: [ "csv/cpuall_cpuall.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu0.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu0.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu0</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu0", null, null, { csvfiles: [ "csv/cpu0_cpu0.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu0", null, null, { csvfiles: [ "csv/cpu0_cpu0.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu1.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu1.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu1</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu1", null, null, { csvfiles: [ "csv/cpu1_cpu1.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu1", null, null, { csvfiles: [ "csv/cpu1_cpu1.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu2.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu2.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu2</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu2", null, null, { csvfiles: [ "csv/cpu2_cpu2.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu2", null, null, { csvfiles: [ "csv/cpu2_cpu2.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu3.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu3.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu3</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu3", null, null, { csvfiles: [ "csv/cpu3_cpu3.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu3", null, null, { csvfiles: [ "csv/cpu3_cpu3.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu4.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu4.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu4</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu4", null, null, { csvfiles: [ "csv/cpu4_cpu4.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu4", null, null, { csvfiles: [ "csv/cpu4_cpu4.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu5.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu5.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu5</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu5", null, null, { csvfiles: [ "csv/cpu5_cpu5.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu5", null, null, { csvfiles: [ "csv/cpu5_cpu5.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu6.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu6.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu6</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu6", null, null, { csvfiles: [ "csv/cpu6_cpu6.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu6", null, null, { csvfiles: [ "csv/cpu6_cpu6.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpu7.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpu7.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpu7</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu7", null, null, { csvfiles: [ "csv/cpu7_cpu7.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu7", null, null, { csvfiles: [ "csv/cpu7_cpu7.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/mpstat/cpuall.html
+++ b/agent/tool-scripts/postprocess/gold/mpstat/cpuall.html
@@ -12,7 +12,7 @@
     <center><h2>mpstat - cpuall</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpuall", null, null, { csvfiles: [ "csv/cpuall_cpuall.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpuall", null, null, { csvfiles: [ "csv/cpuall_cpuall.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/pidstat/context_switches.html
+++ b/agent/tool-scripts/postprocess/gold/pidstat/context_switches.html
@@ -12,12 +12,12 @@
     <center><h2>pidstat - context_switches</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "nonvoluntary_switches_sec", null, null, { csvfiles: [ "csv/context_switches_nonvoluntary_switches_sec.csv" ], threshold: 100 });
+        create_jschart("lineChart", "timeseries", "chart_1", "nonvoluntary_switches_sec", null, null, { csvfiles: [ "csv/context_switches_nonvoluntary_switches_sec.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "voluntary_switches_sec", null, null, { csvfiles: [ "csv/context_switches_voluntary_switches_sec.csv" ], threshold: 100 });
+        create_jschart("lineChart", "timeseries", "chart_2", "voluntary_switches_sec", null, null, { csvfiles: [ "csv/context_switches_voluntary_switches_sec.csv" ], threshold: 100 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/pidstat/cpu_usage.html
+++ b/agent/tool-scripts/postprocess/gold/pidstat/cpu_usage.html
@@ -12,7 +12,7 @@
     <center><h2>pidstat - cpu_usage</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "percent_cpu", null, null, { csvfiles: [ "csv/cpu_usage_percent_cpu.csv" ], threshold: 1 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "percent_cpu", null, null, { csvfiles: [ "csv/cpu_usage_percent_cpu.csv" ], threshold: 1 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/pidstat/file_io.html
+++ b/agent/tool-scripts/postprocess/gold/pidstat/file_io.html
@@ -12,12 +12,12 @@
     <center><h2>pidstat - file_io</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "io_reads_KB_sec", null, null, { csvfiles: [ "csv/file_io_io_reads_KB_sec.csv" ], threshold: 50 });
+        create_jschart("lineChart", "timeseries", "chart_1", "io_reads_KB_sec", null, null, { csvfiles: [ "csv/file_io_io_reads_KB_sec.csv" ], threshold: 50 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "io_writes_KB_sec", null, null, { csvfiles: [ "csv/file_io_io_writes_KB_sec.csv" ], threshold: 50 });
+        create_jschart("lineChart", "timeseries", "chart_2", "io_writes_KB_sec", null, null, { csvfiles: [ "csv/file_io_io_writes_KB_sec.csv" ], threshold: 50 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/pidstat/memory_faults.html
+++ b/agent/tool-scripts/postprocess/gold/pidstat/memory_faults.html
@@ -12,7 +12,7 @@
     <center><h2>pidstat - memory_faults</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "minor_faults_sec", null, null, { csvfiles: [ "csv/memory_faults_minor_faults_sec.csv" ], threshold: 150 });
+        create_jschart("lineChart", "timeseries", "chart_1", "minor_faults_sec", null, null, { csvfiles: [ "csv/memory_faults_minor_faults_sec.csv" ], threshold: 150 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/pidstat/memory_usage.html
+++ b/agent/tool-scripts/postprocess/gold/pidstat/memory_usage.html
@@ -12,12 +12,12 @@
     <center><h2>pidstat - memory_usage</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "resident_set_size", null, null, { csvfiles: [ "csv/memory_usage_resident_set_size.csv" ], threshold: 100 });
+        create_jschart("lineChart", "timeseries", "chart_1", "resident_set_size", null, null, { csvfiles: [ "csv/memory_usage_resident_set_size.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "virtual_size", null, null, { csvfiles: [ "csv/memory_usage_virtual_size.csv" ], threshold: 100 });
+        create_jschart("lineChart", "timeseries", "chart_2", "virtual_size", null, null, { csvfiles: [ "csv/memory_usage_virtual_size.csv" ], threshold: 100 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/proc-interrupts/proc-interrupts-by-cpu.html
+++ b/agent/tool-scripts/postprocess/gold/proc-interrupts/proc-interrupts-by-cpu.html
@@ -12,42 +12,42 @@
     <center><h2>proc-interrupts - proc-interrupts-by-cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "CPU_000", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_000.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "CPU_000", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_000.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "CPU_001", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_001.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "CPU_001", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_001.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "CPU_002", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_002.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "CPU_002", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_002.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "CPU_003", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_003.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "CPU_003", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_003.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "CPU_004", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_004.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "CPU_004", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_004.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "CPU_005", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_005.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "CPU_005", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_005.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_7", "CPU_006", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_006.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_7", "CPU_006", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_006.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_8", "CPU_007", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_007.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_8", "CPU_007", null, null, { csvfiles: [ "csv/proc-interrupts-by-cpu_CPU_007.csv" ], threshold: 100 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/proc-interrupts/proc-interrupts-by-irq.html
+++ b/agent/tool-scripts/postprocess/gold/proc-interrupts/proc-interrupts-by-irq.html
@@ -12,32 +12,32 @@
     <center><h2>proc-interrupts - proc-interrupts-by-irq</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "IRQ_042_IR-PCI-MSI-edge_ahci", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_042_IR-PCI-MSI-edge_ahci.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "IRQ_042_IR-PCI-MSI-edge_ahci", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_042_IR-PCI-MSI-edge_ahci.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "IRQ_044_IR-PCI-MSI-edge_i915", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_044_IR-PCI-MSI-edge_i915.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "IRQ_044_IR-PCI-MSI-edge_i915", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_044_IR-PCI-MSI-edge_i915.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "IRQ_CAL_Function_call_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_CAL_Function_call_interrupts.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "IRQ_CAL_Function_call_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_CAL_Function_call_interrupts.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "IRQ_LOC_Local_timer_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_LOC_Local_timer_interrupts.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "IRQ_LOC_Local_timer_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_LOC_Local_timer_interrupts.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "IRQ_NMI_Non-maskable_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_NMI_Non-maskable_interrupts.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "IRQ_NMI_Non-maskable_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_NMI_Non-maskable_interrupts.csv" ], threshold: 100 });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "IRQ_PMI_Performance_monitoring_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_PMI_Performance_monitoring_interrupts.csv" ], threshold: 100 });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "IRQ_PMI_Performance_monitoring_interrupts", null, null, { csvfiles: [ "csv/proc-interrupts-by-irq_IRQ_PMI_Performance_monitoring_interrupts.csv" ], threshold: 100 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/proc-vmstat/proc-vmstat.html
+++ b/agent/tool-scripts/postprocess/gold/proc-vmstat/proc-vmstat.html
@@ -12,82 +12,82 @@
     <center><h2>proc-vmstat - proc-vmstat</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "compact_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_compact_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "compact_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_compact_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "drop_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_drop_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "drop_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_drop_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "htlb_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_htlb_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "htlb_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_htlb_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "kswapd_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_kswapd_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "kswapd_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_kswapd_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "nr_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_nr_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "nr_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_nr_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "numa_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_numa_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_6", "numa_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_numa_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "pgalloc_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgalloc_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_7", "pgalloc_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgalloc_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("lineChart", "timeseries", "chart_8", "pgmigrate_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgmigrate_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_8", "pgmigrate_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgmigrate_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_9">
       <script>
-        create_graph("lineChart", "timeseries", "chart_9", "pgrefill_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgrefill_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_9", "pgrefill_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgrefill_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_10">
       <script>
-        create_graph("lineChart", "timeseries", "chart_10", "pgscan_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgscan_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_10", "pgscan_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgscan_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_11">
       <script>
-        create_graph("lineChart", "timeseries", "chart_11", "pgsteal_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgsteal_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_11", "pgsteal_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_pgsteal_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_12">
       <script>
-        create_graph("lineChart", "timeseries", "chart_12", "slabs_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_slabs_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_12", "slabs_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_slabs_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_13">
       <script>
-        create_graph("lineChart", "timeseries", "chart_13", "thp_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_thp_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_13", "thp_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_thp_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_14">
       <script>
-        create_graph("lineChart", "timeseries", "chart_14", "unevictable_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_unevictable_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_14", "unevictable_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_unevictable_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_15">
       <script>
-        create_graph("lineChart", "timeseries", "chart_15", "workingset_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_workingset_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_15", "workingset_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_workingset_delta_sec.csv" ] });
       </script>
     </div>
     <div id="chart_16">
       <script>
-        create_graph("lineChart", "timeseries", "chart_16", "zone_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_zone_delta_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_16", "zone_delta_sec", null, null, { csvfiles: [ "csv/proc-vmstat_zone_delta_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/cpu.html
@@ -12,12 +12,12 @@
     <center><h2>sar-0 - cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/memory.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/memory.html
@@ -12,12 +12,12 @@
     <center><h2>sar-0 - memory</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/network_l2.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/network_l2.html
@@ -12,7 +12,7 @@
     <center><h2>sar-0 - network_l2</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "network_Mbits_sec", null, null, { csvfiles: [ "csv/network_l2_network_Mbits_sec.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_1", "network_Mbits_sec", null, null, { csvfiles: [ "csv/network_l2_network_Mbits_sec.csv" ], threshold: 1 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/network_l345.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/network_l345.html
@@ -12,37 +12,37 @@
     <center><h2>sar-0 - network_l345</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "icmp", null, null, { csvfiles: [ "csv/network_l345_icmp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "icmp", null, null, { csvfiles: [ "csv/network_l345_icmp.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "nfs_server", null, null, { csvfiles: [ "csv/network_l345_nfs_server.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "nfs_server", null, null, { csvfiles: [ "csv/network_l345_nfs_server.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_6", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_7", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/per_cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/per_cpu.html
@@ -12,42 +12,42 @@
     <center><h2>sar-0 - per_cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-0/system.html
+++ b/agent/tool-scripts/postprocess/gold/sar-0/system.html
@@ -12,12 +12,12 @@
     <center><h2>sar-0 - system</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/cpu.html
@@ -12,12 +12,12 @@
     <center><h2>sar-1 - cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/memory.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/memory.html
@@ -12,12 +12,12 @@
     <center><h2>sar-1 - memory</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/network_l2.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/network_l2.html
@@ -12,12 +12,12 @@
     <center><h2>sar-1 - network_l2</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "network_Mbits_sec", null, null, { csvfiles: [ "csv/network_l2_network_Mbits_sec.csv" ], threshold: 1 });
+        create_jschart("lineChart", "timeseries", "chart_1", "network_Mbits_sec", null, null, { csvfiles: [ "csv/network_l2_network_Mbits_sec.csv" ], threshold: 1 });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "network_packets_sec", null, null, { csvfiles: [ "csv/network_l2_network_packets_sec.csv" ], threshold: 300 });
+        create_jschart("lineChart", "timeseries", "chart_2", "network_packets_sec", null, null, { csvfiles: [ "csv/network_l2_network_packets_sec.csv" ], threshold: 300 });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/network_l345.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/network_l345.html
@@ -12,27 +12,27 @@
     <center><h2>sar-1 - network_l345</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/per_cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/per_cpu.html
@@ -12,122 +12,122 @@
     <center><h2>sar-1 - per_cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
       </script>
     </div>
     <div id="chart_9">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
       </script>
     </div>
     <div id="chart_10">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
       </script>
     </div>
     <div id="chart_11">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
       </script>
     </div>
     <div id="chart_12">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
       </script>
     </div>
     <div id="chart_13">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
       </script>
     </div>
     <div id="chart_14">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
       </script>
     </div>
     <div id="chart_15">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
       </script>
     </div>
     <div id="chart_16">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
       </script>
     </div>
     <div id="chart_17">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_17", "cpu_16", null, null, { csvfiles: [ "csv/per_cpu_cpu_16.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_17", "cpu_16", null, null, { csvfiles: [ "csv/per_cpu_cpu_16.csv" ] });
       </script>
     </div>
     <div id="chart_18">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_18", "cpu_17", null, null, { csvfiles: [ "csv/per_cpu_cpu_17.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_18", "cpu_17", null, null, { csvfiles: [ "csv/per_cpu_cpu_17.csv" ] });
       </script>
     </div>
     <div id="chart_19">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_19", "cpu_18", null, null, { csvfiles: [ "csv/per_cpu_cpu_18.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_19", "cpu_18", null, null, { csvfiles: [ "csv/per_cpu_cpu_18.csv" ] });
       </script>
     </div>
     <div id="chart_20">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_20", "cpu_19", null, null, { csvfiles: [ "csv/per_cpu_cpu_19.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_20", "cpu_19", null, null, { csvfiles: [ "csv/per_cpu_cpu_19.csv" ] });
       </script>
     </div>
     <div id="chart_21">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_21", "cpu_20", null, null, { csvfiles: [ "csv/per_cpu_cpu_20.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_21", "cpu_20", null, null, { csvfiles: [ "csv/per_cpu_cpu_20.csv" ] });
       </script>
     </div>
     <div id="chart_22">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_22", "cpu_21", null, null, { csvfiles: [ "csv/per_cpu_cpu_21.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_22", "cpu_21", null, null, { csvfiles: [ "csv/per_cpu_cpu_21.csv" ] });
       </script>
     </div>
     <div id="chart_23">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_23", "cpu_22", null, null, { csvfiles: [ "csv/per_cpu_cpu_22.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_23", "cpu_22", null, null, { csvfiles: [ "csv/per_cpu_cpu_22.csv" ] });
       </script>
     </div>
     <div id="chart_24">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_24", "cpu_23", null, null, { csvfiles: [ "csv/per_cpu_cpu_23.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_24", "cpu_23", null, null, { csvfiles: [ "csv/per_cpu_cpu_23.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-1/system.html
+++ b/agent/tool-scripts/postprocess/gold/sar-1/system.html
@@ -12,12 +12,12 @@
     <center><h2>sar-1 - system</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-2/cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-2/cpu.html
@@ -12,12 +12,12 @@
     <center><h2>sar-2 - cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-2/memory.html
+++ b/agent/tool-scripts/postprocess/gold/sar-2/memory.html
@@ -12,12 +12,12 @@
     <center><h2>sar-2 - memory</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-2/network_l345.html
+++ b/agent/tool-scripts/postprocess/gold/sar-2/network_l345.html
@@ -12,37 +12,37 @@
     <center><h2>sar-2 - network_l345</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "icmp", null, null, { csvfiles: [ "csv/network_l345_icmp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "icmp", null, null, { csvfiles: [ "csv/network_l345_icmp.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "nfs_server", null, null, { csvfiles: [ "csv/network_l345_nfs_server.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "nfs_server", null, null, { csvfiles: [ "csv/network_l345_nfs_server.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_6", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("lineChart", "timeseries", "chart_7", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_7", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-2/per_cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-2/per_cpu.html
@@ -12,82 +12,82 @@
     <center><h2>sar-2 - per_cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
       </script>
     </div>
     <div id="chart_9">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
       </script>
     </div>
     <div id="chart_10">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
       </script>
     </div>
     <div id="chart_11">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
       </script>
     </div>
     <div id="chart_12">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
       </script>
     </div>
     <div id="chart_13">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
       </script>
     </div>
     <div id="chart_14">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
       </script>
     </div>
     <div id="chart_15">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
       </script>
     </div>
     <div id="chart_16">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-2/system.html
+++ b/agent/tool-scripts/postprocess/gold/sar-2/system.html
@@ -12,12 +12,12 @@
     <center><h2>sar-2 - system</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-3/cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-3/cpu.html
@@ -12,12 +12,12 @@
     <center><h2>sar-3 - cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-3/memory.html
+++ b/agent/tool-scripts/postprocess/gold/sar-3/memory.html
@@ -12,12 +12,12 @@
     <center><h2>sar-3 - memory</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-3/network_l345.html
+++ b/agent/tool-scripts/postprocess/gold/sar-3/network_l345.html
@@ -12,27 +12,27 @@
     <center><h2>sar-3 - network_l345</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-3/per_cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-3/per_cpu.html
@@ -12,162 +12,162 @@
     <center><h2>sar-3 - per_cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "cpu_01", null, null, { csvfiles: [ "csv/per_cpu_cpu_01.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "cpu_02", null, null, { csvfiles: [ "csv/per_cpu_cpu_02.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_4", "cpu_03", null, null, { csvfiles: [ "csv/per_cpu_cpu_03.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_5", "cpu_04", null, null, { csvfiles: [ "csv/per_cpu_cpu_04.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_6", "cpu_05", null, null, { csvfiles: [ "csv/per_cpu_cpu_05.csv" ] });
       </script>
     </div>
     <div id="chart_7">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_7", "cpu_06", null, null, { csvfiles: [ "csv/per_cpu_cpu_06.csv" ] });
       </script>
     </div>
     <div id="chart_8">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_8", "cpu_07", null, null, { csvfiles: [ "csv/per_cpu_cpu_07.csv" ] });
       </script>
     </div>
     <div id="chart_9">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_9", "cpu_08", null, null, { csvfiles: [ "csv/per_cpu_cpu_08.csv" ] });
       </script>
     </div>
     <div id="chart_10">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_10", "cpu_09", null, null, { csvfiles: [ "csv/per_cpu_cpu_09.csv" ] });
       </script>
     </div>
     <div id="chart_11">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_11", "cpu_10", null, null, { csvfiles: [ "csv/per_cpu_cpu_10.csv" ] });
       </script>
     </div>
     <div id="chart_12">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_12", "cpu_11", null, null, { csvfiles: [ "csv/per_cpu_cpu_11.csv" ] });
       </script>
     </div>
     <div id="chart_13">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_13", "cpu_12", null, null, { csvfiles: [ "csv/per_cpu_cpu_12.csv" ] });
       </script>
     </div>
     <div id="chart_14">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_14", "cpu_13", null, null, { csvfiles: [ "csv/per_cpu_cpu_13.csv" ] });
       </script>
     </div>
     <div id="chart_15">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_15", "cpu_14", null, null, { csvfiles: [ "csv/per_cpu_cpu_14.csv" ] });
       </script>
     </div>
     <div id="chart_16">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_16", "cpu_15", null, null, { csvfiles: [ "csv/per_cpu_cpu_15.csv" ] });
       </script>
     </div>
     <div id="chart_17">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_17", "cpu_16", null, null, { csvfiles: [ "csv/per_cpu_cpu_16.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_17", "cpu_16", null, null, { csvfiles: [ "csv/per_cpu_cpu_16.csv" ] });
       </script>
     </div>
     <div id="chart_18">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_18", "cpu_17", null, null, { csvfiles: [ "csv/per_cpu_cpu_17.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_18", "cpu_17", null, null, { csvfiles: [ "csv/per_cpu_cpu_17.csv" ] });
       </script>
     </div>
     <div id="chart_19">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_19", "cpu_18", null, null, { csvfiles: [ "csv/per_cpu_cpu_18.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_19", "cpu_18", null, null, { csvfiles: [ "csv/per_cpu_cpu_18.csv" ] });
       </script>
     </div>
     <div id="chart_20">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_20", "cpu_19", null, null, { csvfiles: [ "csv/per_cpu_cpu_19.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_20", "cpu_19", null, null, { csvfiles: [ "csv/per_cpu_cpu_19.csv" ] });
       </script>
     </div>
     <div id="chart_21">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_21", "cpu_20", null, null, { csvfiles: [ "csv/per_cpu_cpu_20.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_21", "cpu_20", null, null, { csvfiles: [ "csv/per_cpu_cpu_20.csv" ] });
       </script>
     </div>
     <div id="chart_22">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_22", "cpu_21", null, null, { csvfiles: [ "csv/per_cpu_cpu_21.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_22", "cpu_21", null, null, { csvfiles: [ "csv/per_cpu_cpu_21.csv" ] });
       </script>
     </div>
     <div id="chart_23">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_23", "cpu_22", null, null, { csvfiles: [ "csv/per_cpu_cpu_22.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_23", "cpu_22", null, null, { csvfiles: [ "csv/per_cpu_cpu_22.csv" ] });
       </script>
     </div>
     <div id="chart_24">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_24", "cpu_23", null, null, { csvfiles: [ "csv/per_cpu_cpu_23.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_24", "cpu_23", null, null, { csvfiles: [ "csv/per_cpu_cpu_23.csv" ] });
       </script>
     </div>
     <div id="chart_25">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_25", "cpu_24", null, null, { csvfiles: [ "csv/per_cpu_cpu_24.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_25", "cpu_24", null, null, { csvfiles: [ "csv/per_cpu_cpu_24.csv" ] });
       </script>
     </div>
     <div id="chart_26">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_26", "cpu_25", null, null, { csvfiles: [ "csv/per_cpu_cpu_25.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_26", "cpu_25", null, null, { csvfiles: [ "csv/per_cpu_cpu_25.csv" ] });
       </script>
     </div>
     <div id="chart_27">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_27", "cpu_26", null, null, { csvfiles: [ "csv/per_cpu_cpu_26.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_27", "cpu_26", null, null, { csvfiles: [ "csv/per_cpu_cpu_26.csv" ] });
       </script>
     </div>
     <div id="chart_28">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_28", "cpu_27", null, null, { csvfiles: [ "csv/per_cpu_cpu_27.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_28", "cpu_27", null, null, { csvfiles: [ "csv/per_cpu_cpu_27.csv" ] });
       </script>
     </div>
     <div id="chart_29">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_29", "cpu_28", null, null, { csvfiles: [ "csv/per_cpu_cpu_28.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_29", "cpu_28", null, null, { csvfiles: [ "csv/per_cpu_cpu_28.csv" ] });
       </script>
     </div>
     <div id="chart_30">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_30", "cpu_29", null, null, { csvfiles: [ "csv/per_cpu_cpu_29.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_30", "cpu_29", null, null, { csvfiles: [ "csv/per_cpu_cpu_29.csv" ] });
       </script>
     </div>
     <div id="chart_31">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_31", "cpu_30", null, null, { csvfiles: [ "csv/per_cpu_cpu_30.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_31", "cpu_30", null, null, { csvfiles: [ "csv/per_cpu_cpu_30.csv" ] });
       </script>
     </div>
     <div id="chart_32">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_32", "cpu_31", null, null, { csvfiles: [ "csv/per_cpu_cpu_31.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_32", "cpu_31", null, null, { csvfiles: [ "csv/per_cpu_cpu_31.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-3/system.html
+++ b/agent/tool-scripts/postprocess/gold/sar-3/system.html
@@ -12,12 +12,12 @@
     <center><h2>sar-3 - system</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-4/cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-4/cpu.html
@@ -12,12 +12,12 @@
     <center><h2>sar-4 - cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "all_cpu_busy", null, null, { csvfiles: [ "csv/cpu_all_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "frequency_MHz", null, null, { csvfiles: [ "csv/cpu_frequency_MHz.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-4/memory.html
+++ b/agent/tool-scripts/postprocess/gold/sar-4/memory.html
@@ -12,12 +12,12 @@
     <center><h2>sar-4 - memory</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "memory_activity", null, null, { csvfiles: [ "csv/memory_memory_activity.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "memory_usage", null, null, { csvfiles: [ "csv/memory_memory_usage.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-4/network_l345.html
+++ b/agent/tool-scripts/postprocess/gold/sar-4/network_l345.html
@@ -12,27 +12,27 @@
     <center><h2>sar-4 - network_l345</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "ip", null, null, { csvfiles: [ "csv/network_l345_ip.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "nfs_client", null, null, { csvfiles: [ "csv/network_l345_nfs_client.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "sockets", null, null, { csvfiles: [ "csv/network_l345_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "tcp_sockets", null, null, { csvfiles: [ "csv/network_l345_tcp_sockets.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "udp", null, null, { csvfiles: [ "csv/network_l345_udp.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-4/per_cpu.html
+++ b/agent/tool-scripts/postprocess/gold/sar-4/per_cpu.html
@@ -12,7 +12,7 @@
     <center><h2>sar-4 - per_cpu</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_1", "cpu_00", null, null, { csvfiles: [ "csv/per_cpu_cpu_00.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/sar-4/system.html
+++ b/agent/tool-scripts/postprocess/gold/sar-4/system.html
@@ -12,12 +12,12 @@
     <center><h2>sar-4 - system</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "interrupts_sec", null, null, { csvfiles: [ "csv/system_interrupts_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "proc_cswch_sec", null, null, { csvfiles: [ "csv/system_proc_cswch_sec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/uperf-0/uperf.html
+++ b/agent/tool-scripts/postprocess/gold/uperf-0/uperf.html
@@ -12,22 +12,22 @@
     <center><h2>uperf-0 - uperf</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "trans_sec", null, null, { csvfiles: [ "csv/uperf_trans_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "trans_sec", null, null, { csvfiles: [ "csv/uperf_trans_sec.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "trans_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_trans_sec_per_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "trans_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_trans_sec_per_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "usec", null, null, { csvfiles: [ "csv/uperf_usec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "usec", null, null, { csvfiles: [ "csv/uperf_usec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/uperf-1/uperf.html
+++ b/agent/tool-scripts/postprocess/gold/uperf-1/uperf.html
@@ -12,17 +12,17 @@
     <center><h2>uperf-1 - uperf</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "Gb_sec", null, null, { csvfiles: [ "csv/uperf_Gb_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "Gb_sec", null, null, { csvfiles: [ "csv/uperf_Gb_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "Gb_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_Gb_sec_per_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "Gb_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_Gb_sec_per_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/uperf-2/uperf.html
+++ b/agent/tool-scripts/postprocess/gold/uperf-2/uperf.html
@@ -12,22 +12,22 @@
     <center><h2>uperf-2 - uperf</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "trans_sec", null, null, { csvfiles: [ "csv/uperf_trans_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "trans_sec", null, null, { csvfiles: [ "csv/uperf_trans_sec.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "trans_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_trans_sec_per_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "trans_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_trans_sec_per_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "usec", null, null, { csvfiles: [ "csv/uperf_usec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "usec", null, null, { csvfiles: [ "csv/uperf_usec.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/uperf-3/uperf.html
+++ b/agent/tool-scripts/postprocess/gold/uperf-3/uperf.html
@@ -12,17 +12,17 @@
     <center><h2>uperf-3 - uperf</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "Gb_sec", null, null, { csvfiles: [ "csv/uperf_Gb_sec.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "Gb_sec", null, null, { csvfiles: [ "csv/uperf_Gb_sec.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("lineChart", "timeseries", "chart_2", "Gb_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_Gb_sec_per_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_2", "Gb_sec_per_cpu_busy", null, null, { csvfiles: [ "csv/uperf_Gb_sec_per_cpu_busy.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("lineChart", "timeseries", "chart_3", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_3", "cpu_busy", null, null, { csvfiles: [ "csv/uperf_cpu_busy.csv" ] });
       </script>
     </div>
   </body>

--- a/agent/tool-scripts/postprocess/gold/vmstat/vmstat.html
+++ b/agent/tool-scripts/postprocess/gold/vmstat/vmstat.html
@@ -12,32 +12,32 @@
     <center><h2>vmstat - vmstat</h2></center>
     <div id="chart_1">
       <script>
-        create_graph("lineChart", "timeseries", "chart_1", "block", null, null, { csvfiles: [ "csv/vmstat_block.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_1", "block", null, null, { csvfiles: [ "csv/vmstat_block.csv" ] });
       </script>
     </div>
     <div id="chart_2">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_2", "cpu", null, null, { csvfiles: [ "csv/vmstat_cpu.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_2", "cpu", null, null, { csvfiles: [ "csv/vmstat_cpu.csv" ] });
       </script>
     </div>
     <div id="chart_3">
       <script>
-        create_graph("stackedAreaChart", "timeseries", "chart_3", "memory", null, null, { csvfiles: [ "csv/vmstat_memory.csv" ] });
+        create_jschart("stackedAreaChart", "timeseries", "chart_3", "memory", null, null, { csvfiles: [ "csv/vmstat_memory.csv" ] });
       </script>
     </div>
     <div id="chart_4">
       <script>
-        create_graph("lineChart", "timeseries", "chart_4", "procs", null, null, { csvfiles: [ "csv/vmstat_procs.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_4", "procs", null, null, { csvfiles: [ "csv/vmstat_procs.csv" ] });
       </script>
     </div>
     <div id="chart_5">
       <script>
-        create_graph("lineChart", "timeseries", "chart_5", "swap", null, null, { csvfiles: [ "csv/vmstat_swap.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_5", "swap", null, null, { csvfiles: [ "csv/vmstat_swap.csv" ] });
       </script>
     </div>
     <div id="chart_6">
       <script>
-        create_graph("lineChart", "timeseries", "chart_6", "system", null, null, { csvfiles: [ "csv/vmstat_system.csv" ] });
+        create_jschart("lineChart", "timeseries", "chart_6", "system", null, null, { csvfiles: [ "csv/vmstat_system.csv" ] });
       </script>
     </div>
   </body>

--- a/web-server/v0.3/css/jschart.css
+++ b/web-server/v0.3/css/jschart.css
@@ -52,9 +52,15 @@ text.bold { font-weight: bold; }
 .chart { border: 2px solid black; border-collapse: collapse; font-family: monospace; background-color: white; }
 .chart TH { padding-left: 6px; padding-right: 6px; padding-top: 2px; padding-bottom: 2px; border: 1px solid silver; }
 .chart TD { padding-left: 6px; padding-right: 6px; padding-top: 2px; padding-bottom: 2px; border: 1px solid silver; }
-.chart TR.header { border-bottom: 2px solid black; }
+.chart TR.header { border-bottom: 2px solid black; border-top: 2px solid black; }
 .chart TR.footer { border-top: 2px solid black; }
 .chart TR.section { border-bottom: 2px solid black; border-top: 2px solid black; }
+
+.noborders TABLE { border: none; font-family: monospace; background-color: white; border-collapse: collapse; }
+.noborders TH { border: none; }
+.noborders TD { border: none; }
+
+.nodisplay { display: none; }
 
 body { font-family: monospace; }
 a { text-decoration: none; color: blue; }

--- a/web-server/v0.3/demo.html
+++ b/web-server/v0.3/demo.html
@@ -10,17 +10,17 @@
 <script src="other.js/saveSvgAsPng.js" charset="utf-8"></script>
 <div id='jschart_histogram'>
   <script>
-    create_graph(0, "histogram", "jschart_histogram", "Histogram Demo", "Buckets", "Bucket Size", { csvfiles: [ "demo-data/histogram.csv" ] });
+    create_jschart(0, "histogram", "jschart_histogram", "Histogram Demo", "Buckets", "Bucket Size", { csvfiles: [ "demo-data/histogram.csv" ] });
   </script>
 </div>
 <div id='jschart_timeseries'>
   <script>
-    create_graph(1, "timeseries", "jschart_timeseries", "Timeseries Demo", null, null, { csvfiles: [ "demo-data/timeseries.csv" ], sort_datasets: false });
+    create_jschart(1, "timeseries", "jschart_timeseries", "Timeseries Demo", null, null, { csvfiles: [ "demo-data/timeseries.csv" ], sort_datasets: false });
   </script>
 </div>
 <div id='jschart_xy'>
   <script>
-    create_graph(0, "xy", "jschart_xy", "XY Demo", null, null, { csvfiles: [ "demo-data/xy.csv" ] });
+    create_jschart(0, "xy", "jschart_xy", "XY Demo", null, null, { csvfiles: [ "demo-data/xy.csv" ] });
   </script>
 </div>
 

--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -13,9 +13,420 @@
 //
 // This library depends on 3 external packages: d3.js, d3-queue.js, and saveSvgAsPng.js
 // Those packages are available here or via npm:
-//     https://github.com/mbostock/d3
-//     https://github.com/d3/d3-queue
+//     https://github.com/mbostock/d3 -- API version 3
+//     https://github.com/d3/d3-queue -- API version 3
 //     https://github.com/exupero/saveSvgAsPng
+
+/*
+
+Using jschart:
+
+From a developer user perspective jschart is consumed by calling the
+create_graph function:
+
+  create_jschart(<stacked>, <data model>, <location>, <chart title>, <x axis title>, <y axis title>, <options>);
+
+Here is a summary of each parameter:
+
+  1. <stacked>
+
+     This parameter tells the library whether the chart is a simple
+     line chart or an stacked area chart.  There are two different
+     methodologies of supplying this parameter.  In the original
+     invocation it was a simple boolean field: '1' or 'true' for a
+     stacked area chart and '0' or 'false' for a regular line chart.
+     When jschart was ported to pbench support for two additional
+     values were added: 'stackedAreaChart' and 'lineChart'.  These new
+     parameters were simply mapped to the existing values for
+     compatilibity purposes.
+
+  2. <data model>
+
+     This parameter tells the library what kind of chart is being
+     built, which ultimately results in configuring how the X axis is
+     setup.  There are three possible values for <data model>:
+
+       a. 'xy'
+       b. 'timeseries'
+       c. 'histogram'
+
+     An 'xy' chart means that the supplied data is just a series of
+     X/Y value pairs to be plotted without any additional processing.
+     A 'timeseries' chart differs from the 'xy' chart because the X
+     axis values are milliseconds sinc epoch timestamps.  When the
+     chart is being drawn the integer timestamps are used just like a
+     regular X/Y value pair but at the presentation layer the
+     timestamps are converted into user deciperable timestamps,
+     generally of the form 'YYYY-MM-DD HH:MM:SS'.  A 'histogram' chart
+     is treated very similarly to an 'xy' chart from a plotting
+     perspective, but the values are interpreted to be a bucket/count
+     pair rather than simple X/Y coordinates.  When the data table is
+     populated this results in different statistics being conveyed to
+     the user than a normal 'xy' chart.
+
+  3. <location>
+
+     The <location> parameter tells the library where to insert the
+     chart and it's accompanying table into the HTML DOM.  This is
+     usually implemented in the following fashion:
+
+     ...
+     <div id='foo'>
+       <script>
+         create_jschart(<stacked>, <data model>, 'foo', <chart title>, <x axis title>, <y axis title>, <options>);
+       </script>
+     </div>
+     ...
+
+     This could also be implemented with a much less direct linkage,
+     such as:
+
+     ...
+     <script>
+       ...
+       create_jschart(<stacked>, <data model>, 'bar', <chart title>, <x axis title>, <y axis title>, <options>);
+       ...
+     </script>
+     ...
+     <div id='bar'/>
+     ...
+
+  4. <chart title>
+
+     This is simply the title printed at the top of the chart.
+
+  5. <x axis title>
+
+     This is the title printed below the X axis.
+
+  6. <y axis title>
+
+     This is the title printed above the Y axis.
+
+  7. <options>
+
+     The <options> parameter is a javascript object that is a
+     catch-all for many parameters.  All of the parameters supplied
+     here are optional, but there must be something here.  For
+     example, there are many different ways of supplying data files,
+     but at least one of them must be used in order to achieve a
+     working chart.
+
+     Here is a list of the available options:
+
+       a. timeseries_timezone
+       b. legend_entries
+       c. plotfiles[]
+       d. plotfile
+       e. packed
+       f. csvfiles[]
+       g. json_plotfile
+       h. json_args
+       i. update_interval
+       j. history_length
+       k. raw_data_sources[]
+       l. threshold
+       m. sort_datasets
+       n. x_min
+       o. x_max
+       p. y_min
+       q. y_max
+       r. x_log_scale
+       s. y_log_scale
+
+     Now it is time to break these options down in detail:
+
+       a. timeseries_timezone
+
+          This option is used to configure what time zone is used for
+          the 'timeseries' data model.  Currently only 'local' or
+          'utc' is supported.
+
+	  Example:
+
+	    { ..., timeseries_timezone: "local" }
+
+       b. legend_entries
+
+          The legend_entries options is a variable sized array
+          defining arbitrary entries that should be added to the chart
+          legend.  This is meant to provide a convenient method
+          through which comments can easily be added to a chart.
+
+          Example:
+
+	    { ..., legend_entries: [ "entry #1", "entry #2" ] }
+
+       c. plotfiles[]
+
+          A plot file is the original data file supported by jschart
+          and originally comes from multiple generations of charting
+          programs that predated jschart.  The plot file format is
+          extremely simple, it consists of a header row which defines
+          the data series name and then rows of value pairs which are
+          typically X/Y pairs.  It looks like this:
+
+	    #LABEL:data series name
+	    5 0
+	    10 2
+	    15 8
+	    20 3
+	    25 1
+
+	  In most cases the file consisted of X axis values which were
+	  the interval that a tool produced a sample, in the above
+	  example that interval is 5 seconds.  The Y axis values are
+	  the arbitrary value produced by the tool for that interval's
+	  sample.
+
+	  The jschart library supports multiple plot files to be
+	  specified, so the plotfiles parameter is an arbitrarily
+	  sized array.  It would be used like this in the options
+	  parameter:
+
+	    { plotfiles: [ "plotfiles/file1.plot", "plotfiles/file2.plot", ... ] }
+
+       d. plotfile
+
+          The plotfile options is a simplified version of the
+          plotfiles option which only supports a single plot file
+          being supplied to the jschart library.  It is most
+          applicable when combined with the packed option which is
+          discuused next.
+
+       e. packed
+
+          The packed option is optionally used in conjunction with the
+          plotfile option.  The original plotfile file format only
+          supported a single data series, meaning multiple data series
+          required multiple files.  When jschart was written this
+          demonstrated scalability issues in environments with very
+          large data series counts.  A modified version of the plot
+          file format called a packed plot file was created which
+          combined multiple plot files into a single file with
+          delineations between each data series.  It was a requirement
+          that jschart know in advance the number of data series
+          packed into the single file which is the point of this
+          variable.  Here is an example of how this option could be
+          used and the accompanying plot file:
+
+	  { packed: 2, plotfile: 'plotfiles/2-packed.plot' }
+
+	  Contents of plotfiles/2-packed.plot:
+
+	    --- JSChart Packed Plot File V1 ---
+	    #LABEL:data series 1
+	    5 10
+	    10 9
+	    15 11
+	    20 13
+	    25 7
+	    --- JSChart Packed Plot File V1 ---
+	    #LABEL:data series 2
+	    5 8
+	    10 9
+	    15 5
+	    20 6
+	    25 4
+
+       f. csvfiles[]
+
+          The csvfiles parameter is an arbitrarily sized array that
+          points to one or more CSV formatted data files.  CSV file
+          support was added to jschart when it was adopted by pbench
+          in order to handle the data files that pbench was already
+          producing.  The CSV file format support is similar to the
+          plot file format support, yet still different.  The csvfiles
+          option is an abitrary array like the plotfiles options but
+          since a CSV file can include multiple datasets there is no
+          hackish entity like the packed plot file.  A chart can be
+          populated with one or more CSV files and each CSV file can
+          have one or more data series in it.
+
+	  The jschart library understands two different CSV file
+	  formats which can be briefly described by the following
+	  examples:
+
+	    i.  ts,d0,d1,d2,...,dN
+	    ii. ts0,d0,ts1,d1,ts2,d2,...,tsN,dN
+
+	  In the first format each data sample row has a single
+	  timestamp with an interval sample for each data series at
+	  that timestamp.  In practice, this looks like the following:
+
+	    timestamp_ms,data series 1,data series 2
+	    1461027782000,0,5
+	    1461027783000,4,1
+
+	  The timestamps are in milliseconds since the epoch.
+
+	  The second format has individual timestamps for each data
+	  series sample, even those on the same row of the file.  This
+	  could look something like the following:
+
+	    timestamp_data_series_1_ms,data series 1,timestamp_data_series_2_ms,data series 2
+	    1461027782000,0,1461027782500,5
+	    1461027783000,4,1461027783500,1
+
+	  Using the csvfiles option to jschart would look something
+	  like this:
+
+	    { csvfiles: [ "data-files/samples.csv" ] }
+
+       g. json_plotfile
+
+          The json_plotfile allows jschart to use JSON formatted data
+          files.  Since it is JSON the file format is fairly dynamic,
+          but there are some basic assumptions that must be met.  The
+          JSON output should be based on the following:
+
+	    {
+	      'x_axis_series': <string>,
+	      'data_series_names': [],
+	      'data': []
+	    }
+
+	  The 'data_series_name' and 'data' properties are arrays
+	  which shared the same indexes.  The 'x_axis_series' property
+	  defines which entry in the 'data_series_names' array
+	  contains the X axis value of the X/Y pairs for each dataset.
+	  In practice this would look something like this:
+
+	    {
+	      'x_axis_series': 'time',
+	      'data_series_names': [ 'time', 'data series 1', 'data series 2' ],
+	      'data': [ [ 1461027782000, 0, 1],
+                        [ 1461027783000, 4, 5] ]
+	    }
+
+	  Currently an assumption is made that the JSON output is used
+	  for a 'timeseries' data model and the X axis values are
+	  expected to be in milliseconds since the epoch.
+
+	  It should be noted that the JSON features of jschart have
+	  had limited usage at this time and could probably be
+	  improved upon if required.
+
+       h. json_args
+       i. update_interval
+       j. history_length
+
+          These three options are only used in conjunction with the
+          json_plotfile option, and most often all together (although
+          update_interval and history_length may not be required).
+
+	  The json_args option defines post data that is sent to the
+	  HTTP server when requesting the data pointed to by
+	  json_plotfile.  Typically this would be used to tell the
+	  HTTP server what data is being requested if json_plotfile
+	  refers to a URL whose response is dynamically generated.
+	  For example:
+
+	    { json_plotfile: 'http://some.server.somewhere', json_args: 'type=foo' }
+
+	  In this example, supplying different values for 'type' could
+	  alter the response that server sends depending on it's
+	  implementation.
+
+	  The update_interval options tells the jschart library that
+	  the data being requested is dynamic and should be
+	  re-requested periodically on the defined interval.  This is
+	  typically used for pseudo realtime data monitoring.  After
+	  the initial request is made, subsequent requests are made
+	  every update_interval number of seconds.  These additional
+	  requests will include any json_args that were provided and
+	  will additionally add a 'time=<timestamp>' entry to the post
+	  data so that the server can try to optimize the transfer by
+	  only sending new samples since <timestamp> and avoid
+	  retransmission of existing data.
+
+	  The history_length parameter is tell the jschart library how
+	  many data samples should be retained when new data is being
+	  dynamically added.  This prevents the arrays that contain
+	  the sample data from growing without bounds which would
+	  eventually cause a memory related issue.
+
+	  All combined, these parameters could be used like this:
+
+	    { json_plotfile: 'http://some.server.somewhere', json_args: 'type=foo', update_interval: 5, history_length: 300 }
+
+	  This example would request the available data every 5
+	  seconds and maintain a history of 300 samples.
+
+       k. raw_data_sources[]
+
+          The raw_data_sources option is an arbitrarily sized array
+          that contains links that should be appended to the table
+          associated with each chart.  This is typically used to
+          provide a way to access the raw tool output that the charted
+          data was generated with, hence the name.
+
+	  Example:
+
+	    { csvfiles: [ "data-files/processed.csv" ], raw_data_sources: [ "data-files/tool1.out", "data-files/tool2.out" ] }
+
+       l. threshold
+
+          The threshold option defines a value which is compared
+          against the maximum Y axis value for each dataset.  If the
+          threshold value is larger than the dataset's value then that
+          dataset is automatically hidden by default.  This provides a
+          mechanism which is used to filter out noise from tools that
+          produce large numbers of datasets.  At run time the user can
+          achieve the same functionallity through the UI and also
+          apply the threshold against the dataset average instead of
+          it's maximum value.  The UI controls do not require that any
+          options be provided in the code.
+
+	  Example:
+
+	    { ..., threshold: 5 }
+
+       m. sort_datasets
+
+          The sort_datasets option is a boolean value that determines
+          the order in which datasets are presented to the user.  By
+          default sort_datasets is enabled, unless live_update is used
+          (this is due to the requirement of consistent ordering
+          between the existing and new sample data).  If sort_datasets
+          is disabled by setting it to false then datasets are
+          presented in the order they are supplied to the library
+          (note: this was the default behavior prior to the addition
+          of sort_datasets).
+
+	  Example:
+
+	    { ..., sort_datasets: false }
+
+       n. x_min
+       o. x_max
+       p. y_min
+       q. y_max
+
+          These four options control the default axes domain of the
+          chart view port.  There are many different reasons for doing
+          this but the most common is probably to set a strict range
+          for a known set of values, such as a CPU usage graph which
+          will be a percentage between 0 and 100.
+
+	  Example:
+
+	    { ..., y_min: 0, y_max: 100 }
+
+       r. x_log_scale
+       s. y_log_scale
+
+          These two options are boolean values that control whether or
+          not the corresponding axis scale should be presented with a
+          logarithmic scale (instead of the default linear scale).
+          The one exception to this is if the 'timeseries' data model
+          is used, in that case the x_log_scale option is ignored.
+
+	  Example:
+
+	    { ..., y_log_scale: true }
+
+*/
 
 // array to store objects for each chart, with references to often used variables
 var charts = [];
@@ -198,7 +609,6 @@ function chart(charts, title, stacked, data_model, x_axis_title, y_axis_title, l
 		     plotfiles: null,
 		     csvfiles: null,
 		     plotfile: null,
-		     plotfiles: null,
 		     json_plotfile: null,
 		     json_args: null,
 		     raw_data_source: [],
@@ -1633,7 +2043,7 @@ function zoom_it(chart, zoom_factor) {
 	set_x_axis_timeseries_label(chart);
     }
 }
- 
+
 function generate_chart(stacked, data_model, location, chart_title, x_axis_title, y_axis_title, options, callback) {
     var charts_index = charts.push(new chart(charts, chart_title, stacked, data_model, x_axis_title, y_axis_title, location, options)) - 1;
     charts[charts_index].charts_index = charts_index;
@@ -2322,7 +2732,12 @@ function build_chart(chart) {
 	});
 }
 
+// backwards compatible user call
 function create_graph(stacked, data_model, location, chart_title, x_axis_title, y_axis_title, options) {
+    create_jschart(stacked, data_model, location, chart_title, x_axis_title, y_axis_title, options);
+}
+
+function create_jschart(stacked, data_model, location, chart_title, x_axis_title, y_axis_title, options) {
     if (stacked === "stackedAreaChart") {
 	stacked = 1;
     } else if (stacked === "lineChart") {

--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -71,7 +71,8 @@ function dataset(index, name, mean, median, values, chart) {
 				       p90: null,
 				       p95: null,
 				       p99: null,
-				       p9999: null
+				       p9999: null,
+				       buckets: null
 				     }
 			},
 		 path: null,
@@ -1148,7 +1149,7 @@ function create_table(chart) {
     var colspan;
 
     if (chart.data_model == "histogram") {
-	colspan = 12;
+	colspan = 13;
     } else {
 	colspan = 5;
     }
@@ -1326,6 +1327,10 @@ function create_table(chart) {
 	row.append("th")
 	    .attr("align", "right")
 	    .text("99.99%");
+
+	row.append("th")
+	    .attr("align", "right")
+	    .text("Buckets");
     }
 
     row.append("th")
@@ -1398,6 +1403,10 @@ function create_table(chart) {
 	    chart.datasets.all[i].dom.table.histogram.p9999 = chart.datasets.all[i].dom.table.row.append("td")
 		.attr("align", "right")
 		.text(table_print(chart, chart.datasets.all[i].histogram.p9999));
+
+	    chart.datasets.all[i].dom.table.histogram.buckets = chart.datasets.all[i].dom.table.row.append("td")
+		.attr("align", "right")
+		.text(chart.formatting.table.integer(chart.datasets.all[i].values.length));
 	}
 
 	chart.datasets.all[i].dom.table.samples = chart.datasets.all[i].dom.table.row.append("td")

--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -144,7 +144,8 @@ function chart(charts, title, stacked, data_model, x_axis_title, y_axis_title, l
 			      }
 			 },
 		   viewport_controls: null,
-		   viewport_elements: null
+		   viewport_elements: null,
+		   highlight_points: null
 		 };
 
     this.dom = { div: null,
@@ -1754,6 +1755,15 @@ function build_chart(chart) {
 	.attr("width", chart.dimensions.viewport_width + chart.dimensions.margin.left + chart.dimensions.margin.right)
 	.attr("height", chart.dimensions.viewport_height + chart.dimensions.margin.top + chart.dimensions.margin.bottom + ((Math.ceil(chart.dataset_count / chart.dimensions.legend_properties.columns) - 1 + chart.options.legend_entries.length) * chart.dimensions.legend_properties.row_height));
 
+    var foo = chart.chart.svg.append("defs");
+    var bar = foo.append("marker")
+	.attr("id", "datapoint_" + chart.charts_index)
+	.attr("viewBox", "-2,-2,4,4")
+	.attr("markerWidth", 2)
+	.attr("marerHeight", 2);
+    chart.chart.highlight_points = bar.append("circle")
+	.attr("r", 2);
+
     chart.chart.container = chart.chart.svg.append("g")
 	.attr("transform", "translate(" + chart.dimensions.margin.left + ", " + chart.dimensions.margin.top +")");
 
@@ -2398,7 +2408,12 @@ function highlight(dataset) {
 	    }
 
 	    if (dataset.chart.datasets.valid[i].index == dataset.index) {
-		dataset.chart.datasets.valid[i].dom.path.classed({"unhighlighted": false, "highlightedline": true });
+		dataset.chart.datasets.valid[i].dom.path.classed({"unhighlighted": false, "highlightedline": true })
+		    .attr("marker-mid", "url(#datapoint_" + dataset.chart.charts_index + ")")
+		    .attr("marker-start", "url(#datapoint_" + dataset.chart.charts_index + ")")
+		    .attr("marker-end", "url(#datapoint_" + dataset.chart.charts_index + ")");
+
+		dataset.chart.chart.highlight_points.style("fill", mycolors(dataset.chart.datasets.valid[i].index));
 
 		if (dataset.chart.datasets.valid[i].dom.points) {
 		    dataset.chart.datasets.valid[i].dom.points.classed("unhighlighted", false)
@@ -2454,7 +2469,10 @@ function dehighlight(dataset) {
 		continue;
 	    }
 
-	    dataset.chart.datasets.valid[i].dom.path.classed({"unhighlighted": false, "highlightedline": false});
+	    dataset.chart.datasets.valid[i].dom.path.classed({"unhighlighted": false, "highlightedline": false})
+		.attr("marker-mid", null)
+		.attr("marker-start", null)
+		.attr("marker-end", null);
 
 	    if (dataset.chart.datasets.valid[i].dom.points) {
 		dataset.chart.datasets.valid[i].dom.points.classed("unhighlighted", false)

--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -22,7 +22,7 @@
 Using jschart:
 
 From a developer user perspective jschart is consumed by calling the
-create_graph function:
+create_jschart function:
 
   create_jschart(<stacked>, <data model>, <location>, <chart title>, <x axis title>, <y axis title>, <options>);
 
@@ -31,11 +31,11 @@ Here is a summary of each parameter:
   1. <stacked>
 
      This parameter tells the library whether the chart is a simple
-     line chart or an stacked area chart.  There are two different
+     line chart or a stacked area chart.  There are two different
      methodologies of supplying this parameter.  In the original
      invocation it was a simple boolean field: '1' or 'true' for a
      stacked area chart and '0' or 'false' for a regular line chart.
-     When jschart was ported to pbench support for two additional
+     When jschart was ported to pbench, support for two additional
      values were added: 'stackedAreaChart' and 'lineChart'.  These new
      parameters were simply mapped to the existing values for
      compatilibity purposes.
@@ -53,10 +53,10 @@ Here is a summary of each parameter:
      An 'xy' chart means that the supplied data is just a series of
      X/Y value pairs to be plotted without any additional processing.
      A 'timeseries' chart differs from the 'xy' chart because the X
-     axis values are milliseconds sinc epoch timestamps.  When the
+     axis values are milliseconds since epoch timestamps.  When the
      chart is being drawn the integer timestamps are used just like a
      regular X/Y value pair but at the presentation layer the
-     timestamps are converted into user deciperable timestamps,
+     timestamps are converted into user decipherable timestamps,
      generally of the form 'YYYY-MM-DD HH:MM:SS'.  A 'histogram' chart
      is treated very similarly to an 'xy' chart from a plotting
      perspective, but the values are interpreted to be a bucket/count
@@ -67,7 +67,7 @@ Here is a summary of each parameter:
   3. <location>
 
      The <location> parameter tells the library where to insert the
-     chart and it's accompanying table into the HTML DOM.  This is
+     chart and its accompanying table into the HTML DOM.  This is
      usually implemented in the following fashion:
 
      ...
@@ -192,7 +192,7 @@ Here is a summary of each parameter:
           plotfiles option which only supports a single plot file
           being supplied to the jschart library.  It is most
           applicable when combined with the packed option which is
-          discuused next.
+          discussed next.
 
        e. packed
 
@@ -287,7 +287,7 @@ Here is a summary of each parameter:
 	    }
 
 	  The 'data_series_name' and 'data' properties are arrays
-	  which shared the same indexes.  The 'x_axis_series' property
+	  which share the same indexes.  The 'x_axis_series' property
 	  defines which entry in the 'data_series_names' array
 	  contains the X axis value of the X/Y pairs for each dataset.
 	  In practice this would look something like this:
@@ -325,7 +325,7 @@ Here is a summary of each parameter:
 	    { json_plotfile: 'http://some.server.somewhere', json_args: 'type=foo' }
 
 	  In this example, supplying different values for 'type' could
-	  alter the response that server sends depending on it's
+	  alter the response that the server sends depending on its
 	  implementation.
 
 	  The update_interval options tells the jschart library that
@@ -340,7 +340,7 @@ Here is a summary of each parameter:
 	  only sending new samples since <timestamp> and avoid
 	  retransmission of existing data.
 
-	  The history_length parameter is tell the jschart library how
+	  The history_length parameter tells the jschart library how
 	  many data samples should be retained when new data is being
 	  dynamically added.  This prevents the arrays that contain
 	  the sample data from growing without bounds which would
@@ -373,9 +373,9 @@ Here is a summary of each parameter:
           dataset is automatically hidden by default.  This provides a
           mechanism which is used to filter out noise from tools that
           produce large numbers of datasets.  At run time the user can
-          achieve the same functionallity through the UI and also
+          achieve the same functionality through the UI and also
           apply the threshold against the dataset average instead of
-          it's maximum value.  The UI controls do not require that any
+          its maximum value.  The UI controls do not require that any
           options be provided in the code.
 
 	  Example:


### PR DESCRIPTION
There are several new features in this PR:

1. On a line chart a highlighted dataset will have all of it's individual datapoints displayed as dots along the line
2. Show the number of buckets in a histogram dataset in the table
3. Add developer documentation
4. Create a new, more appropriate interface to the library using the new `create_jschart` function.  Backwards compatibility is maintained as the `create_graph` function still exists.
5. Add View Port Controls to allow the user to set the axis bounds and enable clamping per axis.  This feature addresses issue #317.