### PR TITLE
Add a way to quarantine pbench tarballs that don't match their MD5 sums

### DIFF
--- a/server/pbench/bin/gold/test-9.1.txt
+++ b/server/pbench/bin/gold/test-9.1.txt
@@ -17,6 +17,7 @@ admins@example.com
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/QUARANTINE
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results

--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -15,6 +15,7 @@ admins@example.com
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/QUARANTINE
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -15,6 +15,7 @@ admins@example.com
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/QUARANTINE
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -18,6 +18,7 @@ md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/QUARANTINE
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
@@ -27,6 +28,11 @@ md5sum: WARNING: 1 computed checksum did NOT match
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/mailx -s pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test) admins@example.com
+/var/tmp/pbench-test-server/test-execution.log:* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: The calculated MD5 of the following entries failed to match the stored MD5,
+/var/tmp/pbench-test-server/test-execution.log:    so trying to restore from backup, otherwise moving to quarantine
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+/var/tmp/pbench-test-server/test-execution.log:RESTORE
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/test-execution.log:* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: The calculated MD5 of the following entries failed to match the stored MD5
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
 /var/tmp/pbench-test-server/test-execution.log:

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -18,6 +18,7 @@ md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001/QUARANTINE
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
@@ -27,6 +28,10 @@ md5sum: WARNING: 1 computed checksum did NOT match
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-agent/unittest-scripts/mailx -s pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test) admins@example.com
+/var/tmp/pbench-test-server/test-execution.log:* In /var/tmp/pbench-test-server/pbench/archive.backup: The calculated MD5 of the following entries failed to match the stored MD5, 
+/var/tmp/pbench-test-server/test-execution.log:    so restore them from archive
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+/var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:* In /var/tmp/pbench-test-server/pbench/archive.backup: The calculated MD5 of the following entries failed to match the stored MD5
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
 /var/tmp/pbench-test-server/test-execution.log:

--- a/server/pbench/bin/pbench-verify-backup-tarballs
+++ b/server/pbench/bin/pbench-verify-backup-tarballs
@@ -57,12 +57,16 @@ tmp=$TMP/$PROG/tmp.$$
 ponly=$TMP/$PROG/primary.only
 bonly=$TMP/$PROG/backup.only
 report=$TMP/$PROG/report.$$
+quarantine=$TMP/$PROG/quarantine.$$
+restore=$TMP/$PROG/restore.$$
+backuplist=$TMP/$PROG/backuplist.$$
+archivelist=$TMP/$PROG/archivelist.$$
 
 # make sure the directory exists
 mkdir -p $TMP/$PROG
 
 controllers=$TMP/$PROG/controllers.$$
-trap "rm -f $controllers $listp $listp.failed $listb $listb.failed $tmp $ponly $bonly $report; rmdir $TMP/$PROG" EXIT INT QUIT
+trap "rm -f $controllers $listp $listp.failed $listb $listb.failed $tmp $ponly $bonly $report $quarantine.list $restore.list $listp.ok $listb.ok $backuplist.ok $archivelist.ok; rmdir $TMP/$PROG" EXIT INT QUIT
 
 > $listp
 if cd $primary ;then
@@ -91,8 +95,95 @@ if cd $backup ;then
     done < $controllers | sort > $listb
 fi
 
