### PR TITLE
pbench-server-activate*: do no exit on failures

### DIFF
--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -1,9 +1,12 @@
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/config
 chown pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/crontab/crontab
 chown -R pbench.pbench /var/tmp/pbench-test-server/pbench/opt/pbench-server/lib/locks
-chown pbench.pbench /var/tmp/pbench-test-server/pbench/pbench /var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001 /var/tmp/pbench-test-server/pbench/pbench/public_html /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming /var/tmp/pbench-test-server/pbench/pbench/public_html/results /var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001/* /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming/* /var/tmp/pbench-test-server/pbench/pbench/public_html/results/*
-chown pbench.pbench /var/tmp/pbench-test-server/pbench/logs /var/tmp/pbench-test-server/pbench/logs/*
-chown pbench.pbench /var/tmp/pbench-test-server/pbench/tmp /var/tmp/pbench-test-server/pbench/tmp/*
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/pbench /var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001 /var/tmp/pbench-test-server/pbench/pbench/public_html /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming /var/tmp/pbench-test-server/pbench/pbench/public_html/results
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/pbench /var/tmp/pbench-test-server/pbench/pbench/archive/fs-version-001/* /var/tmp/pbench-test-server/pbench/pbench/public_html/incoming/* /var/tmp/pbench-test-server/pbench/pbench/public_html/results/*
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/logs
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/logs/*
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/tmp
+chown pbench.pbench /var/tmp/pbench-test-server/pbench/tmp/*
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
 /var/tmp/pbench-test-server/pbench/logs

--- a/server/pbench/bin/pbench-server-activate
+++ b/server/pbench/bin/pbench-server-activate
@@ -15,9 +15,29 @@ export CONFIG=$config
 crontabdir=$(getconf.py crontabdir pbench-server)
 crontabdir=${crontabdir:-/opt/pbench-server/lib/crontab}
 
-pbench-server-activate-create-crontab $crontabdir $testdir || exit 2
-pbench-server-activate-setup-results-host-info $testdir || exit 3
-pbench-server-activate-create-results-dir-structure $testdir || exit 4
-pbench-server-activate-start-httpd || exit 5
+typeset -i nerrs=0
+pbench-server-activate-create-crontab $crontabdir $testdir
+sts=$?
+if [ "$sts" != "0" ] ;then
+    nerrs=$nerrs+1
+fi
 
-exit 0
+pbench-server-activate-setup-results-host-info $testdir
+sts=$?
+if [ "$sts" != "0" ] ;then
+    nerrs=$nerrs+1
+fi
+
+pbench-server-activate-create-results-dir-structure $testdir
+sts=$?
+if [ "$sts" != "0" ] ;then
+    nerrs=$nerrs+1
+fi
+
+pbench-server-activate-start-httpd
+sts=$?
+if [ "$sts" != "0" ] ;then
+    nerrs=$nerrs+1
+fi
+
+exit $nerrs

--- a/server/pbench/bin/pbench-server-activate-create-results-dir-structure
+++ b/server/pbench/bin/pbench-server-activate-create-results-dir-structure
@@ -40,12 +40,22 @@ if [ ! -z "$testdir" ] ;then
     archive_dir=${testdir}${archive_dir}
 fi
 
-mkdir -p $archive_dir  || exit 6
-mkdir -p $pbench_dir/public_html/incoming || exit 7
-mkdir -p $pbench_dir/public_html/results || exit 8
+# it's OK if the directories exist already.
+mkdir -p $archive_dir
+mkdir -p $pbench_dir/public_html/incoming
+mkdir -p $pbench_dir/public_html/results
 
-chown $user.$group $pbench_dir $archive_dir $pbench_dir/public_html $pbench_dir/public_html/incoming $pbench_dir/public_html/results \
-                               $archive_dir/* $pbench_dir/public_html/incoming/* $pbench_dir/public_html/results/* || exit 9
+
+chown $user.$group $pbench_dir \
+      $archive_dir $pbench_dir/public_html $pbench_dir/public_html/incoming $pbench_dir/public_html/results
+sts=$?
+if [ "$sts" != "0" ] ;then
+    nerrs=$nerrs+1
+fi
+
+# it's OK if this fails: the directories may be empty
+chown $user.$group $pbench_dir \
+      $archive_dir/* $pbench_dir/public_html/incoming/* $pbench_dir/public_html/results/* 2>/dev/null
 
 if which selinuxenabled > /dev/null 2>&1 && selinuxenabled ;then
      if [ "${_PBENCH_SERVER_TEST}" != 1 ] ;then
@@ -65,13 +75,18 @@ fi
 
 # create the logs directory
 logsdir=$(getconf.py deploy-pbench-logs-dir results)
-mkdir -p $logsdir || exit 9
-chown $user.$group $logsdir $logsdir/* || exit 10
+mkdir -p $logsdir && chown $user.$group $logsdir
+
+# it's OK if this fails
+chown $user.$group $logsdir/* 2>/dev/null
 
 # create the tmp directory
 tmpdir=$(getconf.py deploy-pbench-tmp-dir results)
-mkdir -p $tmpdir || exit 11
-chown $user.$group $tmpdir $tmpdir/* || exit 11
+mkdir -p $tmpdir && chown $user.$group $tmpdir
+
+# it's OK if this fails
+chown $user.$group $tmpdir/* 2>/dev/null
+
 
 exit 0
 

--- a/server/pbench/bin/pbench-server-activate-setup-results-host-info
+++ b/server/pbench/bin/pbench-server-activate-setup-results-host-info
@@ -9,11 +9,9 @@ prog=$(basename $0)
 # It is meant to be run as part of the %postinstall phase of
 # an internal pbench-server RPM, but it can be run manually:
 #
-# pbench-set-results-host-info /home/pbench/lib/config
+# pbench-set-results-host-info
 #
-# In either case, it probably should be run *after* the
-# pbench-activate-local-server-installation script has run,
-# so that the config file is already installed.
+# It assumes that the config file is already installed.
 
 usage="Usage: $prog [<test-dir-prefix>]"
 
@@ -78,6 +76,7 @@ msg="MESSAGE===System Under Maintenance - please retry at a later time ($mailadd
 
 echo $msg > $prefix.maint
 
-ln -sf $prefix.active $prefix
+# it's OK if this fails
+ln -sf $prefix.active $prefix 2>/dev/null
 
 exit 0

--- a/server/pbench/bin/pbench-server-activate-start-httpd
+++ b/server/pbench/bin/pbench-server-activate-start-httpd
@@ -7,6 +7,9 @@ docroot=$(getconf.py documentroot apache)
 
 systemctl enable httpd.service
 systemctl start httpd.service
-ln -s $pbench_dir/public_html/incoming $pbench_dir/public_html/results $docroot
+
+# it's OK if this fails
+ln -s $pbench_dir/public_html/incoming $pbench_dir/public_html/results $docroot 2>/dev/null
 
 exit 0
+


### PR DESCRIPTION
Fixes #739.
The main script, and various sub-scripts it calls, exited when something failed, leaving the rest of the work undone. That causes problems when installing.

Do as much of the work as possilbe: do not exit on errors. They are
going to be reported when the server is installed.

Fix unit test. 