### PR TITLE
pbench-sysinfo-dump: Avoid printing logs to stdout to avoid tar ball corruption

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -108,7 +108,6 @@ function collect_ara_data {
 }
 
 for item in ${sysinfo//,/ };do
-	echo "Collecting $item"
 	debug_log "[$script_name]: collecting $item"
 	if [[ "$item" == "kernel_config" ]]; then
 		collect_kernel_config &


### PR DESCRIPTION
This commit avoids printing the sysinfo type being collected so
that the printed message doesn't end up in the tar ball, thereby
corrupting it.