### PR TITLE
pbench-move-unpacked: fix bug.

### DIFF
--- a/server/pbench/bin/pbench-move-unpacked
+++ b/server/pbench/bin/pbench-move-unpacked
@@ -118,6 +118,9 @@ function process_tarball {
         return 1
     fi
 
+    # If $incoming exists, it can only be a directory or a symlink.
+    # If it does not exist, then we go on; but that's probably a bug
+    # in pbench-unpack-tarballs.
     if [ -d "$incoming" ] ;then
 	# Probably left over from a previous unsuccessful pbench-move-unpacked.
 	# In general, this should be a symlink, *NOT* a directory. We remove it
@@ -126,10 +129,11 @@ function process_tarball {
 	rm -rf "$incoming"
 	status=$?
     elif [ -L "$incoming" ] ;then
+        # this is the standard case
 	# remove the symlink from incoming
 	rm $incoming
 	status=$?
-    else
+    elif [ -e "$incoming" ] ;then
 	# impossible!
 	echo "$TS: Cannot happen - $incoming is neither a dir nor a symlink!" | tee -a $mail_content >&4 
 	return 1


### PR DESCRIPTION
A previously-thought "impossible" situation happened: even though
pbench-unpack-tarball should create an $incoming symlink (in the
case when we are unpacking in a local fs, before moving it to the
dfs afterwards), we have seen situations where $incoming has been
a directory and also now a situation where $incoming does not exist
at all. The directory case was handled in PR #755, which also added
the catch-all case that was deemed impossible.

This commit qualifies that case: if $incoming exists in some form
other than symlink or directory, we deem it impossible and return
an error. If it does not exist at all, we wonder why but we go on
and finish the processing (which creates it as a directory).