### PR TITLE
Parameterize certs and port for prometheus-metrics

### DIFF
--- a/agent/tool-scripts/datalog/prometheus-metrics-datalog
+++ b/agent/tool-scripts/datalog/prometheus-metrics-datalog
@@ -7,12 +7,13 @@ import os,subprocess,warnings,logging
 interval = int(sys.argv[2])
 master = sys.argv[1]
 tool_log = sys.argv[3]
-os.system('scp "%s:/etc/origin/master/admin.crt" "/run/pbench/keys/admin.crt"' % (master) )
-os.system('scp "%s:/etc/origin/master/admin.key" "/run/pbench/keys/admin.key"' % (master) )
+port = int(sys.argv[4])
+cert = sys.argv[5]
+key = sys.argv[6]
 while True:
     time_stamp = int(time.time())
     next_start = time_stamp + interval
-    command = "prom2json --cert=/run/pbench/keys/admin.crt --key=/run/pbench/keys/admin.key https://%s:8443/metrics" % (master)
+    command = "prom2json --cert=%s --key=%s https://%s:%d/metrics" % (cert, key, master, port)
     command_out = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     prom2json_out = command_out.communicate()[0]
     metrics_list = json.loads(prom2json_out)

--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -34,10 +34,14 @@ function usage {
 	printf -- "\t--dir=str                  directory to store data collection (required)\n"
 	printf -- "\t--interval=int             number of seconds between each data collection\n"
 	printf -- "\t--options=str              options passed directly to the tool\n"
-	printf -- "\t--inventory=str            path to the inventory file"
+	printf -- "\t--inventory=str            path to the inventory file\n"
+	printf -- "\t--port=int                 port prometheus is listening on\n"
+	printf -- "\t--cert=str                 path to the cert\n"
+	printf -- "\t--key=str                  path to the key"
+
 }
 # Process options and arguments
-opts=$(getopt -q -o idp --longoptions "inventory:,dir:,group:,iteration:,interval:,options:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o idp --longoptions "inventory:,port:,cert:,key:,dir:,group:,iteration:,interval:,options:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
@@ -67,6 +71,27 @@ while true; do
 		shift;
 		if [ -n "$1" ]; then
 			inventory="$1"
+			shift
+		fi
+		;;
+		--port)
+		shift;
+		if [ -n "$1" ]; then
+			port="$1"
+			shift
+		fi
+		;;
+		--cert)
+		shift;
+		if [ -n "$1" ]; then
+			cert="$1"
+			shift
+		fi
+		;;
+		--key)
+		shift;
+		if [ -n "$1" ]; then
+			key="$1"
 			shift
 		fi
 		;;
@@ -126,12 +151,16 @@ elif [[ ! -s "$inventory" ]] || [[ ! -f "$inventory" ]]; then
 	echo "Please check if the inventory file exists, is not empty and the inventory variable is not set to a directory"
 	exit 1
 fi
+## set default values for port if not defined
+if [ -z "$port" ]; then
+        port=8443
+fi
 ## parse openshift inventory file
 cat "$inventory" | awk -F " " '{ print $1 }' | sed -n '/^\[masters\]/,/^$/p' | awk '{if (NR!=1) {print}}' | sed '/^$/d' > /run/pbench/inv_hosts
 case "$mode" in
 	install)
 	which go &>/dev/null
-	if [[ $(echo $?) != 0 ]]; then
+	if [[ $? != 0 ]]; then
 		yum -y install go &>/dev/null
 		mkdir $pbench_install_dir/.go	
 		echo "GOPATH=$pbench_install_dir/.go" >> ~/.bashrc
@@ -145,7 +174,28 @@ case "$mode" in
 	start)
 	mkdir -p $tool_output_dir/json
 	while read -u 9 master; do
