### PR TITLE
Add containerized pbench agent for openshift environments

### DIFF
--- a/contrib/containerized-pbench/README.md
+++ b/contrib/containerized-pbench/README.md
@@ -1,0 +1,78 @@
+# containerized-pbench
+
+## Openshift
+
+We can either build an image using the following commands or pull the image from dockerhub
+
+Build the image from source like
+
+```
+$ cd containerized-pbench/dockerfiles-pod
+$ docker build -t pbench-agent .
+```
+
+Pull the image from dockerhub, if the image is not present on the openshift nodes, it is pulled automatically from dockerhub or registry
+
+```
+$ docker pull chaitanyaenr/pbench-agent
+```
+
+Run the following commands on openshift master
+
+To launch a pbench-pod on all the nodes:
+```
+$ oc create -f containerized-pbench/openshift-templates/pbench-agent-daemonset.yml
+```
+
+By default pod is not scheduled on the master node since the scheduling is disabled. Since we are using daemonset, pods created by the Daemon controller have the machine already selected (.spec.nodeName is specified when the pod is created, so it is ignored by the scheduler) which means that the unschedulable field of a node is not respected by the DaemonSet controller and DaemonSet controller can make pods even when the scheduler has not been started. For this to work we have to create a service account and add it to the privileged scc like
+
+```
+$ oc create serviceaccount useroot
+$ oc adm policy add-scc-to-user privileged -z useroot
+$ oc patch daemonset pbench-agent --patch '{"spec":{"template":{"spec":{"serviceAccountName": "useroot"}}}}'
+```
+
+For pbench pod to run on the lb, we have configure it as a node ( node+lb ), disable scheduling on lb:
+
+```
+$ oadm manage-node node1.example.com --schedulable=false
+```
+
+Also make sure you label your nodes with type:pbench so that daemonset knows where to schedule the pbench-pod:
+
+```
+$ oc label node <node> type=pbench
+```
+
+## Jump node
+
+### Build pbench-controller image 
+
+```
+$ cd containerized-pbench/dockerfiles-jump_node 
+$ docker build -t pbench-controller .
+```
+
+### Run the container
+
+Mount your ssh-keys, inventory to be used by pbench-ansible in to the container, /var on the host to /var/lib/pbench-agent on the container like 
+
+```
+$ docker run --privileged --net=host -v /path/to/keys:/root/.ssh -v /root/inventory:/root/inventory -v /var:/var/lib/pbench-agent pbench-controller
+```
+
+Make sure you set the pbench_server and benchmark variables in vars file, a sample vars is  located at containerized-pbench/dockerfiles-jump_node/vars ans it looks like
+```
+pbench_server=foo.example.com
+benchmark=pbench-user-benchmark -- sleep 1
+```
+Mount the vars file at /root/vars like
+```
+$ docker run --privileged --net=host -v /path/to/keys:/root/.ssh -v /root/inventory:/root/inventory -v /var/home:/var/lib/pbench-agent -v containerized-pbench/dockerfiles-jump_node/vars/:/root/vars pbench-controller
+```
+This will start a service which basically runs a script which sets up the pbench-agent config file and runs the benchmark.
+
+Also make sure your ssh config file has Port set to 2202. There is a sample ssh config file for reference at containerized-pbench/dockerfiles-jump_node/config
+
+## Need for privileged container
+Docker needs to be run under privileged mode to get access to the host system's devices. Host's /var/lib/pbench-agent directory, /proc are mounted on to the container.

