### PR TITLE
pbench-dispatch: modify to run as a service

### DIFF
--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -285,6 +285,10 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
     ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo \
         "mkdir -p $results_full_path/TODO; cd $results_full_path/TODO; ln -s $results_full_path/$tarball ."
 
+    # add an entry to the dispatch-list file for the inotify implementation of pbench-dispatch.
+    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo \
+        "flock -x $results_path_prefix/dispatch-list echo \"$results_full_path/TODO/$tarball\" >> $results_path_prefix/dispatch-list"
+
     let runs_copied=runs_copied+1
 done
 

--- a/server/pbench/bin/pbench-dispatch-inotify
+++ b/server/pbench/bin/pbench-dispatch-inotify
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+import pyinotify
+import subprocess
+import os
+import sys
+import signal
+import fcntl
+import threading
+
+DISPATCH_LIST = "/pbench/archive/fs-version-001/dispatch-list"
+DISPATCH_LIST_DONE = "/pbench/archive/fs-version-001/dispatch-list-done"
+OLD_DISPATCH_LIST = "/pbench/archive/fs-version-001/processed_tarballs/old-dispatch-list"
+OLD_DISPATCH_LIST_DONE = "/pbench/archive/fs-version-001/processed_tarballs/old-dispatch-list-done"
+
+old_links = []
+
+def cleanit():
+    threading.Timer(3600.0, cleanit).start()
+    if (os.path.getsize(DISPATCH_LIST) > 0):
+        with open(DISPATCH_LIST) as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+        with open(DISPATCH_LIST, 'r+') as f:
+            old_dispatch_list = f.read()
+            f.seek(0)
+            f.truncate()
+        with open(DISPATCH_LIST_DONE, 'r+') as f:
+            old_dispatch_done = f.read()
+            f.seek(0)
+            f.truncate()
+        with open(OLD_DISPATCH_LIST, 'a') as f:
+            f.write(old_dispatch_list)
+        with open(OLD_DISPATCH_LIST_DONE, 'a') as f:
+            f.write(old_dispatch_done)
+        with open(DISPATCH_LIST) as f:
+            fcntl.flock(f, fcntl.LOCK_UN)
+    
+
+def compare_and_dispatch(new_links, old_file_links):
+    diff = [i for i in new_links if (i not in old_file_links)]
+    for i in diff:
+        print ("subprocess call")
+        subprocess.call(['/opt/pbench-server/bin/pbench-dispatch', str(i)])
+    old_links.extend(diff)
+
+
+class EventHandler(pyinotify.ProcessEvent):
+    def process_IN_CLOSE_WRITE(self, event):
+        list = open(DISPATCH_LIST, 'r')
+        fcntl.flock(list, fcntl.LOCK_EX)
+        new_links = list.readlines()
+        fcntl.flock(list, fcntl.LOCK_UN)
+        list.close()
+        compare_and_dispatch(new_links, old_links)
+
+
+def main():
+    def signal_handler(signal, frame):
+        print('Signal %d caught', signal)
+        with open(DISPATCH_LIST_DONE, 'w') as f:
+            for i in old_links:
+                f.write(i)
+        os._exit(1)
+
+    sig_type = ['SIGINT', 'SIGQUIT', 'SIGTERM']
+    for i in sig_type:
+        signum = getattr(signal, i)
+        signal.signal(signum, signal_handler)
+
+    wm = pyinotify.WatchManager()  # Watch Manager
+    mask = pyinotify.IN_CLOSE_WRITE  # watched events
+
+    list = open(DISPATCH_LIST, 'r')
+    fcntl.flock(list, fcntl.LOCK_EX)
+    new_links = list.readlines()
+    with open(DISPATCH_LIST_DONE, 'r') as f:
+        old_file_links = f.readlines()
+    
+    compare_and_dispatch(new_links, old_file_links)
+
+    notifier = pyinotify.ThreadedNotifier(wm, EventHandler())
+    notifier.start()
+    wdd = wm.add_watch(DISPATCH_LIST, mask)
+    fcntl.flock(list, fcntl.LOCK_UN)
+    list.close()
+    cleanit()
+    return 0
+
+
+if __name__ == '__main__':
+    status = main()
+    sys.exit(status)

--- a/server/pbench/lib/config/pbench-dispatch.service.example
+++ b/server/pbench/lib/config/pbench-dispatch.service.example
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pbench Dispatch
+
+[Service]
+User=pbench
+Group=pbench
+Environment=CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
+Environment=MAILTO=ndokos@redhat.com
+Environment=MAILFROM=pbench@dhcp31-176.perf.lab.eng.bos.redhat.com
+ExecStart=/usr/bin/flock -n /opt/pbench-server/lib/locks/pbench-dispatch-inotify.lock /opt/pbench-server/bin/pbench-dispatch-inotify
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #665 

pbench-dispatch is running as a cron job, scheduled every minute. That
adds a minute of latency to the processing. It's a simple script that
examines the TODO subdirs under each controller for tarball symlinks;
when it finds one, it checks its MD5 and dispatches it for further
processing.

Instead of running it as a cron job, we are now running it as a service:
constantly checking, using inotify, for new tarballs in all the TODO
subdirs. When it sees a new tarball, it will do exactly what it does now:
check MD5 and dispatch it appropriately.