-		tool_cmd="$script_path/datalog/$tool-datalog $master $interval $tool_log"
+		# fetch keys from openshift master and set default values for cert and key vars if not defined
+		if [ -z "$cert" ]; then
+			if [ ! -s /run/pbench/keys/admin.crt ]; then
+				scp $master:/etc/origin/master/admin.crt /run/pbench/keys/admin.crt
+				if [[ $? != 0 ]]; then
+					error_log "[$script_name]scp command failed to copy the files from $master, please check if the cert exists in /etc/origin/master directory"
+					exit 1
+				fi
+			fi
+			cert=/run/pbench/keys/admin.crt
+		fi
+		if [ -z "$key" ]; then
+			if [ ! -s /run/pbench/keys/admin.key ]; then
+				scp $master:/etc/origin/master/admin.key /run/pbench/keys/admin.key
+				if [[ $? != 0 ]]; then
+					error_log "[$script_name]scp command failed to copy the files from $master, please check if the key exists in /etc/origin/master directory"
+					exit 1
+				fi	
+			fi
+			key=/run/pbench/keys/admin.key
+		fi
+		tool_cmd="$script_path/datalog/$tool-datalog $master $interval $tool_log $port $cert $key"
 		metrics_data=$tool_output_dir/$master-stdout.txt
 		debug_log "$script_name: running $tool_cmd"
 		$tool_cmd >"$metrics_data" 2>"$tool_stderr_file" & echo $! >>$tool_pid_file

--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -162,14 +162,10 @@ case "$mode" in
 	which go &>/dev/null
 	if [[ $? != 0 ]]; then
 		yum -y install go &>/dev/null
-		mkdir $pbench_install_dir/.go	
-		echo "GOPATH=$pbench_install_dir/.go" >> ~/.bashrc
-		echo "export GOPATH" >> ~/.bashrc
-		echo "PATH=\$PATH:\$GOPATH/bin # Add GOPATH/bin to PATH for scripting" >> ~/.bashrc
-		source ~/.bashrc
 	fi
-	go get github.com/prometheus/prom2json
-	go install github.com/prometheus/prom2json
+	mkdir -p $pbench_install_dir/.go
+	GOPATH=$pbench_install_dir/.go go get github.com/prometheus/prom2json
+	GOPATH=$pbench_install_dir/.go go install github.com/prometheus/prom2json
 	;;
 	start)
 	mkdir -p $tool_output_dir/json
@@ -195,10 +191,10 @@ case "$mode" in
 			fi
 			key=/run/pbench/keys/admin.key
 		fi
-		tool_cmd="$script_path/datalog/$tool-datalog $master $interval $tool_log $port $cert $key"
+		tool_cmd="GOPATH=$pbench_install_dir/.go PATH=$PATH:$GOPATH/bin $script_path/datalog/$tool-datalog $master $interval $tool_log $port $cert $key"
 		metrics_data=$tool_output_dir/$master-stdout.txt
 		debug_log "$script_name: running $tool_cmd"
-		$tool_cmd >"$metrics_data" 2>"$tool_stderr_file" & echo $! >>$tool_pid_file
+		eval $tool_cmd >"$metrics_data" 2>"$tool_stderr_file" & echo $! >>$tool_pid_file
 	done 9</run/pbench/inv_hosts
 	wait
 	;;


### PR DESCRIPTION
- By default prometheus-metrics tool uses cert, key located at
  /etc/origin/master on the master node of OpenShift cluster, fetches
  the metrics exposed by prometheus endpoint running on port 8443. This
  commit will enable us to ping endpoints running on different ports,
  which need different certs.
- User can pass the certs, port as arguments while registering the tool
  like pbench-register-tool --name=prometheus-metrics -- --inventory=
  /path/to/inventory --port <port> --cert=/path/to/cert --key=/path/to/key
- prometheus-metrics-tool checks if go is installed, if yes it won't
  check if GOPATH is set. It sets the GOPATH only when go is not
  installed. This commit fixes that.
- Instead of modifying user's .bashrc, this will set the GOPATH, adds
  the binaries to the PATH variable only while running the tool
  specific scripts, commands.
- Upstream prom2json is broken from July 10th 2017, so it might not be
  possible to test this commit.