### PR TITLE
add 95th percentile to fio histogram-derived latency graph

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess-viz.py
+++ b/agent/bench-scripts/postprocess/fio-postprocess-viz.py
@@ -21,7 +21,7 @@ html = \
 <div id='jschart_latency'>
   <script>
     create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (s)", "Latency (s)",
-        { plotfiles: [ "avg.log", "median.log", "p90.log",
+        { plotfiles: [ "avg.log", "median.log", "p90.log", "p95.log",
                        "p99.log", "min.log", "max.log" ],
           sort_datasets: false, x_log_scale: false
         });


### PR DESCRIPTION
fiologparser_hist.py generates 95th-percentile latency in its output table as the 3rd-to-last column, but the graph generated from this data does not include the 95th-percentile curve, as you can see it's easy to add.