### PR TITLE
Do not assume that unit tests are sequentially numbered

### DIFF
--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -205,7 +205,7 @@ tests="$*"
 if [ -z "$tests" ] ;then
     typeset -i len=${#cmds[@]}
     len=$len-1
-    tests="$(seq -f "test-%02g" 0 $len)"
+    tests=$(echo ${!cmds[*]} | tr ' ' '\n' | sort)
 fi
 
 for tst in $tests; do

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -243,7 +243,7 @@ tests="$*"
 if [ -z "$tests" ] ;then
     typeset -i len=${#tools[@]}
     len=$len-1
-    tests="$(seq -f "test-%02g" 0 $len)"
+    tests=$(echo ${!tools[*]} | tr ' ' '\n' | sort)
 fi
 
 for tst in $tests; do


### PR DESCRIPTION
The unit test names are the indices of the cmds/tools associative
array. If a unittests script is called without arguments, instead of
assuming that the tests are numbered within a sequential range, derive
the complete set of names from the indices of the array and sort them
(otherwise, they appear in hashtable ("random") order).

Modified bench-scripts and utils-scripts unittests accordingly.  The
server unittests script already did that, the tools/postprocess
unittests script uses whatever it finds in the samples subdirectory,
so it does not need this treatment.