### PR TITLE
pidstat-postprocess: nuke commas from commands.

### DIFF
--- a/agent/tool-scripts/postprocess/pidstat-postprocess
+++ b/agent/tool-scripts/postprocess/pidstat-postprocess
@@ -134,6 +134,8 @@ while ($line = <PIDSTAT_TXT>) {
 		$cmd =~ s/\s/_/g;
 		$cmd =~ s/\'//g;
 		$cmd =~ s/\"//g;
+                # commas cause problems in the CSV files.
+                $cmd =~ s/,//g;
 		# avoid 'Invalid conversion in printf: "%=" ' errors if cmd contains a %.
 		$cmd =~ s/%/%%/g;
 		$pid = $pid . "-". $cmd;


### PR DESCRIPTION
Commas in commands cause problems with CSV files, so we nuke them.

Fixes #623.