### PR TITLE
Pbench agent base script: do not recalculate $date

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -83,7 +83,9 @@ function debug_log {
 # Some standard global vars - try the config file first and fall back on hardwired defaults
 # which are valid today.
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
-    date=`date --utc "+%F_%H:%M:%S"`
+    if [ -z "$date" ] ;then
+        export date=`date --utc "+%F_%H:%M:%S"`
+    fi
     hostname=`hostname -s`
     full_hostname=`hostname`
 else


### PR DESCRIPTION
$date is set by the base script which is sourced by every benchmark
script, tool script and util script. It is used by benchmark scripts
to create the results directory for the run, but because it is
recalculated every time the base script is sourced, other components
were getting a different value and e.g. could not find the results
directory for the run.

We now check whether $date has a value already and if so, we just
leave it alone. It is only set the first time that the base script
is sourced.