### PR TITLE
Fiologparser hist needs job file

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess
+++ b/agent/bench-scripts/postprocess/fio-postprocess
@@ -14,8 +14,8 @@ my $js_str;
 my $interval = `cat $dir/fio.job | grep "^log_hist_msec"`;
 if ( ! $interval =~ /^\s*$/ ) {
 	system("mkdir -p $dir/hist");
-        # fiologparser_hist needs the polling interval to do its job,
-        # it gets that from the job file containing log_hist_msec parameter
+	# fiologparser_hist needs the polling interval to do its job,
+	# it gets that from the job file containing log_hist_msec parameter
 	system("fiologparser_hist.py --job-file=$dir/fio.job $dir/fio_clat_hist.*.log.* > $dir/hist/hist.csv");
 	system(abs_path($0) . "-viz.py --job-file=$dir/fio.job $dir/hist");
 }

--- a/agent/bench-scripts/postprocess/fio-postprocess
+++ b/agent/bench-scripts/postprocess/fio-postprocess
@@ -14,7 +14,9 @@ my $js_str;
 my $interval = `cat $dir/fio.job | grep "^log_hist_msec"`;
 if ( ! $interval =~ /^\s*$/ ) {
 	system("mkdir -p $dir/hist");
-	system("fiologparser_hist.py $dir/fio_clat_hist.*.log.* > $dir/hist/hist.csv");
+        # fiologparser_hist needs the polling interval to do its job,
+        # it gets that from the job file containing log_hist_msec parameter
+	system("fiologparser_hist.py --job-file=$dir/fio.job $dir/fio_clat_hist.*.log.* > $dir/hist/hist.csv");
 	system(abs_path($0) . "-viz.py --job-file=$dir/fio.job $dir/hist");
 }
 


### PR DESCRIPTION
See issue #421 for an explanation of why a fix was needed.  This 1-line fix simply passes the fio job file to the fiologparser_hist.py program so that it can extract the histogram logging interval.  This is very important for generating the correct percentiles over the correct time intervals.  If you don't pass this, the program will not work.