### PR TITLE
Add support to use different certs, port for each endpoint, run unit tests on ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: precise
 language: perl
 perl:
  - "5.20"
@@ -7,7 +8,7 @@ perl:
 before_install:
  - sudo apt-get update
 install:
- - sudo apt-get install python python-pip bc libjson-perl realpath
+ - sudo apt-get install python python-pip bc libjson-perl libswitch-perl realpath
  - sudo pip install configtools elasticsearch
  - sudo apt-get install python-software-properties
  - sudo add-apt-repository ppa:fkrull/deadsnakes -y
@@ -18,7 +19,7 @@ install:
  - sudo pip install 'configtools<0.4.0' elasticsearch
  - sudo ln -sf python3.5 /usr/bin/python3
 script:
- - ./agent/bench-scripts/unittests
- - ./agent/tool-scripts/postprocess/unittests
- - ./agent/util-scripts/unittests
- - ./server/pbench/bin/unittests
+ - LANG=C ./agent/bench-scripts/unittests
+ - LANG=C ./agent/tool-scripts/postprocess/unittests
+ - LANG=C ./agent/util-scripts/unittests
+ - LANG=C ./server/pbench/bin/unittests

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -146,6 +146,10 @@ echo $iteration >> $benchmark_iterations
 SECONDS=0
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
 benchmark_duration=$SECONDS
+# make it predictable in the unittest environment
+if [[ $_PBENCH_BENCH_TESTS == 1 ]]; then
+	benchmark_duration=0
+fi
 $script_path/postprocess/user-benchmark-wrapper "$benchmark_run_dir" "$benchmark_duration"
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -105,10 +105,15 @@ function _verify_output {
     tscrpt=$3
     expected_status=${4:-0}
     # fix up stupidities in python exception output: lib64->lib, line numbers->XXX
-    # fix up Ubuntu stupidities: backtick to single quote
+    # fix up Ubuntu stupidities: 
+    # backtick to single quote
+    # UTF-8 left single quote to ASCII apostrophe
+    # UTF-8 right single quote to ASCII apostrophe
     sed 's/lib64/lib/g
          s/, line [1-9][0-9]*, in/, line XXX, in/g' $_testout |
-         tr '\140' '\047' > $_testout.1
+         tr '\140' '\047' |
+         sed 's/\xe2\x80\x98/\x27/' | 
+         sed 's/\xe2\x80\x99/\x27/' > $_testout.1
     diff -cw $_tdir/gold/${tscrpt}/${tname}.txt $_testout.1
     if [[ $? -gt 0 ]]; then
         echo "FAIL - $tname"

--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -151,12 +151,13 @@ elif [[ ! -s "$inventory" ]] || [[ ! -f "$inventory" ]]; then
 	echo "Please check if the inventory file exists, is not empty and the inventory variable is not set to a directory"
 	exit 1
 fi
-## set default values for port if not defined
-if [ -z "$port" ]; then
-        port=8443
-fi
 ## parse openshift inventory file
-cat "$inventory" | awk -F " " '{ print $1 }' | sed -n '/^\[masters\]/,/^$/p' | awk '{if (NR!=1) {print}}' | sed '/^$/d' > /run/pbench/inv_hosts
+if [[ -d /run/pbench ]]; then
+	cat "$inventory" | sed -n '/^\[masters\]/,/^$/p' | awk '{if (NR!=1) {print}}' | sed '/^$/d' > /run/pbench/inv_hosts
+else
+	error_log "creation of /run/pbench directory failed"
+	exit 1
+fi
 case "$mode" in
 	install)
 	which go &>/dev/null
@@ -168,13 +169,29 @@ case "$mode" in
 	;;
 	start)
 	mkdir -p $tool_output_dir/json
