### PR TITLE
pbench-ansible: monitor controller or jump host

### DIFF
--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -76,6 +76,10 @@
     - name: register tools
       shell: sh /run/pbench/register.sh {{ default_tools_interval }} {{ ose_master_interval }} {{ ose_node_interval }} {{ file }} {{ inventory_file_path }}
 
+    - name: register tools on the controller or jump host
+      shell: pbench-register-tool-set
+      when: inventory_hostname not in groups['masters']|default([])
+
     - name: create .kube directory to store config file
       file: path={{ ansible_env.HOME }}/.kube state=directory
     


### PR DESCRIPTION
This commit registers default tool-set on the controller needed to
monitor the runs including openshift-ansible.