### PR TITLE
Pbench cron job scripts: now run as a service.

### DIFF
--- a/server/pbench/bin/pbench-backup-tarballs
+++ b/server/pbench/bin/pbench-backup-tarballs
@@ -23,7 +23,7 @@ stats=$TMP/${PROG}.$$
 
 trap "rm -f $stats" EXIT INT QUIT
                  
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 echo "start-$(timestamp)"
 

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -90,7 +90,9 @@ function mk_dirs {
 }
 
 function log_init {
-    LOG_DIR=$LOGSDIR/$(basename $0)
+    #LOG_DIR=$LOGSDIR/$(basename $0)
+    #TMP_DIR=$TMP/$(basename $0).$$
+    LOG_DIR=$2
     mkdir -p $LOG_DIR
     if [[ $? -ne 0 || ! -d "$LOG_DIR" ]]; then
         doexit "Unable to find/create logging directory, $LOG_DIR"
@@ -112,4 +114,29 @@ function log_finish {
     exec 2>&200  # Restore stderr
     exec 100>&-  # Close log file
     exec 4>&-    # Close error file
+}
+
+# The inotify script runs the server scripts like dispatch 
+# and unpack asynchronously (more will be added in future), 
+# results in multiple instances of those scripts running in 
+# parallel. If every instance tries to write in the same file 
+# then it will be chaos and make things difficult to debug. 
+# In that case, this function will acquire a lock on the main
+# log file and allow every instance to append the log saved in 
+# the /tmp directory (with different PID) to the main log file.
+
+function log_append {
+    #log_append $TMP/$(basename $0).$$ $LOGSDIR/$(basename $0)
+    TMP_DIR=$1
+    LOG_DIR=$2
+    mkdir -p $LOG_DIR
+    if [[ $? -ne 0 || ! -d "$LOG_DIR" ]]; then
+        doexit "Unable to find/create logging directory, $LOG_DIR"
+    fi
+
+    log_file=$LOG_DIR/$(basename $0).log
+    error_file=$LOG_DIR/$(basename $0).error
+
+    flock -n $log_file cat $TMP_DIR/$(basename $0).log >> $log_file
+    flock -n $error_file cat $TMP_DIR/$(basename $0).error >> $error_file
 }

--- a/server/pbench/bin/pbench-clean-up-dangling-results-links
+++ b/server/pbench/bin/pbench-clean-up-dangling-results-links
@@ -17,7 +17,7 @@ esac
 
 # TOP, ARCHIVE, RESULTS are defined by the base file
 . $dir/pbench-base.sh
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"

--- a/server/pbench/bin/pbench-copy-sosreports
+++ b/server/pbench/bin/pbench-copy-sosreports
@@ -53,7 +53,7 @@ esac
 . $dir/pbench-base.sh
 ###########################################################################
 
-log_init $PROG
+log_init $PROG $LOGSDIR/$(basename $0)
 
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"

--- a/server/pbench/bin/pbench-dispatch
+++ b/server/pbench/bin/pbench-dispatch
@@ -47,7 +47,7 @@ esac
 . $dir/pbench-base.sh
 ###########################################################################
 
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"

--- a/server/pbench/bin/pbench-dispatch-inotify
+++ b/server/pbench/bin/pbench-dispatch-inotify
@@ -1,0 +1,172 @@
+#! /bin/bash
+# -*- mode: shell-script -*-
+
+# This script is the first part of the pipeline that processes pbench
+# results tarballs.
+
+# First stage:  pbench-dispatch looks in all the TODO
+#               directories, checks MD5 sums and
+#               creates symlinks in all the state directories for
+#               the particular environment where this server runs
+#               (e.g. for the production environment, links are created
+#               in the TO-UNPACK, TO-INDEX, TO-COPY-SOS and TO-BACKUP
+#               directories; for a satellite, it will only create links
+#               in the TO-UNPACK and TO-SYNC directories). Then the
+#               symlink in TODO is deleted: we don't want to deal with
+#               this tarball again; but if there are errors, we may
+#               keep it in TODO and try again, if the error is recoverable.
+#               Any errors are reported for possible action by an admin.
+#               
+
+# assumptions:
+# - this script runs as a cron job
+# - tarballs and md5 sums are uploaded by pbench-move/copy-results to
+#   $ARCHIVE/$(hostname -s) area.
+# - pbench-move/copy-results also makes a symlink to each tarball it uploads
+#   in $ARCHIVE/TODO, thereby telling this script to process the tarball.
+
+# This script loops over the contents of $archive/<hostname>/TODO, verifies the md5
+# sum of each tarball, and if correct, it dispatches the tarball for further
+# processing.
+
+
+###########################################################################
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)
+        PROG=$(basename $0)
+        ;;
+esac
+
+. $dir/pbench-base.sh
+###########################################################################
+
+log_init $(basename $0) $TMP/$(basename $0).$$
+
+# check that all the directories exist
+test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"
+test -d $UNPACK_DIR || doexit "Bad UNPACK=$UNPACK_DIR"
+
+# make sure only one copy is running.
+# Use 'flock -n $LOCKFILE /path/to/pbench-dispatch' in the
+# crontab to ensure that only one copy is running. The script itself
+# does not use any locking.
+
+typeset -i ntb=0
+typeset -i ntotal=0
+typeset -i nerrs=0
+typeset -i ndups=0
+
+trap "rm -rf $TMP/$(basename $0).$$" EXIT INT QUIT
+
+# the link source and destination for this script
+linksrc=TODO
+linkdestlist=$(getconf.py -l dispatch-states pbench-server)
+if [[ -z "$linkdestlist" ]]; then
+    echo "$TS: config file error: either no dispach-states defined or a typo" >&4
+    subj="$PROG.$TS($PBENCH_ENV) - Config file error"
+    echo "config file error: either no dispach-states defined or a typo" | mailx -s "$subj" $mail_recipients
+    exit 1
+else
+    echo $TS
+    shift
+    for i in $@; do
+        ntotal=$ntotal+1
+
+        link=`echo $i | sed 's;/TODO;;'`
+        if [ ! -f "$link" ] ;then
+            echo "$TS: $link does not exist" | tee -a $mail_content >&4 
+            nerrs=$nerrs+1
+            continue
+        fi
+
+        result=$i
+        resultname=$(basename $result)
+        resultname=${resultname%.tar.xz}
+        hostname=$(basename $(dirname $link))
+
+        # make sure that all the relevant state directories exist
+        mk_dirs $hostname
+        # ... and a couple of other necessities.
+        if [[ $? -ne 0 ]] ;then
+            echo "$TS: Creation of $hostname processing directories failed: code $status" >&4
+            nerrs=$nerrs+1
+            continue
+        fi
+        
+        mkdir -p $TMP/$PROG/$hostname
+        status=$?
+        if [[ $status -ne 0 ]] ;then
+            echo "$TS: mkdir -p $TMP/$PROG/$hostname failed: code $status" >&4
+            nerrs=$nerrs+1
+            continue
+        fi
+        
+        # XXXX - for now, if it's a duplicate name, just punt and avoid producing the error - the full
+        # solution will involve renaming the unpacked directory appropriately.
+        if [ ${resultname%%.*} == "DUPLICATE__NAME" ] ;then
+            ndups=$ndups+1
+            continue
+        fi
+
+        # check the md5 sum
+        md5=$(cat $link.md5 2> /dev/null | cut -d' ' -f1)
+        md5tar=$(md5sum $link 2> /dev/null | cut -d' ' -f1)
+        if [ "$md5" != "$md5tar" ] ;then
+            echo "$TS: MD5 check failed on $link" >&4
+            # move the link so that the script does not report the error continuously
+            mv $result $(echo $result | sed 's/TODO/BAD-MD5/')
+            nerrs=$nerrs+1
+            continue
+        fi
+
+        # move any prefix file to the .prefix subdir
+        basedir=$(dirname $link)
+        prefixfile=$basedir/prefix.$resultname
+        if [ -f $prefixfile ] ;then
+            mkdir -p $basedir/.prefix
+            mv $prefixfile $basedir/.prefix
+        fi
+
+        # create a link in each state dir - if any fail, we should delete them all? No, that
+        # would be racy.
+        for state in $linkdestlist ;do
+            ln -sf $link $(echo $result | sed "s/$linksrc/$state/")
+            status=$?
+            if [[ $status -ne 0 ]] ;then
+               echo "$TS: Cannot create $result link from $linksrc to $state: code $status" >&4
+               nerrs=$nerrs+1
+               continue
+           else
+               echo $result >> $INOTIFY_STATE_DIR/$state-LIST
+            fi
+        done
+        # this needs checking
+        rm $result
+
+        # log the success
+        echo "$TS: $hostname/$resultname: success"
+        ntb=$ntb+1
+    done
+fi
+
+echo "$TS: Processed $ntb tarballs"
+
+log_finish
+log_append $TMP/$(basename $0).$$ $LOGSDIR/$(basename $0)
+
+if [[ $nerrs -gt 0 ]]; then
+    subj="$PROG.$TS($PBENCH_ENV) - w/ $nerrs errors"
+    # don't send mail when running unittests
+    if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
+        echo "Processed $ntotal result tar balls, $ntb successfully, with $nerrs errors and $ndups duplicates" | mailx -s "$subj" $mail_recipients
+    fi
+fi
+
+exit 0

