### PR TITLE
Refactor  prometheus-metrics tool to be more generic

### DIFF
--- a/agent/tool-scripts/datalog/prometheus-metrics-datalog
+++ b/agent/tool-scripts/datalog/prometheus-metrics-datalog
@@ -5,7 +5,7 @@ import sys, json
 import os,subprocess,warnings,logging
 
 interval = int(sys.argv[2])
-master = sys.argv[1]
+host = sys.argv[1]
 tool_log = sys.argv[3]
 port = int(sys.argv[4])
 cert = sys.argv[5]
@@ -13,7 +13,10 @@ key = sys.argv[6]
 while True:
     time_stamp = int(time.time())
     next_start = time_stamp + interval
-    command = "prom2json --cert=%s --key=%s https://%s:%d/metrics" % (cert, key, master, port)
+    if (cert == "None") or (key == "None"):
+        command = "prom2json http://%s:%d/metrics" % (host, port)
+    else:
+        command = "prom2json --cert=%s --key=%s https://%s:%d/metrics" % (cert, key, host, port)
     command_out = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE)
     prom2json_out = command_out.communicate()[0]
     metrics_list = json.loads(prom2json_out)

--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -138,8 +138,6 @@ tool_output_dir=$tool_dir/$tool # all tools keep data in their tool specific dir
 tool_pid_file=$pbench_tmp/$group.$iteration.$tool.pid
 tool_stderr_file=$tool_output_dir/$tool-stderr.txt
 tool_log=$tool_output_dir/tool.log
-## create directory to save the keys from openshift master, hosts
-mkdir -p /run/pbench/keys
 ## check if the inventory variable is set correctly
 if [[ -z "$inventory" ]]; then
 	usage
@@ -148,9 +146,11 @@ elif [[ ! -s "$inventory" ]] || [[ ! -f "$inventory" ]]; then
 	echo "Please check if the inventory file exists, is not empty and the inventory variable is not set to a directory"
 	exit 1
 fi
-## parse openshift inventory file
+## create pbench directory to store info about endpoints
+mkdir -p /run/pbench
+## parse inventory file
 if [[ -d /run/pbench ]]; then
-	cat "$inventory" | sed -n '/^\[masters\]/,/^$/p' | awk '{if (NR!=1) {print}}' | sed '/^$/d' > /run/pbench/inv_hosts
+	cat "$inventory" | sed -n '/^\[prometheus-metrics\]/,/^$/p' | awk '{if (NR!=1) {print}}' | sed '/^$/d' > /run/pbench/inv_hosts
 else
 	error_log "creation of /run/pbench directory failed"
 	exit 1
@@ -174,43 +174,19 @@ case "$mode" in
 		port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
 		cert=$(echo $file | grep -w "cert" | awk -F " " '{ print $3 }' | awk -F "=" '{print $2}')
 		key=$(echo $file | grep -w "key" | awk -F " " '{ print $4 }' | awk -F "=" '{print $2}')
-		# fetch keys from openshift master and set default values for port, cert and key vars if not defined
+		# Exit if port, cert or key is not defined
 		if [ -z "$port" ]; then
-			port=8443
+			echo "metrics endpoint port is not defined for $host, the syntax is <host> port=<port> cert=<path-to-cert> key=<path-to-cert>"
+			error_log "[$script_name] port is not defined for $host"
+			exit 1
 		fi
 		if [ -z "$cert" ]; then
-			if [ ! -s /run/pbench/keys/admin.crt ]; then
-				scp $host:/etc/origin/master/admin.crt /run/pbench/keys/admin.crt
-				if [[ $? != 0 ]]; then
-					error_log "[$script_name]scp command failed to copy the files from $host, please check if the cert exists in /etc/origin/master directory"
-					exit 1
-				fi
-			fi
-			cert=/run/pbench/keys/admin.crt
-		else
-			scp $host:$cert /run/pbench/keys/
-			if [[ $? != 0 ]]; then
-				error_log "[$script_name]scp command failed to copy the files from $host, please check if the cert exists in the path provided"
-				exit 1
-			fi
-			cert=/run/pbench/keys/$(basename $cert)
+			debug_log "[$script_name] cert is not defined for $host, assuming that the endpoint doesn't need authentication"
+			cert="None"
 		fi
 		if [ -z "$key" ]; then
