### PR TITLE
correct timezone to UTC while os.stat'g tb fname

### DIFF
--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -1135,7 +1135,7 @@ def mk_user_specified_metadata(options):
 
 def mk_metadata(fname, tb, mdconf, md5sum):
     """Return a dict with metadata about a tarball"""
-    mtime = datetime.fromtimestamp(os.stat(fname)[stat.ST_MTIME])
+    mtime = datetime.utcfromtimestamp(os.stat(fname)[stat.ST_MTIME])
 
     mddict = {'generated-by': _NAME_,
               'generated-by-version': _VERSION_,


### PR DESCRIPTION
pretty much $SUBJECT (backstory: unit tests behave differently on Travis CI vs when they're run locally)