### PR TITLE
Check for spurious files/subdirectories of tools-<group> dir

### DIFF
--- a/agent/util-scripts/pbench-clear-tools
+++ b/agent/util-scripts/pbench-clear-tools
@@ -98,7 +98,7 @@ if [ -d "$tool_group_dir" ]; then
 			# if a tool name was provided, only remove that tool.  If not, all tools should be removed
 			if [ -z "$name" -o "$name" == "$this_tool_file" ]; then
 				echo "removing $tool_group_dir/$this_tool_file"
-				/bin/rm -f "$tool_group_dir/$this_tool_file"
+				/bin/rm -rf "$tool_group_dir/$this_tool_file"
 			fi
 		fi
 	done

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 script_path=`dirname $0`
 script_name=`basename $0`
@@ -140,6 +141,14 @@ for this_tool_file in `/bin/ls $tool_group_dir`; do
 		label=`cat $tool_group_dir/$this_tool_file`
 		debug_log "gather_remote_sysinfo_data $remote_hostname $label"
 		gather_remote_sysinfo_data $remote_hostname $label &
+	elif [ -d $tool_group_dir/$this_tool_file ] ;then
+		# skip spurious subdirectory of $tool_group_dir
+		warn_log "[$script_name]$this_tool_file is a directory in $tool_group_dir; that should not happen. Please consider deleting it."
+		continue
+	elif [ ! -e "$pbench_bin/tool-scripts/$this_tool_file" ] ;then
+		# skip spurious file - not a tool.
+		warn_log "[$script_name]$this_tool_file does not exist in $pbench_bin/tool-scripts; spurious file perhaps? Please consider deleting it."
+		continue
 	else
 		# any other file is assumed to be a local tool
 		let lcl_cnt=lcl_cnt+1

--- a/agent/util-scripts/pbench-list-tools
+++ b/agent/util-scripts/pbench-list-tools
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 script_path=`dirname $0`
 script_name=`basename $0`
@@ -90,6 +91,14 @@ if [ -d "$pbench_run" ]; then
                                 	tool=`echo $this_tool_file | awk -F@ '{print $1}'`
                                 	remote_tools=`ssh $ssh_opts -n $remote_host ". ${pbench_install_dir}/profile; pbench-list-tools $with_options_opt --group=$group" | sed -e s/"^$group: "//`
 					tools="$tools,$remote_host[$remote_tools]"
+	                        elif [ -d $tool_group_dir/$this_tool_file ] ;then
+					# skip spurious subdirectory of $tool_group_dir
+					warn_log "[$script_name]$this_tool_file is a directory in $tool_group_dir; that should not happen. Please consider deleting it."
+					continue
+	                        elif [ ! -e "$pbench_bin/tool-scripts/$this_tool_file" ] ;then
+					# skip spurious file - not a tool.
+					warn_log "[$script_name]$this_tool_file does not exist in $pbench_bin/tool-scripts; spurious file perhaps? Please consider deleting it."
+					continue
                         	else
 					if [ $with_options -eq 1 ]; then
 						this_tool_file="$this_tool_file `cat $tool_group_dir/$this_tool_file`"

--- a/agent/util-scripts/pbench-postprocess-tools
+++ b/agent/util-scripts/pbench-postprocess-tools
@@ -146,6 +146,14 @@ for this_tool_file in `/bin/ls $tool_group_dir`; do
 		debug_log "[$script_name]running this tool on $remote: ssh $ssh_opts -n $remote pbench-$action-tools --iteration=$iteration --group=$group --dir=$dir"
 		ssh $ssh_opts -n $remote pbench-$action-tools --iteration=$iteration --group=$group --dir=$dir &
 		pids="$pids $!"
+	elif [ -d $tool_group_dir/$this_tool_file ] ;then
+		# skip spurious subdirectory of $tool_group_dir
+		warn_log "[$script_name]$this_tool_file is a directory in $tool_group_dir; that should not happen. Please consider deleting it."
+		continue
+	elif [ ! -e "$pbench_bin/tool-scripts/$this_tool_file" ] ;then
+		# skip spurious file - not a tool.
+		warn_log "[$script_name]$this_tool_file does not exist in $pbench_bin/tool-scripts; spurious file perhaps? Please consider deleting it."
+		continue
 	else
 		# tool is local
 		# assemble the tool options in to an array
@@ -195,6 +203,17 @@ if [ "$action" == "postprocess" ]; then
 	# down to $tool_output_dir/[$label:]$hostname.
 	for this_tool_file in `/bin/ls $tool_group_dir`; do
 		if echo $this_tool_file | grep -q -v "@"; then
+			if [ -d $tool_group_dir/$this_tool_file ] ;then
+				# skip spurious subdirectory of $tool_group_dir
+				warn_log "[$script_name]$this_tool_file is a directory in $tool_group_dir; that should not happen. Please consider deleting it."
+				continue
+			fi
+			if [ ! -e "$pbench_bin/tool-scripts/$this_tool_file" ] ;then
+				# skip spurious file - not a tool.
+				warn_log "[$script_name]$this_tool_file does not exist in $pbench_bin/tool-scripts; spurious file perhaps? Please consider deleting it."
+				continue
+			fi
+			
 			pushd $tool_output_dir >/dev/null
 			if [ -f "$tool_group_dir/label" ]; then
 				label="`cat "$tool_group_dir/label"`"


### PR DESCRIPTION
Issue #273.

Check for spurious subdirectories/files of the tools-<group> directory
in pbench-{start,stop,postprocess}-tools and skip them with a warning.
Ditto for pbench-list-tools and pbench-collect-sysinfo. Modify
pbench-clear-tools to remove any such subdirectories (it already
removed spurious files in addition to bona fide tools).