### PR TITLE
pidstat-postprocess: nuke commas in commands.

### DIFF
--- a/agent/tool-scripts/postprocess/pidstat-postprocess
+++ b/agent/tool-scripts/postprocess/pidstat-postprocess
@@ -134,6 +134,8 @@ while ($line = <PIDSTAT_TXT>) {
 		$cmd =~ s/\s/_/g;
 		$cmd =~ s/\'//g;
 		$cmd =~ s/\"//g;
+                # commas cause problems in the CSV files.
+                $cmd =~ s/,//g;
 		# avoid 'Invalid conversion in printf: "%=" ' errors if cmd contains a %.
 		$cmd =~ s/%/%%/g;
 		$pid = $pid . "-". $cmd;

--- a/server/pbench/bin/pbench-rsync-satellite
+++ b/server/pbench/bin/pbench-rsync-satellite
@@ -1,35 +1,5 @@
 #! /bin/bash
 
-# pbench-move-results copies tarballs to the server and creates
-# symlinks to them in the controller's TODO directory. That signals
-# pbench-unpack-tarballs to process them.
-
-# This script simulates what pbench-move-results does with the
-# tarballs that it copies from a satellite server. It runs as a cron
-# job every night.
-
-# The script rsyncs the archive of pbench tarballs of a satellite
-# server to the archive of the internal production server. In the
-# process, it renames the local copy of each remote host directory by
-# prepending a specified prefix.  That way, hosts associated with the
-# satellite are disambiguated and distinguished from every other host
-# (internal or from another satellite), as long as the prefixes are
-# unique.
-
-# The tarballs are sorted by size and the list is passed to the
-# scheduler (pbench-rsync-satellite-process-work-queue), which chops
-# down the list into chunks whose total size does not exceed 50MB. The
-# scheduler then creates the link in the TODO directory of each host,
-# just as if pbench-move-results had moved the tarball here. The
-# scheduler waits for the last tarball of the chunk to be finished,
-# before submitting the next chunk. In order to make steady progress
-# through the list, the scheduler will always submit at least one
-# file, so files larger than 50MB are submitted individually. The hope
-# is that that will reduce the chance of any breakage in the
-# distributed file system where the archive is stored and will limit
-# the wait for the processing of any tarballs that are submitted by
-# pbench-move-results.
-
 # load common things
 opts=$SHELLOPTS
 case $opts in
@@ -64,9 +34,7 @@ if [[ -z "$mail_recipients" ]] ;then
     echo "$PROG: mail_recipients is not defined"
     exit -1
 fi
-# for testing, limit it to a few hosts and stay away from the largest tarballs
-# hosts=$(ssh $remotehost "cd $remotearchive; ls | grep -v 300 | sed 4q")
-files=$(ssh $remotehost "if cd $remotearchive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi")
+files=$(if cd $remotearchive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi)
 rc=$?
 if [[ $rc != 0 ]] ;then
     echo "$PROG: ssh $remotehost \"cd $remotearchive; ls\" failed."
@@ -95,7 +63,7 @@ mkdir -p $tmp
 exclude=$tmp/exclude
 echo $EXCLUDE_DIRS | tr ' ' '\n' > $exclude
 
-log_init $(basename $0)
+#log_init $(basename $0)
 logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
 mkdir -p $logdir
 rc=$?
@@ -106,175 +74,30 @@ fi
 
 let start_time=$(timestamp-seconds-since-epoch)
 echo "$TS: start - $(timestamp)"
-let failures=0
 for host in $hosts ;do
-    localdir=$ARCHIVE/$prefix::$host
-    if [ ! -d $localdir ] ;then
-        mkdir -p $localdir || exit 1
-    fi
+    localdir=$ARCHIVE/$host
     pushd $localdir >/dev/null || exit 2
     if [ ! -d $logdir/$host ] ;then
         mkdir -p $logdir/$host
     fi
-    echo "rsync -av --exclude-from=$exclude --log-file=$logdir/$host/rsync.log $remotehost:$remotearchive/$host/ ."
-    rsync -av --exclude-from=$exclude --log-file=$logdir/$host/rsync.log $remotehost:$remotearchive/$host/ .
+    echo "rsync -av --exclude-from=$exclude --log-file=$logdir/$host/rsync.log . $remotehost:$remotearchive/$prefix::$host/"
+    rsync -av --exclude-from=$exclude --log-file=$logdir/$host/rsync.log . $remotehost:$remotearchive/$prefix::$host/
     rc=$?
     if [[ $rc != 0 ]] ;then
         echo "FAILED:    rsync -av $remotehost:$remotearchive/$host/ ."
-        let failures=failures+1
     fi
 
-    # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
-    mk_dirs $prefix::$host
-
-    # check md5s and delete remote tarballs that check
-    # generate list of downloaded md5 files
+    # change the state directory of the symlinks which are successfully synced.
+    mv TO-SYNC/* SYNCED
+    status=$?
+    if [[ $status != 0 ]] ;then
+        echo "FAILED:    mv $logdir/$host/TO-SYNC SYNCED"
+    fi
     rsync_log=$logdir/$host/rsync.log
-    md5list=$tmp/$host.md5.list
-    grep '>f' $rsync_log | awk '/.md5$/	{ print $5; }' | sed '/^$/d' > $md5list
-    # check tarballs
-    if [ -s $md5list ] ;then
-        md5sum -c $(cat $md5list) | sed "s/^/$host: /" > $logdir/$host/md5-checks.log
-        # delete all that check out
-        grep 'OK' $logdir/$host/md5-checks.log > $logdir/$host/ok-checks.log
-        if [ -s $logdir/$host/ok-checks.log ] ;then
-            ssh $remotehost "cd $remotearchive/$host; /opt/pbench-server/bin/pbench-satellite-cleanup" \
-                    < $logdir/$host/ok-checks.log > $logdir/$host/rm.log 2>&1
-            if [[ $? != 0 ]]; then
-                mailx -s "$PROG: $prefix: remove failure"\
-                $mail_recipients < $logdir/$host/ok-checks.log
-            fi
-        fi
-    fi
     popd > /dev/null
 done
-
-# generate a list of downloaded files in the form "<prefix>::<host>/<file>" from the rsync log files
-list=$tmp/tb.list
-for host in $hosts ;do
-    rsync_log=$logdir/$host/rsync.log
-    cat $rsync_log | grep '>f' |
-        awk -v prefix=$prefix -v host=$host '{printf("%s::%s/%s\n", prefix, host, $5);}'
-done | sort -k1,1 > $list
-
-# decorate the list with the sizes and sort by size
-cd $ARCHIVE
-for host in $hosts ;do
-    find $prefix::$host -type f -name '*.tar.xz' -printf "%p\t%s\n" 
-done | sort -k1,1 | join - $list | sort -k2,2 -n > $logdir/$PROG.wq
-
-# we now have a work queue - process-work-queue dequeues a number of
-# them (the current batch), and for each one, adds a link to the TODO
-# directory of the corresponding host. We let pbench-unpack-tarballs
-# take care of the rest. process-work-queue waits for the last one in
-# the current batch to finish and then submits another batch. A batch
-# consists of a number of tarballs with a total size < 50MB - if the
-# constraint cannot be satisfied, a batch consists of a single tarball.
-# That way, we make progress through the queue until we are done.
-
-# XXX - limitations - trimming won't be necessary if/when these are lifted.
-# DUPLICATE names cause problems - skip them
-# No subdirectories - there is a badly named tarball (the name includes a '*' and that causes
-# a problem somewhere: not chased it down yet), which I've moved into an ASIDE subdir
-# on the satellite. 
-
-grep -v DUPLICATE $logdir/$PROG.wq | awk -F'/' 'NF==2' > $logdir/$PROG.wq.trimmed
-
-$dir/pbench-rsync-satellite-process-work-queue $dryrun --archive=$ARCHIVE $logdir/$PROG.wq.trimmed
-rc=$?
-
-# prepare status file
-failed_rm=$tmp/failed_rm.log
-for host in $hosts ;do
-    if [ -s $logdir/$prefix/$host/rm.log ] ;then
-        grep "^$host: " $logdir/$prefix/$host/rm.log
-    fi
-done > $failed_rm
-
-failed_md5=$tmp/failed_md5.log
-for host in $hosts ;do
-    if [ -n "$(grep -v 'OK$' $logdir/$host/md5-checks.log 2>/dev/null)" ] ;then
-        grep "^$host: " $logdir/$host/md5-checks.log | grep -v 'OK$'
-    fi
-done > $failed_md5
-
-nprocessed=$(wc -l < $logdir/$PROG.wq.trimmed)
-nfailed_rm=$(wc -l < $failed_rm)
-nfailed_md5=$(wc -l < $failed_md5)
-nskipped=0
-
-if [ -f $logdir/$PROG.wq.skipped ] ;then
-    nskipped=$(wc -l < $logdir/$PROG.wq.skipped)
-fi
-ncurrent=0
-if [ -f $logdir/$PROG.wq.current-batch ] ;then
-    ncurrent=$(wc -l $logdir/$PROG.wq.current-batch)
-fi
-nremaining=0
-if [ -f $logdir/$PROG.wq.remaining ] ;then
-    nremaining=$(wc -l $logdir/$PROG.wq.remaining)
-fi
-
-(echo Processed files:;
- if [ -s $logdir/$PROG.wq.trimmed ] ;then
-     cat $logdir/$PROG.wq.trimmed
-
- else
-     echo None
- fi;
- echo;
- echo =================;
- if [ -s $failed_rm ] ;then
-     echo Failed removals:;
-     cat $failed_rm
-     echo;
-     echo =================;
- fi;
- if [ -s $failed_md5 ] ;then
-     echo Failed MD5 checks:;
-     cat $failed_md5
-     echo;
-     echo =================;
- fi;
- if [ -f "$logdir/$PROG.wq.skipped" ] ;then
-     echo Skipped tarballs:;
-     cat $logdir/$PROG.wq.skipped;
-     echo;
-     echo =================;
- fi; ) > $tmp/$status
-
-if [[ $rc == 1 ]] ;then
-     echo "pbench-rsync-satellite-process-work-queue exited with status 1"
-     echo "Check $logdir/$PROG.wq.current-batch and $logdir/$PROG.wq.remaining"
-     if [ -f $logdir/$PROG.wq.current-batch ] ;then
-         echo "Current batch (some of these may have been processed already):"
-         cat $logdir/$PROG.wq.current-batch
-         echo
-         echo =================
-     fi
-     if [ -f "$logdir/$PROG.wq.files" ] ;then
-         echo "Remaining tarballs:"
-         cat $logdir/$PROG.wq.remaining
-         echo
-         echo =================
-     fi
-     echo
-     echo "$ncurrent files in current batch, $nremaining files remaining to be processed"
-     echo "Call 1-800-GHOSTBUSTERS and tell ndk about it"
-elif [[ $rc != 0 ]] ;then
-     echo "pbench-rsync-satellite-process-work-queue exited with non-zero status $rc - why?"
-fi >> $tmp/$status
-
-# ... and mail it
-if [ "$nprocessed" -gt 0 -o "$nfailed_rm" -gt 0 -o "$nfailed_md5" -gt 0 ]  ;then
-    mailx -s \
-    "$PROG: $prefix: $nprocessed files processed, $nfailed_rm remove failures, $nfailed_md5 md5 failures"\
-    $mail_recipients < $tmp/$status
-fi
 
 let end_time=$(timestamp-seconds-since-epoch)
 let duration=end_time-start_time
 echo "$TS: end - $(timestamp)"
 echo "$TS: duration (secs): $duration"
-
-exit $failures


### PR DESCRIPTION
Commas in commands cause problems with CSV files, so we nuke them.
    
Fixes #623 