### PR TITLE
Pass sysinfo opts as comma separated values

### DIFF
--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -16,14 +16,16 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # Defaults
 group=default
 dir="/tmp"
+# array containing all the possible sysinfo options
 sysinfo_opts_default=( block libvirt kernel_config sos topology ara )
-sysinfo_opts=${sysinfo_opts_default[*]}
+# get comma seperated values
+sysinfo_opts_default_comma_separated=$(IFS=,; echo "${sysinfo_opts_default[*]}")
 check=false
 
 # Display sysinfo options 
 function display_sysinfo_opts {
 	printf "default, none, all"
-	for item in ${sysinfo_opts[*]}; do printf ", %s" $item ; done
+	for item in ${sysinfo_opts_default[*]}; do printf ", %s" $item ; done
 }
 
 # Process options and arguments
@@ -94,12 +96,13 @@ while true; do
 	esac
 done
 
+# check if the input sysinfo parameter passed by the user is a valid option or not
 if $check; then
 	if [ "$sysinfo" == "all" ] || [ "$sysinfo" == "default" ] || [ "$sysinfo" == "none" ]; then
 		:
 	else
 		for item in ${sysinfo//,/ }; do
-			if echo "${sysinfo_opts[@]}" | grep -q -w "$item"; then
+			if echo "${sysinfo_opts_default[@]}" | grep -q -w "$item"; then
 				continue
 			else
 				if [ "$item" == "all" ] || [ "$item" == "default" ] || [ "$item" == "none" ]; then
@@ -113,14 +116,13 @@ if $check; then
 	fi
 	exit 0
 fi
+# don't collect anything if sysinfo is none
 if [ "$sysinfo" == "none" ]; then
 	exit 0
 fi
-if [ "$sysinfo" == "default" ]; then
-	sysinfo=${sysinfo_opts_default[*]}
-fi
-if [ "$sysinfo" == "all" ]; then
-	sysinfo=${sysinfo_opts[*]}
+# collect everything if sysinfo is all or default
+if [ "$sysinfo" == "default" ] || [ "$sysinfo" == "all" ]; then
+	sysinfo=${sysinfo_opts_default_comma_separated}
 fi
 
 name="$1"


### PR DESCRIPTION
This commit fixes the following:
when default is passed as a syinfo option, pbench-sysinfo-dump
collects just block info since it finds space separated values
instead of comma separated values.