### PR TITLE
add ara support for pbench

### DIFF
--- a/agent/ansible/ara.yml
+++ b/agent/ansible/ara.yml
@@ -1,0 +1,40 @@
+---
+- hosts: all
+  user: root
+  vars:
+    - tool_output_dir: "{{ TOOL_OUTPUT_DIR }}"
+    - ara_results_dir: ~/.ara
+    - ara_static_web_path: /tmp/ara
+  tasks:
+    - stat: path=~/ansible.cfg
+      register: config_status
+    - stat: path=/var/log/ansible.log
+      register: log_status
+    - name: get ansible config file from home dir
+      fetch: src=~/ansible.cfg dest={{ tool_output_dir }}/{{ ansible_hostname }}/ansible.cfg flat=yes
+      when: config_status.stat.exists == True
+    - name: get ansible_config file from /etc/ansible/ansible.cfg
+      fetch: src=/etc/ansible/ansible.cfg dest={{ tool_output_dir }}/{{ ansible_hostname }}/ansible.cfg flat=yes
+      when: config_status.stat.exists == False
+    - name: copy ansible.log when logging is enabled
+      fetch: src=/var/log/ansible.log  dest={{ tool_output_dir }}/{{ ansible_hostname }}/ansible.log flat=yes
+      when: log_status.stat.exists == True
+    - name: fetch ara data from remote
+      synchronize:
+          src: "{{ ara_results_dir }}/"
+          dest: "{{ tool_output_dir }}/{{ ansible_hostname }}"
+          mode: pull
+          archive: yes
+    - name: create dir to store ara_static_files
+      file: path={{ tool_output_dir }}/{{ ansible_hostname }}/web state=directory
+    - name: Generate static content of the web application
+      shell: ara generate {{ ara_static_web_path }}
+    - name: fetch web application
+      synchronize:
+          src: "{{ ara_static_web_path }}/"
+          dest: "{{ tool_output_dir }}/{{ ansible_hostname }}/web"
+          mode: pull
+          archive: yes
+    - name: clear ara web directory contents
+      file: path={{ ara_static_web_path }} state=absent
+

--- a/agent/ansible/pbench-ara.yml
+++ b/agent/ansible/pbench-ara.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  user: root
+  roles:
+  - role: chaitanyaenr.ara

--- a/agent/tool-scripts/ara
+++ b/agent/tool-scripts/ara
@@ -1,0 +1,76 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
+
+script_path=`dirname $0`
+script_name=`basename $0`
+pbench_bin="`cd ${script_path}/..; /bin/pwd`"
+
+# source the base script
+. "$pbench_bin"/base
+
+# Defaults
+tool=$script_name
+group=default
+dir="/tmp"
+
+# Process options and arguments
+opts=$(getopt -q -o idp --longoptions "dir:,group:,iteration,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
+eval set -- "$opts";
+while true; do
+	case "$1" in
+		--install)
+		mode="install"
+		shift;
+		;;
+		--start)
+		mode="start"
+		shift;
+		;;
+		--stop)
+		mode="stop"
+		shift;
+		;;
+		--postprocess)
+		mode="postprocess"
+		shift;
+		;;
+		-d|--dir)
+		shift;
+		if [ -n "$1" ]; then
+			dir="$1"
+			shift
+		fi
+		;;
+		-g|--group)
+		shift;
+		if [ -n "$1" ]; then
+			group="$1"
+			shift
+		fi
+		;;
+		--)
+		shift;
+		break;
+		;;
+	esac
+done
+
+tool_dir="$dir/tools-$group"
+tool_output_dir=$tool_dir/$tool # all tools keep data in their tool specific dir
+tool_cmd_file="$tool_output_dir/$tool.cmd"
+tool_pid_file=$pbench_tmp/$group.$iteration.$tool.pid
+tool_stdout_file=$tool_output_dir/$tool-stdout.txt
+tool_stderr_file=$tool_output_dir/$tool-stderr.txt
+case "$mode" in
+        install)
+        check_install_rpm ansible
+        check_install_rpm pbench_role_ara
+        ;;
+        start)
+        ;;
+        stop)
+        ;;
+        postprocess)
+        debug_log "postprocessing $script_name"
+        $script_path/postprocess/$script_name-postprocess $tool_output_dir $tool_group_dir
+esac

--- a/agent/tool-scripts/postprocess/ara-postprocess
+++ b/agent/tool-scripts/postprocess/ara-postprocess
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+tool_output_dir=$1
+tools_group_dir=$2
+function generate_inventory {
+        export INVENTORY=/tmp/inventory.$$
+        echo "[controller]"
+        echo $HOSTNAME
+        echo "[remote]"
+        ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+        trap "rm -f $INVENTORY" QUIT INT EXIT
+}
+
+function collect_ansible_facts {
+        mkdir $tool_output_dir/ansible-facts
+        ansible -i ${INVENTORY} -m setup all --tree $tool_output_dir/ansible-facts --private-key $HOME/.ssh/id_rsa -u root
+}
+
+function collect_ara_data {
+#        mkdir -p $tool_output_dir
+        ansible-playbook -vvv -i ${INVENTORY} --extra-vars '{"TOOL_OUTPUT_DIR":"'$tool_output_dir'"}' /opt/pbench-agent/ansible/ara.yml
+}
+generate_inventory >> /tmp/inventory.$$
+collect_ara_data
+collect_ansible_facts &>/dev/null


### PR DESCRIPTION
Ara which tracks ansible runs is integrated with pbench. pbench-register-tool-set installs ara on remotes. During the pbench-post-process step, ansible.cfg, ansible.log,ara.log, static files of web application on the remote hosts are collected.