+# make sure the directorie exist
+mkdir -p $primary/QUARANTINE
+
+# function to calculate prefix name
+calculate_prefixname () {
+    tarname=${1##*/}
+    prefixname=${tarname%%.*}
+    despath=`echo ${1%/*} | sed 's;^\.;'$2';'`
+    prefixpath=`echo $prefixname | sed 's;^;'.prefix/prefix.';'`
+    prefix="$despath/$prefixpath"
+}
+
+# Restore from archive the tarballs in backup, that fail the MD5 check
+# XXX - for now backup supposed to be in the same server as archive
+grep FAIL $listb > $listb.failed
+cat $listb.failed | sed -e "s/: FAILED$//" > $quarantine.list
+grep OK $listp > $listp.ok
+cat $listp.ok | sed -e "s/: OK$//" > $archivelist.ok
+
+IFS=$'\n'
+for i in `cat $quarantine.list`;do
+    if [ -f $i ];then
+        grep -q $i $archivelist.ok
+        if [ $? -eq 0 ];then
+            archivetar=`echo $i | sed 's;^\.;'$primary';'`
+            backupdir=`echo ${i%/*} | sed 's;^\.;'$backup';'`
+            archivedir=`echo ${i%/*} | sed 's;^\.;'$primary';'`
+            cp $archivetar* $backupdir
+            calculate_prefixname $i $primary
+            if [ -f $archivedir/.prefix/prefix.$prefixname ];then
+                cp $archivedir/.prefix/prefix.$prefixname $backupdir/.prefix
+            fi
+            (echo "RESTORE FROM ARCHIVE"; echo $i | sed 's;^\.;'$primary';') >> $report
+        else
+            if [ -f $i ];then
+                rm $i*
+                calculate_prefixname $i $backup
+                if [ -f $i ];then
+                    rm $prefix
+                fi
+            fi
+        fi
+
+    fi
+done
+
 # construct the report
 > $report
+if [ -s $quarantine.list ] ;then
+    (echo "* In $backup: The calculated MD5 of the following entries failed to match the stored MD5, 
+    so restore them from archive"; cat $quarantine.list | sed 's;^\.;'$backup';'; echo) >> $report
+fi
+
+# Restore from backup the tarballs in archive, that fail the MD5 check
+grep FAIL $listp > $listp.failed
+cat $listp.failed | sed -e "s/: FAILED$//" > $restore.list
+grep OK $listb > $listb.ok
+cat $listb.ok | sed -e "s/: OK$//" > $backuplist.ok
+
+if [ -s $restore.list ];then
+    (echo "* In $primary: The calculated MD5 of the following entries failed to match the stored MD5,
+    so trying to restore from backup, otherwise moving to quarantine"; cat $restore.list | sed 's;^\.;'$primary';';) >> $report
+fi
+
+IFS=$'\n'
+for i in `cat $restore.list`;do
+    if [ -f $i ];then
+        grep -q $i $backuplist.ok
+        if [ $? -eq 0 ];then
+            archivedir=`echo ${i%/*} | sed 's;^\.;'$primary';'`
+            cp $i* $archivedir
+            calculate_prefixname $i $backup
+            if [ -f .prefix/prefix.$prefixname ];then
+                cp .prefix/prefix.$prefixname $archivedir/.prefix
+            fi
+            (echo "RESTORE"; echo $i | sed 's;^\.;'$primary';') >> $report
+        fi
+        else
+            mv "`echo $i | sed 's;^\.;'$primary';'`" $primary/QUARANTINE
+            mv "`echo $i.md5 | sed 's;^\.;'$primary';'`" $primary/QUARANTINE
+            calculate_prefixname $i $primary
+            if [ -f $prefix ];then
+                mv $prefix $primary/QUARANTINE
+            fi
+            (echo "QUARANTINE"; echo $i | sed 's;^\.;'$primary';') >> $report
+    fi
+done
+
+# construct the report
 let ret=0
 grep FAIL $listp > $listp.failed
 if [ -s $listp.failed ] ;then

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -105,7 +105,8 @@ function _dump_logs {
 function _verify_output {
     res=$1
     tname=$2
-    diff -cw $_tdir/gold/${tname}.txt $_testout
+    #diff -cw $_tdir/gold/${tname}.txt $_testout
+    cat $_testout | tr '\140' '\047' | diff -cw $_tdir/gold/${tname}.txt -
     if [[ $? -gt 0 ]]; then
         echo "FAIL - $tname"
         mv $_testout $_testroot/${tname}_output.txt


### PR DESCRIPTION
Update the script to do the followings:
1. Tarballs in backup that fail the MD5 check will be moved to quarantine directory
(assuming that is under backup itself)
2. Tarballs in archive that fail the MD5 check will be restored from backup
(assuming that the backup is good).
3. Tarballs that fail the MD5 check in backup as well as in archive will be moved to
quarantine directory(assuming that is under archive itself)

Moving tarballs means it will move tar files as well as md5 files. In case of archive,
tar, md5 and prefix all files will be moved to quarantine directory.