### PR TITLE
Add older ansible version < 2.4 support to pbench-ansible

### DIFF
--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -65,11 +65,18 @@
 
     - name: copy inventory file to pbench-controller
       copy:
+        src: "{{inventory_file}}"
+        dest: "{{ inventory_file_path }}"
+      when: "ansible_version.full | version_compare('2.4', '<')"
+
+    - name: copy inventory file to pbench-controller
+      copy:
         src: "{{ inventory_dir }}/{{inventory_file}}"
         dest: "{{ inventory_file_path }}"
+      when: "ansible_version.full | version_compare('2.4', '>=')"
 
     - name: copy inventory file to master
-      shell: scp {{ inventory_dir }}/{{ inventory_file }} {{ item }}:{{ inventory_file_path }}
+      shell: scp {{ inventory_file_path }} {{ item }}:{{ inventory_file_path }}
       with_items:
         - "{{ groups['masters'] }}"
 


### PR DESCRIPTION
openshift ansible doesn't support using the latest ansible version
which is 2.4. This commit will add support to use older ansible versions
till the issue is fixed.