### PR TITLE
pbench-sync-satellite: rectify the undefined host outside the loop

### DIFF
--- a/server/pbench/bin/pbench-sync-satellite
+++ b/server/pbench/bin/pbench-sync-satellite
@@ -61,7 +61,7 @@ shift 3
 # TOP, TMP, LOGSDIR, ARCHIVE, TS are all defined in pbench-base.sh
 . $dir/pbench-base.sh
 if [[ -z "$mail_recipients" ]] ;then
-    echo "$PROG: mail_recipients is not defined"
+    echo "$PROG: mail_recipients is not defined" >&4
     exit 1
 fi
 
@@ -78,20 +78,42 @@ else
     dryrun=
 fi
 
+# check whether any previous ssh failure; if any try again and if it fails again then exit without going further.
+if [ -s $LOGSDIR/change_state.$prefix.log ] ;then
+    ssh $remotehost "cd $remotearchive; /opt/pbench-server/bin/pbench-satellite-state-change" < $LOGSDIR/change_state.$prefix.log
+    status=$?
+    if [[ $status != 0 ]] ;then
+        echo "Unable to change the state directories of tarballs, in $remotehost, due to ssh failure" | mailx -s \
+        "FAILED: $PROG: $prefix: ssh to $remotehost failed twice"\
+        $mail_recipients
+        exit 1
+    else
+        rm $LOGSDIR/change_state.$prefix.log
+        status=$?
+        if [[ $status != 0 ]]; then
+            echo "ssh to the $remotehost sucessfull for changing the state of tarballs, but failed to remove $LOGSDIR/change_state.$prefix.log" \
+            | mailx -s "$PROG: $prefix: Failed to remove $LOGSDIR/change_state.$prefix.log" $mail_recipients
+            exit 1
+        fi
+    fi
+fi
+
 typeset -i nprocessed=0
 typeset -i nfailed_md5=0
+typeset -i nerrs=0
 
-unpack=$tmp/unpack
-trap "rm -rf $tmp $unpack" EXIT
+unpack=$tmp/unpack.$prefix
+mail_content=$tmp/mail.log
+trap "rm -rf $tmp" EXIT
 
 mkdir -p $tmp
 mkdir -p $unpack
 
 # get the tarball from remote
-ssh $remotehost "/opt/pbench-server/bin/pbench-sync-package-tarballs" > $tmp/satellite.tar
+ssh $remotehost "/opt/pbench-server/bin/pbench-sync-package-tarballs" > $tmp/satellite.$prefix.tar
 rc=$? 
 if [[ $rc != 0 ]] ;then
-    echo "$PROG: ssh $remotehost /opt/pbench-server/bin/pbench-package-tarballs: failed."
+    echo "$PROG: ssh $remotehost /opt/pbench-server/bin/pbench-package-tarballs: failed." >&4
     exit 2
 fi
 
@@ -100,19 +122,25 @@ logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
 mkdir -p $logdir
 rc=$?
 if [[ $rc != 0 ]] ;then
-    echo Failed: mkdir -p $logdir
+    echo Failed: mkdir -p $logdir >&4
     exit 2
 fi
 
 # unpack the tarball into tmp directory
-tar -xvf $tmp/satellite.tar -C $unpack
+tar -xvf $tmp/satellite.$prefix.tar -C $unpack
 files=$(find $unpack -path '*.tar.xz' -printf '%P\n')
 hosts="$(for host in $files;do echo ${host%%/*};done | sort -u )"
 
+# initialize change state log and mail content
+> $LOGSDIR/change-state.$prefix.log
+> $mail_content
+
 let start_time=$(timestamp-seconds-since-epoch)
-echo "$TS: start - $(timestamp)"
-let failures=0
+echo "$TS: start - $(timestamp)" >&4
+
 for host in $hosts ;do
+    typeset -i processed=0
+    typeset -i failed_md5=0
     localdir=$ARCHIVE/$prefix::$host
     if [ ! -d $localdir ] ;then
         mkdir -p $localdir || exit 1
@@ -123,12 +151,7 @@ for host in $hosts ;do
     fi
 
     # move the unpacked files from tmp directory to archive
