### PR TITLE
use correct units for fio histogram-derived latency graph

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess-viz.py
+++ b/agent/bench-scripts/postprocess/fio-postprocess-viz.py
@@ -20,7 +20,7 @@ html = \
 <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
 <div id='jschart_latency'>
   <script>
-    create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (s)", "Latency (s)",
+    create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
         { plotfiles: [ "avg.log", "median.log", "p90.log",
                        "p99.log", "min.log", "max.log" ],
           sort_datasets: false, x_log_scale: false

--- a/agent/bench-scripts/postprocess/fio-postprocess-viz.py
+++ b/agent/bench-scripts/postprocess/fio-postprocess-viz.py
@@ -20,7 +20,7 @@ html = \
 <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
 <div id='jschart_latency'>
   <script>
-    create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (s)", "Latency (s)",
+    create_jschart(0, "%s", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
         { plotfiles: [ "avg.log", "median.log", "p90.log", "p95.log",
                        "p99.log", "min.log", "max.log" ],
           sort_datasets: false, x_log_scale: false


### PR DESCRIPTION
fio typically reports latencies in microseconds and outputs timestamps for latency logs in milliseconds since the start of the test.  These may not be ideal units for everyone, but at least the axis labels are now consistent with the data.