### PR TITLE
Use xz with multi-threaded support when copying/moving results.

### DIFF
--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -162,7 +162,7 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
 
     tarball="$pbench_run_name.tar.xz"
     echo tar Jcf $tarball $pbench_run_name
-    tar --create --xz --force-local --file="$tarball" "$pbench_run_name"
+    tar --create --force-local "$pbench_run_name" | xz -T0 > "$tarball"
     if [ $? -ne 0 ]; then
         error_log "ERROR: tar failed for $pbench_run/$pbench_run_name, skipping"
         rm -f "$tarball"


### PR DESCRIPTION
When compressing large amounts of data collected by Pbench or other tools that add data to Pbench directories, the current method of compressing data uses only a single thread.  This can cause significant delays during test runs when compressing the data and copying them to a safe location on a Pbench server.  I propose to utilise as many cores as possible and use the xz -T0 option as tar seems to support only a single thread of execution when compressing data.  I have drastically reduced the pbench-copy-results times by doing this from a couple of hours to nearly "couple of hours"/number of cores available during the last OpenShift testing in the scale lab.