--- a/server/pbench/bin/pbench-edit-prefixes
+++ b/server/pbench/bin/pbench-edit-prefixes
@@ -34,7 +34,7 @@ esac
 # TOP, ARCHIVE, INCOMING, RESULTS are defined by the base file
 . $dir/pbench-base.sh
 ###########################################################################
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -75,7 +75,7 @@ TMPDIR=$TMP/pbench-index.$$
 # index-pbench need to get at it
 export TMPDIR
 
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 echo "$TS: starting at $(timestamp)"
 

--- a/server/pbench/bin/pbench-inotify
+++ b/server/pbench/bin/pbench-inotify
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+
+"""
+This script is a generic inotify script running as a systemd
+service. Using this script, the various server scripts can be invoked
+directly and immediately, instead of having to wait to be invoked by
+cron.
+
+Not every server script will be converted: some will continue to
+be run as cron jobs.
+
+The script uses the pyinotify library to create a watch for a file and
+triggers the associationed command if any changes happen to the
+file. IOW, we assume that a new entry is added to the file when a user
+submits a new result (i.e.  pbench-move-results on the agent side
+needs to be modified).
+"""
+
+import pyinotify
+import subprocess
+import os
+import sys
+import signal
+import fcntl
+import threading
+
+DEBUG = False
+
+
+class Association(object):
+
+    """The Association class associates a server script to the administrative
+    files that are used to figure out whether the script needs to be
+    called.
+
+    The list_file is modified externally(e.g. remotely by
+    pbench-move-results). At initialization, the inotify handler
+    establishes watches on *all* the list_files, so when a change is seen,
+    it use the file name of the changed file as a key in a dict of
+    associations to select the correct one and calls the
+    compare_and_dispatch() routine for this association.
+
+    compare_and_dispatch() calculates the difference between the list_file
+    and the(in-memory) done_links list, to figure out the list of new
+    results. It then calls the script for this association, passing it
+    that list of new results.
+
+    Periodically during cleanup, the list_file is appended to
+    old_list_file and the done_links list is appended to the
+    old_done_file.
+
+    done_links is an in-memory list of symlinks (to tarballs). When a
+    tarball is processed, the link is added to done_links. If the
+    script terminates for whatever reason, the list is saved in a file
+    (done_file). When the script is (re)started, done_links is
+    initialized from the done_file.
+
+    """
+
+    # class variable
+    INOTIFY_STATE_DIR = "/pbench/archive/fs-version-001/inotify_state"
+
+    def __init__(self, script, args, listf, donef, olistf, odonef):
+        self.script = script
+        self.args = args
+        self.list_file = "%s/%s" % (self.INOTIFY_STATE_DIR, listf)
+        self.done_file = "%s/%s" % (self.INOTIFY_STATE_DIR, donef)
+        self.old_list_file = "%s/%s" % (self.INOTIFY_STATE_DIR, olistf)
+        self.old_done_file = "%s/%s" % (self.INOTIFY_STATE_DIR, odonef)
+        self.done_links = []
+        self.mutex = threading.Lock()
+
+        # Make sure the directory and files are present
+        if not os.path.exists(self.INOTIFY_STATE_DIR):
+            os.makedirs(self.INOTIFY_STATE_DIR)
+        if not os.path.exists(self.list_file):
+            with open(self.list_file, 'w'):
+                pass
+        if not os.path.exists(self.done_file):
+            with open(self.done_file, 'w'):
+                pass
+        if not os.path.exists(self.old_list_file):
+            with open(self.old_list_file, 'w'):
+                pass
+        if not os.path.exists(self.old_done_file):
+            with open(self.old_done_file, 'w'):
+                pass
+
+    def compare_and_dispatch(self, new_links):
+        """
+        This function calculates the difference between the files
+        already processed and the ones that are yet to be done, and
+        then passes it to the script. It then update the done_links
+        list to include the new files.
+        """
+        diff = [i for i in new_links if (i not in self.done_links)]
+        if DEBUG:
+            print("LEN_DIFF: %s" % len(diff))
+            print("NEW: %s" % new_links)
+            print("DONE: %s" % self.done_links)
+            print("DIFF: %s" % diff)
+        if len(diff) > 0:
+            if DEBUG:
+                print(self.script, self.args)
+            p = subprocess.Popen(
+                [self.script, str(self.args)] + diff, env=os.environ.copy())
+        self.mutex.acquire()
+        self.done_links.extend(diff)
+        self.mutex.release()
+
+    def spill_done_links(self):
+        """
+        This function allows cleanit to acquire the same mutex for
+        locking on the done_links and do the cleanup.
+        """
+        self.mutex.acquire()
+        links = '\n'.join(self.done_links)
+        self.done_links = []
+        self.mutex.release()
+        return links
+
+
+""" 
+The associations dictionary contains an entry for each script that
+is to be run by the inotify script. It is indexed by the (simple)
+filename of the list file that inotify watches.
+
+A dictionary is being used here so that when we convert a cronjob to a
+service,all we need to do is add an entry to the dict.
+"""
+associations = {
+    'TO-DISPATCH-LIST': Association(
+        '/opt/pbench-server/bin/pbench-dispatch',
+        '',
+        'TO-DISPATCH-LIST',
+        'TO-DISPATCH-DONE-LIST',
+        'OLD-TO-DISPATCH-LIST',
+        'OLD-TO-DISPATCH-DONE-LIST'),
+    'TO-UNPACK-LIST': Association(
+        '/opt/pbench-server/bin/pbench-unpack-tarballs',
+        '/pbench/public_html/incoming',
+        'TO-UNPACK-LIST',
+        'TO-UNPACK-DONE-LIST',
+        'OLD-TO-UNPACK-LIST',
+        'OLD-TO-UNPACK-DONE-LIST')
+}
+
+
+def cleanit():
+    """
+    Thread that runs periodically to keep in-memory structures
+    within limits.
+    """
+    threading.Timer(3600.0, cleanit).start()  # time in seconds
+    for j in associations:
+        if (os.path.getsize(associations[j].list_file) > 0):
+            with open(associations[j].list_file) as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+            old_done_links = associations[j].spill_done_links()
+            with open(associations[j].list_file, 'r+') as f:
+                old_file_list = f.read()
+                f.seek(0)
+                f.truncate()
+            with open(associations[j].old_list_file, 'a') as f:
+                f.write(old_file_list)
+            with open(associations[j].old_done_file, 'a') as f:
+                f.write(old_done_links)
+            with open(associations[j].list_file) as f:
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+
+class EventHandler(pyinotify.ProcessEvent):
+    """
+    This class handles the events for the scripts. If some changes are
+    detected on the watch file then this class get triggered.
+    """
+
+    def process_IN_CLOSE_WRITE(self, event):
+        filename = event.pathname.split("/")[-1]
+        if DEBUG == "True":
+            print("\nTRIGERRED BY: %s" % filename)
+        script_to_run = associations[filename].script
+        args = associations[filename].args
+        list = open(associations[filename].list_file, 'r')
+        fcntl.flock(list, fcntl.LOCK_EX)
+        new_links = list.readlines()
+        fcntl.flock(list, fcntl.LOCK_UN)
+        list.close()
+        associations[filename].compare_and_dispatch(new_links)
+
+
+def main():
+    # set up signal handlers to save the in-memory done_links to the done_file.
+    def signal_handler(signal, frame):
+        for j in associations:
+            with open(associations[j].done_file, 'w') as f:
+                for i in associations[j].done_links:
+                    f.write(i)
+        os._exit(1)
+
+    sig_type = ['SIGINT', 'SIGQUIT', 'SIGTERM']
+    for i in sig_type:
+        signum = getattr(signal, i)
+        signal.signal(signum, signal_handler)
+
+    # set up the inotify handler
+    wm = pyinotify.WatchManager()  # Watch Manager
+    mask = pyinotify.IN_CLOSE_WRITE  # watched events
+    notifier = pyinotify.ThreadedNotifier(wm, EventHandler())
+    notifier.start()
+
+    # now that the inotify handler is set up, add a watch to the list
+    # file for each association, but first make sure that any work
+    # that was interrupted earlier (or was submitted while this script
+    # was not running) is done now: for each association,
+    # read the list file, initialize the in-memory done_links from the
+    # done file and call compare_and_dispatch(). We take an exclusive
+    # lock on the list file, so it will not be modified during the
+    # initialization period: any pbench-move-results will have to wait
+    # for this to finish.
+
+    for j in associations:
+        list = open(associations[j].list_file, 'r')
+        fcntl.flock(list, fcntl.LOCK_EX)
+        new_links = list.readlines()
+        with open(associations[j].done_file, 'r') as f:
+            done_links = f.readlines()
+            associations[j].done_links = done_links
+        associations[j].compare_and_dispatch(new_links)
+        wm.add_watch(associations[j].list_file, mask)
+        fcntl.flock(list, fcntl.LOCK_UN)
+        list.close()
+
+    # start the cleanit thread
+    cleanit()
+
+    return 0
+
+
+if __name__ == '__main__':
+    status = main()
+    sys.exit(status)

