### PR TITLE
Rename result files to include port to avoid conflicts

### DIFF
--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -35,9 +35,6 @@ function usage {
 	printf -- "\t--interval=int             number of seconds between each data collection\n"
 	printf -- "\t--options=str              options passed directly to the tool\n"
 	printf -- "\t--inventory=str            path to the inventory file\n"
-	printf -- "\t--port=int                 port prometheus is listening on\n"
-	printf -- "\t--cert=str                 path to the cert\n"
-	printf -- "\t--key=str                  path to the key"
 
 }
 # Process options and arguments
@@ -174,15 +171,9 @@ case "$mode" in
 		# In case the file doesn't have certs, port and they are not defined while registering the tool, the default values are set.
 		# host port=<port> cert=<cert> key=<key>
 		host=$(echo $file | awk -F " " '{ print $1 }')
-		if [[ -z "$port" ]]; then
-			port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
-		fi
-		if [[ -z "$cert" ]]; then
-			cert=$(echo $file | grep -w "cert" | awk -F " " '{ print $3 }' | awk -F "=" '{print $2}')
-		fi
-		if [[ -z "$key" ]]; then
-			key=$(echo $file | grep -w "key" | awk -F " " '{ print $4 }' | awk -F "=" '{print $2}')
-		fi
+		port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
+		cert=$(echo $file | grep -w "cert" | awk -F " " '{ print $3 }' | awk -F "=" '{print $2}')
+		key=$(echo $file | grep -w "key" | awk -F " " '{ print $4 }' | awk -F "=" '{print $2}')
 		# fetch keys from openshift master and set default values for port, cert and key vars if not defined
 		if [ -z "$port" ]; then
 			port=8443
@@ -196,6 +187,13 @@ case "$mode" in
 				fi
 			fi
 			cert=/run/pbench/keys/admin.crt
+		else
+			scp $host:$cert /run/pbench/keys/
+			if [[ $? != 0 ]]; then
+				error_log "[$script_name]scp command failed to copy the files from $host, please check if the cert exists in the path provided"
+				exit 1
+			fi
+			cert=/run/pbench/keys/$(basename $cert)
 		fi
 		if [ -z "$key" ]; then
 			if [ ! -s /run/pbench/keys/admin.key ]; then
@@ -206,9 +204,16 @@ case "$mode" in
 				fi	
 			fi
 			key=/run/pbench/keys/admin.key
+		else
+			scp $host:$key /run/pbench/keys/
+			if [[ $? != 0 ]]; then
+				error_log "[$script_name]scp command failed to copy the files from $host, please check if the key exists in the path provided"
+				exit 1
+			fi
+			key=/run/pbench/keys/$(basename $key)
 		fi
 		tool_cmd='GOPATH=$pbench_install_dir/.go PATH=$PATH:$GOPATH/bin $script_path/datalog/$tool-datalog $host $interval $tool_log $port $cert $key'
-		metrics_data=$tool_output_dir/$host-stdout.txt
+		metrics_data=$tool_output_dir/"$host"-"$port"-stdout.txt
 		debug_log "$script_name: running $tool_cmd"
 		eval $tool_cmd >"$metrics_data" 2>"$tool_stderr_file" & echo $! >>$tool_pid_file
 	done 9</run/pbench/inv_hosts
@@ -226,7 +231,11 @@ case "$mode" in
 		debug_log "postprocessing $script_name"
 		while read -u 11 file;do
 			host=$(echo $file | awk -F " " '{ print $1 }')
-			$script_path/postprocess/$script_name-postprocess $tool_output_dir/$host-stdout.txt $tool_output_dir/json/"$host".json
+			port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
+			if [[ -z $port ]]; then
+				port=8443
+			fi
+			$script_path/postprocess/$script_name-postprocess $tool_output_dir/"$host"-"$port"-stdout.txt $tool_output_dir/json/"$host"-"$port".json
 		done 11</run/pbench/inv_hosts
 	else
 		debug_log "Non-default options $options: skipping postprocessing for $script_name"

--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -65,8 +65,8 @@
 
     - name: copy inventory file to pbench-controller
       copy:
-        src: {{ inventory_file }}
-        dest: {{ inventory_file_path }}
+        src: "{{ inventory_file }}"
+        dest: "{{ inventory_file_path }}"
 
     - name: copy inventory file to master
       shell: scp {{ inventory_file }} {{ item }}:{{ inventory_file_path }}


### PR DESCRIPTION
This commit
- renames the result files to include port to avoid conflicts.This case
  arises when we are monitoring the same endppoint but with a different
  port. An example use case would be monitoring apiserver and
  kubelet which expose metrics on port 8443 and 10250 respectively.
- disables passing port, certs on command line.