### PR TITLE
Pbench fio cache drop

### DIFF
--- a/agent/bench-scripts/drop-cache-example.sh
+++ b/agent/bench-scripts/drop-cache-example.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+# drop-cache.sh - an example of a pbench-fio cache-dropping script
+# here is an example cache dropping script for Ceph cluster
+# it assumes that there is a ceph-ansible inventory file in /root/ansible-hosts
+# containing a [osds] host group and a list of Ceph OSD hosts underneath
+# the script must be set to be executable using a command like
+#   chmod 755 drop-cache.sh
+
+ansible -m shell -f 12 -i /root/ansible-hosts -a "sync ; echo 3 > /proc/sys/vm/drop_caches" osds

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -51,7 +51,7 @@ runtime=""
 ramptime=""
 iodepth=""
 ioengine=""
-cache_drop_script=""
+pre_iteration_script=""
 job_mode="concurrent" # serial or concurrent
 file_size=""
 direct="" # don't cache IO's by default
@@ -122,9 +122,9 @@ function fio_usage() {
 		printf "\t\tnumber of jobs to run, if not given then fio default of numjobs=1 will be used\n"
 		printf -- "\t--job-file=<path>\n"
 		printf "\t\tprovide the path of a fio job config file, (default is $job_file)\n"
-		printf -- "\t--cache-drop-script=str\n"
-		printf -- "\t\tuse executable script/program to drop cache on storage servers\n"
-		printf -- "\t\texample: --cache-drop-script=\$HOME/drop-cache.sh\n"
+		printf -- "\t--pre-iteration-script=str\n"
+		printf -- "\t\tuse executable script/program to prepare the system for test iteration\n"
+		printf -- "\t\texample: --pre-iteration-script=\$HOME/drop-cache.sh\n"
 		printf -- "\t--samples=<int>\n"
 		printf "\t\tnumber of samples to use per test iteration (default is $nr_samples)\n"
 	        printf -- "\t--max-stddev=<int>\n"
@@ -137,7 +137,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,cache-drop-script:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,pre-iteration-script:," -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -337,12 +337,12 @@ function fio_process_options() {
 
 			fi
 			;;
-			--cache-drop-script)
+			--pre-iteration-script)
 			shift;
 			if [ -n "$1" ]; then
-				cache_drop_script="$1"
-				if [ ! -x $cache_drop_script ]; then
-					printf "ERROR: $cache_drop_script must be executable\n"
+				pre_iteration_script="$1"
+				if [ ! -x $pre_iteration_script ]; then
+					printf "ERROR: $pre_iteration_script must be executable\n"
 					exit 1
 				fi
 				shift;
@@ -530,14 +530,14 @@ function fio_run_job() {
 		mkdir -p $benchmark_results_dir/clients/localhost
 	fi
 
-	# cache dropping is a bit hard on the system, give it a few
-	# seconds to start caching OS directories and files again
+	# certain test preparation steps such as cache dropping 
+	# can be a bit hard on the system, give it a few
+	# seconds before actually starting test
 	# by putting this before pbench-start-tools, 
-	# also ensures that pbench files will be cached
 
-	if [ -n "$cache_drop_script" ] ; then
-		printf "running cache-drop command: $cache_drop_script\n"
-		eval "$cache_drop_script"
+	if [ -n "$pre_iteration_script" ] ; then
+		printf "running pre-iteration-script command: $pre_iteration_script\n"
+		eval "$pre_iteration_script"
 	fi
 	pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 	local client_opts=""

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -51,6 +51,7 @@ runtime=""
 ramptime=""
 iodepth=""
 ioengine=""
+cache_drop_script=""
 job_mode="concurrent" # serial or concurrent
 file_size=""
 direct="" # don't cache IO's by default
@@ -121,6 +122,9 @@ function fio_usage() {
 		printf "\t\tnumber of jobs to run, if not given then fio default of numjobs=1 will be used\n"
 		printf -- "\t--job-file=<path>\n"
 		printf "\t\tprovide the path of a fio job config file, (default is $job_file)\n"
+		printf -- "\t--cache-drop-script=str\n"
+		printf -- "\t\tuse executable script/program to drop cache on storage servers\n"
+		printf -- "\t\texample: --cache-drop-script=\$HOME/drop-cache.sh\n"
 		printf -- "\t--samples=<int>\n"
 		printf "\t\tnumber of samples to use per test iteration (default is $nr_samples)\n"
 	        printf -- "\t--max-stddev=<int>\n"
@@ -133,7 +137,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,cache-drop-script:" -n "getopt.sh" -- "$@");
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
 		fio_usage
@@ -330,6 +334,18 @@ function fio_process_options() {
 			if [ -n "$1" ]; then
 				job_file="$1"
 				shift;
+
+			fi
+			;;
+			--cache-drop-script)
+			shift;
+			if [ -n "$1" ]; then
+				cache_drop_script="$1"
+				if [ ! -x $cache_drop_script ]; then
+					printf "ERROR: $cache_drop_script must be executable\n"
+					exit 1
+				fi
+				shift;
 			fi
 			;; 
 			--)
@@ -512,6 +528,16 @@ function fio_run_job() {
 		wait
 	else
 		mkdir -p $benchmark_results_dir/clients/localhost
+	fi
+
+	# cache dropping is a bit hard on the system, give it a few
+	# seconds to start caching OS directories and files again
+	# by putting this before pbench-start-tools, 
+	# also ensures that pbench files will be cached
+
+	if [ -n "$cache_drop_script" ] ; then
+		printf "running cache-drop command: $cache_drop_script\n"
+		eval "$cache_drop_script"
 	fi
 	pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 	local client_opts=""


### PR DESCRIPTION
This PR addresses issue #381 .  The first commit adds a --cache-drop-script option to pbench-fio.  I made a decision not to try to pass a cache dropping command in its entirety in this option because of the potential for syntax mayhem in parsing quoted strings within quoted strings, etc.  Instead the user just passes the pathname of an executable script file, which is responsible for knowing which hosts to drop cache on and how to do that.  ok?

The 2nd commit is an example of a cache dropping script for a Ceph (ceph-ansible-based) cluster.  It uses ansible to fire cache dropping command on all OSD hosts.  It is there for documentation purposes but does not have to be put in the RPM.  It has been tested.