### PR TITLE
Check for oc client instead of openshift rpm's

### DIFF
--- a/agent/tool-scripts/oc
+++ b/agent/tool-scripts/oc
@@ -24,8 +24,6 @@ mode=""
 iteration="1"
 options="none"
 interval=10
-origin_master="/etc/sysconfig/origin-master"
-ose_openshift_master="/etc/sysconfig/atomic-openshift-master"
 
 opts=$(getopt -o d --longoptions "dir:,group:,iteration:,occomponent:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
 # occomponent not used at time, place holder for eventual future PR where oc parameters will be specified from command line 
@@ -116,11 +114,10 @@ oc_data_once() {
 
 case "$mode" in 
     install)
-        if [[ -e $ose_openshift_master  ||  -e $origin_master ]]; then 
-            check_install_rpm $tool_package 
-        else
-            printf "This machine is not Openshift master, ... not possible to start $tool on this machine\n"
-        fi 
+	if ! oc --help >/dev/null 2>&1 ; then
+            printf "${script_name} needs an OpenShift client to work\n"
+            exit 1
+	fi
     ;; 
     start)
         mkdir -p $tool_output_dir


### PR DESCRIPTION
Containerized environments won't have openshift rpm's. So instead
of checking for atomic-openshift-client, we can check if oc is
installed. Usually oc client is installed only on the master node,
even if the oc client is installed on rest of the nodes,
pbench-ansible will make sure oc tool is installed only on the
master.