### PR TITLE
uperf-postprocess: force port_labels to be strings

### DIFF
--- a/agent/bench-scripts/postprocess/uperf-postprocess
+++ b/agent/bench-scripts/postprocess/uperf-postprocess
@@ -175,7 +175,7 @@ foreach $result_file (sort readdir($dh) ) {
 	if ( $result_file =~ /^client::(.+)-server::(.+):(\d+)--client_output\.txt$/) {
 		my $client_hostname = $1;
 		my $server_hostname = $2;
-		my $server_port = int $3;
+		my $server_port = "$3";
 		my $role = "client";
 		my $average;
 		my @throughput_samples;
@@ -231,7 +231,7 @@ foreach $result_file (sort readdir($dh) ) {
 			my $mean = get_mean(\@latency_samples);
 			%this_lat_dataset = ( 	get_label('uid_label') => create_uid('client_hostname_label', 'server_hostname_label', 'server_port_label'), get_label('description_label') => $description,
 						get_label('role_label') => $role, get_label('client_hostname_label') => $client_hostname,
-						get_label('server_hostname_label') => $server_hostname, get_label('server_port_label') => int $server_port,
+						get_label('server_hostname_label') => $server_hostname, get_label('server_port_label') => "$server_port",
 						get_label('value_label') => $mean, get_label('timeseries_label') => \@latency_samples   );
 			push(@usec, \%this_lat_dataset);
 		}
@@ -240,7 +240,7 @@ foreach $result_file (sort readdir($dh) ) {
 			my %this_tput_dataset;
 			my $mean = get_mean(\@throughput_samples);
 			%this_tput_dataset = ( 	get_label('role_label') => $role, get_label('client_hostname_label') => $client_hostname,
-						get_label('server_hostname_label') => $server_hostname, get_label('server_port_label') => int $server_port,
+						get_label('server_hostname_label') => $server_hostname, get_label('server_port_label') => "$server_port",
 						get_label('value_label') => $mean, get_label('timeseries_label') => \@throughput_samples,
 						get_label('uid_label') => create_uid('client_hostname_label', 'server_hostname_label', 'server_port_label')  );
 			if ($test_type =~ /rr/) {


### PR DESCRIPTION
Depending on the perl version, these port labels might
be represented as intergers or strings.  Aggregate
metrics also use "all" as the port label, so let's just
force all port labels to be strings.  Port labels are
not processed as numbers anyway, even though they happen
to be a number (in most cases).  Forcing strings also
ensures the different perl versions should always produce
strings for this data when converting to JSON.