### PR TITLE
pbench-fio: fix pre-iteration-script and targets option handling.

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -194,7 +194,12 @@ if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
 
 else
     function check_install_rpm {
-        echo $1
+        # this deals with python-pandas/python2-pandas dichotomy - see bench-scripts/pbench-fio
+        if [ -z "$3" ] ;then
+            echo $1
+        else
+            echo $3
+        fi
         #$2 is the version which will vary
         return 0
     }

--- a/agent/bench-scripts/gold/pbench-fio/test-19.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-19.txt
@@ -1,0 +1,16 @@
++++ Running test-19 pbench-fio
+ERROR: foo must be executable
+--- Finished test-19 pbench-fio (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/samples
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+grep: /var/tmp/pbench-test-bench/pbench/pbench.log: No such file or directory
+--- pbench.log file contents
++++ test-execution.log file contents
+--- test-execution.log file contents

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -144,7 +144,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,sysinfo:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,sysinfo:,pre-iteration-script:" -n "getopt.sh" -- "$@");
 
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
@@ -448,7 +448,8 @@ function pandas_install() {
 		if [[ -z ${pandas_pkg} ]] ;then
 			return 1
 		fi
-		if check_install_rpm ${pandas_pkg}; then
+		# args 2 and 3 used in unit tests only.
+		if check_install_rpm ${pandas_pkg} "" python-pandas; then
 			debug_log "[$script_name]python-pandas is installed"
 		else
 			debug_log "[$script_name]python-pandas installation failed, exiting."
@@ -502,7 +503,7 @@ function fio_create_jobfile() {
 		-ramptime="$8" \
 		-size="$9" \
 		-rate_iops="${10}" \
-		-targets `echo "${11}" | sed -e 's/,/" "/g'` \
+		-targets $(echo "${11}" | sed -e 's/,/ /g') \
 		| sed -e 's/ = /=/g' > $fio_job_file
 
 	if [ $? -ne 0 ]; then

--- a/agent/bench-scripts/samples/pbench-agent.cfg
+++ b/agent/bench-scripts/samples/pbench-agent.cfg
@@ -1,3 +1,3 @@
 [packages]
-pandas-package = python-pandas
+pandas-package = python2-pandas
 

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -91,7 +91,7 @@ function _dump_logs {
     grep -HvF "\-\-should-n0t-ex1st--" $_testdir/pbench.log >> $_testout 2>&1
     echo "--- pbench.log file contents" >> $_testout
     echo "+++ test-execution.log file contents" >> $_testout
-    grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log | sort >> $_testout 2>&1
+    grep -sHvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log | sort >> $_testout 2>&1
     echo "--- test-execution.log file contents" >> $_testout
     rm -f $_testroot/test-execution.log
     if [ ! -z "$1" ] ;then
@@ -181,7 +181,8 @@ declare -A cmds=(
     [test-16]="pbench-uperf --help"
     [test-17]="pbench-fio --sysinfo=bad"
     [test-18]="pbench-fio --help"
-
+    [test-19]="pbench-fio --pre-iteration-script=foo"
+#    [test-20]="pbench-fio --targets=/dev/foo,/dev/bar --config=test-06  --test-type=throughput --samples=1 --client-file=/tmp/foo"
 )
 
 declare -A expected_status=(
@@ -189,6 +190,7 @@ declare -A expected_status=(
     [test-13]=1
     [test-15]=1
     [test-17]=1
+    [test-19]=1
 )
 
 date="1900.01.01T00.00.00"

--- a/agent/config/pbench-agent.cfg.example
+++ b/agent/config/pbench-agent.cfg.example
@@ -29,10 +29,17 @@ interval = 3
 interval = 30
 
 [packages]
+# If you install using an "internal" RPM, that should
+# take care of installing the right package, depending
+# on the distro.
+
+# If you are copying this example file to create the "real"
+# pbench-agent.cfg file, you need to uncomment one of the
+# following pandas-package lines.
 # RHEL has python-pandas
-pandas-package = python-pandas
+# pandas-package = python-pandas
 # Fedora has python2-pandas and python3-pandas
-pandas-package = python2-pandas
+# pandas-package = python2-pandas
 
 [config]
 path = %(pbench_install_dir)s/config


### PR DESCRIPTION
Fixes #718
Fixes #723

Multiple targets are mishandled in the generation of the fio
jobfile. This commit fixes the generation of the jobfile.

The pre-iteration-script option was left out of the getopts string, so
it is not recognized as a legitimate option (although the rest of the
implementation is fine). This commit adds the option to getopts.

Add a unit test for the option handling. A unit test for the jobfile
generation is TBD.