### PR TITLE
Add support to pbench-collect-sysinfo to collect only the info requested

### DIFF
--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -8,7 +8,7 @@
 # To run a custom benchmark, run "user-benchmark --config="your-config-description" -- "your benchmark's executable with any options"
 #			for example: user-benchmark --config="specjbb2005-4-JVMs" -- /root/SPECjbb/run_specjbb4.sh
 #
-# for running in docker example would be 
+# for running in docker example would be
 #
 # user-benchmark --config="specjbb2005-4-JVMs" -- docker run -it _docker_image_ /root/SPECjbb/run_specjbb4.sh
 # for example: user-benchmark --config="docker-specjbb2005-4-JVMs" -- docker run -it r7perf /root/SPECjbb/run_specjbb4.sh
@@ -32,9 +32,10 @@ benchmark="pbench-user-benchmark"
 # Defaults
 config=""
 tool_group=default
+sysinfo=default
 
 # Process options and arguments
-opts=$(getopt -q -o C: --longoptions "config:,tool-group:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o C: --longoptions "config:,tool-group:,sysinfo:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf -- "$*\n"
 	printf "\n"
@@ -42,6 +43,8 @@ if [ $? -ne 0 ]; then
 	printf "\tThe following options are available:\n\n"
 	printf -- "\t\t-C str --config=str            name of the test config\n"
 	printf -- "\t\t       --tool-group=str\n"
+	printf -- "\t\t       --sysinfo=str,          str = comma seperated values of sysinfo to be collected\n"
+	printf -- "\t\t                                     available: $(pbench-collect-sysinfo --options)\n"
 	exit 1
 fi
 eval set -- "$opts";
@@ -62,6 +65,19 @@ while true; do
 			shift;
 		fi
 		;;
+                --sysinfo)
+                shift;
+                if [ -n "$1" ]; then
+			sysinfo="$1"
+			pbench-collect-sysinfo --sysinfo=$sysinfo --check
+			if [ $? == 0 ]; then
+				:
+			else
+				exit 1
+			fi
+			shift;
+                fi
+                ;;
 		--)
 		shift;
 		break;
@@ -105,6 +121,5 @@ echo $iteration >> $benchmark_iterations
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
-pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir end
-
+pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo end
 rmdir $benchmark_results_dir/.running

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -16,22 +16,31 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 group=default
 dir="/tmp"
+sysinfo_opts_default=( block libvirt kernel_config sos topology )
+sysinfo_opts=${sysinfo_opts_default[*]}
+check=false
 
-# always notify the user, as collection can sometimes take a while
-echo "Collecting system information"
+# Display sysinfo options 
+function display_sysinfo_opts {
+	printf "default, none, all"
+	for item in ${sysinfo_opts[*]}; do printf ", %s" $item ; done
+}
 
 # Process options and arguments
 
-opts=$(getopt -q -o d:g: --longoptions "dir:,group:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o d:g: --longoptions "dir:,group:,options,sysinfo:,check" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
 	printf "The following are required:\n\n"
-	printf -- "\t-d str --dir=str, str = a directory where the $script_name\n"
-	printf -- "\t                        will store and process data\n"
+	printf -- "\t-d str --dir=str,     str = a directory where the $script_name\n"
+	printf -- "\t                            will store and process data\n"
 	printf "\n"
-	printf -- "\t-g str --group=str, str = a tool group used in a benchmark\n"
-	printf -- "\t                          (the default group is 'default')\n"
+	printf -- "\t-g str --group=str,   str = a tool group used in a benchmark\n"
+	printf -- "\t                            (the default group is 'default')\n"
+	printf -- "\t       --sysinfo=str, str = comma seperated values of sysinfo to be collected\n"
+	printf -- "\t                            available: $(display_sysinfo_opts)\n"
+	printf -- "\t       --check,       checks if sysinfo is set to one of the accepted values\n"
 	printf "\n"
 	exit 1
 fi
@@ -52,12 +61,52 @@ while true; do
 			shift;
 		fi
 		;;
+		--options)
+		display_sysinfo_opts
+		exit 0
+		;;
+		--sysinfo)
+		shift;
+		if [ -n "$1" ]; then
+			sysinfo="$1"
+			shift;
+		fi
+		;;
+		--check)
+		check=true
+		shift;
+		;;
 		--)
 		shift;
 		break;
 		;;
 	esac
 done