--- a/contrib/containerized-pbench/dockerfiles-jump_node/Dockerfile
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/Dockerfile
@@ -1,0 +1,37 @@
+#Dockerfile for pbench-controller
+FROM centos/tools
+MAINTAINER Ravi Elluri <nelluri@redhat.com>
+
+# Setup pbench
+RUN curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo && \
+    yum --enablerepo=ndokos-pbench install -y configtools openssh-clients pbench-agent pbench-sysstat iproute sysvinit-tools openssh-server git && \
+    source /etc/profile.d/pbench-agent.sh && \
+    curl -L https://github.com/openshift/origin/releases/download/v1.2.1/openshift-origin-client-tools-v1.2.1-5e723f6-linux-64bit.tar.gz | tar -zx && \
+    mv openshift*/oc /usr/local/bin && \
+    rm -rf openshift-origin-client-tools-*
+
+# Install ansible and other dependencies
+RUN mkdir -p /root/.ssh 
+RUN yum install -y epel-release && yum install -y ansible
+RUN yum -y install bind-utils blktrace ethtool findutils git gnuplot golang httpd-tools hwloc iotop iptables-services kernel ltrace mailx maven netsniff-ng net-tools ntp ntpdate numactl pciutils perf python-docker-py python-flask python-pip python-rbd python2-boto3 powertop psmisc rpm-build screen sos strace tar tcpdump tmux vim-enhanced xauth wget yum-utils rpmdevtools ceph-common glusterfs-fuse iscsi-initiator-utils
+
+# setup pbench-ansible, svt
+COPY pbench-agent.cfg /opt/pbench-agent/config/pbench-agent.cfg
+WORKDIR /root
+RUN git clone https://github.com/distributed-system-analysis/pbench.git && git clone https://github.com/openshift/svt.git
+COPY script.sh script.sh
+RUN chmod +x script.sh 
+
+# Setup sshd
+RUN yum install -y openssh-server openssh-clients && yum clean all
+RUN sed -i "s/#Port 22/Port 2022/" /etc/ssh/sshd_config
+RUN systemctl enable sshd
+EXPOSE 2022
+
+# initscripts
+RUN yum install -y initscripts && yum clean all
+
+# Run pbench as service
+COPY pbench.service /etc/systemd/system/pbench.service
+RUN systemctl enable pbench.service
+ENTRYPOINT ["/usr/sbin/init"]

--- a/contrib/containerized-pbench/dockerfiles-jump_node/config
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/config
@@ -1,0 +1,14 @@
+Host <pbench_server> 
+    User root
+    Port 22
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    UserKnownHostsFile ~/.ssh/known_hosts
+    IdentityFile /opt/pbench-agent/id_rsa
+Host *
+    User root
+    Port 2202
+    StrictHostKeyChecking no
+    PasswordAuthentication no
+    UserKnownHostsFile ~/.ssh/known_hosts
+    IdentityFile ~/.ssh/id_rsa

--- a/contrib/containerized-pbench/dockerfiles-jump_node/inventory
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/inventory
@@ -1,0 +1,12 @@
+[pbench-controller]
+
+[masters]
+
+[nodes]
+
+[etcd]
+
+[lb]
+
+[pbench-controller:vars]
+register_all_nodes=False

--- a/contrib/containerized-pbench/dockerfiles-jump_node/pbench-agent.cfg
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/pbench-agent.cfg
@@ -1,0 +1,36 @@
+[DEFAULT]
+pbench_install_dir = /opt/pbench-agent
+pbench_results_redirector = $pbench_server
+pbench_web_server = $pbench_server
+
+[pbench-agent]
+install-dir = %(pbench_install_dir)s
+pbench_user = pbench
+pbench_group = pbench
+pbench_run = /var/lib/pbench-agent
+pbench_log = %(pbench_run)s/pbench.log
+
+[pbench-agent-internal]
+install-dir = /opt/pbench-agent-internal
+
+[results]
+user = pbench
+host_path = http://%(pbench_results_redirector)s/pbench-archive-host
+dir = /pbench/public_html/incoming
+ssh_opts = -o StrictHostKeyChecking=no
+webserver = %(pbench_web_server)s
+host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
+
+[pbench/tools]
+default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat
+interval = 3
+
+[sosreports]
+# if you want to collect rpm -q information, uncomment the rpm-options
+# line and (after having set up your remotes) execute pbench-distribute-config-file
+# to propagate the change to all the remotes.
+# rpm-options = -o rpm rpm.rpmq on
+
+[config]
+path = %(pbench_install_dir)s/config
+files = pbench-agent.cfg

--- a/contrib/containerized-pbench/dockerfiles-jump_node/pbench.service
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/pbench.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=pbench daemon
+After=sshd.service
+
+[Service]
+EnvironmentFile=/root/vars
+ExecStart=/root/script.sh
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/containerized-pbench/dockerfiles-jump_node/script.sh
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/script.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+. /etc/profile.d/pbench-agent.sh
+mkdir -p /var/lib/pbench-agent/tools-default
+cp /root/.ssh/id_rsa /opt/pbench-agent/id_rsa
+sed -i "/^pbench_results_redirector/c pbench_results_redirector = ${pbench_server}" /opt/pbench-agent/config/pbench-agent.cfg
+sed -i "/^pbench_web_server/c pbench_web_server = ${pbench_server}"  /opt/pbench-agent/config/pbench-agent.cfg
+pbench-clear-tools
+pbench-clear-results
+ansible-playbook -i /root/inventory /root/pbench/contrib/ansible/openshift/pbench_register.yml
+${benchmark}
+pbench-move-results
+while true; do sleep 1; done

