### PR TITLE
pbench-stop-tools will warn instead of failing with a non-zero exit code

### DIFF
--- a/agent/tool-scripts/kvm-spinlock
+++ b/agent/tool-scripts/kvm-spinlock
@@ -371,30 +371,34 @@ case "$mode" in
 	;;
 	stop)
 	debug_log "stopping $script_name"
-	pid=`cat $tool_pid_file`
-	if [ ! -z "$pid" ] ;then
-		if [ "$tool" == "kvmtrace" ]; then
-			if [ -z "$sleep_cmd" ]; then
-				# kill the perf cmd
-				safe_kill $tool $pid INT
-			else
-				# kill the sleep process if it still exists
-				sleep_pid=`ps --ppid $pid | pgrep sleep`
-				if [ ! -z "$sleep_pid" ]; then
-					safe_kill $tool $sleep_pid
+	if [[ -s "$tool_pid_file" ]]; then
+		pid=`cat $tool_pid_file`
+		if [ ! -z "$pid" ] ;then
+			if [ "$tool" == "kvmtrace" ]; then
+				if [ -z "$sleep_cmd" ]; then
+					# kill the perf cmd
+					safe_kill $tool $pid INT
+				else
+					# kill the sleep process if it still exists
+					sleep_pid=`ps --ppid $pid | pgrep sleep`
+					if [ ! -z "$sleep_pid" ]; then
+						safe_kill $tool $sleep_pid
+					fi
 				fi
+				# wait for the trace-cmd pid to complete
+				while [ -d /proc/$pid ]; do
+					debug_log "waiting for PID $pid to die"
+					sleep 0.5
+				done
+				rc=0
+			else
+				safe_kill $tool $pid
+				rc=$?
+				/bin/rm -f "$tool_pid_file"
 			fi
-			# wait for the trace-cmd pid to complete
-			while [ -d /proc/$pid ]; do
-				debug_log "waiting for PID $pid to die"
-				sleep 0.5
-			done
-			rc=0
-		else
-			safe_kill $tool $pid
-			rc=$?
-			/bin/rm -f "$tool_pid_file"
 		fi
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
 	fi
 	;;
 	postprocess)

--- a/agent/tool-scripts/pcp
+++ b/agent/tool-scripts/pcp
@@ -164,9 +164,13 @@ case "$mode" in
 	fi
 	;;
 	stop)
-	pid=`cat "$tool_pid_file"`
-	debug_log "stopping $script_name"
-	kill $pid && /bin/rm "$tool_pid_file"
+	if [[ -s "$tool_pid_file" ]]; then
+		pid=`cat "$tool_pid_file"`
+		debug_log "stopping $script_name"
+		kill $pid && /bin/rm "$tool_pid_file"
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	debug_log "postprocessing $script_name"

--- a/agent/tool-scripts/perf
+++ b/agent/tool-scripts/perf
@@ -132,22 +132,26 @@ case "$mode" in
 	popd >/dev/null
 	;;
 	stop)
-	pushd $tool_output_dir >/dev/null
-	pid=`cat "$tool_pid_file"`
-	if [ ! -z "$pid" ]; then
-		kill -SIGINT $pid
-		# wait for perf to finish recording.
-		# if you do not wait, 'perf report' will not be correct.
-		# perf is not a child process, so we cannot use "wait".
-		# this is an alternative.
-		pidcmd=`ps -p $pid | tail -1 | awk '{print $4}'`
-		while [ -d /proc/$pid ]; do
-			debug_log "waiting for PID $pid ($pidcmd) to finish"
-			sleep 0.5
-		done
+	if [[ -s "$tool_pid_file" ]]; then
+		pushd $tool_output_dir >/dev/null
+		pid=`cat "$tool_pid_file"`
+		if [ ! -z "$pid" ]; then
+			kill -SIGINT $pid
+			# wait for perf to finish recording.
+			# if you do not wait, 'perf report' will not be correct.
+			# perf is not a child process, so we cannot use "wait".
+			# this is an alternative.
+			pidcmd=`ps -p $pid | tail -1 | awk '{print $4}'`
+			while [ -d /proc/$pid ]; do
+				debug_log "waiting for PID $pid ($pidcmd) to finish"
+				sleep 0.5
+			done
+		fi
+		/bin/rm "$tool_pid_file"
+		popd >/dev/null
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
 	fi
