### PR TITLE
pbench-collect-sysinfo: collect security mitigation data

### DIFF
--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
@@ -9,7 +9,7 @@ Options specified can be one of:
 	                            (the default group is 'default')
 
 	       --sysinfo=str, str = comma separated values of system information to be collected
-	                            available: default, none, all, block, libvirt, kernel_config, sos, topology, ara
+	                            available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
 
 	       --check,       checks if sysinfo is set to one of the accepted values
 --- Finished test-23 pbench-collect-sysinfo (status=0)

--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
@@ -1,5 +1,5 @@
 +++ Running test-24 pbench-collect-sysinfo
-default, none, all, block, libvirt, kernel_config, sos, topology, ara
+default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
 --- Finished test-24 pbench-collect-sysinfo (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -17,8 +17,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 group=default
 dir="/tmp"
 # array containing all the possible sysinfo options
-sysinfo_opts_default=( block libvirt kernel_config sos topology )
-sysinfo_opts_available=( block libvirt kernel_config sos topology ara )
+sysinfo_opts_default=( block libvirt kernel_config security_mitigations sos topology )
+sysinfo_opts_available=( block libvirt kernel_config security_mitigations sos topology ara )
 # get comma seperated values
 sysinfo_opts_default_comma_separated=$(IFS=,; echo "${sysinfo_opts_default[*]}")
 sysinfo_opts_available_comma_separated=$(IFS=,; echo "${sysinfo_opts_available[*]}")

--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -37,6 +37,13 @@ function collect_kernel_config {
 	fi
 }
 
+function collect_mitigation_data {
+	# spectre and meltdown
+	if [ -d /sys/kernel/debug ] ;then
+		find /sys/kernel/debug/x86 -name '*enabled' -print -exec cat {} \; > $dir/security-mitigation-data.txt
+	fi
+}
+	   
 function collect_libvirt {
 	if [[ -e /var/log/libvirt && -e /etc/libvirt ]]; then
 		debug_log "[$script_name]collecting libvirt data"
@@ -111,6 +118,8 @@ for item in ${sysinfo//,/ };do
 	debug_log "[$script_name]: collecting $item"
 	if [[ "$item" == "kernel_config" ]]; then
 		collect_kernel_config &
+	elif [[ "$item" == "security_mitigations" ]]; then
+		collect_mitigation_data &
 	elif [[ "$item" == "libvirt" ]]; then
 		collect_libvirt &
 	elif [[ "$item" == "topology" ]]; then


### PR DESCRIPTION
Fixes #738.

Add a security-mitigations option to pbench-collect-sysinfo
and enable it by default.

The option makes pbench-sysinfo-dump look for relevant files in
/sys/kernel/debug/x86 and, if any are found, collect their contents in
a (new) security-mitigation.txt file.