### PR TITLE
Update the script to check distro before installing python-pandas.

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -444,7 +444,11 @@ function fio_install() {
 # install python-pandas on the controller: fiologparser_hist.py needs it
 function pandas_install() {
 	if [ "$postprocess_only" = "n" ]; then
-		if check_install_rpm python-pandas; then
+		pandas_pkg=$(getconf.py pandas-package packages)
+		if [[ -z ${pandas_pkg} ]] ;then
+			return 1
+		fi
+		if check_install_rpm ${pandas_pkg}; then
 			debug_log "[$script_name]python-pandas is installed"
 		else
 			debug_log "[$script_name]python-pandas installation failed, exiting."
@@ -745,6 +749,11 @@ fio_install
 # pandas installed only on controller
 if [ "$remote_only" = "n" ] ;then
 	pandas_install
+	sts=$?
+	if [[ $sts != 0 ]] ;then
+		echo "Could not install pandas package"
+		exit $sts
+	fi
 fi
 if [ "$install_only" = "y" ]; then
 	exit 0

--- a/agent/bench-scripts/samples/pbench-agent.cfg
+++ b/agent/bench-scripts/samples/pbench-agent.cfg
@@ -1,0 +1,3 @@
+[packages]
+pandas-package = python-pandas
+

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -201,9 +201,9 @@ declare -A rundirs=(
     
 )
 declare -A pre=(
-    [test-04]="cp $_tdir/samples/test-04.tar.xz $_testdir/samples"
-    [test-05]="cp $_tdir/samples/test-05.tar.xz $_testdir/samples"
-    [test-06]="cp $_tdir/samples/test-06.tar.xz $_testdir/samples; echo foo bar baz | tr ' ' '\n' > /tmp/foo"
+    [test-04]="cp $_tdir/samples/test-04.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
+    [test-05]="cp $_tdir/samples/test-05.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
+    [test-06]="cp $_tdir/samples/test-06.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg; echo foo bar baz | tr ' ' '\n' > /tmp/foo"
 )
 
 declare -A post=(

--- a/agent/config/pbench-agent.cfg.example
+++ b/agent/config/pbench-agent.cfg.example
@@ -24,6 +24,12 @@ dir = /pbench/public_html/incoming
 default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat
 interval = 3
 
+[packages]
+# RHEL has python-pandas
+pandas-package = python-pandas
+# Fedora has python2-pandas and python3-pandas
+pandas-package = python2-pandas
+
 [config]
 path = %(pbench_install_dir)s/config
 files = pbench-agent.cfg


### PR DESCRIPTION
FIX #579 

Fedora 24 (and maybe later) has python2-pandas and python3-pandas packages, but no python-pandas.
pbench-fio on the other hand tries to install the latter. So now the script will install package
according to the distro.