### PR TITLE
Update the subject and body message of ssh failure mail

### DIFF
--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -141,8 +141,9 @@ for host in $hosts ;do
             ssh $remotehost "cd $remotearchive/$host; /opt/pbench-server/bin/pbench-satellite-cleanup" \
                     < $logdir/$host/ok-checks.log > $logdir/$host/rm.log 2>&1
             if [[ $? != 0 ]]; then
-                mailx -s "$PROG: $prefix: remove failure"\
-                $mail_recipients < $logdir/$host/ok-checks.log
+                (echo "The following tarballs were transferred, but they are not removed from the satellite because ssh failed";
+                cat $logdir/$host/ok-checks.log) |
+                mailx -s "$PROG: $prefix: Transferred but not removed from satellite" $mail_recipients
             fi
         fi
     fi


### PR DESCRIPTION
FIX #614 
The subject and the body was very confusing of the ssh failure mail which was sent to recipients. As the subject only says "remove failure" in the subject and have list of tarballs reported "OK" in the body of message. 

So changed it to better understand that tarballs were transferred successfully, but they are not removed from the satellite because ssh failed.