### PR TITLE
pbench-move-unpacked: fix long-standing bug

### DIFF
--- a/server/pbench/bin/pbench-move-unpacked
+++ b/server/pbench/bin/pbench-move-unpacked
@@ -57,9 +57,6 @@ mkdir -p $tmp
 find $ARCHIVE/*/$linksrc -type l -name '*.tar.xz' -printf "%l\n" 2>/dev/null | grep -v DUPLICATE | xargs du -b --exclude "." 2>/dev/null | sort -n > $list
 
 typeset -i ntb=0
-typeset -i ntotal=0
-typeset -i nerrs=0
-typeset -i ndups=0
 
 # Initialize mail content
 > $mail_content
@@ -67,12 +64,10 @@ typeset -i ndups=0
 function process_tarball {
     result=$1
     size=$2
-    ntotal=$ntotal+1
 
     link=$(readlink -e $result)
     if [ ! -f "$link" ] ;then
         echo "$TS: $link does not exist" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
         return 1
     fi
     resultname=$(basename $result)
@@ -84,21 +79,18 @@ function process_tarball {
     # ... and a couple of other necessities.
     if [[ $? -ne 0 ]] ;then
         echo "$TS: Creation of $hostname processing directories failed: code $status" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
         return 1
     fi
     mkdir -p $INCOMING/$hostname
     if [[ $? -ne 0 ]] ;then
         echo "$TS: Creation of $INCOMING/$hostname failed: code $status" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
         return 1
     fi
     
     # XXXX - for now, if it's a duplicate name, just punt and avoid producing the error - the full
     # solution will involve renaming the unpacked directory appropriately.
     if [ ${resultname%%.*} == "DUPLICATE__NAME" ] ;then
-        ndups=$ndups+1
-        return 1
+        return 2
     fi
 
     incoming=$INCOMING/$hostname/$resultname
@@ -113,13 +105,25 @@ function process_tarball {
     status=$?
     if [[ $status -ne 0 ]] ;then
         echo "$TS: Cannot copy $UNPACK_PATH/$hostname/$resultname to $incoming.copy: code $status" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
         return 1
     fi
 
-    # remove the symlink from incoming
-    rm $incoming 2>/dev/null
-    status=$?
+    if [ -d "$incoming" ] ;then
+	# Probably left over from a previous unsuccessful pbench-move-unpacked.
+	# In general, this should be a symlink, *NOT* a directory. We remove it
+	# forcibly, but that's OK, since $incoming.copy was successfully created
+	# above (otherwise we'd never get here).
+	rm -rf "$incoming"
+	status=$?
+    elif [ -L "$incoming" ] ;then
+	# remove the symlink from incoming
+	rm $incoming
+	status=$?
+    else
+	# impossible!
+	echo "$TS: Cannot happen - $incoming is neither a dir nor a symlink!" | tee -a $mail_content >&4 
+	return 1
+    fi
     if [[ $status -ne 0 ]] ;then
 	rm $RESULTS/$hostname/$prefix$resultname
         if [ -d $incoming.copy ] ;then
@@ -129,7 +133,6 @@ function process_tarball {
             (echo "$TS: $incoming could not be removed for some reason: code $status";
              ls $incoming; echo "----") | tee -a $mail_content >&4
         fi
-	nerrs=$nerrs+1
 	return 1
     fi
 
@@ -138,19 +141,22 @@ function process_tarball {
     mv $incoming.copy $incoming
     status=$?
     if [[ $status -ne 0 ]] ;then
-	rm $RESULTS/$hostname/$prefix$resultname
-        ln -s $incoming.copy $RESULTS/$hostname/$prefix$resultname
+        ln -sf $incoming.copy $RESULTS/$hostname/$prefix$resultname
         echo "$TS: Cannot rename $incoming.copy to $incoming: code $status" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
         return 1
+    else
+	# fix up the results link: this is usually not necessary
+	# but if $incoming was a dir (see above), then the link
+	# would point to $incoming.copy
+        ln -sf $incoming $RESULTS/$hostname/$prefix$resultname
     fi
+        
 
     # remove the unpacked tarballs from UNPACK_PATH directory
     rm -R $UNPACK_PATH/$hostname/$resultname
     status=$?
     if [[ $status -ne 0 ]] ;then
         echo "$TS: Cannot remove $UNPACK_PATH/$hostname/$resultname: code $status" | tee -a $mail_content >&4 
-        nerrs=$nerrs+1
 	return 1
     fi
 
@@ -160,7 +166,6 @@ function process_tarball {
     if [[ $status -ne 0 ]] ;then
         echo "$TS: Cannot move $ARCHIVE/$hostname/$resultname from $linksrc to $linkdest: code $status" | tee -a $mail_content >&4 
         rm $RESULTS/$hostname/$prefix$resultname
-        nerrs=$nerrs+1
         return 1
     fi
     let end_time=$(date +%s)
@@ -190,6 +195,9 @@ if [[ ! -s $list ]] ;then
     exit 0
 fi
 
+# echo job pool commands
+job_pool_echo_command=1
+
 job_pool_init $njobs 0
 
 while read size result ;do
@@ -209,13 +217,13 @@ echo "$TS: Processed $ntb tarballs"
 
 log_finish
 
-if [[ $nerrs -gt 0 ]]; then
+if [[ -s $mail_content ]]; then
     subj="$PROG.$TS($PBENCH_ENV) - w/ $nerrs errors"
     # don't send mail when running unittests
     if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
         (echo "Processed $ntotal result tar balls, $ntb successfully, with $nerrs errors and $ndups duplicates";
         echo ;
-        cat mail_content) | 
+        cat $mail_content) | 
         mailx -s "$subj" $mail_recipients
     fi
 fi


### PR DESCRIPTION
pbench-unpack-tarballs is supposed to leave the following structure in place
for pbench-move-unpacked to handle:

- an unpacked tarball in tmp
- a symlink to it in $incoming
- a symlink to *that* in $results

When pbench-move-unpacked runs, it finds all the tarballs
in move-unpacked state and for each tarball, it would

- copy the unpacked tarball from tmp to $incoming.copy
- rm the $incoming symlink
- mv $incoming.copy $incoming
- change the state of the tarball

If all goes well, this works. But pbench-move-unpacked occasionally
got a failure in one of those steps that caused it to not finish
processing a tarball. It would then lather, rinse and repeat, but
would not be able to get out of the rut, because a step would fail,
the state would *not* be changed, and the same tarball(s) would be
handled again and again.

One such failure is caused by an initial run that succeeded in
creating the $incoming directory followed by some (unknown) failure
that would not change the state. That left pbench-move-unpacked
vulnerable to the infinite regress described above, because on entry
it always assumed that $incoming is a symlink, and it would try to
remove it with `rm`. But if $incoming is a directory, this would fail
and it could never get out of that rut.

Modify the handling to check if $incoming is a directory, a symlink
or something else: if it is a directory, `rm -rf` it; if it is a symlink,
`rm` it; if it's something else, fail.

That cures the symptom, but not the underlying cause: why was $incoming
a directory in the first place? That remains TBD.

In addition, most of the counters (number of errors in particular) are
useless in this context: they were decared at top level, incremented
in the function and used at the end. But the function is not called
directly: instead we use job_pool.sh which sets up a bunch of
pre-forked processes that call the function by communicating over a
FIFO with the main process.  Since they don't have any shared context,
this does not work. We enable the job log and should use that to find
out the fate of the sub-processes, but that remains TBD.

Instead of using the error counter to figure out whether to send mail
or not, we now use the temp file that accumulates the mail to send: if
it's empty we skip sending any mail out.

There was also a typo, a missing $ when cat'ing the mail_content file
into mailx, that is now fixed.