-	/bin/rm "$tool_pid_file"
-	popd >/dev/null
 	;;
 	postprocess)
 	pushd $tool_output_dir >/dev/null

--- a/agent/tool-scripts/prometheus-metrics
+++ b/agent/tool-scripts/prometheus-metrics
@@ -196,11 +196,15 @@ case "$mode" in
 	wait
 	;;
 	stop)
-	while read -u 10 pid; do
-		debug_log "stopping $script_name"
-		kill $pid
-	done 10<"$tool_pid_file"
-	/bin/rm "$tool_pid_file"
+	if [[ -s "$tool_pid_file" ]]; then
+		while read -u 10 pid; do
+			debug_log "stopping $script_name"
+			kill $pid
+		done 10<"$tool_pid_file"
+		/bin/rm "$tool_pid_file"
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	if [ -z "$options" ]; then

--- a/agent/tool-scripts/sar
+++ b/agent/tool-scripts/sar
@@ -162,9 +162,13 @@ case "$mode" in
 	wait
 	;;
 	stop)
-	pid=`cat "$tool_pid_file"`
-	debug_log "stopping $script_name"
-	kill $pid && /bin/rm "$tool_pid_file"
+	if [[ -s "$tool_pid_file" ]]; then
+		pid=`cat "$tool_pid_file"`
+		debug_log "stopping $script_name"
+		kill $pid && /bin/rm "$tool_pid_file"
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	if [ -z "$options" ] ;then

--- a/agent/tool-scripts/strace
+++ b/agent/tool-scripts/strace
@@ -127,10 +127,14 @@ case "$mode" in
         wait
         ;;
         stop)
-	for tool_pid_file in `/bin/ls $pbench_tmp | grep "$group.$iteration.$tool"`; do
-        	tool_pid=`cat "$pbench_tmp/$tool_pid_file"`
-        	kill $tool_pid && /bin/rm "$pbench_tmp/$tool_pid_file"
-	done
+	if [[ -s "$tool_pid_file" ]]; then
+		for tool_pid_file in `/bin/ls $pbench_tmp | grep "$group.$iteration.$tool"`; do
+        		tool_pid=`cat "$pbench_tmp/$tool_pid_file"`
+        		kill $tool_pid && /bin/rm "$pbench_tmp/$tool_pid_file"
+		done
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	;;

--- a/agent/tool-scripts/systemtap
+++ b/agent/tool-scripts/systemtap
@@ -129,9 +129,13 @@ case "$mode" in
 	wait
 	;;
 	stop)
-	pid=`cat "$tool_pid_file"`
-	debug_log "stopping $script_name"
-	kill $pid && /bin/rm "$tool_pid_file"
+	if [[ -s "$tool_pid_file" ]]; then
+		pid=`cat "$tool_pid_file"`
+		debug_log "stopping $script_name"
+		kill $pid && /bin/rm "$tool_pid_file"
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	debug_log "postprocessing $script_name"

--- a/agent/tool-scripts/user-tool
+++ b/agent/tool-scripts/user-tool
@@ -161,9 +161,13 @@ case "$mode" in
 	wait
 	;;
 	stop)
-	pid=`cat $tool_pid_file`
-	debug_log "stopping $script_name"
-	kill $pid && /bin/rm -f $tool_pid_file
+	if [[ -s "$tool_pid_file" ]]; then
+		pid=`cat $tool_pid_file`
+		debug_log "stopping $script_name"
+		kill $pid && /bin/rm -f $tool_pid_file
+	else
+		warn_log "[$script_name]: tool is not running, nothing to kill"
+	fi
 	;;
 	postprocess)
 	debug_log "postprocessing $script_name"


### PR DESCRIPTION
pbench-stop-tools will fail unless there are some tools running.
This commit will modify pbench-stop-tools to warn when there are
no pids to kill instead of failing since we would want to run it
to ensure that there are no tools running before registering the
tools.

Fixes #636