### PR TITLE
Check ssh status in pbench-rsync-satellite

### DIFF
--- a/server/pbench/bin/gold/test-10.txt
+++ b/server/pbench/bin/gold/test-10.txt
@@ -34,7 +34,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/pbench-rsync-satellite.log:run-1900-01-01T00:00:00-UTC: duration (secs): 0
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo.bar.com cd /var/tmp/pbench-test-server/pbench/archive; ls
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo.bar.com if cd /var/tmp/pbench-test-server/pbench/archive;then ls ;else exit 1 ;fi
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/mailx -s pbench-rsync-satellite: TEST: 0 files processed, 0 remove failures, 0 md5 failures admins@example.com
 /var/tmp/pbench-test-server/test-execution.log:Processed files:
 /var/tmp/pbench-test-server/test-execution.log:None

--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -68,7 +68,12 @@ if [[ -z "$mail_recipients" ]] ;then
 fi
 # for testing, limit it to a few hosts and stay away from the largest tarballs
 # hosts=$(ssh $remotehost "cd $remotearchive; ls | grep -v 300 | sed 4q")
-hosts=$(ssh $remotehost "cd $remotearchive; ls")
+hosts=$(ssh $remotehost "if cd $remotearchive;then ls ;else exit 1 ;fi")
+rc=$?
+if [[ $rc != 0 ]] ;then
+    echo "$PROG: ssh $remotehost \"cd $remotearchive; ls\" failed."
+    exit -2
+fi
 
 tmp=$TMP/$PROG.$$
 


### PR DESCRIPTION
Turn remote command errors into an error exit for ssh. Then check
the status of the ssh command.

Issue #449