--- a/contrib/containerized-pbench/dockerfiles-jump_node/vars
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/vars
@@ -1,0 +1,2 @@
+pbench_server=foo.example.com
+benchmark=pbench-user-benchmark -- sleep 1

--- a/contrib/containerized-pbench/dockerfiles-pod/Dockerfile
+++ b/contrib/containerized-pbench/dockerfiles-pod/Dockerfile
@@ -1,0 +1,45 @@
+#Dockerfile for pbench-agent
+FROM centos:latest
+MAINTAINER Ravi Elluri <nelluri@redhat.com>
+
+# Setup pbench
+RUN curl -s https://copr.fedorainfracloud.org/coprs/ndokos/pbench/repo/epel-7/ndokos-pbench-epel-7.repo > /etc/yum.repos.d/copr-pbench.repo && \
+    yum --enablerepo=ndokos-pbench install -y configtools openssh-clients pbench-agent pbench-sysstat iproute sysvinit-tools openssh-server git && \
+    source /etc/profile.d/pbench-agent.sh && \
+    curl -L https://github.com/openshift/origin/releases/download/v1.2.1/openshift-origin-client-tools-v1.2.1-5e723f6-linux-64bit.tar.gz | tar -zx && \
+    mv openshift*/oc /usr/local/bin && \
+    rm -rf openshift-origin-client-tools-*
+
+# Install ansible
+RUN mkdir -p /root/.ssh 
+RUN yum install -y epel-release && yum install -y ansible
+
+#Setting up systemd
+ENV container docker
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+VOLUME [ "/sys/fs/cgroup" ]
+
+# Setup sshd
+RUN yum install -y openssh-server openssh-clients && yum clean all
+RUN sed -i "s/#Port 22/Port 2022/" /etc/ssh/sshd_config
+RUN systemctl enable sshd
+EXPOSE 2022
+
+# initscripts
+RUN yum install -y initscripts && yum clean all
+
+# Mount /proc
+COPY mount.sh /root/mount.sh
+COPY pbench-pod.service /etc/systemd/system/pbench-pod.service
+RUN systemctl enable pbench-pod.service
+
+ENTRYPOINT ["/usr/sbin/init"]

--- a/contrib/containerized-pbench/dockerfiles-pod/mount.sh
+++ b/contrib/containerized-pbench/dockerfiles-pod/mount.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. /etc/profile.d/pbench-agent.sh
+mkdir -p /var/lib/pbench-agent/tools-default
+mount -o bind /proc_host /proc

--- a/contrib/containerized-pbench/dockerfiles-pod/pbench-pod.service
+++ b/contrib/containerized-pbench/dockerfiles-pod/pbench-pod.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=pbench daemon
+After=sshd.service
+
+[Service]
+ExecStart=/root/mount.sh
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/containerized-pbench/openshift-templates/pbench-agent-daemonset.yml
+++ b/contrib/containerized-pbench/openshift-templates/pbench-agent-daemonset.yml
@@ -1,0 +1,40 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: pbench-agent
+  labels:
+    name: pbench-agent
+spec:
+  template:
+    metadata:
+      labels:
+        name: pbench-agent
+    spec:
+      hostNetwork: true
+      containers:
+      - image: chaitanyaenr/pbench-agent
+        name: pbench-agent
+        imagePullPolicy: "IfNotPresent"
+        securityContext:
+          privileged: true
+        volumeMounts:
+          - name: kube-config
+            mountPath: /root/.kube
+          - name: proc-mount
+            mountPath: /proc_host
+          - name: ssh-keys
+            mountPath: /root/.ssh
+        ports:
+          - containerPort: 2022
+      volumes:
+        - name: kube-config
+          hostPath:
+            path: /root/.kube
+        - name: proc-mount
+          hostPath:
+            path: /proc
+        - name: ssh-keys
+          hostPath:
+            path: /root/.ssh
+      nodeSelector: 
+        type: pbench


### PR DESCRIPTION
This commit adds:
- openshift template to launch pbench-agent pod as daemonset
- dockerfiles for running containerized pbench-agent on the jump node
  acting as a controller
- dockerfiles for running containerized pbench-agent on the
  openshift cluster
- Readme which explains about how to get this working on openshift