### PR TITLE
Final changes for automating server installation

### DIFF
--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -1,6 +1,7 @@
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/config
 chown pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/crontab/crontab
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/locks
+chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/pbench
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/logs
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/tmp
 +++ pbench tree state
@@ -26,12 +27,14 @@ chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/tmp
 /var/tmp/pbench-test-server/pbench/var/www
 /var/tmp/pbench-test-server/pbench/var/www/html
 /var/tmp/pbench-test-server/pbench/var/www/html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/pbench/var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL001
 /var/tmp/pbench-test-server/pbench/var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
 /var/tmp/pbench-test-server/pbench/var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
 --- pbench tree state
 +++ pbench log file contents
 --- pbench log file contents
 +++ test-execution.log file contents
-grep: /var/tmp/pbench-test-server/test-execution.log: No such file or directory
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ln -sf pbench-results-host-info.URL001.active pbench-results-host-info.URL001
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/systemctl enable httpd.service
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/systemctl start httpd.service
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ln -s /pbench/public_html/incoming /pbench/public_html/results /var/www/html
 --- test-execution.log file contents

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -78,7 +78,7 @@ function mk_dirs {
         fi
     done
     # to accommodate different exit codes from index-pbench
-    mkdir -p $ARCHIVE/$hostname/WONT-INDEX.{1..9}
+    mkdir -p $ARCHIVE/$hostname/WONT-INDEX.{1..12}
     if [[ $? -ne 0 ]]; then
         return 2
     fi

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -140,8 +140,8 @@ while read size result ;do
         PROGLOC=$(getconf.py install-dir pbench-server)
         if which python3 > /dev/null 2>&1 ;then
             # we have a python3 here
-            PYTHONPATH=${PROGLOC}/../lib:$PYTHONPATH eval\
-                "python3 ${PROGLOC}/index-pbench --config ${PROGLOC}/../lib/config/pbench-index.cfg $link"
+            PYTHONPATH=${PROGLOC}/lib:$PYTHONPATH eval\
+                "python3 ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
             status=$?
         elif which scl > /dev/null 2>&1 ;then
             # we fall back to SCL

--- a/server/pbench/bin/pbench-server-activate
+++ b/server/pbench/bin/pbench-server-activate
@@ -18,5 +18,6 @@ crontabdir=${crontabdir:-/opt/pbench-server/lib/crontab}
 pbench-server-activate-create-crontab $crontabdir $testdir || exit 2
 pbench-server-activate-setup-results-host-info $testdir || exit 3
 pbench-server-activate-create-results-dir-structure $testdir || exit 4
+pbench-server-activate-start-httpd || exit 5
 
 exit 0

--- a/server/pbench/bin/pbench-server-activate-create-results-dir-structure
+++ b/server/pbench/bin/pbench-server-activate-create-results-dir-structure
@@ -44,7 +44,7 @@ mkdir -p $archive_dir  || exit 6
 mkdir -p $pbench_dir/public_html/incoming || exit 7
 mkdir -p $pbench_dir/public_html/results || exit 8
 
-# chown -R $user.$group $pbench_dir || exit 9
+chown -R $user.$group $pbench_dir || exit 9
 
 if which selinuxenabled > /dev/null 2>&1 && selinuxenabled ;then
      if [ "${_PBENCH_SERVER_TEST}" != 1 ] ;then

--- a/server/pbench/bin/pbench-server-activate-start-httpd
+++ b/server/pbench/bin/pbench-server-activate-start-httpd
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# This script will need mods for non-systemd, non-apache environments.
+
+pbench_dir=$(getconf.py pbench-top-dir pbench-files)
+docroot=$(getconf.py documentroot apache)
+
+systemctl enable httpd.service
+systemctl start httpd.service
+ln -s $pbench_dir/public_html/incoming $pbench_dir/public_html/results $docroot
+
+exit 0

--- a/server/pbench/bin/pbench-server-activate-web-server
+++ b/server/pbench/bin/pbench-server-activate-web-server
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+pbench_install_dir=$(getconf.py install-dir pbench-server)
+docroot=$(getconf.py documentroot apache)
+
+ln -s /opt/pbench-web-server/html/static $docroot
+
+exit 0

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -233,7 +233,8 @@ while read size result ;do
     fi
 
     # now move the directory - remove the link on failure
-    mv $TMP/$PROG/$hostname/$resultname $incoming
+    # -Z needed for proper selinux labeling, but it works when selinux is disabled as well.
+    mv -Z $TMP/$PROG/$hostname/$resultname $incoming
     status=$?
     if [[ $status -ne 0 ]] ;then
         echo "$TS: Cannot move $TMP/$PROG/$hostname/$resultname to $incoming: code $status" >&4

--- a/server/pbench/bin/test-bin/ln
+++ b/server/pbench/bin/test-bin/ln
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo "$0 $*" >> $_testlog

--- a/server/pbench/bin/test-bin/systemctl
+++ b/server/pbench/bin/test-bin/systemctl
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+echo "$0 $*" >> $_testlog

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -118,7 +118,7 @@ function _verify_output {
 }
 function _setup_state {
     _state_tb=$_tdir/state/${1}.tar.xz
-    (cd $_testroot; tar xf $_state_tb; if [ ! -z "${2}" ] ;then ln -s ${2}.tar.xz ${1}.tar.xz ;fi)
+    (cd $_testroot; tar xf $_state_tb; if [ ! -z "${2}" ] ;then /bin/ln -s ${2}.tar.xz ${1}.tar.xz ;fi)
     if [[ $? -gt 0 ]]; then
         echo "ERROR: unable to create pbench hierarchy for state $1" >&2
         exit 1


### PR DESCRIPTION
With these changes, server installation requires
installing two RPMs (pbench-server-internal and pbench-web-server)
and two manual steps:

 - Install public key into pbench users authorized_keys file.
 - Enable the generated crontab after inspection.

Changes:

Uncomment the chown of $pbench_dir:
Not sure why that was commented out, but it is necessary.

Add -Z option to mv:
When moving the results from the tmp directory to incoming/, with
selinux enabled, the files need to be relabeled as httpd_content_t
in order to allow httpd to access them. `mv -Z' does that and it does
not create any problems on non-selinux-enabled systems.

Add script to start httpd:
Add a script to start httpd and make the appropriate links into the
document root. Call the script from the postinstall
pbench-server-activate script.

Add script to make the static link for pbench-web-server. Add this
script to the pbench-web-server postinstall actions.

Make script executable and fix unit tests:
Make pbench-server-activate-start-httpd executable.
Mock out systemctl and ln for use in unit tests.
Make the ln in unittests/_setup_state be the "real" ln (/bin/ln).
Fix the test-8 gold output.