--- a/server/pbench/bin/pbench-move-unpacked
+++ b/server/pbench/bin/pbench-move-unpacked
@@ -30,7 +30,7 @@ if [[ -z "$mail_recipients" ]] ;then
     exit 1
 fi
 
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 # make sure only one copy is running.
 # Use 'flock -n $LOCKFILE /home/pbench/bin/pbench-move-unpacked' in the

--- a/server/pbench/bin/pbench-satellite-cleanup
+++ b/server/pbench/bin/pbench-satellite-cleanup
@@ -41,7 +41,7 @@ trap "rm -rf $tmp" EXIT
 
 mkdir -p "$tmp"
 
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 echo $TS: $PROG starting
 

--- a/server/pbench/bin/pbench-sync-package-tarballs
+++ b/server/pbench/bin/pbench-sync-package-tarballs
@@ -41,12 +41,7 @@ typeset -i nprocessed=0
 
 mkdir -p "$tmp"
 
-log_init $(basename $0)
-if [[ -z "$mail_recipients" ]] ;then
-    echo "$TS: $PROG: mail_recipients is not defined" >&4
-    exit 1
-fi
-
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
 mkdir -p "$logdir"
 rc=$?

--- a/server/pbench/bin/pbench-sync-satellite
+++ b/server/pbench/bin/pbench-sync-satellite
@@ -105,12 +105,7 @@ trap "rm -rf $tmp" EXIT QUIT INT
 mkdir -p $tmp
 mkdir -p $unpack
 
