### PR TITLE
Downgrade required version of sysstat to 11.2.0

### DIFF
--- a/agent/tool-scripts/sar
+++ b/agent/tool-scripts/sar
@@ -19,7 +19,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 tool=$script_name
 tool_package_name="pbench-sysstat"
-tool_package_ver="11.5.1"
+tool_package_ver="11.4.1"
 tool_bin=/usr/local/bin/$tool
 group=default
 dir="/tmp"

--- a/agent/tool-scripts/sar
+++ b/agent/tool-scripts/sar
@@ -19,7 +19,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 tool=$script_name
 tool_package_name="pbench-sysstat"
-tool_package_ver="11.4.1"
+tool_package_ver="11.2.0"
 tool_bin=/usr/local/bin/$tool
 group=default
 dir="/tmp"


### PR DESCRIPTION
11.4.1 and 11.5.1 have pidstat problems that @mffiedler ran into.