### PR TITLE
remote tools listed at the end #issue

### DIFF
--- a/agent/util-scripts/pbench-list-tools
+++ b/agent/util-scripts/pbench-list-tools
@@ -114,7 +114,7 @@ if [ -d "$pbench_run" ]; then
 			done
 
                         if [ "$all_remote_tools" == "" ]; then
-                                tools="tools"
+                                tools="$tools"
                         else
                                 tools="$tools,$all_remote_tools"
       

--- a/agent/util-scripts/pbench-list-tools
+++ b/agent/util-scripts/pbench-list-tools
@@ -81,6 +81,7 @@ if [ -d "$pbench_run" ]; then
 		fi
 		for group in $groups; do
 			tools=""
+			all_remote_tools=""
 			tool_group_dir="tools-$group"
 			for this_tool_file in `/bin/ls $tool_group_dir`; do
 				if [ "$this_tool_file" == "label" ]; then
@@ -90,7 +91,12 @@ if [ -d "$pbench_run" ]; then
                                 	remote_host=`echo $this_tool_file | awk -F@ '{print $2}'`
                                 	tool=`echo $this_tool_file | awk -F@ '{print $1}'`
                                 	remote_tools=`ssh $ssh_opts -n $remote_host ". ${pbench_install_dir}/profile; pbench-list-tools $with_options_opt --group=$group" | sed -e s/"^$group: "//`
-					tools="$tools,$remote_host[$remote_tools]"
+					if [ "$all_remote_tools" == "" ]; then
+						all_remote_tools="$remote_host[$remote_tools]"
+					else
+						all_remote_tools="$all_remote_tools,$remote_host[$remote_tools]"
+				 	fi
+
 	                        elif [ -d $tool_group_dir/$this_tool_file ] ;then
 					# skip spurious subdirectory of $tool_group_dir
 					warn_log "[$script_name]$this_tool_file is a directory in $tool_group_dir; that should not happen. Please consider deleting it."
@@ -106,6 +112,7 @@ if [ -d "$pbench_run" ]; then
 					tools="$tools,$this_tool_file"
                         	fi
 			done
+			tools="$tools,$all_remote_tools"
 			tools=`echo $tools | sed -e s/"^,"//`
 			# do not print anything for this group if there are no tools
 			if [ ! -z "$tools" ]; then

--- a/agent/util-scripts/pbench-list-tools
+++ b/agent/util-scripts/pbench-list-tools
@@ -117,6 +117,7 @@ if [ -d "$pbench_run" ]; then
                                 tools="$tools"
                         else
                                 tools="$tools,$all_remote_tools"
+                        fi
       
 			tools=`echo $tools | sed -e s/"^,"//`
 			# do not print anything for this group if there are no tools

--- a/agent/util-scripts/pbench-list-tools
+++ b/agent/util-scripts/pbench-list-tools
@@ -112,7 +112,12 @@ if [ -d "$pbench_run" ]; then
 					tools="$tools,$this_tool_file"
                         	fi
 			done
-			tools="$tools,$all_remote_tools"
+
+                        if [ "$all_remote_tools" == "" ]; then
+                                tools="tools"
+                        else
+                                tools="$tools,$all_remote_tools"
+      
 			tools=`echo $tools | sed -e s/"^,"//`
 			# do not print anything for this group if there are no tools
 			if [ ! -z "$tools" ]; then

--- a/agent/util-scripts/pbench-postprocess-tools
+++ b/agent/util-scripts/pbench-postprocess-tools
@@ -192,6 +192,7 @@ for this_tool_file in `/bin/ls $tool_group_dir`; do
 	fi
 done
 for p in $pids ;do
+        echo "stopping pid: $p"
 	wait $p
 	rc=$?
 	if [[ $rc -ne 0 ]] ;then

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -197,6 +197,7 @@ declare -A tools=(
     [test-28]="pbench-collect-sysinfo"
     [test-29]="pbench-collect-sysinfo"
     [test-30]="pbench-collect-sysinfo"
+    [test-31]="pbench-list-tools"
 )
 declare -A options=(
     [test-00]="--name=mpstat --group=default -- --interval=10"


### PR DESCRIPTION
1. collect all remote tools while going through the list of tools at /var/lib/pbench-agent
2. add the list of remote tools to the tools list at the end of the loop
3. still the tools are listed on per group basis. Not sure if that is ok or do we want remote tools from ALL groups listed at the end?