### PR TITLE
Add support to user-benchmark to add run info to metadata.log, emit a json file to be indexed

### DIFF
--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
@@ -1,0 +1,36 @@
++++ Running test-09 pbench-user-benchmark
+Running user-benchmark-script no-file
+WARNING:root:benchmark run didn't create a /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json or the file is empty
+--- Finished test-09 pbench-user-benchmark (status=0)
+{
+    "duration":0,
+    "duration_units":"sec"
+}+++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark__1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script no-file
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
@@ -1,0 +1,37 @@
++++ Running test-10 pbench-user-benchmark
+Running user-benchmark-script no-duration
+--- Finished test-10 pbench-user-benchmark (status=0)
+{
+    "duration":0,
+    "duration_units":"sec",
+    "that":"tother",
+    "this":"that"
+}+++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark__1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script no-duration
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
@@ -1,0 +1,37 @@
++++ Running test-11 pbench-user-benchmark
+Running user-benchmark-script with-duration
+--- Finished test-11 pbench-user-benchmark (status=0)
+{
+    "duration":10,
+    "duration-units":"sec",
+    "that":"tother",
+    "this":"that"
+}+++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark__1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script with-duration
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
@@ -1,0 +1,48 @@
++++ Running test-12 pbench-user-benchmark
+Running user-benchmark-script bad-format
+ERROR:root:current position: 51
+Traceback (most recent call last):
+  File "/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/user-benchmark-wrapper", line 10, in <module>
+    data = json.load(data_file)
+  File "/usr/lib/python2.7/json/__init__.py", line 278, in load
+    **kw)
+  File "/usr/lib/python2.7/json/__init__.py", line 326, in loads
+    return _default_decoder.decode(s)
+  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
+    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
+  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
+    obj, end = self.scan_once(s, idx)
+ValueError: Expecting object: line 3 column 25 (char 50)
+--- Finished test-12 pbench-user-benchmark (status=0)
+{
+    "duration":0,
+    "duration_units":"sec"
+}+++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark__1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script bad-format
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -99,10 +99,15 @@ if [ $? != 0 ]; then
 fi
 verify_tool_group $tool_group
 iteration="1" # there can be only 1 iteration for user-benchmark
+iteration_name="1"
 benchmark_bin="$@"
 benchmark_fullname="${benchmark}_${config}_${date}"
 benchmark_run_dir="$pbench_run/${benchmark_fullname}"
+
+# we'll record the iterations in this file
 benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
+mdlog=${benchmark_run_dir}/metadata.log
+
 # make the run dir available to the user script
 export benchmark_run_dir
 benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
@@ -120,6 +125,17 @@ export benchmark_results_dir=$benchmark_results_dir
 export benchmark config
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir beg
 
+# Add data to metadata.log
+function record_iteration {
+	local iteration=$1
+	local iteration_name=$2
+	local benchmark_bin=$3
+
+	echo ${iteration} >> ${benchmark_iterations}
+	echo $iteration_name | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
+	echo $benchmark_bin | pbench-add-metalog-option ${mdlog} iterations/${iteration} user_script
+}
+record_iteration ${iteration} ${iteration_name} ${benchmark_bin}
 # on abnormal exit, make sure that the metadata log exists and is complete.
 trap "pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir int" INT QUIT
 
@@ -127,7 +143,10 @@ pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_r
 echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"
 echo $iteration >> $benchmark_iterations
+SECONDS=0
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
+benchmark_duration=$SECONDS
+$script_path/postprocess/user-benchmark-wrapper "$benchmark_run_dir" "$benchmark_duration"
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end

--- a/agent/bench-scripts/postprocess/user-benchmark-wrapper
+++ b/agent/bench-scripts/postprocess/user-benchmark-wrapper
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys, json, os, logging
+import sys, json, os, logging, shutil
 
 benchmark_run_dir = sys.argv[1]
 benchmark_duration = int(sys.argv[2])
@@ -8,12 +8,13 @@ benchmark_duration = int(sys.argv[2])
 with open('%s/user-benchmark-summary.json' % benchmark_run_dir, 'a+') as data_file:
     try:
         data = json.load(data_file)
-    except ValueError:
-        data = {}
-    if "duration" in data:
-        # JSON file has a duration field, so we don't have to do anything.
-        pass
-    else:
+    except ValueError as e:
+        position = data_file.tell()
+        if position != 0:
+            # Log the exception if the position is not 0.
+            logging.exception("current position: %d", position)
+        data = {}        
+    if "duration" not in data:
         # At this point we may or may not have a dictionary of data loaded from
         # the JSON file, but we do know that if we did load some JSON it did not
         # have a duration field in it.
@@ -22,7 +23,10 @@ with open('%s/user-benchmark-summary.json' % benchmark_run_dir, 'a+') as data_fi
     if data_file.tell() == 0:
         # Either there was nothing in the file, or they didn't create the file.
         logging.warn("benchmark run didn't create a %s/user-benchmark-summary.json or the file is empty", benchmark_run_dir)
