### PR TITLE
Update the rsync script to remove slowness

### DIFF
--- a/server/pbench/bin/gold/test-10.txt
+++ b/server/pbench/bin/gold/test-10.txt
@@ -34,5 +34,5 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/pbench-rsync-satellite.log:run-1900-01-01T00:00:00-UTC: duration (secs): 0
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo.bar.com if cd /var/tmp/pbench-test-server/pbench/archive;then ls ;else exit 1 ;fi
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo.bar.com if cd /var/tmp/pbench-test-server/pbench/archive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi
 --- test-execution.log file contents

--- a/server/pbench/bin/gold/test-11.txt
+++ b/server/pbench/bin/gold/test-11.txt
@@ -23,9 +23,12 @@
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/INDEXED
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/SYNCED
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/TO-COPY-SOS
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/TODO
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/TO-INDEX
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/TO-LINK
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/TO-SYNC
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/WONT-INDEX
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/WONT-INDEX.1
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/WONT-INDEX.10
@@ -81,7 +84,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/pbench-rsync-satellite.wq.trimmed:TEST2::controller/fio__2016-08-16_22:03:11.tar.xz 1558168
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo2.bar.com if cd /var/tmp/pbench-test-server/pbench/archive;then ls ;else exit 1 ;fi
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo2.bar.com if cd /var/tmp/pbench-test-server/pbench/archive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -av --exclude-from=/var/tmp/pbench-test-server/pbench/tmp/pbench-rsync-satellite.XXXXX/exclude --log-file=/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/controller/rsync.log foo2.bar.com:/var/tmp/pbench-test-server/pbench/archive/controller/ .
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
@@ -101,7 +104,7 @@
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:sent ### bytes  received ### bytes  ###.## bytes/sec
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:total size is 0  speedup is 0.00
 /var/tmp/pbench-test-server/test-execution.log:
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo2.bar.com cd /var/tmp/pbench-test-server/pbench/archive/controller; xargs rm
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/ssh foo2.bar.com cd /var/tmp/pbench-test-server/pbench/archive/controller; /opt/pbench-server/bin/pbench-satellite-cleanup
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/mailx -s pbench-rsync-satellite: TEST2: 2 files processed, 0 remove failures, 1 md5 failures admins@example.com
 /var/tmp/pbench-test-server/test-execution.log:Processed files:
 /var/tmp/pbench-test-server/test-execution.log:TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz 7028

--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -30,7 +30,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -20,7 +20,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of files: 1 (dir: 1)
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:Number of created files: 0

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -65,7 +65,10 @@ fi
 mail_recipients=$(getconf.py mailto pbench-server)
 
 # make all the state directories for the pipeline and any others needed
-LINKDIRS="TODO TO-COPY-SOS TO-INDEX INDEXED WONT-INDEX DONE BAD-MD5"
+LINKDIRS="TODO TO-COPY-SOS TO-SYNC SYNCED TO-LINK TO-INDEX INDEXED WONT-INDEX DONE BAD-MD5"
+
+# list of the state directories which will be excluded during rsync
+EXCLUDE_DIRS="$LINKDIRS WONT-INDEX*"
 
 function mk_dirs {
     hostname=$1

--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -66,7 +66,7 @@ if [[ -z "$mail_recipients" ]] ;then
 fi
 # for testing, limit it to a few hosts and stay away from the largest tarballs
 # hosts=$(ssh $remotehost "cd $remotearchive; ls | grep -v 300 | sed 4q")
-hosts=$(ssh $remotehost "if cd $remotearchive;then ls ;else exit 1 ;fi")
+files=$(ssh $remotehost "if cd $remotearchive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi")
 rc=$?
 if [[ $rc != 0 ]] ;then
     echo "$PROG: ssh $remotehost \"cd $remotearchive; ls\" failed."
@@ -74,7 +74,7 @@ if [[ $rc != 0 ]] ;then
 fi
 
 # check if we are running under the unit test regime
-if [ ${_PBENCH_SERVER_TEST} = "1" ] ;then
+if [ "${_PBENCH_SERVER_TEST}" = "1" ] ;then
     # make the names reproducible for unit tests
     tmp=$TMP/$PROG.XXXXX
     status=status.XXXXX
@@ -86,19 +86,14 @@ else
     dryrun=
 fi
 
+hosts="$(for host in $files;do echo ${host%%/*};done | sort -u )"
+
 trap "rm -rf $tmp" EXIT
 
 mkdir -p $tmp
 
 exclude=$tmp/exclude
-cat <<EOF > $exclude
-TODO
-TO-INDEX
-TO-COPY-SOS
-INDEXED
-DONE
-WONT-INDEX*
-EOF
+echo $EXCLUDE_DIRS | tr ' ' '\n' > $exclude
 
 log_init $(basename $0)
 logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
@@ -128,6 +123,7 @@ for host in $hosts ;do
         echo "FAILED:    rsync -av $remotehost:$remotearchive/$host/ ."
         let failures=failures+1
     fi
+
     # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
     mk_dirs $prefix::$host
 
@@ -140,9 +136,8 @@ for host in $hosts ;do
     if [ -s $md5list ] ;then
         md5sum -c $(cat $md5list) | sed "s/^/$host: /" > $logdir/$host/md5-checks.log
         # delete all that check out
-        for x in $(sed -n '/OK$/s/: OK//p' $logdir/$host/md5-checks.log) ;do
-            echo $x $x.md5
-        done | ssh $remotehost "cd $remotearchive/$host; xargs rm" > $logdir/$host/rm.log 2>&1
+        grep 'OK' $logdir/$host/md5-checks.log |
+            ssh $remotehost "cd $remotearchive/$host; /opt/pbench-server/bin/pbench-satellite-cleanup" > $logdir/$host/rm.log 2>&1
     fi
     popd > /dev/null
 done

--- a/server/pbench/bin/pbench-satellite-cleanup
+++ b/server/pbench/bin/pbench-satellite-cleanup
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import sys
+import os
+import shutil
+for line in sys.stdin:
+    tarball = line.split(": ")[1]
+    try:
+        src = "TO-SYNC/%s" % tarball
+        des = "SYNCED"
+        shutil.move(src, des)
+    except Exception as e:
+        print (e)
+        continue
+    try:
+        os.remove('%s' % tarball)
+    except Exception as e:
+        print (e)
+    try:
+        os.remove('%s.md5' % tarball)
+    except Exception as e:
+        print (e)
+    name = ('.prefix/prefix.%s' % tarball.strip('.tar.xz'))
+    if name:
+        try:
+            os.remove(name)
+        except Exception as e:
+            print (e)


### PR DESCRIPTION
Fix of #537 #555 #557 

The trouble is that the rsync is run for every host, whether that host has any tarballs for copying or not. Unfortunately, that takes about 5 seconds, even if the host directory is empty. For a couple of hundred hosts, we end up spending 20 minutes in this loop, even if there is nothing to be done.

But now the script is updated to sync only that hosts, which has tarballs to copy. Two more state directories are made, named TO-SYNC and SYNCED, to track which tarballs are getting synced. If a user, uses any prefix while moving result it will saved under .prefix/ in the production server. It will also get deleted from the .prefix/ on the remote server.