### PR TITLE
pbench-move-unpacked: do not create spurious links

### DIFF
--- a/server/pbench/bin/pbench-move-unpacked
+++ b/server/pbench/bin/pbench-move-unpacked
@@ -155,13 +155,17 @@ function process_tarball {
     mv $incoming.copy $incoming
     status=$?
     if [[ $status -ne 0 ]] ;then
+        # move failed, $incoming.copy still exists
+        rm -f $RESULTS/$hostname/$prefix$resultname
         ln -sf $incoming.copy $RESULTS/$hostname/$prefix$resultname
         echo "$TS: Cannot rename $incoming.copy to $incoming: code $status" | tee -a $mail_content >&4 
         return 1
     else
 	# fix up the results link: this is usually not necessary
 	# but if $incoming was a dir (see above), then the link
-	# would point to $incoming.copy
+	# would point to $incoming.copy.
+        # Remove the link first (issue #771).
+        rm -f $RESULTS/$hostname/$prefix$resultname
         ln -sf $incoming $RESULTS/$hostname/$prefix$resultname
     fi
         


### PR DESCRIPTION
Fixes #771

If a symlink in results/ points to an existing directory in incoming/,
then trying to recreate the symlink will instead create a spurious
symlink in the incoming/ directory, resolving to itself.

Remove the existing symlink in results/ before recreating it.