### PR TITLE
Fix incorrect addressing of 'webserver' variable

### DIFF
--- a/agent/config/pbench-agent.cfg.example
+++ b/agent/config/pbench-agent.cfg.example
@@ -17,7 +17,7 @@ user = pbench
 host_path = http://%(pbench_result_redirector)s/pbench-archive-host
 ssh_opts = -o StrictHostKeyChecking=no
 webserver = %(pbench_web_server)s
-host_info_url = http://%swebserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
+host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
 dir = /pbench/public_html/incoming
 
 [pbench/tools]


### PR DESCRIPTION
Fix incorrect addressing of 'webserver' variable that would prevent rendering host_info_url setting.