-log_init $(basename $0)
-if [[ -z "$mail_recipients" ]] ;then
-    echo "$PROG: mail_recipients is not defined" >&4
-    exit 1
-fi
-
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
 # remove the tmp dir on exit; try to remove an empty $logdir
 # but suppress any complaints.

--- a/server/pbench/bin/pbench-sync-satellite
+++ b/server/pbench/bin/pbench-sync-satellite
@@ -214,6 +214,9 @@ for host in $hosts ;do
                 $PWD/$x TODO/$x" | tee -a $mail_content >&4 
                 continue
             fi
+            # For the synced tarballs, add an entry to the dispatch
+            # list watching by inotify script.  
+            flock -x $INOTIFY_STATE_DIR/TO-DISPATCH-LIST echo $PWD/TODO/$x >> $INOTIFY_STATE_DIR/TO-DISPATCH-LIST
         done
     fi
     # save the contents of ok checks to further use it for state change

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -58,7 +58,7 @@ UNPACK_PATH=$1
 . $dir/pbench-base.sh
 ###########################################################################
 
-log_init $(basename $0)
+log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"

--- a/server/pbench/bin/pbench-unpack-tarballs-inotify
+++ b/server/pbench/bin/pbench-unpack-tarballs-inotify
@@ -1,0 +1,268 @@
+#! /bin/bash
+# -*- mode: shell-script -*-
+
+# This script is the first part of the pipeline that processes pbench
+# results tarballs.
+
+# First stage:  pbench-unpack-tarballs looks in all the TODO
+#               directories, unpacks tarballs, checks MD5 sums and
+#               moves the symlink from the TODO subdir to the
+#               TO-COPY-SOS subdir.  It runs under cron once a minute
+#               in order to minimize the delay between uploading the
+#               results and making them available for viewing over the
+#               web.
+
+# Second stage: pbench-copy-sosreports looks in all the TO-COPY-SOS
+#               subdirs, extracs the sos report from the tarball and
+#               copies it to the VoS incoming area for further
+#               processing. Assuming that all is well, it moves the
+#               symlink from the TO-COPY-SOS subdir to the TO-INDEX
+#               subdir.
+
+# Third stage:  pbench-index looks in all the TO-INDEX subdirs and
+#               calls the pbench-results-indexer script to index the
+#               results tarball into ES. It then moves the symlink from
+#               the TO-INDEX subdir to the DONE subdir.
+
+# assumptions:
+# - this script runs as a cron job
+# - tarballs and md5 sums are uploaded by move/copy-results to
+#   $ARCHIVE/$(hostname -s) area.
+# - move/copy-results also makes a symlink to each tarball it uploads
+#   in $ARCHIVE/TODO.
+
+# This script loops over the contents of $archive/TODO, verifies the md5
+# sum of each tarball, and if correct, it unpacks the tarball into
+# .../incoming/$(hostname -s)/.  If everything works, it then moves the
+# symlink from $ARCHIVE/TODO to $ARCHIVE/TO-COPY-SOS.
+
+
+###########################################################################
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)
+        PROG=$(basename $0)
+        ;;
+esac
+
+UNPACK_PATH=$1
+#mkdir -p $UNPACK_PATH
+
+# TOP, ARCHIVE, INCOMING, RESULTS are all defined by the base file
+. $dir/pbench-base.sh
+###########################################################################
+
+# check that all the directories exist
+test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"
+test -d $INCOMING || doexit "Bad INCOMING=$INCOMING"
+test -d $RESULTS || doexit "Bad RESULTS=$RESULTS"
+
+log_init $(basename $0) $TMP/$(basename $0).$$
+
+# make sure only one copy is running.
+# Use 'flock -n $LOCKFILE /home/pbench/bin/pbench-unpack-tarballs' in the
+# crontab to ensure that only one copy is running. The script itself
+# does not use any locking.
+
+# the link source and destination for this script
+linksrc=TO-UNPACK
+linkdest=UNPACKED
+echo $TS
+
+tmp=$TMP/$PROG.$$
+
+#trap 'rm -rf $tmp' EXIT INT QUIT
+trap "rm -rf $tmp $TMP/$(basename $0).$$" EXIT INT QUIT
+
+mkdir -p $tmp
+
+# accumulate errors in a file for mailing at end
+mail_content=$tmp/mail_content.log
+
+# get the list of files we'll be operating on - sort them by size
+list=$tmp/$PROG.list
+
+# find command will not generate any result if the linksrc is empty, and because of that du will not get any result 
+# to calculate the size. In that scenario du generates the size of the current directory as output, to handle
+# that exclude the current directory.
+#find $ARCHIVE/*/$linksrc -type l -name '*.tar.xz' -printf "%l\n" 2>/dev/null | grep -v DUPLICATE | xargs du -b --exclude "." 2>/dev/null | sort -n > $list
+
+typeset -i ntb=0
+typeset -i ntotal=0
+typeset -i nerrs=0
+typeset -i ndups=0
+
+# Initialize mail content
+> $mail_content
+
+shift
+for i in $@;do
+    ntotal=$ntotal+1
+
+    link=`echo $i | sed 's;/TODO;;'`
+    if [ ! -f "$link" ] ;then
+        echo "$TS: $link does not exist" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        continue
+    fi
+
+    result=$i
+    resultname=$(basename $result)
+    resultname=${resultname%.tar.xz}
+    hostname=$(basename $(dirname $link))
+
+    # echo "Link=$link"
+    # echo "Resultname=$resultname"
+    # echo "Hostname=$hostname"
+    # continue
+
+    # make sure that all the relevant state directories exist
+    mk_dirs $hostname
+    # ... and a couple of other necessities.
+    if [[ $? -ne 0 ]] ;then
+        echo "$TS: Creation of $hostname processing directories failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        continue
+    fi
+    mkdir -p $INCOMING/$hostname
+    if [[ $? -ne 0 ]] ;then
+        echo "$TS: Creation of $INCOMING/$hostname failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        continue
+    fi
+    
+    mkdir -p $UNPACK_PATH/$hostname
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: mkdir -p $UNPACK_PATH/$hostname failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        continue
+    fi
+    
+    # XXXX - for now, if it's a duplicate name, just punt and avoid producing the error - the full
+    # solution will involve renaming the unpacked directory appropriately.
+    if [ ${resultname%%.*} == "DUPLICATE__NAME" ] ;then
+        ndups=$ndups+1
+        continue
+    fi
+    
+    let start_time=$(date +%s)
+    pushd $UNPACK_PATH/$hostname > /dev/null 2>&1
+    tar --extract --no-same-owner --no-overwrite-dir --touch --file="$result"
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: 'tar -xf $result' failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        popd > /dev/null 2>&1
+        continue
+    fi
+
+    # chmod directories to at least 555
+    find . -type d -print0 | xargs -0 chmod ugo+rx
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: 'chmod ugo+rx' of subdirs failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        rm -rf $resultname
+        popd > /dev/null 2>&1
+        continue
+    fi
+
+    # chmod files to at least 444
+    chmod -R ugo+r .
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: 'chmod -R ugo+r .' failed: code $status" | tee -a $mail_content >&4 
+        nerrs=$nerrs+1
+        rm -rf $resultname
+        popd > /dev/null 2>&1
+        continue
+    fi
+    popd > /dev/null 2>&1
+
+    # if there is a prefix file, create a link as specified by the prefix
+    # even if no prefix is specified, we still want to link from the results/ hierarchy to incoming/.
+    # user access will eventually be through results/ only.
+
+    basedir=$(dirname $link)
+    # pbench-dispatch has already moved it to the .prefix subdir
+    prefixfile=$basedir/.prefix/prefix.$resultname
+    if [ -f $prefixfile ] ;then
+        # add the slash to make both cases uniform in what follows
+        prefix=$(cat $prefixfile)/
+    else
+        prefix=""
+    fi
+
+    incoming=$INCOMING/$hostname/$resultname
+    mkdir -p $RESULTS/$hostname/$prefix
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: code $status: mkdir -p $RESULTS/$hostname/$prefix" | tee -a $mail_content >&4
+        continue
+    else
+        # when unpack path is incoming
+        if [[ $UNPACK_PATH -ef $INCOMING ]]; then
+            :
+        # when unpack path is tmp directory
+        else
+            echo "ln -s $UNPACK_PATH/$hostname/$resultname $incoming"
+            ln -s $UNPACK_PATH/$hostname/$resultname $incoming
+            status=$?
+            if [[ $status -ne 0 ]] ;then
+                echo "$TS: code $status: ln -s $UNPACK_PATH/$hostname/$resultname $incoming" | tee -a $mail_content >&4
+                # Cleanup needed here but trap takes care of it.
+                continue 
+            fi
+        fi
+        echo "ln -s $incoming $RESULTS/$hostname/$prefix$resultname"
+        ln -s $incoming $RESULTS/$hostname/$prefix$resultname
+        status=$?
+        if [[ $status -ne 0 ]] ;then
+            echo "$TS: code $status: ln -s $incoming $RESULTS/$hostname/$prefix$resultname" | tee -a $mail_content >&4
+            rm -rf $incoming
+            continue
+        fi
+    fi
+
+    mv $ARCHIVE/$hostname/$linksrc/$resultname.tar.xz $ARCHIVE/$hostname/$linkdest/$resultname.tar.xz
+    status=$?
+    if [[ $status -ne 0 ]] ;then
+        echo "$TS: Cannot move $ARCHIVE/$hostname/$resultname from $linksrc to $linkdest: code $status" | tee -a $mail_content >&4
+        # Cleanup needed here but trap takes care of it.
+        rm -rf $incoming
+        rm $RESULTS/$hostname/$prefix$resultname
+        nerrs=$nerrs+1
+        continue
+    fi
+
+    let end_time=$(date +%s)
+    let duration=end_time-start_time
+    # log the success
+    echo "$TS: $hostname/$resultname: success - elapsed time (secs): $duration"
+    ntb=$ntb+1
+done
+
+echo "$TS: Processed $ntb tarballs"
+
+log_finish
+log_append $TMP/$(basename $0).$$ $LOGSDIR/$(basename $0)
+
+if [[ $nerrs -gt 0 ]]; then
+    subj="$PROG.$TS($PBENCH_ENV) - w/ $nerrs errors"
+    # don't send mail when running unittests
+    if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
+        (echo "Processed $ntotal result tar balls, $ntb successfully, with $nerrs errors and $ndups duplicates";
+        echo ;
+        cat mail_content) | 
+        mailx -s "$subj" $mail_recipients
+    fi
+fi
+
+exit 0

