### PR TITLE
pbench-sync-satellite: fix the file list for md5 checking

### DIFF
--- a/server/pbench/bin/gold/test-10.txt
+++ b/server/pbench/bin/gold/test-10.txt
@@ -21,7 +21,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.error
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.log
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST/run-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results

--- a/server/pbench/bin/gold/test-11.txt
+++ b/server/pbench/bin/gold/test-11.txt
@@ -32,7 +32,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.error
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.log
 /var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST2
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST2/run-1900-01-01T00:00:00-UTC
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results

--- a/server/pbench/bin/pbench-sync-satellite
+++ b/server/pbench/bin/pbench-sync-satellite
@@ -104,13 +104,16 @@ typeset -i nerrs=0
 
 unpack=$tmp/unpack.$prefix
 mail_content=$tmp/mail.log
-trap "rm -rf $tmp" EXIT
+trap "rm -rf $tmp" EXIT QUIT INT
 
 mkdir -p $tmp
 mkdir -p $unpack
 
 log_init $(basename $0)
 logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
+# remove the tmp dir on exit; try to remove an empty $logdir
+# but suppress any complaints.
+trap "rm -rf $tmp; rmdir $logdir 2>/dev/null" EXIT QUIT INT
 mkdir -p $logdir
 rc=$?
 if [[ $rc != 0 ]] ;then
@@ -128,7 +131,7 @@ fi
 
 
 # unpack the tarball into tmp directory
-tar -xvf $tmp/satellite.$prefix.tar -C $unpack
+tar -xf $tmp/satellite.$prefix.tar -C $unpack
 files=$(find $unpack -path '*.tar.xz' -printf '%P\n')
 hosts="$(for host in $files;do echo ${host%%/*};done | sort -u )"
 
@@ -151,14 +154,25 @@ for host in $hosts ;do
         mkdir -p $logdir/$host
     fi
 
-    # move the unpacked files from tmp directory to archive
-    mv $unpack/$host/* $unpack/$host/.prefix* .
+    # get the tarball list for this host
+    flist=$(find $unpack/$host -type f -name '*.tar.xz.md5' | sed 's;'$unpack/$host/';;')
 
+    echo $flist
+    
+    # move the unpacked files from tmp directory to archive
+    mv $unpack/$host/* .
+
+    # move prefix files if present
+    if [[ -d $unpack/$host/.prefix ]] ;then
+        mkdir -p ./.prefix
+        mv $unpack/$host/.prefix/* ./.prefix
+    fi
+    
     # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
     mk_dirs $prefix::$host
 
     # check md5s and move md5s to its appropriate state directories according to pass or fail
-    md5_list=$(find . -path '*.tar.xz.md5' -printf '%P\n')
+    md5_list="$flist"
     md5sum -c $md5_list > $logdir/$host/md5-checks.log
     processed=$(wc -l < $logdir/$host/md5-checks.log)
     nprocessed=$((nprocessed + processed))
@@ -236,7 +250,7 @@ if [ -s $LOGSDIR/change_state.$prefix.log ] ;then
     fi
 fi
 
- # ... and mail it
+#  if there are errors, mail the report
 if [ "$nerrs" -gt 0 ]  ;then
     mailx -s \
     "$PROG: $prefix: $nprocessed files processed, with $nfailed_md5 md5 failures and $nerrs errors"\


### PR DESCRIPTION
The list of files to check should be a subset the list that came
from the satellite in the current run of the script. It was
calculated incorrectly by checking the files in the archive
directory.

A few other changes:

- apply the trap to QUIT and INT signals, as well as to EXIT.

- try to rmdir the run directory under logs: this will succeed if the
  directory is empty. If it is not, we keep it and suppress the rmdir
  error message.

- Remove -v from the tar extraction. That printed the list of files
  before the start message which was confusing.

- Echo the md5 list on each iteration: this will print the list of files
  for each host on a separate line.

- Fix unit test gold files 10 and 11.