### PR TITLE
Add --dst-macs option to pbench-moongen

### DIFF
--- a/agent/bench-scripts/pbench-moongen
+++ b/agent/bench-scripts/pbench-moongen
@@ -47,6 +47,7 @@ traffic="unidirec"
 max_drop_pcts="0"
 rates=""
 portlist="0,1"
+dst_maclist=""
 frame_sizes="64" # in bytes
 queues_per_task="3"
 mpps_per_queue="5"
@@ -71,7 +72,7 @@ install_only="n"
 one_shot="n"
 
 # Process options and arguments
-opts=$(getopt -q -o i:c:t:r:m:p:M:S:C:o --longoptions "portlist:,rate:,rates:,max-drop-pct:,max-drop-pcts:,client-label:,server-label:,tool-label-pattern:,install,start-iteration-num:,config:,nr-flows:,test-type:,traffic:,latency-runtime:,search-runtime:,validation-runtime:,frame-sizes:,samples:,client:,clients:,servers:,server:,max-stddev:,max-failures:,log-response-times:,postprocess-only:,run-dir:,tool-group:,one-shot,mpps-per-queue:,queues-per-task:" -n "getopt.sh" -- "$@")
+opts=$(getopt -q -o i:c:t:r:m:p:M:S:C:o --longoptions "portlist:,rate:,rates:,max-drop-pct:,max-drop-pcts:,client-label:,server-label:,tool-label-pattern:,install,start-iteration-num:,config:,nr-flows:,test-type:,traffic:,latency-runtime:,search-runtime:,validation-runtime:,frame-sizes:,samples:,client:,clients:,servers:,server:,max-stddev:,max-failures:,log-response-times:,postprocess-only:,run-dir:,tool-group:,one-shot,mpps-per-queue:,queues-per-task:,dst-macs:" -n "getopt.sh" -- "$@")
 if [ $? -ne 0 ]; then
 	printf -- "$*\n"
 	printf "\n"
@@ -116,6 +117,7 @@ if [ $? -ne 0 ]; then
 	printf -- "\t\t             --tool-group=str\n"
 	printf -- "\t\t             --mpps-per-queue=int       how many millions of packets to process per queue (default $mpps_per_queue)\n"
 	printf -- "\t\t             --queues-per-task=int      how many tasks queues to bind to each task (default $queues_per_task)\n"
+	printf -- "\t\t             --dst-macs=mac[,mac]       list of destination mac addresses, each mac in the list corresponds to a port from the port list\n"
 	exit 1
 fi
 eval set -- "$opts"
@@ -282,6 +284,13 @@ while true; do
 		    shift
 		fi
 		;;
+		--dst-macs)
+		shift
+		if [ -n "$1" ]; then
+		    dst_maclist="$1"
+		    shift
+		fi
+		;;
 		*)
 		error_log "[$script_name] bad option, \"$1 $2\""
 		break
@@ -378,6 +387,13 @@ for rate in `echo $rates | sed -e s/,/" "/g`; do
         							echo "frameSize = $frame_size,">>$cfg_file
 								echo "mppsPerQueue = $mpps_per_queue," >>$cfg_file
 								echo "queuesPerTask = $queues_per_task," >>$cfg_file
+								if [ -n "$dst_maclist" ]; then
+									echo -n "dstMacs = {">>$cfg_file
+									for mac in `echo $dst_maclist | sed -e s/,/" "/g`; do
+										echo -n "\"$mac\",">>$cfg_file
+									done
+									echo "},">>$cfg_file
+								fi
         							echo "ports = {$portlist}" >>$cfg_file
 								echo "}">>$cfg_file
 								cp $cfg_file $moongen_dir/


### PR DESCRIPTION
- This allows pbench-moongen to set the destination MAC addresses for
  the ports that packets are sent on.

- This feature is neccessary for environments such as SRIOV and
  non-direct connect.