### PR TITLE
pbench-server-activate-create-results-dir-structure: Avoid chown -R

### DIFF
--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -1,9 +1,9 @@
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/config
 chown pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/crontab/crontab
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/locks
-chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/pbench
-chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/logs
-chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/tmp
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/pbench /var/tmp/pbench-test-server/pbench/pbench//var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001 /var/tmp/pbench-test-server/pbench/pbench/public_html /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming /var/tmp/pbench-test-server/pbench/pbench/public_html/results /var/tmp/pbench-test-server/pbench/pbench//var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001/* /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming/* /var/tmp/pbench-test-server/pbench/pbench/public_html/results/*
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/logs /var/tmp/pbench-test-server/pbench/logs/*
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/tmp /var/tmp/pbench-test-server/pbench/tmp/*
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
 /var/tmp/pbench-test-server/pbench/logs

--- a/server/pbench/bin/pbench-server-activate-create-results-dir-structure
+++ b/server/pbench/bin/pbench-server-activate-create-results-dir-structure
@@ -44,7 +44,8 @@ mkdir -p $archive_dir  || exit 6
 mkdir -p $pbench_dir/public_html/incoming || exit 7
 mkdir -p $pbench_dir/public_html/results || exit 8
 
-chown -R $user.$group $pbench_dir || exit 9
+chown $user.$group $pbench_dir $pbench_dir/$archive_dir $pbench_dir/public_html $pbench_dir/public_html/incoming $pbench_dir/public_html/results \
+                               $pbench_dir/$archive_dir/* $pbench_dir/public_html/incoming/* $pbench_dir/public_html/results/* || exit 9
 
 if which selinuxenabled > /dev/null 2>&1 && selinuxenabled ;then
      if [ "${_PBENCH_SERVER_TEST}" != 1 ] ;then
@@ -56,21 +57,21 @@ if which selinuxenabled > /dev/null 2>&1 && selinuxenabled ;then
 
         # we assume that semanage and restorecon are available.
         # fix up the public_html subdirs for selinux
-        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/incoming'(/.*)?'
-        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/results'(/.*)?'
-        restorecon -R -v $pbench_dir/public_html
+        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/incoming
+        semanage fcontext -a -t httpd_sys_content_t $pbench_dir/public_html/results
+        restorecon -v $pbench_dir/public_html $pbench_dir/public_html/incoming $pbench_dir/public_html/results
     fi
 fi
 
 # create the logs directory
 logsdir=$(getconf.py deploy-pbench-logs-dir results)
 mkdir -p $logsdir || exit 9
-chown -R $user.$group $logsdir || exit 10
+chown $user.$group $logsdir $logsdir/* || exit 10
 
 # create the tmp directory
 tmpdir=$(getconf.py deploy-pbench-tmp-dir results)
 mkdir -p $tmpdir || exit 11
-chown -R $user.$group $tmpdir || exit 11
+chown $user.$group $tmpdir $tmpdir/* || exit 11
 
 exit 0
 


### PR DESCRIPTION
chown -R is too expensive to do on the pbench directories. Just make
sure that the top level directories are chown'ed correctly.

Also, fix the unit test for this change.