-    mv $unpack/$host/{.,}* .
-    rc=$?
-    if [[ $rc != 0 ]] ;then
-        echo "FAILED:    mv $unpack/$host/* ."
-        let failures=failures+1
-    fi
+    mv $unpack/$host/* $unpack/$host/.prefix* .
 
     # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
     mk_dirs $prefix::$host
@@ -136,53 +159,93 @@ for host in $hosts ;do
     # check md5s and move md5s to its appropriate state directories according to pass or fail
     md5_list=$(find . -path '*.tar.xz.md5' -printf '%P\n')
     md5sum -c $md5_list > $logdir/$host/md5-checks.log
+    processed=$(wc -l < $logdir/$host/md5-checks.log)
+    nprocessed=$((nprocessed + processed))
     grep 'OK' $logdir/$host/md5-checks.log > $logdir/$host/ok-checks.log
     if [ -s $logdir/$host/ok-checks.log ] ;then
         md5_pass=$(cat $logdir/$host/ok-checks.log | sed -n 's/: OK//p')
         for x in $md5_pass; do
-            ln -s $x SATELLITE-MD5-PASSED/$x
+            ln -sf $PWD/$x SATELLITE-MD5-PASSED/$x
+            status=$?
+            if [[ $status != 0 ]] ;then
+                nerrs=$nerrs+1
+                echo "Failed to create the symlink for md5 check passed tarballs: ln -sf \
+                $PWD/$x SATELLITE-MD5-PASSED/$x" | tee -a $mail_content >&4 
+                continue
+            fi
         done
     fi
     grep 'FAIL' $logdir/$host/md5-checks.log > $logdir/$host/fail-checks.log
+    cat $logdir/$host/fail-checks.log >> $mail_content
+    failed_md5=$(wc -l < $logdir/$host/fail-checks.log)
+    nfailed_md5=$((nfailed_md5 + failed_md5))
     if [ -s $logdir/$host/fail-checks.log ] ;then
         md5_fail=$(cat $logdir/$host/fail-checks.log | sed -n 's/: FAIL//p')
         for x in $md5_fail; do
-            ln -s $x SATELLITE-MD5-FAILED/$x
+            ln -sf $PWD/$x SATELLITE-MD5-FAILED/$x
+            status=$?
+            if [[ $status != 0 ]] ;then
+                nerrs=$nerrs+1
+                echo "Failed to create the symlink for md5 check failed tarballs: ln -sf \
+                $PWD/$x SATELLITE-MD5-FAILED/$x" | tee -a $mail_content >&4 
+                continue
+            fi
         done
     fi
     # create symlinks for the synced tarballs in TODO
     if [ -s $logdir/$host/ok-checks.log ] ;then
         for x in $md5_pass; do
-            ln -s $x TODO/$x
+            ln -sf $PWD/$x TODO/$x
+            status=$?
+            if [[ $status != 0 ]] ;then
+                nerrs=$nerrs+1
+                echo "Failed to create the symlink for TODO state directory: ln -sf \
+                $PWD/$x TODO/$x" | tee -a $mail_content >&4 
+                continue
+            fi
         done
     fi
     # save the contents of ok checks to further use it for state change
     if [ -s $logdir/$host/ok-checks.log ] ;then
         state_list=$(cat $logdir/$host/ok-checks.log | sed -n 's/: OK//p')
         for x in $state_list; do
-            echo "$host/TO-SYNC/$x" >> $tmp/change_state.log
+            echo "$host/TO-SYNC/$x" >> $LOGSDIR/change_state.$prefix.log
         done
     fi 
     popd > /dev/null
 done
 
 # change the state of the tarballs on remote
-ssh $remotehost "cd $remotearchive; /opt/pbench-server/bin/pbench-satellite-state-change" < $tmp/change_state.log > $logdir/$host/mv.log 2>&1
-
-nprocessed=$(wc -l < $logdir/$host/md5-checks.log)
-nfailed_md5=$(wc -l < $logdir/$host/fail-checks.log)
+if [ -s $LOGSDIR/change_state.$prefix.log ] ;then
+    ssh $remotehost "cd $remotearchive; /opt/pbench-server/bin/pbench-satellite-state-change" < $LOGSDIR/change_state.$prefix.log > $logdir/mv.log 2>&1
+    status=$?
+    if [[ $status != 0 ]] ;then
+        echo "FAILED: ssh $remotehost; cd $remotearchive; /opt/pbench-server/bin/pbench-satellite-state-change < $LOGSDIR/change_state.$prefix.log" >&4
+        echo "Unable to change the state directories of tarballs, in $remotehost, due to ssh failure" | mailx -s \
+        "FAILED: $PROG: $prefix: ssh $remotehost; cd $remotearchive; /opt/pbench-server/bin/pbench-satellite-state-change"\
+        $mail_recipients
+    else
+        rm $LOGSDIR/change_state.$prefix.log
+        status=$?
+        if [[ $status != 0 ]]; then
+            echo "Failed to remove $LOGSDIR/change_state.$prefix.log" >&4
+            echo "ssh to the $remotehost sucessfull for changing the state of tarballs, but failed to remove $LOGSDIR/change_state.$prefix.log" \
+            | mailx -s "$PROG: $prefix: Failed to remove $LOGSDIR/change_state.$prefix.log" $mail_recipients
+        fi
+    fi
+fi
 
  # ... and mail it
-if [ "$nfailed_md5" -gt 0 ]  ;then
+if [ "$nerrs" -gt 0 ]  ;then
     mailx -s \
-    "$PROG: $prefix: $nprocessed files processed, with $nfailed_md5 md5 failures"\
-    $mail_recipients < $logdir/$host/fail-checks.log
+    "$PROG: $prefix: $nprocessed files processed, with $nfailed_md5 md5 failures and $nerrs errors"\
+    $mail_recipients < $mail_content
 fi
 
 let end_time=$(timestamp-seconds-since-epoch)
 let duration=end_time-start_time
-echo "$TS: end - $(timestamp)"
-echo "$TS: duration (secs): $duration"
+echo "$TS: end - $(timestamp)" >&4
+echo "$TS: duration (secs): $duration" >&4
+echo "$TS: Total $nprocessed files processed, with $nfailed_md5 md5 failures and $nerrs errors" >&4
 
-exit $failures
-
+exit 0


### PR DESCRIPTION
There was some undefined variable named $host, which is outside the loop. That's why it is unrecognizable which results in an error.

Now I have updated the script to calculate total processed as well as failed md5 in a different way so that it will not be required the host variable. As well as updated some logs destination too.