### PR TITLE
fio-postprocess: treat fio jobs as separate clients

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess
+++ b/agent/bench-scripts/postprocess/fio-postprocess
@@ -172,8 +172,9 @@ foreach $client_hostname_dir (@client_hostname_dirs) {
 		# # "samples" : {1407890808: 7.75, 1407890809: 7.77}  <-time series data from workload output
 		# # "value" : "7.76" <-the average of the time series data
 		# # },
-		if ( $log_file =~ /^fio_(iops|lat|slat|clat)\.1\.log$/) {
+		if ( $log_file =~ /^fio_(iops|lat|slat|clat)\.(\d+)\.log$/) {
 			my $log_type = $1;
+			my $job_id = $2;
 			my $date_base = 1471365291000;
 			my $role = "client";
 			my $average;
@@ -223,7 +224,7 @@ foreach $client_hostname_dir (@client_hostname_dirs) {
 				trim_series(\@samples, $series_trim, $series_trim);
 				my %this_dataset;
 				my $mean = get_mean(\@samples);
-				%this_dataset = ( 	get_label('role_label') => $role, get_label('client_hostname_label') => $client_hostname_dir,
+				%this_dataset = ( 	get_label('role_label') => $role, get_label('client_hostname_label') => $client_hostname_dir . "-" . $job_id,
 							get_label('value_label') => $mean, get_label('timeseries_label') => \@samples,
 							get_label('uid_label') => create_uid('client_hostname_label')  );
 				$this_dataset{get_label('description_label')} = $description_label;

--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_clat.csv
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_clat.csv
@@ -1,4 +1,4 @@
-timestamp_client_hostname:all-server_hostname:all-server_port:all-server_port:all_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,timestamp_client_hostname:localhost_ms,client_hostname:localhost
+timestamp_client_hostname:all-server_hostname:all-server_port:all-server_port:all_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,timestamp_client_hostname:localhost-1_ms,client_hostname:localhost-1
 1000,2888,1000,2888
 1966,2885.102,2000,2885
 2933,2886.866,3000,2887

--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_lat.csv
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_lat.csv
@@ -1,4 +1,4 @@
-timestamp_client_hostname:all-server_hostname:all-server_port:all-server_port:all_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,timestamp_client_hostname:localhost_ms,client_hostname:localhost
+timestamp_client_hostname:all-server_hostname:all-server_port:all-server_port:all_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,timestamp_client_hostname:localhost-1_ms,client_hostname:localhost-1
 1000,2909,1000,2909
 1966,2906.102,2000,2906
 2933,2907.866,3000,2908

--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_slat.csv
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/csv/fio_slat.csv
@@ -1,4 +1,4 @@
-timestamp_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,client_hostname:localhost
+timestamp_ms,client_hostname:all-server_hostname:all-server_port:all-server_port:all,client_hostname:localhost-1
 1000,21,21
 2000,21,21
 3000,20,20

--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/fio-average.txt
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/fio-average.txt
@@ -1,6 +1,6 @@
 clat-client_hostname:all-server_hostname:all-server_port:all-server_port:all=2888.974767
-clat-client_hostname:localhost=2930.193548
+clat-client_hostname:localhost-1=2930.193548
 lat-client_hostname:all-server_hostname:all-server_port:all-server_port:all=2909.837000
-lat-client_hostname:localhost=2951.129032
+lat-client_hostname:localhost-1=2951.129032
 slat-client_hostname:all-server_hostname:all-server_port:all-server_port:all=19.733333
-slat-client_hostname:localhost=20.433333
+slat-client_hostname:localhost-1=20.433333

--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/result.json
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/result.json
@@ -133,7 +133,7 @@
             "value" : 2888.97476666667
          },
          {
-            "client_hostname" : "localhost",
+            "client_hostname" : "localhost-1",
             "description" : "Average completion latency per I/O operation",
             "role" : "client",
             "timeseries" : [
@@ -430,7 +430,7 @@
             "value" : 2909.837
          },
          {
-            "client_hostname" : "localhost",
+            "client_hostname" : "localhost-1",
             "description" : "Average total latency per I/O operation",
             "role" : "client",
             "timeseries" : [
@@ -731,7 +731,7 @@
             "value" : 19.741935483871
          },
          {
-            "client_hostname" : "localhost",
+            "client_hostname" : "localhost-1",
             "description" : "Average submission latency per I/O operation",
             "role" : "client",
             "timeseries" : [


### PR DESCRIPTION
- This ensures profiles with multiple jobs are properly handles since
  before only jobs with id=1 were processed