### PR TITLE
proposal to change exported time format

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -44,7 +44,7 @@ pbench_tspp_dir=$pbench_install_dir/tool-scripts/postprocess
 pbench_bspp_dir=$pbench_install_dir/bench-scripts/postprocess
 export pbench_install_dir pbench_tspp_dir pbench_bspp_dir pbench_run
 
-TS_FORMAT="%FT%H:%M:%S"
+TS_FORMAT="%FT%H_%M_%S"
 
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     function timestamp {


### PR DESCRIPTION
from 
`TS_FORMAT="%FT%H:%M:%S"`
to
`TS_FORMAT="%FT%H_%M_%S"`

reason for this, when trying to export $benchmark_run_dir inside container , eg

docker run  --privileged -it -v $benchmark_run_dir:/pbench  image bash

it will fail with

```
/usr/bin/docker-current: Error response from daemon: Invalid bind mount spec "/var/lib/pbench-agent/pbench-user-benchmark_sysbenchincontainer_2017-04-11_15:17:06:/pbench": Invalid volume specification: '/var
```
time format with ":" in directory name is not working with docker as that is interpreted as point where to look `source:destination` when "-v" volume flag is used

Signed-off-by: Elvir Kuric <elvirkuric@gmail.com>