+    # copy the input user-benchmark-summary.json file to 
+    # user-benchmark-summary-debug.json for debugging purposes
+    shutil.copyfile('%s/user-benchmark-summary.json' % benchmark_run_dir, '%s/user-benchmark-summary-debug.json' % benchmark_run_dir)
     # Prepare to re-write the file with an updated JSON document.
-    data_file.seek(0, os.SEEK_SET)
-    data_file.truncate(0)
-    json.dump(data, data_file, sort_keys=True, indent=4, separators=(',', ':'))
+    with open('%s/user-benchmark-summary-tmp.json' % benchmark_run_dir, 'w') as tmp_data_file:
+        json.dump(data, tmp_data_file, sort_keys=True, indent=4, separators=(',', ':'))
+    shutil.move('%s/user-benchmark-summary-tmp.json' % benchmark_run_dir, '%s/user-benchmark-summary.json' % benchmark_run_dir)

--- a/agent/bench-scripts/postprocess/user-benchmark-wrapper
+++ b/agent/bench-scripts/postprocess/user-benchmark-wrapper
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import sys, json, os, logging
+
+benchmark_run_dir = sys.argv[1]
+benchmark_duration = int(sys.argv[2])
+
+with open('%s/user-benchmark-summary.json' % benchmark_run_dir, 'a+') as data_file:
+    try:
+        data = json.load(data_file)
+    except ValueError:
+        data = {}
+    if "duration" in data:
+        # JSON file has a duration field, so we don't have to do anything.
+        pass
+    else:
+        # At this point we may or may not have a dictionary of data loaded from
+        # the JSON file, but we do know that if we did load some JSON it did not
+        # have a duration field in it.
+        data['duration'] = benchmark_duration
+        data['duration_units'] = "sec"
+    if data_file.tell() == 0:
+        # Either there was nothing in the file, or they didn't create the file.
+        logging.warn("benchmark run didn't create a %s/user-benchmark-summary.json or the file is empty", benchmark_run_dir)
+    # Prepare to re-write the file with an updated JSON document.
+    data_file.seek(0, os.SEEK_SET)
+    data_file.truncate(0)
+    json.dump(data, data_file, sort_keys=True, indent=4, separators=(',', ':'))

--- a/agent/bench-scripts/test-bin/mock-postprocess/user-benchmark-wrapper
+++ b/agent/bench-scripts/test-bin/mock-postprocess/user-benchmark-wrapper
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "$0 $*" >> $_testlog

--- a/agent/bench-scripts/test-bin/mock-postprocess/user-benchmark-wrapper
+++ b/agent/bench-scripts/test-bin/mock-postprocess/user-benchmark-wrapper
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "$0 $*" >> $_testlog

--- a/agent/bench-scripts/test-bin/user-benchmark-script
+++ b/agent/bench-scripts/test-bin/user-benchmark-script
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# unit test script to be called by user-benchmark-wrapper
+# Depending on arguments, it can produce a normal json
+# file with no duration, a normal json file with duration,
+# a badly formatted json file, or no json file at all.
+
+arg=$1
+json='
+        "this": "that",
+        "that": "tother"'
+
+file=$benchmark_run_dir/user-benchmark-summary.json
+
+case $arg in
+    no-file)
+        exit 0
+        ;;
+    no-duration)
+        printf "{%s\n        }\n" "$json" > $file
+        ;;
+    with-duration)
+        printf "{%s,\n        \"duration\": 10,\n        \"duration-units\": \"sec\"\n        }\n" "$json" > $file
+        ;;
+     bad-format)
+        printf "{%s\n" "$json" > $file
+        ;;
+esac

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -151,6 +151,11 @@ declare -A cmds=(
     [test-06]="pbench-fio --config=test-06  --test-type=throughput --samples=1 --client-file=/tmp/foo"
     [test-07]="pbench-user-benchmark --help"
     [test-08]="pbench-user-benchmark --sysinfo=bad"
+    [test-09]="pbench-user-benchmark -- user-benchmark-script no-file"
+    [test-10]="pbench-user-benchmark -- user-benchmark-script no-duration"
+    [test-11]="pbench-user-benchmark -- user-benchmark-script with-duration"
+    [test-12]="pbench-user-benchmark -- user-benchmark-script bad-format"
+    
 )
 
 declare -A expected_status=(
@@ -172,6 +177,10 @@ declare -A pre=(
 
 declare -A post=(
     [test-06]="rm -f /tmp/foo"
+    [test-09]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
+    [test-10]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
+    [test-11]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
+    [test-12]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
 )
 
 


### PR DESCRIPTION
This commit creates a user-benchmark-summary.json if not created by the benchmark run and adds info about the duration if not provided by callee.