### PR TITLE
Run move, clear results only when the respective variables are set

### DIFF
--- a/contrib/containerized-pbench/README.md
+++ b/contrib/containerized-pbench/README.md
@@ -61,11 +61,14 @@ Mount your ssh-keys, inventory to be used by pbench-ansible in to the container,
 $ docker run --privileged --net=host -v /path/to/keys:/root/.ssh -v /root/inventory:/root/inventory -v /var:/var/lib/pbench-agent pbench-controller
 ```
 
-Make sure you set the pbench_server and benchmark variables in vars file, a sample vars is  located at containerized-pbench/dockerfiles-jump_node/vars ans it looks like
+Make sure you set the pbench_server, benchmark and move_results variables in the vars file, the results are moved to the pbench server only when the move_results variable in the vars file is set to true. You can also set clear_results variable to true in case you want to clear off the existing results before starting a benchmark. A sample vars file is located at containerized-pbench/dockerfiles-jump_node/vars and it looks like
 ```
 pbench_server=foo.example.com
+clear_results=
 benchmark=pbench-user-benchmark -- sleep 1
+move_results=
 ```
+
 Mount the vars file at /root/vars like
 ```
 $ docker run --privileged --net=host -v /path/to/keys:/root/.ssh -v /root/inventory:/root/inventory -v /var/home:/var/lib/pbench-agent -v containerized-pbench/dockerfiles-jump_node/vars/:/root/vars pbench-controller

--- a/contrib/containerized-pbench/dockerfiles-jump_node/config
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/config
@@ -7,7 +7,7 @@ Host <pbench_server>
     IdentityFile /opt/pbench-agent/id_rsa
 Host *
     User root
-    Port 2202
+    Port 2022
     StrictHostKeyChecking no
     PasswordAuthentication no
     UserKnownHostsFile ~/.ssh/known_hosts

--- a/contrib/containerized-pbench/dockerfiles-jump_node/script.sh
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/script.sh
@@ -6,8 +6,12 @@ cp /root/.ssh/id_rsa /opt/pbench-agent/id_rsa
 sed -i "/^pbench_results_redirector/c pbench_results_redirector = ${pbench_server}" /opt/pbench-agent/config/pbench-agent.cfg
 sed -i "/^pbench_web_server/c pbench_web_server = ${pbench_server}"  /opt/pbench-agent/config/pbench-agent.cfg
 pbench-clear-tools
-pbench-clear-results
 ansible-playbook -i /root/inventory /root/pbench/contrib/ansible/openshift/pbench_register.yml
+if [[ "${clear_results}" == "true" ]] || [[ "${clear_results}" == "True" ]]; then
+       pbench-clear-results
+fi       
 ${benchmark}
-pbench-move-results
+if [[ "${move_results}" == "true" ]] || [[ "${move_results}" == "True" ]]; then  
+	pbench-move-results
+fi
 while true; do sleep 1; done

--- a/contrib/containerized-pbench/dockerfiles-jump_node/vars
+++ b/contrib/containerized-pbench/dockerfiles-jump_node/vars
@@ -1,2 +1,4 @@
 pbench_server=foo.example.com
+clear_results=
 benchmark=pbench-user-benchmark -- sleep 1
+move_results=


### PR DESCRIPTION
pbench-agent container runs pbench-clear-results and pbench-move-results
commands before and after each benchmark run. This commit fixes it to
run the commands only when the move_results and clear_results vars are
set to true in the vars file. This will allow us to move, clear the
results only when we want to.