### PR TITLE
playbook to register pbench-tools on openshift cluster

### DIFF
--- a/contrib/ansible/openshift/README.md
+++ b/contrib/ansible/openshift/README.md
@@ -1,0 +1,40 @@
+## Pbench Ansible
+Playbook to register pbench tools on openshift cluster
+
+### Requirements
+You need to have these installed
+   - Openshift
+   - pbench
+
+### Tools registered
+master - sar, pidstat, iostat, oc, pprof
+nodes - sar, pidstat, iostat, pprof
+etcd - sar, pidstat, iostat
+lb - sar, pidstat, iostat
+
+### Sample inventory
+Your inventory should have groups of hosts describing the roles they play in the openshift cluster. This playbook looks for the following groups in the inventory file:
+
+[pbench-controller]
+
+[masters]
+
+[nodes]
+
+[etcd]
+
+[lb]
+
+### Run
+Currently for pbench is run under the root user, so the playbook also needs to run as root.
+```
+$ ansible-playbook -i /path/to/inventory --extra-vars '{ "ansible_ssh_private_key_file":"" }' pbench_register.yml
+```
+By default the interval for ose_master_interval, ose_node_interval and default_tools_interval are set to 10 seconds.
+
+You can override the variables like
+```
+$ ansible-playbook -i /path/to/inventory --extra-vars '{"default_tools_interval":"30"}' pbench_register.yml
+```
+### labeling of nodes
+Each node has a label, <index> associated with it. Masters are labeled with svt_master_<index>, so for the first master, the label looks like svt_master_1. Similarly nodes are labeled with svt_node_<index>, etcd with svt_etcd_<index> and lb with svt_lb_<index>. If the nodes in groups are same, for example if first master and second etcd nodes are same then the label looks like svt_master_1_etcd_2.

--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -1,0 +1,37 @@
+---
+- hosts: pbench-controller
+  user: root
+  vars:
+    - default_tools_interval: "{{ DEFAULT_TOOLS_INTERVAL|default('10') }}"
+    - ose_master_interval: "{{ OSE_MASTER_INTERVAL|default('10') }}"
+    - ose_node_interval: "{{ OSE_NODE_INTERVAL|default('10') }}"
+    - file: /run/pbench/register.hosts
+  tasks:
+    - name: create pbench directory
+      file: path=/run/pbench state=directory
+    - name: clear file contents
+      file: path={{ file }} state=absent
+    - name: copy, set permissions on the register script
+      copy:
+        src: register.sh
+        dest: /run/pbench/register.sh
+        owner: root
+        group: root
+        mode: 0755
+    - name: add masters to the file
+      shell: echo -e {{ item.1 }} master {{ item.0 }} svt_master_{{ item.0}} >> {{ file }}
+      with_indexed_items:
+       - "{{ groups['masters'] }}"
+    - name: add nodes to the file
+      shell: echo -e {{ item.1 }} node {{ item.0 }} svt_node_{{ item.0}} >> {{ file }}
+      with_indexed_items: 
+       - "{{ groups['nodes'][-1] }}" 
+       - "{{ groups['nodes'][-2] }}"
+    - name: add etcd nodes to the file
+      shell: echo -e {{ item.1 }} etcd {{ item.0 }} svt_etcd_{{ item.0 }} >> {{ file }}
+      with_indexed_items: "{{ groups['etcd'] }}"
+    - name: add lb to the file
+      shell: echo -e {{ item.1}} lb {{ item.0 }} svt_lb_{{ item.0}} >> {{ file }}
+      with_indexed_items: "{{ groups['lb'] }}"
+    - name: register tools
+      shell: sh /run/pbench/register.sh {{ default_tools_interval }} {{ ose_master_interval }} {{ ose_node_interval }} {{ file }}

--- a/contrib/ansible/openshift/register.sh
+++ b/contrib/ansible/openshift/register.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+pbench_bin=/opt/pbench-agent
+# source the base script
+. "$pbench_bin"/base
+
+default_tools_interval=$1
+ose_master_interval=$2
+ose_node_interval=$3
+file=$4
+hosts=/run/pbench/register.tmp.hosts
+declare -a remote
+declare -a group
+declare -a index
+declare -a label
+
+pbench-stop-tools
+if [ $? -ne 0 ]; then
+  error_log "pbench-stop-tools failed"
+  exit 1
+fi
+pbench-kill-tools
+if [ $? -ne 0 ]; then
+  error_log "pbench-kill-tools failed"
+  exit 1
+fi
+pbench-clear-tools
+if [ $? -ne 0 ]; then
+  error_log "pbench-clear-tools failed"
+  exit 1
+fi
+while read -u 9 line;do
+  remote_name=$(echo $line | awk -F' ' '{print $1}')
+  group_name=$(echo $line | awk -F' ' '{print $2}')
+  index_value=$(echo $line | awk -F' ' '{print $3}')
+  label_name=$(echo $line | awk -F' ' '{print $4}')
+  remote[${#remote[@]}]=$remote_name 
+  group[${#group[@]}]=$group_name
+  index[${#index[@]}]=$index_value
+  label[${#label[@]}]=$label_name
+done 9< $file
+array_length=${#remote[*]}
+for ((i=0; i<$array_length; i++));do
+  for ((j=i+1; j<$array_length; j++));do
+    if [[ ${remote[i]} == ${remote[j]} ]] && [[ ${remote[i]} != '' ]]; then
+      label[i]=$(echo ${label[i]}_${group[j]}_${index[j]})
+      unset label[j]
+      unset remote[j]
+      unset group[j]
+      unset index[j]
+    fi
+  done
+  if [[ ${remote[i]} != '' ]]; then
+    echo ${remote[i]} ${group[i]} ${index[i]} ${label[i]} >> $hosts
+  fi
+done
+while read -u 11 line;do
+  remote=$(echo $line | awk -F' ' '{print $1}')
+  group=$(echo $line | awk -F' ' '{print $2}')
+  index=$(echo $line | awk -F' ' '{print $3}')
+  index=$(( index + 1 ))
+  label=$(echo $line | awk -F' ' '{print $4}')
+  ## register tools
+  if [ "$group"  == "master" ]; then
+    pbench-register-tool --label=$label --name=sar --remote $remote
+    pbench-register-tool --label=$label --name=iostat --remote $remote
+    pbench-register-tool --label=$label --name=pidstat --remote $remote
+    pbench-register-tool --label=$label --name=oc --remote $remote
+    pbench-register-tool --label=$label --name=pprof --remote $remote -- --osecomponent=master --interval=$ose_master_interval
+  else
+    pbench-register-tool --label=$label --name=sar --remote $remote
+    pbench-register-tool --label=$label --name=iostat --remote $remote
+    pbench-register-tool --label=$label --name=pidstat --remote $remote
+  fi
+  if [ "$group" == "node" ]; then
+    pbench-register-tool --label=$label --name=pprof --remote $remote -- --osecomponent=node --interval=$ose_node_interval
+  fi
+done 11< $hosts
+## delete host files
+/bin/rm $file
+if [ $? -ne 0 ]; then
+  warn_log "cannot delete input file" 
+fi
+/bin/rm $hosts
+if [ $? -ne 0 ]; then
+  warn_log "cannot delete hosts file" 
+fi
+exit 0


### PR DESCRIPTION
This playbook registers pbench tools including sar, pidstat, iostat, oc, pprof on openshift cluster. It registers tools only when they haven't been registered yet.