### PR TITLE
Add flexible way to register tools on 2 or all nodes

### DIFF
--- a/contrib/ansible/openshift/README.md
+++ b/contrib/ansible/openshift/README.md
@@ -28,8 +28,13 @@ Your inventory should have groups of hosts describing the roles they play in the
 
 [lb]
 
+[pbench-controller:vars]
+register_all_nodes=False
+
+By default, tools registration is done on only two of the nodes, setting the register_all_nodes to True will register tools on all of the nodes.
+
 ### Run
-Currently for pbench is run under the root user, so the playbook also needs to run as root.
+Currently pbench is run under the root user, so the playbook also needs to run as root.
 ```
 $ ansible-playbook -i /path/to/inventory --extra-vars '{ "ansible_ssh_private_key_file":"" }' pbench_register.yml
 ```

--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -28,7 +28,12 @@
       with_indexed_items: 
        - "{{ groups['nodes'][-1] }}" 
        - "{{ groups['nodes'][-2] }}"
-      when: groups['nodes']|default([])
+      when: groups['nodes']|default([]) and not ( register_all_nodes | bool )
+    - name: add nodes to the file
+      shell: echo -e {{ item.1 }} node {{ item.0 }} >> {{ file }}
+      with_indexed_items:
+       - "{{ groups['nodes'] }}"
+      when: groups['nodes']|default([]) and ( register_all_nodes | bool )
     - name: add etcd nodes to the file
       shell: echo -e {{ item.1 }} etcd {{ item.0 }} >> {{ file }}
       with_indexed_items: "{{ groups['etcd'] }}"


### PR DESCRIPTION
By default, tools are registered on two of the nodes. This commit
enables users to choose whether to register tools on two or all of
the nodes.