### PR TITLE
 pbench-fio: put defaults in config file

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-04.txt
@@ -18,7 +18,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -46,7 +45,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -74,7 +72,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -102,7 +99,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -130,7 +126,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -158,7 +153,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -186,7 +180,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -214,7 +207,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -242,7 +234,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -270,7 +261,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -298,7 +288,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -326,7 +315,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -354,7 +342,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -382,7 +369,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -410,7 +396,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -438,7 +423,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -466,7 +450,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -494,7 +477,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -522,7 +504,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -550,7 +531,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -578,7 +558,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -606,7 +585,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -634,7 +612,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -662,7 +639,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -690,7 +666,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -718,7 +693,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -746,7 +720,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -774,7 +747,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -802,7 +774,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -830,7 +801,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -8009,7 +7979,7 @@ warning: timestamp already exists with this RW type, skipping this sample (file 
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 2.14 is installed
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]python-pandas is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio_device_check() /tmp/fio 
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/sample1/fio.job ]

--- a/agent/bench-scripts/gold/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-05.txt
@@ -19,7 +19,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -51,7 +50,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -83,7 +81,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -210,7 +207,7 @@ fio-postprocess: could not find any result files to process, exiting
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 2.14 is installed
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]python-pandas is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio_device_check() /tmp/fio foo,bar

--- a/agent/bench-scripts/gold/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-06.txt
@@ -19,7 +19,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -53,7 +52,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -87,7 +85,6 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
-log_hist_coarseness=4 # 76 bins
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -253,7 +250,7 @@ fio-postprocess: could not find any result files to process, exiting
 /var/tmp/pbench-test-bench/pbench/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 2.14 is installed
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-fio]python-pandas is installed
 /var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] fio_device_check() /tmp/fio foo,bar,baz

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -17,7 +17,7 @@ export benchmark_run_dir=""
 if [[ -z "$benchmark_bin" ]]; then
 	benchmark_bin=/usr/local/bin/$benchmark
 fi	
-ver=2.14
+ver=3.3
 
 job_file="${script_path}/templates/fio.job"
 

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -17,7 +17,11 @@ export benchmark_run_dir=""
 if [[ -z "$benchmark_bin" ]]; then
 	benchmark_bin=/usr/local/bin/$benchmark
 fi	
-ver=3.3
+ver=$(getconf.py version pbench-fio)
+if [ -z "$ver" ] ;then
+	echo "pbench-fio: package version is missing in config file" > /dev/tty
+	exit 1
+fi
 
 job_file="${script_path}/templates/fio.job"
 
@@ -64,7 +68,10 @@ tool_label_pattern="fio-"
 tool_group="default"
 max_key_length=20
 primary_metric="readwrite_IOPS"
-histogram_interval_msec=10000
+histogram_interval_msec=$(getconf.py histogram-interval-msec pbench-fio)
+if [ -z "$histogram_interval_msec" ] ;then
+	histogram_interval_msec=10000
+fi
 sysinfo="default"
 
 function fio_usage() {
@@ -610,8 +617,7 @@ function fio_run_job() {
 				mv $i `echo $i | sed -e s/\.$client//`
 			done
 			# Process the histograms
-			# Determine histogram interval based on value used in job file. Should really make
-			# this an option, but perfectly reasonable default.
+			# Determine histogram interval based on value used in job file.
 			#my $log_interval = `cat $dir/fio.job | grep "^log_hist_msec"`;
 			#if [ ! $log_interval =~ /^\s*$/ ]; then
 			if grep -q "^log_hist_msec" $fio_job_file; then

--- a/agent/bench-scripts/samples/pbench-agent.cfg
+++ b/agent/bench-scripts/samples/pbench-agent.cfg
@@ -1,3 +1,7 @@
 [packages]
 pandas-package = python2-pandas
 
+[pbench-fio]
+version = 3.3
+histogram_interval_msec = 10000
+

--- a/agent/bench-scripts/templates/fio.job
+++ b/agent/bench-scripts/templates/fio.job
@@ -22,7 +22,7 @@ write_lat_log = fio
 log_avg_msec = 1000
 write_hist_log = fio
 log_hist_msec = 10000
-log_hist_coarseness = 4 # 76 bins
+# log_hist_coarseness = 4 # 76 bins
 
 [job-$target]
 filename = $target


### PR DESCRIPTION
Put default values in the config file: do not hardwire them into the script.
    
For now, just the version and histogram_interval_msec are treated. The rest will follow if everything works according to plan.
    
Also the rest of the scripts will be treated the same way at some point.
    
Fix the unit tests.
    
Fixes #741.