-			if [ ! -s /run/pbench/keys/admin.key ]; then
-				scp $host:/etc/origin/master/admin.key /run/pbench/keys/admin.key
-				if [[ $? != 0 ]]; then
-					error_log "[$script_name]scp command failed to copy the files from $host, please check if the key exists in /etc/origin/master directory"
-					exit 1
-				fi	
-			fi
-			key=/run/pbench/keys/admin.key
-		else
-			scp $host:$key /run/pbench/keys/
-			if [[ $? != 0 ]]; then
-				error_log "[$script_name]scp command failed to copy the files from $host, please check if the key exists in the path provided"
-				exit 1
-			fi
-			key=/run/pbench/keys/$(basename $key)
+			debug_log "[$script_name] key is not defined for $host, assuming that the endpoint doesn't need authentication"
+			key="None"
 		fi
 		tool_cmd='GOPATH=$pbench_install_dir/.go PATH=$PATH:$GOPATH/bin $script_path/datalog/$tool-datalog $host $interval $tool_log $port $cert $key'
 		metrics_data=$tool_output_dir/"$host"-"$port"-stdout.txt
@@ -232,9 +208,6 @@ case "$mode" in
 		while read -u 11 file;do
 			host=$(echo $file | awk -F " " '{ print $1 }')
 			port=$(echo $file | grep -w "port" | awk -F " " '{ print $2 }' | awk -F "=" '{print $2}')
-			if [[ -z $port ]]; then
-				port=8443
-			fi
 			$script_path/postprocess/$script_name-postprocess $tool_output_dir/"$host"-"$port"-stdout.txt $tool_output_dir/json/"$host"-"$port".json
 		done 11</run/pbench/inv_hosts
 	else

--- a/contrib/ansible/openshift/README.md
+++ b/contrib/ansible/openshift/README.md
@@ -32,6 +32,10 @@ Your inventory should have groups of hosts describing the roles they play in the
 
 [glusterfs]
 
+[prometheus-metrics]
+<host> port=8443 cert=<cert> key=<key>
+<host> port=10250 cert=/etc/origin/master/admin.crt key=/etc/origin/master/admin.key
+
 [pbench-controller:vars]
 register_all_nodes=False
 ```
@@ -41,14 +45,12 @@ By default, tools registration is done on only two of the nodes, infra nodes. Se
 Inventory file is copied on to the masters and pbench-controller. It will be available at /root/inv.
 
 ### Monitoring multiple endpoints using prometheus-metrics
-By default the registered prometheus-metrics tool collects metrics from master's metrics endpoint, in case you want to monitor other endpoints, you need to add the endpoints under the [masters] group in the inventory as follows:
+prometheus-metrics tool is registered on the first master, the endpoints to be monitored should be added under the [prometheus-metrics] group in the inventory file as follows:
 ```
-[masters]
+[prometheus-metrics]
 <master> port=<port> cert=<cert> key=<key>
 <endpoint> port=<port> cert=<cert> key=<key>
 ```
-
-Note: if the port, cert and key are not defined, prometheus-metrics uses default values i.e  port=8443, cert=/etc/origin/master/admin.crt, key=/etc/origin/master/admin.key
 
 ### Accessing OpenShift Cluster
 Kube config file is copied from the master node on to the pbench-controller. So you should be able to run oc commands and clusterloader from pbench-controller node.


### PR DESCRIPTION
This commit:
- Modifies the tool to monitor the endpoints under prometheus-metrics
  group instead of masters.
- Makes the tool more generic by not assuming default certs, port.