### PR TITLE
move non-workload params to global section

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-04.txt
@@ -12,11 +12,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -24,6 +19,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample1/fio.job
 fio job complete
@@ -40,11 +40,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -52,6 +47,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample2/fio.job
 fio job complete
@@ -68,11 +68,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -80,6 +75,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample3/fio.job
 fio job complete
@@ -96,11 +96,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -108,6 +103,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample4/fio.job
 fio job complete
@@ -124,11 +124,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -136,6 +131,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample5/fio.job
 fio job complete
@@ -152,11 +152,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -164,6 +159,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB/sample1/fio.job
 fio job complete
@@ -180,11 +180,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -192,6 +187,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB/sample2/fio.job
 fio job complete
@@ -208,11 +208,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -220,6 +215,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB/sample3/fio.job
 fio job complete
@@ -236,11 +236,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -248,6 +243,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB/sample4/fio.job
 fio job complete
@@ -264,11 +264,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -276,6 +271,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB/sample5/fio.job
 fio job complete
@@ -292,11 +292,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -304,6 +299,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB/sample1/fio.job
 fio job complete
@@ -320,11 +320,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -332,6 +327,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB/sample2/fio.job
 fio job complete
@@ -348,11 +348,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -360,6 +355,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB/sample3/fio.job
 fio job complete
@@ -376,11 +376,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -388,6 +383,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB/sample4/fio.job
 fio job complete
@@ -404,11 +404,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=rw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -416,6 +411,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=rw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB/sample5/fio.job
 fio job complete
@@ -432,11 +432,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -444,6 +439,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/4-randrw-4KiB/sample1/fio.job
 fio job complete
@@ -460,11 +460,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -472,6 +467,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/4-randrw-4KiB/sample2/fio.job
 fio job complete
@@ -488,11 +488,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -500,6 +495,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/4-randrw-4KiB/sample3/fio.job
 fio job complete
@@ -516,11 +516,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -528,6 +523,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/4-randrw-4KiB/sample4/fio.job
 fio job complete
@@ -544,11 +544,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -556,6 +551,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/4-randrw-4KiB/sample5/fio.job
 fio job complete
@@ -572,11 +572,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -584,6 +579,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/5-randrw-64KiB/sample1/fio.job
 fio job complete
@@ -600,11 +600,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -612,6 +607,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/5-randrw-64KiB/sample2/fio.job
 fio job complete
@@ -628,11 +628,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -640,6 +635,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/5-randrw-64KiB/sample3/fio.job
 fio job complete
@@ -656,11 +656,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -668,6 +663,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/5-randrw-64KiB/sample4/fio.job
 fio job complete
@@ -684,11 +684,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -696,6 +691,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/5-randrw-64KiB/sample5/fio.job
 fio job complete
@@ -712,11 +712,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -724,6 +719,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample1/fio.job
 fio job complete
@@ -740,11 +740,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -752,6 +747,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample2/fio.job
 fio job complete
@@ -768,11 +768,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -780,6 +775,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample3/fio.job
 fio job complete
@@ -796,11 +796,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -808,6 +803,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample4/fio.job
 fio job complete
@@ -824,11 +824,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=randrw
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -836,6 +831,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=randrw
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample5/fio.job
 fio job complete

--- a/agent/bench-scripts/gold/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-05.txt
@@ -13,11 +13,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -25,6 +20,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/1-throughput-4KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/1-throughput-4KiB/sample1/*.log.foo': No such file or directory
@@ -45,11 +45,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -57,6 +52,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/2-throughput-64KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/2-throughput-64KiB/sample1/*.log.foo': No such file or directory
@@ -77,11 +77,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -89,6 +84,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/3-throughput-1024KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-05_1900.01.01T00.00.00/3-throughput-1024KiB/sample1/*.log.foo': No such file or directory

--- a/agent/bench-scripts/gold/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-06.txt
@@ -13,11 +13,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -25,6 +20,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/1-throughput-4KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/1-throughput-4KiB/sample1/*.log.foo': No such file or directory
@@ -47,11 +47,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -59,6 +54,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/2-throughput-64KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/2-throughput-64KiB/sample1/*.log.foo': No such file or directory
@@ -81,11 +81,6 @@ sync=0
 time_based=1
 clocksource=gettimeofday
 ramp_time=5
-
-[job-/tmp/fio]
-filename=/tmp/fio
-rw=throughput
-size=4096M
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -93,6 +88,11 @@ log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
 log_hist_coarseness=4 # 76 bins
+
+[job-/tmp/fio]
+filename=/tmp/fio
+rw=throughput
+size=4096M
 
 running fio job: /var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/3-throughput-1024KiB/sample1/fio.job
 /bin/mv: cannot stat '/var/tmp/pbench-test-bench/pbench/fio_test-06_1900.01.01T00.00.00/3-throughput-1024KiB/sample1/*.log.foo': No such file or directory

--- a/agent/bench-scripts/templates/fio.job
+++ b/agent/bench-scripts/templates/fio.job
@@ -16,19 +16,18 @@ sync = 0
 time_based = 1
 clocksource = gettimeofday
 ramp_time = 5
+write_bw_log = fio
+write_iops_log = fio
+write_lat_log = fio
+log_avg_msec = 1000
+write_hist_log = fio
+log_hist_msec = 10000
+log_hist_coarseness = 4 # 76 bins
 
 [job-$target]
 filename = $target
 rw = $@
 size = 4096M
-write_bw_log = fio
-write_iops_log = fio
-write_lat_log = fio
-log_avg_msec = 1000
-
-write_hist_log = fio
-log_hist_msec = 10000
-log_hist_coarseness = 4 # 76 bins
 
 #rate_iops=10
 #directory=/tmp/fio


### PR DESCRIPTION
There is no reason to put non-workload parameters like "log_hist_msec" in the per-target section of the job file, where they get repeated for each target.  This fix makes the job file much shorter and easier to read.