--- a/server/pbench/bin/unittests-inotify
+++ b/server/pbench/bin/unittests-inotify
@@ -1,0 +1,236 @@
+#!/bin/bash
+
+_tdir=$(dirname $(readlink -f $0))
+_tlib=${_tdir}/../lib
+
+_testroot=/var/tmp/pbench-test-server
+mkdir -p $_testroot
+if [[ ! -d $_testroot ]]; then
+    echo "ERROR: failed to create test root directory, \"$_testroot\"" >&2
+    exit 1
+fi
+rm -rf $_testroot/*
+if [[ $? -gt 0 ]]; then
+    echo "ERROR: failed to empty test root directory, \"$_testroot\"" >&2
+    exit 1
+fi
+_testout=$_testroot/output.txt
+export _testlog=$_testroot/test-execution.log
+_testdir=$_testroot/pbench
+mkdir -p $_testdir
+if [[ ! -d $_testdir ]]; then
+    echo "ERROR: failed to create test pbench directory, \"$_testdir\"" >&2
+    exit 1
+fi
+
+# Fixed timestamp output
+export _PBENCH_SERVER_TEST=1
+
+# execution environment
+_testopt=$_testroot/opt/pbench-agent
+res=0
+mkdir -p $_testopt/unittest-scripts/
+let res=res+$?
+cp $_tdir/test-bin/* $_testopt/unittest-scripts/
+let res=res+$?
+
+export PATH=$_testopt/unittest-scripts:$_tconfigtoolsbin:$PATH
+export CONFIG=$_testroot/opt/pbench-server/config/pbench-server.cfg
+
+function _run {
+    tname=$1
+    shift
+    echo "+++ Running $tname" >> $_testout
+    $_tdir/$tname $@ >> $_testout 2>&1
+    echo "--- Finished $tname (status=$?}" >> $_testout
+}
+
+function _run_index {
+    dname=$1
+    shift
+    # Will get deleted by _reset_state
+    mkdir -p $_testroot/pbench
+    mkdir -p $_testroot/tmp
+    echo "+++ Running indexing on $dname" >> $_testout
+    TMPDIR=$_testroot/tmp PYTHONPATH=${_tlib}:$PYTHONPATH $_tdir/index-pbench -U -C ${_tlib}/config/pbench-index.cfg.example $(readlink -f $dname.tar.xz) >> $_testout 2>&1
+    echo "--- Finished indexing on $dname (status=$?)" >> $_testout
+    _gitdir=$(dirname $(dirname $(dirname $_tdir)))
+    sed -i '/File "'$(echo ${_gitdir} | sed 's;/;\\/;g')'/s;'${_gitdir}'/server/;/home/user/repo/pbench/server/;' $_testout
+}
+
+function _run_activate {
+    rootdir=${1%/}
+    $_tdir/pbench-server-config-activate ${rootdir}/pbench-server-internal/pbench/lib/config/pbench-server.cfg ${_testdir} >> $_testout
+    rc=$?
+    if [ $rc != 0 ] ;then
+        return 1
+    fi
+    PATH=$_tdir:$PATH
+    $_tdir/pbench-server-activate ${_testdir}/opt/pbench-server/lib/config/pbench-server.cfg ${_testdir} >> $_testout
+}
+
+function _run_allscripts {
+    # _run pbench-backup-tarballs
+    # These next three are related and would flow in this order
+    _run pbench-unpack-tarballs $_testdir
+    _run pbench-copy-sosreports
+    _run pbench-index
+    # These two are independent
+    _run pbench-clean-up-dangling-results-links
+    _run pbench-edit-prefixes
+}
+function _save_tree {
+    # Save state of the tree
+    echo "+++ pbench tree state" >> $_testout
+    find $_testdir | sort |
+        sed 's;tmp/pbench-unpack-tarballs.[0-9]*;tmp/pbench-unpack-tarballs.NNNN;' >> $_testout
+    echo "--- pbench tree state" >> $_testout
+}
+function _dump_logs {
+    # Dump the state of any generated script logs
+    echo "+++ pbench log file contents" >> $_testout
+    if [ -d $_testdir/logs ] ;then
+        find $_testdir/logs -type f | sort | \
+            while read fname; do
+                grep -HvF "\-\-should-n0t-ex1st--" $fname >> $_testout 2>&1
+            done
+    fi
+    echo "--- pbench log file contents" >> $_testout
+    echo "+++ test-execution.log file contents" >> $_testout
+    grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log >> $_testout 2>&1
+    echo "--- test-execution.log file contents" >> $_testout
+    rm -f $_testroot/test-execution.log
+
+}
+function _verify_output {
+    res=$1
+    tname=$2
+    diff -cw $_tdir/gold/${tname}.txt $_testout
+    if [[ $? -gt 0 ]]; then
+        echo "FAIL - $tname"
+        mv $_testout $_testroot/${tname}_output.txt
+        res=1
+    else
+        echo "PASS - $tname"
+        rm $_testout
+    fi
+    return $res
+}
+function _setup_state {
+    _state_tb=$_tdir/state/${1}.tar.xz
+    (cd $_testroot; tar xf $_state_tb; if [ ! -z "${2}" ] ;then /bin/ln -s ${2}.tar.xz ${1}.tar.xz ;fi)
+    if [[ $? -gt 0 ]]; then
+        echo "ERROR: unable to create pbench hierarchy for state $1" >&2
+        exit 1
+    fi
+}
+function _reset_state {
+    rm -rf $_testdir
+    if [[ -d $_testdir ]]; then
+        echo "ERROR: unable to remove pbench hierarchy" >&2
+        exit 1
+    fi
+    rm -rf $_testroot/tmp
+    if [[ -d $_testroot/tmp ]]; then
+        echo "ERROR: unable to remove tmp hierarchy" >&2
+        exit 1
+    fi
+}
+
+declare -A cmds=(
+    # check for no TMP directory
+    [test-1]="_run_allscripts"
+    # check for no ARCHIVE directory
+    [test-2]="_run_allscripts"
+    # check for no INCOMING directory
+    [test-3]="_run_allscripts"
+    # check for no RESULTS directory
+    [test-4]="_run_allscripts"
+    # check that it runs if everything is there
+    [test-5]="_run_allscripts"
+
+    # backup tests
+    # check for normal operation
+    [test-6]="_run pbench-backup-tarballs"
+    # check for no ARCHIVE directory
+    [test-6.1]="_run pbench-backup-tarballs"
+    # check for no ARCHIVE link resolution
+    [test-6.2]="_run pbench-backup-tarballs"
+    # checks that the dest directory is not bogus
+    [test-6.3]="_run pbench-backup-tarballs"
+    # real dest directory - should succeed
+    [test-6.4]="_run pbench-backup-tarballs"
+
+    # indexing tests
+    [test-7.1]="_run_index $_testroot/test-7.1"
+    [test-7.2]="_run_index $_testroot/test-7.2"
+    [test-7.3]="_run_index $_testroot/test-7.3"
+    [test-7.4]="_run_index $_testroot/test-7.4"
+    [test-7.5]="_run_index $_testroot/test-7.5"
+    [test-7.6]="_run_index $_testroot/test-7.6"
+    [test-7.7]="_run_index $_testroot/test-7.7"
+    # uperf tarball
+    [test-7.8]="_run_index $_testroot/test-7.8"
+    # pbench-user-benchmark tarball
+    [test-7.9]="_run_index $_testroot/test-7.9"
+
+    # uperf, fio results data and prometheus data
+    # with float conversion
+    [test-7.10]="_run_index $_testroot/test-7.10"
+    [test-7.11]="_run_index $_testroot/test-7.11"
+    [test-7.12]="_run_index $_testroot/test-7.12"
+    
+    # activation test
+    [test-8]="_run_activate $_testroot/test-8"
+
+    # pbench-verify-backup-tarballs
+    # normal case
+    [test-9.1]="_run pbench-verify-backup-tarballs"
+    # more tarballs in archive
+    [test-9.2]="_run pbench-verify-backup-tarballs"
+    # more tarballs in backup
+    [test-9.3]="_run pbench-verify-backup-tarballs"
+    # bad md5 in orig
+    [test-9.4]="_run pbench-verify-backup-tarballs"
+    # bad md5 in backup
+    [test-9.5]="_run pbench-verify-backup-tarballs"
+
+    # pbench-sync-satellite - currently broken
+    # trivial results: no mail
+    [test-10]="_run pbench-sync-satellite TEST foo.bar.com $_testroot/pbench/archive"
+    # non-trivial results: mail
+    [test-11]="_run pbench-sync-satellite TEST2 foo2.bar.com $_testroot/pbench/archive"
+)
+
+declare -A links=(
+    [test-7.8]="uperf__2016-10-06_16:34:03"
+    [test-7.9]="pbench-user-benchmark__2017-04-21_20:38:16"
+    [test-7.10]="uperf_uperftest_2018.02.02T20.58.00"
+    [test-7.11]="fio_rw_2018.02.01T22.40.57"
+    [test-7.12]="pbench-user-benchmark__2018.02.05T20.35.36"
+)
+
+# indexing unit tests - why is this necessary?
+PATH=/usr/local/bin:$PATH
+
+tests=$*
+if [ -z "$tests" ] ;then
+    tests=$(for x in ${!cmds[@]} ;do echo $x ;done | sort -t- -k 2 -n)
+fi
+
+let failures=0
+for test in  $tests ;do
+    _setup_state ${test} ${links[$test]}
+    cmd=${cmds[$test]}
+    # echo ${test}: ${cmd}
+    ${cmd}
+    _save_tree; _dump_logs
+    _verify_output $res ${test}
+    res=$?
+    if [[ $res != 0 ]] ;then
+        let failures=failures+1
+    fi
+    _reset_state
+done
+exit $failures
+

--- a/server/pbench/lib/config/pbench-inotify.service.example
+++ b/server/pbench/lib/config/pbench-inotify.service.example
@@ -1,0 +1,14 @@
+[Unit]
+Description=Pbench Inotify
+
+[Service]
+User=pbench
+Group=pbench
+Environment=CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
+Environment=MAILTO=
+Environment=MAILFROM=
+ExecStart=/usr/bin/flock -n /opt/pbench-server/lib/locks/pbench-inotify.lock /opt/pbench-server/bin/pbench-inotify
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes #665 #786 

pbench-dispatch is running as a cron job, scheduled every minute. That
adds a minute of latency to the processing. It's a simple script that
examines the TODO subdirs under each controller for tarball symlinks;
when it finds one, it checks its MD5 and dispatches it for further
processing.

Instead of running it as a cron job, we are now running it as a service:
constantly checking, using inotify, for new tarballs in all the TODO
subdirs. When it sees a new tarball, it will do exactly what it does now:
check MD5 and dispatch it appropriately.

pbench-unpack-tarballs is also running as a cron job, scheduled every minute. So now we are runnning this also as a service. It will do exactly what it does now.

