### PR TITLE
pbench-user-tool: pass SIGTERM to the tool for graceful handling

### DIFF
--- a/agent/tool-scripts/user-tool
+++ b/agent/tool-scripts/user-tool
@@ -148,7 +148,12 @@ case "$mode" in
 	start)
 	mkdir -p $tool_output_dir
 	pushd $tool_output_dir >/dev/null
-	echo "$tool_cmd" >$tool_cmd_file
+	echo '#!/bin/bash' >$tool_cmd_file
+	echo "trap '{ kill \${TOOL_PID}; }' SIGTERM" >>$tool_cmd_file
+	echo "${tool_cmd} &" >>$tool_cmd_file
+	echo 'TOOL_PID=$!' >>$tool_cmd_file
+	echo 'wait' >>$tool_cmd_file
+	echo 'wait' >>$tool_cmd_file
 	chmod +x $tool_cmd_file
 	debug_log "$script_name: running $tool_cmd"
 	$tool_cmd_file >"$tool_stdout_file" 2>"$tool_stderr_file" & echo $! >$tool_pid_file


### PR DESCRIPTION
- Two calls to wait are required because the initial trap breaks out
  of the first wait prematurely, requiring a second wait to avoid
  exiting prior to the tool handling the SIGTERM gracefully.

- Addresses #658 