### PR TITLE
Event collection has to be for all namespaces

### DIFF
--- a/agent/tool-scripts/oc
+++ b/agent/tool-scripts/oc
@@ -110,9 +110,8 @@ oc_data_collect() {
 }
 
 oc_data_once() { 
-    for oc_event in ev nodes; do 
-        oc get $oc_event -o wide >> "${tool_output_dir}"/"${oc_event}".txt 
-    done 
+    oc get nodes -o wide >> "${tool_output_dir}"/nodes.txt 
+    oc get ev --all-namespaces -o wide >> "${tool_output_dir}"/ev.txt 
 } 
 
 case "$mode" in 


### PR DESCRIPTION
OpenShift event collection should be for all namespaces.   The current approach only gets the events for whatever the current namespace happens to be.   Treat node and event collection separately.

cc: @ekuric 

Tested on OpenShift 3.3 and 3.4
