### PR TITLE
Correct invalid jschart API calls

### DIFF
--- a/web-server/v0.3/js/jschart.js
+++ b/web-server/v0.3/js/jschart.js
@@ -2054,7 +2054,7 @@ function create_table(chart) {
 
 	chart.dom.table.stacked.mean = row.append("td")
 	    .attr("align", "right")
-	    .text(table_print(chart.table.stacked_mean));
+	    .text(table_print(chart, chart.table.stacked_mean));
 
 	row.append("td");
 
@@ -2075,7 +2075,7 @@ function create_table(chart) {
 
 	chart.dom.table.stacked.median = row.append("td")
 	    .attr("align", "right")
-	    .text(table_print(chart.table.stacked_median));
+	    .text(table_print(chart, chart.table.stacked_median));
 
 	row.append("td");
     }


### PR DESCRIPTION
- Two function calls are missing a mandatory argument.

- This addresses pbench issue #453