+	
+if $check; then
+	if [ "$sysinfo" == "all" ] || [ "$sysinfo" == "default" ] || [ "$sysinfo" == "none" ]; then
+		:
+	else
+		for item in ${sysinfo//,/ }; do
+			if echo "${sysinfo_opts[@]}" | grep -q -w "$item"; then
+				continue
+			else
+				echo "$item is not a valid sysinfo option"
+				exit 1
+			fi
+		done
+	fi
+	exit 0
+fi
+if [ "$sysinfo" == "none" ]; then
+	exit 0
+fi
+if [ "$sysinfo" == "default" ]; then
+	sysinfo=${sysinfo_opts_default[*]}
+fi
+if [ "$sysinfo" == "all" ]; then
+	sysinfo=${sysinfo_opts[*]}
+fi
 
 name="$1"
 if [ -z "$name" ]; then
@@ -75,6 +124,9 @@ if [ ! -d $dir ]; then
 	error_log "Unable to create working directory, $dir"
 	exit 1
 fi
+
+# always notify the user, as collection can sometimes take a while
+echo "Collecting system information"
 
 # Ensure we have a tools group directory to work with
 if [ -d "$pbench_run/tools-$group" ]; then
@@ -104,7 +156,7 @@ function gather_remote_sysinfo_data {
 	local remote_host=$1
 	local remote_label=$2
 	debug_log "[$script_name]running sysinfo-dump on $remote_host"
-	cmd="ssh $ssh_opts -n $remote_host pbench-remote-sysinfo-dump $sysinfo_path $remote_label"
+	cmd="ssh $ssh_opts -n $remote_host pbench-remote-sysinfo-dump $sysinfo_path "$sysinfo" $remote_label"
 	debug_log "[$script_name] $cmd > $sysinfo_path/$remote_label$remote_host.tar.xz 2> $sysinfo_path/$remote_label$remote_host.err"
 	$cmd > $sysinfo_path/$remote_label$remote_host.tar.xz 2> $sysinfo_path/$remote_label$remote_host.err
 	if [ $? -ne 0 ]; then
@@ -157,7 +209,7 @@ done
 if [ $lcl_cnt -gt 0 ]; then
 	# We found local tools, or a label, specified in the tools group
 	# file, so we should collect sysinfo data locally
-        pbench-sysinfo-dump "$sysinfo_path" $lcl_label &
+	pbench-sysinfo-dump "$sysinfo_path" "$sysinfo" "$lcl_label" &
 fi
 wait
 
@@ -166,4 +218,3 @@ pbench-metadata-log --group=$group --dir=$dir $name
 status=$?
 
 exit $status
-

--- a/agent/util-scripts/pbench-remote-sysinfo-dump
+++ b/agent/util-scripts/pbench-remote-sysinfo-dump
@@ -12,7 +12,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # other output and emitting that on stderr.
 
 sysinfo_path=$1
-label=$2
+sysinfo=$2
+label=$3
 
 mkdir -p $sysinfo_path
 if [ ! -d $sysinfo_path ]; then
@@ -20,7 +21,7 @@ if [ ! -d $sysinfo_path ]; then
 	exit 1
 fi
 
-pbench-sysinfo-dump $sysinfo_path $label
+pbench-sysinfo-dump $sysinfo_path "$sysinfo" $label
 if [ $? -ne 0 ]; then
 	echo "\"pbench-sysinfo-dump $sysinfo_path $label\" failed!" >&2
 	exit 1

--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -4,6 +4,7 @@
 script_path=`dirname $0`
 script_name=`basename $0`
 pbench_bin="`cd ${script_path}/..; /bin/pwd`"
+sysinfo=$2
 
 # source the base script
 . "$pbench_bin"/base
@@ -18,7 +19,7 @@ if [[ ! -d "$dir" ]]; then
 	exit 1
 fi
 
-label=$2
+label=$3
 if [[ -z "$label" ]]; then
     dir="$dir/$hostname"
 else
@@ -95,10 +96,20 @@ function collect_sos {
 	fi
 }
 
-collect_kernel_config &
-collect_libvirt &
-collect_topology &
-collect_sos &
-collect_block &
+for item in ${sysinfo//,/ };do
+        if [[ "$item" == "kernel_config" ]]; then
+		collect_kernel_config &
+        elif [[ "$item" == "libvirt" ]]; then
+        	collect_libvirt &
+        elif [[ "$item" == "topology" ]]; then
+        	collect_topology &
+        elif [[ "$item" == "sos" ]]; then
+        	collect_sos &
+        elif [[ "$item" == "block" ]]; then
+        	collect_block &
+	else
+		debug_log "[$script_name]bad sysinfo value"
+     	fi
+done
 wait
 chmod -R 775 $dir


### PR DESCRIPTION
By default collect-sysinfo collects kernel_config, block, libvirt, sos and block. This commit will allow users to choose whether to collect sysinfo or not. This also adds ability to pass the info to be collected as comma separated values when starting a benchmark run. Ara which helps in tracking ansible runs is also available as an option. 