-	while read -u 9 master; do
-		# fetch keys from openshift master and set default values for cert and key vars if not defined
+	while read -u 9 file; do
+		# If the port, cert or key is not set while registering the tool, read the input file for host, port, cert and key if any. 
+		# In case the file doesn't have certs, port and they are not defined while registering the tool, the default values are set.
+		# host port=<port> cert=<cert> key=<key>
+		host=$(echo $file | awk -F " " '{ print $1 }')
+		if [[ -z "$port" ]]; then
+			port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
+		fi
+		if [[ -z "$cert" ]]; then
+			cert=$(echo $file | grep -w "cert" | awk -F " " '{ print $3 }' | awk -F "=" '{print $2}')
+		fi
+		if [[ -z "$key" ]]; then
+			key=$(echo $file | grep -w "key" | awk -F " " '{ print $4 }' | awk -F "=" '{print $2}')
+		fi
+		# fetch keys from openshift master and set default values for port, cert and key vars if not defined
+		if [ -z "$port" ]; then
+			port=8443
+		fi
 		if [ -z "$cert" ]; then
 			if [ ! -s /run/pbench/keys/admin.crt ]; then
-				scp $master:/etc/origin/master/admin.crt /run/pbench/keys/admin.crt
+				scp $host:/etc/origin/master/admin.crt /run/pbench/keys/admin.crt
 				if [[ $? != 0 ]]; then
-					error_log "[$script_name]scp command failed to copy the files from $master, please check if the cert exists in /etc/origin/master directory"
+					error_log "[$script_name]scp command failed to copy the files from $host, please check if the cert exists in /etc/origin/master directory"
 					exit 1
 				fi
 			fi
@@ -182,16 +199,16 @@ case "$mode" in
 		fi
 		if [ -z "$key" ]; then
 			if [ ! -s /run/pbench/keys/admin.key ]; then
-				scp $master:/etc/origin/master/admin.key /run/pbench/keys/admin.key
+				scp $host:/etc/origin/master/admin.key /run/pbench/keys/admin.key
 				if [[ $? != 0 ]]; then
-					error_log "[$script_name]scp command failed to copy the files from $master, please check if the key exists in /etc/origin/master directory"
+					error_log "[$script_name]scp command failed to copy the files from $host, please check if the key exists in /etc/origin/master directory"
 					exit 1
 				fi	
 			fi
 			key=/run/pbench/keys/admin.key
 		fi
-		tool_cmd='GOPATH=$pbench_install_dir/.go PATH=$PATH:$GOPATH/bin $script_path/datalog/$tool-datalog $master $interval $tool_log $port $cert $key'
-		metrics_data=$tool_output_dir/$master-stdout.txt
+		tool_cmd='GOPATH=$pbench_install_dir/.go PATH=$PATH:$GOPATH/bin $script_path/datalog/$tool-datalog $host $interval $tool_log $port $cert $key'
+		metrics_data=$tool_output_dir/$host-stdout.txt
 		debug_log "$script_name: running $tool_cmd"
 		eval $tool_cmd >"$metrics_data" 2>"$tool_stderr_file" & echo $! >>$tool_pid_file
 	done 9</run/pbench/inv_hosts
@@ -207,8 +224,9 @@ case "$mode" in
 	postprocess)
 	if [ -z "$options" ]; then
 		debug_log "postprocessing $script_name"
-		while read -u 11 master;do
-			$script_path/postprocess/$script_name-postprocess $tool_output_dir/$master-stdout.txt $tool_output_dir/json/$master.json
+		while read -u 11 file;do
+			host=$(echo $file | awk -F " " '{ print $1 }')
+			$script_path/postprocess/$script_name-postprocess $tool_output_dir/$host-stdout.txt $tool_output_dir/json/"$host".json
 		done 11</run/pbench/inv_hosts
 	else
 		debug_log "Non-default options $options: skipping postprocessing for $script_name"


### PR DESCRIPTION
- Prometheus-metrics tool uses the same cert, key and port for all the
  endpoints in the inventory file passed. This will enable it to have
  different certs, port for each endpoint.
- User can define the port, cert, key to be used by a particular
  endpoint in the inventory like host port=prometheus_port 
   cert=/path/to/cert key=/path/to/key
- Add support to run unit tests on ubuntu.