### PR TITLE
Register tools on OpenShift infra, cns nodes

### DIFF
--- a/contrib/ansible/openshift/README.md
+++ b/contrib/ansible/openshift/README.md
@@ -1,22 +1,24 @@
 ## Pbench Ansible
-Playbook to register pbench tools on openshift cluster.
+Playbook to register pbench tools on OpenShift cluster.
 
 ### Requirements
 You need to have these installed
-   - Openshift
+   - OpenShift
    - pbench
 
 ### Tools registered
-master - sar, pidstat, iostat, oc, pprof
+master - sar, pidstat, iostat, oc, pprof, prometheus-metrics, disk
 
-nodes - sar, pidstat, iostat, pprof
+nodes - sar, pidstat, iostat, pprof, disk
 
-etcd - sar, pidstat, iostat
+etcd - sar, pidstat, iostat, disk
 
-lb - sar, pidstat, iostat
+lb - sar, pidstat, iostat, disk
+
+glusterfs - sar, pidstat, iostat, pprof, disk
 
 ### Sample inventory
-Your inventory should have groups of hosts describing the roles they play in the openshift cluster. This playbook looks for the following groups in the inventory file:
+Your inventory should have groups of hosts describing the roles they play in the OpenShift cluster. This playbook looks for the following groups in the inventory file:
 
 [pbench-controller]
 
@@ -28,10 +30,13 @@ Your inventory should have groups of hosts describing the roles they play in the
 
 [lb]
 
+[glusterfs]
+
 [pbench-controller:vars]
 register_all_nodes=False
 
-By default, tools registration is done on only two of the nodes, setting the register_all_nodes to True will register tools on all of the nodes.
+Note: glusterfs group represents cns nodes.
+By default, tools registration is done on only two of the nodes, infra nodes. Setting the register_all_nodes to True will register tools on all of the nodes. 
 
 ### Run
 Currently pbench is run under the root user, so the playbook also needs to run as root.

--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -9,8 +9,10 @@
   tasks:
     - name: create pbench directory
       file: path=/run/pbench state=directory
+
     - name: clear file contents
       file: path={{ file }} state=absent
+
     - name: copy, set permissions on the register script
       copy:
         src: register.sh
@@ -18,34 +20,54 @@
         owner: root
         group: root
         mode: 0755
+
     - name: add masters to the file
       shell: echo -e {{ item.1 }} master {{ item.0 }} >> {{ file }}
       with_indexed_items:
        - "{{ groups['masters'] }}"
       when: groups['masters']|default([])
+
     - name: add nodes to the file
       shell: echo -e {{ item.1 }} node {{ item.0 }} >> {{ file }}
       with_indexed_items: 
        - "{{ groups['nodes'][-1] }}" 
        - "{{ groups['nodes'][-2] }}"
-      when: groups['nodes']|default([]) and not ( register_all_nodes | bool )
+      when: groups['nodes']|default([]) and not ( register_all_nodes | default(False) | bool )
+    
+    #  registers tools on the nodes with the following label openshift_node_labels="{'region': 'infra'} in the inventory
+    #  along with the last two nodes when register_all_nodes is set to False in the inventory
+    - name: add infra nodes to the file
+      shell: index=1; for infra in $(cat {{ inventory_file }} | grep -w "'region'":" 'infra'" | cut -d ' ' -f1); do echo -e $infra infra $index >> {{ file }} && ((index+=1)); done
+      when: groups['nodes']|default([]) and not ( register_all_nodes | default(False) | bool )
+
+    - name: add cns nodes to file
+      shell: echo -e {{ item.1 }} cns {{ item.0 }} >> {{ file }}
+      with_indexed_items:
+       - "{{ groups['glusterfs'] }}"
+      when: groups['glusterfs']|default([])
+
     - name: add nodes to the file
       shell: echo -e {{ item.1 }} node {{ item.0 }} >> {{ file }}
       with_indexed_items:
        - "{{ groups['nodes'] }}"
-      when: groups['nodes']|default([]) and ( register_all_nodes | bool )
+      when: groups['nodes']|default([]) and ( register_all_nodes | default(False) | bool )
+
     - name: add etcd nodes to the file
       shell: echo -e {{ item.1 }} etcd {{ item.0 }} >> {{ file }}
       with_indexed_items: "{{ groups['etcd'] }}"
       when: groups['etcd']|default([])
+
     - name: add lb to the file
       shell: echo -e {{ item.1}} lb {{ item.0 }} >> {{ file }}
       with_indexed_items: "{{ groups['lb'] }}"
       when: groups['lb']|default([]) 
+
     - name: register tools
       shell: sh /run/pbench/register.sh {{ default_tools_interval }} {{ ose_master_interval }} {{ ose_node_interval }} {{ file }} {{ inventory_file }}
+
     - name: create .kube directory to store config file
       file: path={{ ansible_env.HOME }}/.kube state=directory
+
     - name: get kube config from openshift master
       shell: scp {{ item }}:{{ ansible_env.HOME }}/.kube/config {{ ansible_env.HOME }}/.kube/
       with_items:

--- a/contrib/ansible/openshift/register.sh
+++ b/contrib/ansible/openshift/register.sh
@@ -73,7 +73,7 @@ while read -u 11 line;do
     pbench-register-tool --label=$label --name=haproxy-ocp --remote $remote -- --interval=$ose_master_interval --counters-clear-all
     pbench-register-tool --label=$label --name=prometheus-metrics --remote $remote -- --inventory=$inventory_file_path
   fi
-  if [ "$group" == "node" ]; then
+  if [ "$group" == "node" ] || [ "$group" == "cns" ]; then
     pbench-register-tool --label=$label --name=pprof --remote $remote -- --osecomponent=node --interval=$ose_node_interval
   fi
 done 11< $hosts


### PR DESCRIPTION
This commit will allow us to:
-  register tools on the cns nodes under [glusterfs] group
-  register tools on the nodes with the following label
   openshift_node_labels="{'region': 'infra'} in the inventory
   along with the last two nodes when register_all_nodes is set
   to False in the inventory.
