### PR TITLE
add param histogram-interval-msec, default 10 sec not 60

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-17.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-17.txt
@@ -73,6 +73,8 @@ The following options are available:
 		Default is n
 	--remote-only
 	run this on the remotes only
+	--histogram-interval-msec=<int>
+	set the histogram logging interval in milliseconds (default 10000)
 	--sysinfo=str            str= comma seperated values of sysinfo to be collected
 	                              available: default,none,all,a,b,c,d,e
 --- Finished test-17 pbench-fio (status=1)

--- a/agent/bench-scripts/gold/pbench-fio/test-18.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-18.txt
@@ -69,6 +69,8 @@ The following options are available:
 		Default is n
 	--remote-only
 	run this on the remotes only
+	--histogram-interval-msec=<int>
+	set the histogram logging interval in milliseconds (default 10000)
 	--sysinfo=str            str= comma seperated values of sysinfo to be collected
 	                              available: default,none,all,a,b,c,d,e
 --- Finished test-18 pbench-fio (status=0)

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -64,6 +64,7 @@ tool_label_pattern="fio-"
 tool_group="default"
 max_key_length=20
 primary_metric="readwrite_IOPS"
+histogram_interval_msec=10000
 sysinfo="default"
 
 function fio_usage() {
@@ -139,12 +140,14 @@ function fio_usage() {
 		printf "\t\tDefault is n\n"
 		printf -- "\t--remote-only\n"
 		printf "\trun this on the remotes only\n"
+		printf "\t--histogram-interval-msec=<int>\n"
+		printf "\tset the histogram logging interval in milliseconds (default 10000)\n"
 		printf -- "\t--sysinfo=str            str= comma seperated values of sysinfo to be collected\n"
 		printf -- "\t                              available: $(pbench-collect-sysinfo --options)\n"
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,sysinfo:,pre-iteration-script:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,sysinfo:,pre-iteration-script:,histogram-interval-msec:" -n "getopt.sh" -- "$@");
 
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
@@ -364,6 +367,11 @@ function fio_process_options() {
 				shift;
 			fi
 			;;
+			--histogram-interval-msec)
+			shift;
+			histogram_interval_msec="$1"
+			shift
+			;;
 			--sysinfo)
 			shift;
 			if [ -n "$1" ]; then
@@ -490,7 +498,7 @@ function fio_device_check() {
 }
 
 function fio_create_jobfile() {
-	local fio_job_file="${12}"
+	local fio_job_file="${13}"
 
 	mkdir -p "`dirname \"$fio_job_file\"`"
 	"${script_path}/templates/make-fio-jobfile.py" -j $job_file \
@@ -503,7 +511,8 @@ function fio_create_jobfile() {
 		-ramptime="$8" \
 		-size="$9" \
 		-rate_iops="${10}" \
-		-targets $(echo "${11}" | sed -e 's/,/ /g') \
+		-log_hist_msec="${11}" \
+		-targets $(echo "${12}" | sed -e 's/,/ /g') \
 		| sed -e 's/ = /=/g' > $fio_job_file
 
 	if [ $? -ne 0 ]; then
@@ -693,7 +702,7 @@ function fio_run_benchmark() {
 								fi
 								mkdir -p $benchmark_results_dir
 								fio_job_file="$benchmark_results_dir/fio.job"
-								fio_create_jobfile "$test_type" "$ioengine" "$block_size" "$iodepth" "$direct" "$sync" "$runtime" "$ramptime" "$file_size" "$rate_iops" "$dev" "$fio_job_file"
+								fio_create_jobfile "$test_type" "$ioengine" "$block_size" "$iodepth" "$direct" "$sync" "$runtime" "$ramptime" "$file_size" "$rate_iops" "$histogram_interval_msec" "$dev" "$fio_job_file" 
 								fio_run_job "$iteration" "$benchmark_results_dir" "$fio_job_file" "$clients"
 							else
 								# if we are only postprocessing, then we might have to untar an existing result

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -141,7 +141,7 @@ function fio_usage() {
 		printf -- "\t--remote-only\n"
 		printf "\trun this on the remotes only\n"
 		printf "\t--histogram-interval-msec=<int>\n"
-		printf "\tset the histogram logging interval in milliseconds (default 10000)\n"
+		printf "\tset the histogram logging interval in milliseconds (default $histogram_interval_msec)\n"
 		printf -- "\t--sysinfo=str            str= comma seperated values of sysinfo to be collected\n"
 		printf -- "\t                              available: $(pbench-collect-sysinfo --options)\n"
 }

--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -96,7 +96,7 @@ def replace_val(dct, magic, delta):
 # Other arguments that can override those given in the job file:
 other_args = \
     ['bs', 'rw', 'ioengine', 'iodepth', 'direct', 'sync',
-     'runtime', 'ramptime', 'size', 'rate_iops']
+     'runtime', 'ramptime', 'size', 'rate_iops', 'log_hist_msec']
 
 def main(ctx):
 


### PR DESCRIPTION
Allow user to change histogram logging interval, and change default to 10 seconds.   This change in default  means that most users will see histogram logs now even if they use a small test time , where before they were getting empty histogram logs.  This depends on a previous fio fix to not segfault when retrieving histogram logs, this is in fio 3.3.