### PR TITLE
change to new pbench-fio version

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -17,7 +17,7 @@ export benchmark_run_dir=""
 if [[ -z "$benchmark_bin" ]]; then
 	benchmark_bin=/usr/local/bin/$benchmark
 fi	
-ver=2.14
+ver=3.3-1
 
 job_file="${script_path}/templates/fio.job"
 


### PR DESCRIPTION
pbench-fio won't run unless the "ver" variable matches the pbench-fio RPM version, which is now 3.3-1.