### PR TITLE
Record iterations

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -83,7 +83,9 @@ function debug_log {
 # Some standard global vars - try the config file first and fall back on hardwired defaults
 # which are valid today.
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
-    date=`date --utc "+%F_%H:%M:%S"`
+    if [ -z "$date" ] ;then
+        export date=`date --utc "+%F_%H:%M:%S"`
+    fi
     hostname=`hostname -s`
     full_hostname=`hostname`
 else

--- a/agent/bench-scripts/gold/pbench-dbench/test-02.txt
+++ b/agent/bench-scripts/gold/pbench-dbench/test-02.txt
@@ -94,6 +94,7 @@ Iteration 2-48thread complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench/dbench__1900-01-01_00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/dbench__1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-04.txt
@@ -1105,6 +1105,7 @@ Iteration 6-randrw-1024KiB complete (6 of 6), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/fio__1900-01-01_00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-05.txt
@@ -561,6 +561,7 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/fio__1900-01-01_00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-06.txt
@@ -562,6 +562,7 @@ Iteration 3-throughput-1024KiB complete (3 of 3), with 1 pass and 6 failures
 /var/tmp/pbench-test-bench/pbench/fio__1900-01-01_00:00:00/summary-result.txt
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/fio__1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-moongen/test-03.txt
+++ b/agent/bench-scripts/gold/pbench-moongen/test-03.txt
@@ -76,6 +76,7 @@ Iteration 4-throughput-unidirec-1024B-1024flows-1pct_drop complete (4 of 4), wit
 /var/tmp/pbench-test-bench/pbench/moongen__1900-01-01_00:00:00/pbench-moongen.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/moongen__1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-uperf/test-00.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-00.txt
@@ -17,6 +17,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/uperf_test-00_1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/gold/pbench-uperf/test-01.txt
+++ b/agent/bench-scripts/gold/pbench-uperf/test-01.txt
@@ -25,6 +25,7 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/uperf_test-01_1900-01-01_00:00:00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -104,7 +104,9 @@ if [[ $? -ne 0 ]]; then
 	exit 1
 fi
 
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
 if [ ! -z "$cpu" ]; then
@@ -137,6 +139,7 @@ for runtime in `echo $runtimes | sed -e s/,/" "/g`; do
 	if [ ! -z "$cpu" ]; then
 		iteration="$iteration-cpu_$cpu"
 	fi
+        echo $iteration >> $benchmark_iterations
 	benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result/"
 	result_file=$benchmark_results_dir/result.txt
 	benchmark_cmd_file=$benchmark_results_dir/cyclictest.cmd

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -240,14 +240,17 @@ while true; do
 done
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
-	benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+	benchmark_fullname="${benchmark}_${config}_${date}"
+	benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 else
 	# We have an explicit run directory provided by --run-dir, so warn
 	# the user if they also used --config
 	if [[ ! -z "$config" ]]; then
 		warn_log "[$script_name] ignoring --config=\"$config\" in favor of --rundir=\"$benchmark_run_dir\""
 	fi
+	benchmark_fullname="$(basename $benchmark_run_dir)"
 fi
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 
 if [ -z "$clients" ]; then
 	clients=127.0.0.1
@@ -304,6 +307,7 @@ for thread_count in `echo $thread_counts | sed -e s/,/" "/g`; do
 		echo "Starting iteration $iteration ($count of $total_iterations)"
 		log "Starting iteration $iteration ($count of $total_iterations)"
 		iteration="${count}-${thread_count}thread"
+                echo $iteration >> $benchmark_iterations
 		iteration_dir="$benchmark_run_dir/$iteration"
 		result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 		failures=0

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -372,14 +372,17 @@ function fio_process_options() {
 		esac
 	done
 	if [ "$postprocess_only" = "n" ]; then
-		benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+		benchmark_fullname="${benchmark}_${config}_${date}"
+		benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 	else
 		if [ -z "$run_dir" ]; then
-			echo "I need a directory if postprocessing an existing result (--run-dir=)"
-		else
-			benchmark_run_dir="$run_dir"
+			err_log "I need a directory if postprocessing an existing result (--run-dir=)"
+			exit 1
 		fi
+		benchmark_fullname="$(basename $run_dir)"
+		benchmark_run_dir="$run_dir"
 	fi
+	benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 
 	verify_tool_group $tool_group
 }
@@ -638,6 +641,8 @@ function fio_run_benchmark() {
 			for block_size in `echo $block_sizes | sed -e s/,/" "/g`; do
 				job_num=1
 				iteration="${count}-${test_type}-${block_size}KiB"
+				   
+                                echo $iteration >> $benchmark_iterations
 				iteration_dir=$benchmark_run_dir/$iteration
 				result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 				failures=0

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # pbench-iozone 0.01 initial version 
 # TODO
@@ -155,7 +156,9 @@ done
 
 verify_tool_group $tool_group
 
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 benchmark_summary_file="$benchmark_run_dir/$benchmark-summary.txt"
 
 mkdir -p $benchmark_run_dir/.running
@@ -163,7 +166,7 @@ export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir beg
 
 benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
-
+echo $iteration >> $benchmark_iterations
 benchmark_tools_dir="$benchmark_results_dir/tools-$tool_group"
 mkdir -p $benchmark_results_dir $benchmark_tools_dir
 

--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # This is a script to run the linpack benchmark
 
@@ -106,7 +107,9 @@ else
     exit 1
 fi
 
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
 
@@ -118,6 +121,7 @@ result_file=$benchmark_results_dir/result.txt
 mkdir -p $benchmark_results_dir
 export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir beg
+echo $iteration >> $benchmark_iterations
 ## Run the benchmark and start/stop perf analysis tools
 pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pushd /usr/local/linpack_11.1.3/benchmarks/linpack

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # This is a script to run the migrate benchmark
 # Author: Andrew Theurer
@@ -309,11 +310,14 @@ function do_migrate() {
 
 if [ "$postprocess" = "only" ]; then
 	# user provides directory for previous test
+	benchmark_fullname=$(basename $benchmark_data_dir)
 	benchmark_run_dir="$benchmark_data_dir"
 else
 	config="from_${src_host}_to_${dest_host}--$config"
-	benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+	benchmark_fullname="${benchmark}_${config}_${date}"
+	benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 fi
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
 
@@ -328,6 +332,7 @@ export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir beg
 for i in `seq 1 $loops`; do
 	iteration="$count-from-$src_host-to-$dest_host"
+	echo $iteration >> $benchmark_iterations
 	benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
 	if [ "$postprocess" != "only" ]; then
 		mkdir -p $benchmark_results_dir

--- a/agent/bench-scripts/pbench-moongen
+++ b/agent/bench-scripts/pbench-moongen
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # This is a script to run the moongen benchmark
 # Author: Andrew Theurer
@@ -305,14 +306,17 @@ while true; do
 done
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
-	benchmark_run_dir="$pbench_run/${benchmark_name}_${config}_$date"
+	benchmark_fullname="${benchmark_name}_${config}_${date}"
+	benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 else
 	# We have an explicit run directory provided by --run-dir, so warn
 	# the user if they also used --config
 	if [[ ! -z "$config" ]]; then
 		warn_log "[$script_name] ignoring --config=\"$config\" in favor of --rundir=\"$benchmark_run_dir\""
 	fi
+	benchmark_fullname=$(basename $benchmark_run_dir)
 fi
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 mkdir -p $benchmark_run_dir/.running
 # save a copy of the command, in case the test needs to be reproduced or post-processed again
 echo "$script_name $pbench_cmd" >$benchmark_run_dir/$script_name.cmd
@@ -355,6 +359,7 @@ for rate in `echo $rates | sed -e s/,/" "/g`; do
 						else 
 							iteration="${count}-${test_type}-${traffic_direction}-${frame_size}B-${nr_flow}flows-${max_drop_pct}pct_drop"
 						fi
+                                                echo $iteration >> $benchmark_iterations
 						iteration_dir="$benchmark_run_dir/$iteration"
 						result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 						failures=0

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # This is a script to run the netperf benchmark
 # Note: This script is under development, and since netperf and uperf have very similar
@@ -51,7 +52,9 @@ spacing=25
 
 # Defaults
 
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 protocols="tcp,udp"
 test_types="stream,maerts,bidirec,rr"
 message_sizes="1,64,1024,16384" # in bytes
@@ -410,6 +413,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 			for instance in `echo $instances | sed -e s/,/" "/g`; do
 				if [ $count -ge $start_iteration_num ]; then
 					iteration="${count}-${protocol}_${test_type}-${message_size}B-${instance}i"
+					echo $iteration >> $benchmark_iterations
 					iteration_dir="$benchmark_run_dir/$iteration"
 					result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 					failures=0

--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 # This is a script to run the specjbb2005 benchmark
 # Author: Andrew Theurer
@@ -158,7 +159,9 @@ if [ "$stop_warehouses" == "default" ]; then
 fi
 ## Ensure the right version of the benchmark is installed
 
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
 benchmark_results_dir="$benchmark_run_dir"
@@ -214,6 +217,7 @@ for i in `seq $start_warehouses $inc_warehouses $stop_warehouses`; do
 	# for each of the test iterations (each test with a specific number of warehouses), copy the raw result data for that iteration in iteraration directory
 	grep "test$i" SPECjbb.raw >$i/reference-result/SPECjbb.raw
 	new_iteration_name="$iteration-warehouses:$i"
+        echo $new_iteration_name >> $benchmark_iterations
 	mv $iteration $new_iteration_name
 	pbench-postprocess-tools --group=$tool_group --iteration=$new_iteration_name --dir=$benchmark_results_dir/$new_iteration_name/reference-result
 	let iteration=$iteration+1

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -367,14 +367,17 @@ while true; do
 done
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
-	benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+	benchmark_fullname="${benchmark}_${config}_${date}"
+	benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 else
 	# We have an explicit run directory provided by --run-dir, so warn
 	# the user if they also used --config
 	if [[ ! -z "$config" ]]; then
 		warn_log "[$script_name] ignoring --config=\"$config\" in favor of --rundir=\"$benchmark_run_dir\""
 	fi
+	benchmark_fullname=$(basename $benchmark_run_dir)
 fi
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 
 # Verify the tool group exists
 verify_tool_group $tool_group
@@ -472,6 +475,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 					echo "Starting iteration $iteration ($count of $total_iterations)"
 					log "Starting iteration $iteration ($count of $total_iterations)"
 					iteration="${count}-${protocol}_${test_type}-${message_size}B-${instance}i"
+                                        echo $iteration >> $benchmark_iterations
 					iteration_dir="$benchmark_run_dir/$iteration"
 					result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 					failures=0

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -75,13 +75,14 @@ done
 verify_tool_group $tool_group
 iteration="1" # there can be only 1 iteration for user-benchmark
 benchmark_bin="$@"
-benchmark_run_dir="$pbench_run/${benchmark}_${config}_$date"
+benchmark_fullname="${benchmark}_${config}_${date}"
+benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 # make the run dir available to the user script
 export benchmark_run_dir
 benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
 mkdir -p $benchmark_results_dir/.running
 export benchmark_results_dir=$benchmark_results_dir
-
 
 # For now, since we only ever run one iteration here, don't bother
 # collecting sysinfo data before and after, just do it after.
@@ -100,6 +101,7 @@ trap "pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir int" INT 
 pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"
+echo $iteration >> $benchmark_iterations
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir

--- a/agent/bench-scripts/test-bin/ssh
+++ b/agent/bench-scripts/test-bin/ssh
@@ -2,10 +2,6 @@
 
 echo "$0 $*" >> $_testlog
 
-if [[ "$4" == "netstat" && "$5" == "-tlpn" ]]; then
-    echo "tcp        0      0 0.0.0.0:21000               0.0.0.0:*                   LISTEN      5830/uperf"
-fi
-
 while true ;do
     case $1 in
         -o)
@@ -20,6 +16,14 @@ while true ;do
     esac
 done
 remote=$1
+
+if [[ "$2" == "netstat" && "$3" == "-tlnp" ]]; then
+    echo "tcp        0      0 0.0.0.0:21000               0.0.0.0:*                   LISTEN      5830/uperf"
+fi
+
+if [[ "$2" == "hostname" && "$3" == "-s" ]]; then
+    echo "$remote"
+fi
 
 if [[ "$remote" == "fubar" ]] ;then
     exit 255

--- a/agent/util-scripts/gold/pbench-metadata-log/test-01.txt
+++ b/agent/util-scripts/gold/pbench-metadata-log/test-01.txt
@@ -15,12 +15,6 @@ config:
 date: 1900-01-01_00:00:00
 rpm-version: 
 
-[tools]
-hosts: testhost 
-
-[tools/testhost]
-mpstat: --interval="10"
- 
 [run]
 controller: testhost.example.com
 --- pbench tree state

--- a/agent/util-scripts/gold/pbench-metadata-log/test-02.txt
+++ b/agent/util-scripts/gold/pbench-metadata-log/test-02.txt
@@ -39,6 +39,7 @@ rpm-version:
 
 [tools]
 hosts: testhost 
+group: default
 
 [tools/testhost]
 iostat: --interval=3

--- a/agent/util-scripts/gold/pbench-metadata-log/test-03.txt
+++ b/agent/util-scripts/gold/pbench-metadata-log/test-03.txt
@@ -48,6 +48,7 @@ rpm-version:
 
 [tools]
 hosts: testhost dhcp31-174 perf104 
+group: default
 
 [tools/testhost]
 iostat: --interval=3
@@ -74,6 +75,8 @@ grep: /var/tmp/pbench-test-utils/pbench/pbench.log: No such file or directory
 --- pbench.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum list installed pbench-agent
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no -n dhcp31-174 hostname -s
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no -n perf104 hostname -s
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no dhcp31-174 /bin/ls /var/tmp/pbench-test-utils/pbench/tools-default
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no perf104 /bin/ls /var/tmp/pbench-test-utils/pbench/tools-default
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-metadata-log/test-04.txt
+++ b/agent/util-scripts/gold/pbench-metadata-log/test-04.txt
@@ -43,6 +43,7 @@ rpm-version:
 
 [tools]
 hosts: testhost 
+group: default
 
 [tools/testhost]
 iostat: --interval=3

--- a/agent/util-scripts/gold/pbench-metadata-log/test-21.txt
+++ b/agent/util-scripts/gold/pbench-metadata-log/test-21.txt
@@ -1,0 +1,76 @@
++++ Running test-21 pbench-metadata-log
+--- Finished test-21 pbench-metadata-log (status=0}
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/metadata.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tmp/pbench.iterations
+/var/tmp/pbench-test-utils/pbench/tools-default
+/var/tmp/pbench-test-utils/pbench/tools-default/iostat
+/var/tmp/pbench-test-utils/pbench/tools-default/mpstat
+/var/tmp/pbench-test-utils/pbench/tools-default/perf
+/var/tmp/pbench-test-utils/pbench/tools-default/pidstat
+/var/tmp/pbench-test-utils/pbench/tools-default/proc-interrupts
+/var/tmp/pbench-test-utils/pbench/tools-default/proc-vmstat
+/var/tmp/pbench-test-utils/pbench/tools-default/sar
+/var/tmp/pbench-test-utils/pbench/tools-default/turbostat
+/var/tmp/pbench-test-utils/pbench/tools-default/iostat:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/mpstat:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/perf:
+--record-opts=-a -freq=100
+--record-opts=--call-graph
+--record-opts=--event=branch-misses
+--record-opts=--event=cache-misses
+--record-opts=--event=instructions
+/var/tmp/pbench-test-utils/pbench/tools-default/pidstat:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/proc-interrupts:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/proc-vmstat:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/sar:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tools-default/turbostat:
+--interval=3
+/var/tmp/pbench-test-utils/pbench/tmp/pbench.iterations:
+iter1
+iter2
+iter3
+--- pbench tree state
++++ metadata.log file contents
+/var/tmp/pbench-test-utils/pbench/metadata.log:[pbench]
+/var/tmp/pbench-test-utils/pbench/metadata.log:name = pbench
+/var/tmp/pbench-test-utils/pbench/metadata.log:script = 
+/var/tmp/pbench-test-utils/pbench/metadata.log:config = 
+/var/tmp/pbench-test-utils/pbench/metadata.log:date = 1900-01-01_00:00:00
+/var/tmp/pbench-test-utils/pbench/metadata.log:rpm-version = 
+/var/tmp/pbench-test-utils/pbench/metadata.log:iterations = iter1, iter2, iter3
+/var/tmp/pbench-test-utils/pbench/metadata.log:
+/var/tmp/pbench-test-utils/pbench/metadata.log:[tools]
+/var/tmp/pbench-test-utils/pbench/metadata.log:hosts = testhost
+/var/tmp/pbench-test-utils/pbench/metadata.log:group = default
+/var/tmp/pbench-test-utils/pbench/metadata.log:
+/var/tmp/pbench-test-utils/pbench/metadata.log:[tools/testhost]
+/var/tmp/pbench-test-utils/pbench/metadata.log:iostat = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:mpstat = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:perf = --record-opts=-a -freq=100 --record-opts=--call-graph --record-opts=--event=branch-misses --record-opts=--event=cache-misses --record-opts=--event=instructions
+/var/tmp/pbench-test-utils/pbench/metadata.log:pidstat = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:proc-interrupts = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:proc-vmstat = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:sar = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:turbostat = --interval=3
+/var/tmp/pbench-test-utils/pbench/metadata.log:
+/var/tmp/pbench-test-utils/pbench/metadata.log:[run]
+/var/tmp/pbench-test-utils/pbench/metadata.log:controller = testhost.example.com
+/var/tmp/pbench-test-utils/pbench/metadata.log:start_run = 1900-01-01T00:00:00.000000
+/var/tmp/pbench-test-utils/pbench/metadata.log:end_run = 1900-01-01T00:00:00.000000
+/var/tmp/pbench-test-utils/pbench/metadata.log:
+--- metadata.log file contents
++++ pbench.log file contents
+grep: /var/tmp/pbench-test-utils/pbench/pbench.log: No such file or directory
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum list installed pbench-agent
+--- test-execution.log file contents

--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -1,0 +1,33 @@
+#! /usr/bin/env python2
+
+# Usage: pbench-add-metalog-option <options.file> <metadata log file> <option>
+
+# Add an option to the [pbench] section of the metadata.log file.
+# E.g. using an 'iterations' arg for the option
+#
+# iterations: 1-iter, 2-iter, 3-iter
+#
+# where the iterations are in the <iterations.file>, one iteration per line.
+
+import sys
+try:
+    # python3
+    from configparser import SafeConfigParser
+except:
+    from ConfigParser import SafeConfigParser
+
+def main(ifile, lfile, section):
+   config = SafeConfigParser()
+   config.read(lfile)
+   # python3
+   # config['pbench']['iterations'] = ', '.join(open(ifile).read().split())
+   config.set('pbench', section, ', '.join(open(ifile).read().split()))
+   config.write(open(lfile, "w"))
+   
+if __name__ == '__main__':
+   ifile = sys.argv[1]
+   lfile = sys.argv[2]
+   section = sys.argv[3]
+   status = main(ifile, lfile, section)
+   sys.exit(status)
+   

--- a/agent/util-scripts/pbench-metadata-log
+++ b/agent/util-scripts/pbench-metadata-log
@@ -62,76 +62,28 @@ function usage {
 }
 
 function metadata_log_tools {
-    log=$1
+    local log=$1
 
-    if [ -d $pbench_run/tools-$group ] ;then
-        metadata_log_tools_dir $log
-    else
-        metadata_log_tools_file $log
-    fi
-}
-
-function metadata_log_tools_file {
-    # This is provided for backwards compatibility.
-    # v0.35 introduced the tools-<group> directory: if that
-    # directory exists, we assume that it is authoritative.
-    # If it does not, we fall back to the tools.<group> file.
-
-    # Get the remotes from the local tools.$group file
-    # then get the remote tools.$group files for each remote
-
-    remotes="$(grep @ $pbench_run/tools.$group | sed 's/.*@//
-s/:[^:]*$//' | tr '\n' ' ')"
- 
-    # check if the local tools.$group file includes any local tools
-    local=0
-    if grep -v @ $pbench_run/tools.$group > /dev/null 2>&1 ;then
-        local=1
-    fi
-
-    # if yes ...
-    if [ $local == 1 ] ;then
-        cat >> $log <<EOF
-[tools]
-hosts: $hostname $remotes
-
-[tools/$hostname]
-$(cat $pbench_run/tools.$group)
- 
-EOF
-     else
-        # just remotes
-        if [ ! -z "$remotes" ] ;then
-            cat >> $log <<EOF
-[tools]
-hosts: $remotes
-
-EOF
-        fi
-    fi
-    
-    for remote in $remotes ;do
-        cat >> $log <<EOF
-[tools/$remote]
-$(ssh $ssh_opts $remote cat $pbench_run/tools.$group)
-
-EOF
-    done
-}
-
-function metadata_log_tools_dir {
-    # we have a tools-<group> dir.
-    
-    log=$1
     # get the remotes from the local tools-$group directory
     # then get the remote tools-$group dirs for each remote
-    
-    remotes="$(ls $pbench_run/tools-$group/ | grep @ | sed 's/.*@//
+    local remotes="$(/bin/ls $pbench_run/tools-$group/ 2> /dev/null | grep @ | sed 's/.*@//
 s/:[^:]*$//' | tr '\n' ' ')"
+
+    # the remotes may have different names than what the controller uses,
+    # so go ask them - the names of the remotes in the metadata log have to
+    # agree with the names of the remotes used when postprocessing the tool
+    # results, otherwise the indexing will fail.
+    local rems=""
+    for remote in $remotes ;do
+        # if the ssh fails, just leave the name alone
+        rem=$(ssh $ssh_opts -n $remote hostname -s 2>/dev/null || echo $remote)
+        rems="$rems $rem"
+    done
+    remotes=$rems
 
     # check if the local tools-$group directory includes any local tools
     local=0
-    if /bin/ls $pbench_run/tools-$group | grep -q -v "^remote@" ;then
+    if /bin/ls $pbench_run/tools-$group 2> /dev/null | grep -q -v "^remote@" ;then
         local=1
     fi
 
@@ -140,10 +92,11 @@ s/:[^:]*$//' | tr '\n' ' ')"
         cat >> $log <<EOF
 [tools]
 hosts: $hostname $remotes
+group: $group
 
 [tools/$hostname]
 EOF
-        for tool in $(/bin/ls $pbench_run/tools-$group) ;do
+        for tool in $(/bin/ls $pbench_run/tools-$group 2> /dev/null) ;do
             # add the options with a space in front, effectively making them continuation
             # lines as far the python config module is concerned.
             echo $tool: $(cat $pbench_run/tools-$group/$tool | sed 's/^/ /')
@@ -155,6 +108,7 @@ EOF
             cat >> $log <<EOF
 [tools]
 hosts: $remotes
+group: $group
 
 EOF
         fi
@@ -172,12 +126,13 @@ EOF
 }
 
 function metadata_log_start {
-    dir=$1
-    ts=$2
-    log=$dir/metadata.log
+    local dir=$1
+    local group=$2
+    local ts=$3
+    local log=$dir/metadata.log
 
     if [ -z "$ts" ] ;then
-        ts=$(date --utc '+%F_%H:%M:%S.%N')
+        ts=$(timestamp)
     fi
     cat > $log <<EOF
 [pbench]
@@ -188,7 +143,7 @@ date: $date
 rpm-version: $(yum list installed pbench-agent 2>/dev/null | tail -n 1 | awk '{print $2}')
 
 EOF
-    metadata_log_tools $log
+    metadata_log_tools $log $group
     cat >> $log <<EOF
 [run]
 controller: $full_hostname
@@ -197,9 +152,10 @@ EOF
 }
 
 function metadata_log_end {
-    dir=$1
-    int=$2
-    log=$dir/metadata.log
+    local dir=$1
+    local group=$2
+    local int=$3
+    local log=$dir/metadata.log
 
     if [ ! -f $log ] ;then
         # Somehow, metadata_log_start was never called !?!?
@@ -207,11 +163,11 @@ function metadata_log_end {
         # Manufacture a start_run timestamp and pass it
         # explicitly. The manufactured stamp is the date that
         # the base file calculates (now in UTC).
-        start_ts=$date
-        metadata_log_start $dir $start_ts
+        local start_ts=$(timestamp)
+        metadata_log_start $dir $group $start_ts
     fi
     if ! grep -q end_run $log ;then
-        echo "end_run: $(date --utc '+%F_%H:%M:%S.%N')" >> $log
+        echo "end_run: $(timestamp)" >> $log
     fi
     if [ "$int" == "int" ] ;then
         echo "run_interrupted: true" >> $log
@@ -221,13 +177,17 @@ function metadata_log_end {
 mkdir -p $dir
 case $1 in
     beg)
-        metadata_log_start $dir
+        metadata_log_start $dir $group
         ;;
     end)
-        metadata_log_end $dir
+        metadata_log_end $dir $group
+        name=$(basename $dir)
+        if [ -f $pbench_tmp/$name.iterations ] ;then
+            pbench-add-metalog-option $pbench_tmp/$name.iterations $dir/metadata.log iterations
+        fi
         ;;
     int)
-        metadata_log_end $dir int
+        metadata_log_end $dir $group int
         ;;
     *)
         usage

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tmp/pbench.iterations
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tmp/pbench.iterations
@@ -1,0 +1,3 @@
+iter1
+iter2
+iter3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/iostat
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/iostat
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/mpstat
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/mpstat
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/perf
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/perf
@@ -1,0 +1,5 @@
+--record-opts=-a -freq=100
+--record-opts=--call-graph
+--record-opts=--event=branch-misses
+--record-opts=--event=cache-misses
+--record-opts=--event=instructions

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/pidstat
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/pidstat
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/proc-interrupts
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/proc-interrupts
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/proc-vmstat
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/proc-vmstat
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/sar
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/sar
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/turbostat
+++ b/agent/util-scripts/samples/pbench-metadata-log/test-21/tools-default/turbostat
@@ -1,0 +1,1 @@
+--interval=3

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -99,6 +99,11 @@ function _save_tree {
 }
 function _dump_logs {
     # Dump the state of any generated script logs
+    if [ -f $_testdir/metadata.log ] ;then
+        echo "+++ metadata.log file contents" >> $_testout
+        grep -HvF "\-\-should-n0t-ex1st--" $_testdir/metadata.log >> $_testout 2>&1
+        echo "--- metadata.log file contents" >> $_testout
+    fi
     echo "+++ pbench.log file contents" >> $_testout
     grep -HvF "\-\-should-n0t-ex1st--" $_testdir/pbench.log >> $_testout 2>&1
     echo "--- pbench.log file contents" >> $_testout
@@ -182,7 +187,7 @@ declare -A tools=(
     [test-18]="pbench-list-triggers"
     [test-19]="pbench-tool-trigger-test"
     [test-20]="pbench-postprocess-tools"
-    [test-21]="pbench-clear-tools"
+    [test-21]="pbench-metadata-log"
 )
 declare -A options=(
     [test-00]="--name=mpstat --group=default -- --interval=10"
@@ -204,7 +209,7 @@ declare -A options=(
     [test-17]="--group=default"
     [test-18]="--group=foo"
     [test-20]="--dir=$_testdir/tmp --group=default --iteration=1"
-    [test-21]="--remote=fubar2"
+    [test-21]="--dir=$_testdir end"
 )
 
 declare -A expected_status=(


### PR DESCRIPTION
Bench scripts record their iterations in a temp file, which is then used by pbench-metadata-log to add a [pbench] iterations field. If that is not done, then we have to trawl through the tarball and guess the iteration names, when it is time to index. Since the benchmark scripts know their iterations, it make sense to have them save that information for later use.