### PR TITLE
Add support to collect-sysinfo to collect ara data

### DIFF
--- a/agent/ansible/ara/ara.yml
+++ b/agent/ansible/ara/ara.yml
@@ -1,0 +1,40 @@
+---
+- hosts: all
+  user: root
+  vars:
+    - sysinfo_dir: "{{ SYSINFO_DIR }}"
+    - ara_results_dir: ~/.ara
+    - ara_static_web_path: /tmp/ara
+  tasks:
+    - stat: path=~/ansible.cfg
+      register: config_status
+    - stat: path=/var/log/ansible.log
+      register: log_status
+    - name: get ansible config file from home dir
+      fetch: src=~/ansible.cfg dest={{ sysinfo_dir }}/ara/ansible.cfg flat=yes
+      when: config_status.stat.exists == True
+    - name: get ansible_config file from /etc/ansible/ansible.cfg
+      fetch: src=/etc/ansible/ansible.cfg dest={{ sysinfo_dir }}/ara/ansible.cfg flat=yes
+      when: config_status.stat.exists == False
+    - name: copy ansible.log when logging is enabled
+      fetch: src=/var/log/ansible.log  dest={{ sysinfo_dir }}/ara/ansible.log flat=yes
+      when: log_status.stat.exists == True
+    - name: fetch ara data from remote
+      synchronize:
+          src: "{{ ara_results_dir }}/"
+          dest: "{{ sysinfo_dir }}/ara"
+          mode: pull
+          archive: yes
+    - name: create dir to store ara_static_files
+      file: path={{ sysinfo_dir }}/ara/web state=directory
+    - name: Generate static content of the web application
+      shell: ara generate {{ ara_static_web_path }}
+    - name: fetch web application
+      synchronize:
+          src: "{{ ara_static_web_path }}/"
+          dest: "{{ sysinfo_dir }}/ara/web"
+          mode: pull
+          archive: yes
+    - name: clear ara web directory contents
+      file: path={{ ara_static_web_path }} state=absent
+

--- a/agent/base
+++ b/agent/base
@@ -208,6 +208,16 @@ function verify_tool_group {
 	return 0
 }
 
+# generate inventory file with controller and remotes
+export INVENTORY=/tmp/inventory.$$
+trap "rm -f $INVENTORY" QUIT INT EXIT
+function generate_inventory {
+	echo "[controller]"
+	echo $HOSTNAME
+	echo "[remote]"
+	ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+}
+
 if [[ "${_PBENCH_BENCH_TESTS}" == 1 ]] ;then
     # For unit tests, we use a mock kill:
     # disable the built-in.

--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
@@ -9,7 +9,7 @@ Options specified can be one of:
 	                            (the default group is 'default')
 
 	       --sysinfo=str, str = comma separated values of system information to be collected
-	                            available: default, none, all, block, libvirt, kernel_config, sos, topology
+	                            available: default, none, all, block, libvirt, kernel_config, sos, topology, ara
 
 	       --check,       checks if sysinfo is set to one of the accepted values
 --- Finished test-23 pbench-collect-sysinfo (status=0)

--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
@@ -1,5 +1,5 @@
 +++ Running test-24 pbench-collect-sysinfo
-default, none, all, block, libvirt, kernel_config, sos, topology--- Finished test-24 pbench-collect-sysinfo (status=0)
+default, none, all, block, libvirt, kernel_config, sos, topology, ara--- Finished test-24 pbench-collect-sysinfo (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/tmp

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -16,7 +16,7 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 group=default
 dir="/tmp"
-sysinfo_opts_default=( block libvirt kernel_config sos topology )
+sysinfo_opts_default=( block libvirt kernel_config sos topology ara )
 sysinfo_opts=${sysinfo_opts_default[*]}
 check=false
 
@@ -93,7 +93,7 @@ while true; do
 		;;
 	esac
 done
-	
+
 if $check; then
 	if [ "$sysinfo" == "all" ] || [ "$sysinfo" == "default" ] || [ "$sysinfo" == "none" ]; then
 		:

--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -96,20 +96,33 @@ function collect_sos {
 	fi
 }
 
+function collect_ara_data {
+	# collect data only when ara is installed
+	if python -c "import ara" &>/dev/null; 
+		mkdir $dir/ara
+		generate_inventory > $INVENTORY
+		ansible-playbook -i ${INVENTORY} --extra-vars '{"SYSINFO_DIR":"'$dir'"}' "$pbench_install_dir/ansible/ara/ara.yml"
+	else
+		debug_log "[$script_name]skipping, $item not installed"
+	fi
+}
+
 for item in ${sysinfo//,/ };do
-        if [[ "$item" == "kernel_config" ]]; then
+	if [[ "$item" == "kernel_config" ]]; then
 		collect_kernel_config &
-        elif [[ "$item" == "libvirt" ]]; then
-        	collect_libvirt &
-        elif [[ "$item" == "topology" ]]; then
-        	collect_topology &
-        elif [[ "$item" == "sos" ]]; then
-        	collect_sos &
-        elif [[ "$item" == "block" ]]; then
-        	collect_block &
+	elif [[ "$item" == "libvirt" ]]; then
+		collect_libvirt &
+	elif [[ "$item" == "topology" ]]; then
+		collect_topology &
+	elif [[ "$item" == "sos" ]]; then
+		collect_sos &
+	elif [[ "$item" == "block" ]]; then
+		collect_block &
+	elif [[ "$item" == "ara" ]]; then
+		collect_ara_data &> $pbench_log
 	else
 		debug_log "[$script_name]bad sysinfo value"
-     	fi
+	fi
 done
 wait
 chmod -R 775 $dir


### PR DESCRIPTION
This will allow us to collect ara data from the remotes involved in a benchmark run so that we will be able to view the dashboard when the results are moved to the pbench server.