### PR TITLE
Show labels of oc-nodes

### DIFF
--- a/agent/tool-scripts/oc
+++ b/agent/tool-scripts/oc
@@ -110,7 +110,7 @@ oc_data_collect() {
 }
 
 oc_data_once() { 
-    oc get nodes -o wide >> "${tool_output_dir}"/nodes.txt 
+    oc get nodes -o wide --show-labels >> "${tool_output_dir}"/nodes.txt 
     oc get ev --all-namespaces -o wide >> "${tool_output_dir}"/ev.txt 
 } 
 


### PR DESCRIPTION
Add option --show-labels into oc get nodes command.

The labels are useful when checking pbench results.
Eg, Openshift cluster can use labels to tell the role of the nodes.