### PR TITLE
Use the built-in variable fixed in recent ansible version

### DIFF
--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -67,13 +67,6 @@
       copy:
         src: "{{inventory_file}}"
         dest: "{{ inventory_file_path }}"
-      when: "ansible_version.full | version_compare('2.4', '<')"
-
-    - name: copy inventory file to pbench-controller
-      copy:
-        src: "{{ inventory_dir }}/{{inventory_file}}"
-        dest: "{{ inventory_file_path }}"
-      when: "ansible_version.full | version_compare('2.4', '>=')"
 
     - name: copy inventory file to master
       shell: scp {{ inventory_file_path }} {{ item }}:{{ inventory_file_path }}


### PR DESCRIPTION
inventory_file built-in variable in ansible used to resolve to a
different path for ansible version >= 2.4. This got fixed recently,
so we don't need to use different built-in variables to get the
inventory path.