### PR TITLE
Fix invocation of index-pbench

### DIFF
--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -144,7 +144,7 @@ while read size result ;do
                 "python ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
             status=$?
         else
-            echo "index-pbench needs python3, either directory or through SCL" >&4
+            echo "index-pbench needs python3, either directly or through SCL" >&4
             # this is fatal
             exit 127
         fi

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -50,7 +50,8 @@ case $opts in
         ;;
 esac
 
-# TOP, ARCHIVE, TMP are defined by the base file
+# TOP, TMP, ARCHIVE, LOGS are defined in pbench-base.sh
+
 . $dir/pbench-base.sh
 ###########################################################################
 
@@ -117,24 +118,36 @@ while read size result ;do
         continue
     fi
 
-    # index-pbench depends on a whole hierarchy - this script and index-pbench
-    # are in /home/pbench/bin when deployed, but it depends on /home/pbench/lib/config/pbench-index.cfg,
-    # /home/pbench/lib/vos etc. On a devel system, however, they are under .../pbench/server/pbench
-    # in the git clone. So tell the script where things are explicitly: hence PROGLOC. We use one for
-    # the real runs and a different one for unit testing. The actual command executed is the same, but
-    # since the "real" box does not have a python3, we use Software Collections; on the unit test box,
-    # we just executed python3 directly.
-    if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
-        PROGLOC=/home/pbench
-        PYTHONPATH=${PROGLOC}/lib:$PYTHONPATH scl enable python33 \
-                  "python ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
-        status=$?
-    else
-        # assume that we are in the right directory
+    # index-pbench depends on a whole hierarchy - this script and
+    # index-pbench are in /opt/pbench-server/bin when deployed, but it
+    # depends on /opt/pbench-server/lib/config/pbench-index.cfg,
+    # /opt/pbench-server/lib/vos etc. On a devel system, however, they are
+    # under .../pbench/server/pbench in the git clone.
+    # Also, index-pbench requires python3: that's available on Fedora
+    # but, for RHEL7, we need software collections.
+    if [[ "$_PBENCH_SERVER_TEST" == 1 ]] ;then
+        # running unittests: assume that we are in the bin directory
         PROGLOC=$dir
         PYTHONPATH=${PROGLOC}/../lib:$PYTHONPATH eval\
-                  "python3 ${PROGLOC}/index-pbench -U --config ${PROGLOC}/../lib/config/pbench-index.cfg $link"
+             "python3 ${PROGLOC}/index-pbench -U --config ${PROGLOC}/../lib/config/pbench-index.cfg $link"
         status=$?
+    else
+        PROGLOC=$(getconf.py install-dir pbench-server)
+        if which python3 > /dev/null 2>&1 ;then
+            # we have a python3 here
+            PYTHONPATH=${PROGLOC}/../lib:$PYTHONPATH eval\
+                "python3 ${PROGLOC}/index-pbench --config ${PROGLOC}/../lib/config/pbench-index.cfg $link"
+            status=$?
+        elif which scl > /dev/null 2>&1 ;then
+            # we fall back to SCL
+            PYTHONPATH=${PROGLOC}/lib:$PYTHONPATH scl enable python33 \
+                "python ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
+            status=$?
+        else
+            echo "index-pbench needs python3, either directory or through SCL" >&4
+            # this is fatal
+            exit 127
+        fi
     fi
     
     if [ $status -ne 0 ] ;then


### PR DESCRIPTION
It should work in all cases:

- when unit-testing in development environment
- when python3 is explicitly available
- when python3 is available through SCL

Issue #463