### PR TITLE
Fix short-form -n option in pbench-clear-tools

### DIFF
--- a/agent/util-scripts/pbench-clear-tools
+++ b/agent/util-scripts/pbench-clear-tools
@@ -19,7 +19,7 @@ group="default"
 
 # Process options and arguments
 
-opts=$(getopt -q -o d:g: --longoptions "group:,name:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o g:n: --longoptions "group:,name:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"


### PR DESCRIPTION
Fixes issues #402 and #415. In the longer term, we plan to get rid of short-form options: see issue #418.