### PR TITLE
Ignore go_memstats_last_gc_time_seconds metric during postprocess

### DIFF
--- a/agent/tool-scripts/postprocess/gold/prometheus-metrics/json/metrics.json
+++ b/agent/tool-scripts/postprocess/gold/prometheus-metrics/json/metrics.json
@@ -26525,12 +26525,6 @@
     },
     {
         "@timestamp":1491850959,
-        "metric":"go_memstats_last_gc_time_seconds",
-        "type":"GAUGE",
-        "value":1.4918508911861354e+19
-    },
-    {
-        "@timestamp":1491850959,
         "metric":"go_memstats_lookups_total",
         "type":"COUNTER",
         "value":7399
@@ -54548,12 +54542,6 @@
         "metric":"go_memstats_heap_sys_bytes",
         "type":"GAUGE",
         "value":267354112.0
-    },
-    {
-        "@timestamp":1491850969,
-        "metric":"go_memstats_last_gc_time_seconds",
-        "type":"GAUGE",
-        "value":1.4918508911861354e+19
     },
     {
         "@timestamp":1491850969,

--- a/agent/tool-scripts/postprocess/prometheus-metrics-postprocess
+++ b/agent/tool-scripts/postprocess/prometheus-metrics-postprocess
@@ -79,11 +79,12 @@ with open(output_file, 'w') as f:
             if len(values[0]) > 1:
                 denormalize_data(values)
             else:
-                item['metric'] = item['name']
-                item['value'] = convert_value(values[0].values()[0])
-                del item['name']
-                del item['metrics']
-                metrics.append(item)
+                if item['name'] != "go_memstats_last_gc_time_seconds":
+                    item['metric'] = item['name']
+                    item['value'] = convert_value(values[0].values()[0])
+                    del item['name']
+                    del item['metrics']
+                    metrics.append(item)
         elif len(values) > 1:
             denormalize_data(values)
         else:


### PR DESCRIPTION
We don't need go_memstats_last_gc_time_seconds in the json generated
by prometheus-metrics tool to be indexed into elasticsearch.