### PR TITLE
Fix a subsitution bug in BenchPostprocess::get_uid

### DIFF
--- a/agent/bench-scripts/postprocess/BenchPostprocess.pm
+++ b/agent/bench-scripts/postprocess/BenchPostprocess.pm
@@ -83,7 +83,7 @@ sub get_uid {
 	while ( $uid && $uid =~ s/^([^%]*)%([^%]+)%// ) {
 		my $before_uid_marker = $1;
 		my $uid_marker = $2;
-		if ( $$uid_sources_ref{$uid_marker} ) {
+		if ( exists $$uid_sources_ref{$uid_marker} ) {
 			$mapped_uid = $mapped_uid . $before_uid_marker . $$uid_sources_ref{$uid_marker};
 		} else {
 			$mapped_uid = $mapped_uid . $before_uid_marker . "%" . $uid_marker . "%";


### PR DESCRIPTION
- Check for the existence of the hash element rather than it having a
  value which evaluates as true.

- It is possible that the value of the hash element will evaluate as
  false in which case checking it's value will fail the if
  statement. By checking for the elements existence it's value is
  irrelevant, as it should be.

- This bug was previously fixed by PR #346 but then accidentally
  reverted by PR #434.