### PR TITLE
Fix ansible 2.4 compatibility issues

### DIFF
--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -65,11 +65,11 @@
 
     - name: copy inventory file to pbench-controller
       copy:
-        src: "{{ inventory_file }}"
+        src: "{{ inventory_dir }}/{{inventory_file}}"
         dest: "{{ inventory_file_path }}"
 
     - name: copy inventory file to master
-      shell: scp {{ inventory_file_path }} {{ item }}:{{ inventory_file_path }}
+      shell: scp {{ inventory_dir }}/{{ inventory_file }} {{ item }}:{{ inventory_file_path }}
       with_items:
         - "{{ groups['masters'] }}"
 


### PR DESCRIPTION
The builtin {{ inventory_file }} outputs relative path instead of
absolute path. This commit fixes it by using {{ inventory_dir }}/
{{inventory_file}}.

Fixes #681 