### PR TITLE
Fill gaps in server installation

### DIFF
--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -1,8 +1,11 @@
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/config
 chown pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/crontab/crontab
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/locks
+chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/logs
+chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/tmp
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/logs
 /var/tmp/pbench-test-server/pbench/opt
 /var/tmp/pbench-test-server/pbench/opt/pbench-server
 /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib
@@ -18,6 +21,7 @@ chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/
 /var/tmp/pbench-test-server/pbench/pbench/public_html
 /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/pbench/public_html/results
+/var/tmp/pbench-test-server/pbench/tmp
 /var/tmp/pbench-test-server/pbench/var
 /var/tmp/pbench-test-server/pbench/var/www
 /var/tmp/pbench-test-server/pbench/var/www/html

--- a/server/pbench/bin/pbench-server-activate-create-results-dir-structure
+++ b/server/pbench/bin/pbench-server-activate-create-results-dir-structure
@@ -46,5 +46,26 @@ mkdir -p $pbench_dir/public_html/results || exit 8
 
 # chown -R $user.$group $pbench_dir || exit 9
 
+if selinuxenabled ;then
+    # make sure restorecon and semanage are available (but not in the unit tests: they don't run as root)
+    if [ ${_PBENCH_SERVER_TEST} != 1 ] ;then
+        yum install -y policycoreutils policycoreutils-python-utils
+        # fix up the public_html subdirs for selinux
+        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/incoming'(/.*)?'
+        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/results'(/.*)?'
+        restorecon -R -v $pbench_dir/public_html
+    fi
+fi
+
+# create the logs directory
+logsdir=$(getconf.py deploy-pbench-logs-dir results)
+mkdir -p $logsdir || exit 9
+chown -R $user.$group $logsdir || exit 10
+
+# create the tmp directory
+tmpdir=$(getconf.py deploy-pbench-tmp-dir results)
+mkdir -p $tmpdir || exit 11
+chown -R $user.$group $tmpdir || exit 11
+
 exit 0
 


### PR DESCRIPTION
Create TMP and LOGS directory.

Fix up selinux labels if necessary.

Fix unit test.

Issue: #461