### PR TITLE
Server-side result state setting script.

### DIFF
--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -281,9 +281,10 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
         fi
     fi
 
-    # make a symlink in the remote TODO directory so that the tarball will be unpacked by the cron job
+    # set the state of the result appropriately so that it will be processed
+    # by the server scripts.
     ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo \
-        "mkdir -p $results_full_path/TODO; cd $results_full_path/TODO; ln -s $results_full_path/$tarball ."
+	/opt/pbench-server/bin/pbench-server-set-result-state $results_full_path $tarball
 
     let runs_copied=runs_copied+1
 done

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -34,6 +34,7 @@ BDIR=$(getconf.py pbench-backup-dir pbench-files)
 LOGSDIR=$(getconf.py pbench-logs-dir pbench-files)
 
 ARCHIVE=${TOP}/archive/fs-version-001
+INOTIFY_STATE_DIR=${ARCHIVE}/inotify_state
 INCOMING=${TOP}/public_html/incoming
 # this is where the symlink forest is going to go
 RESULTS=${TOP}/public_html/results

--- a/server/pbench/bin/pbench-server-set-result-state
+++ b/server/pbench/bin/pbench-server-set-result-state
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+###########################################################################
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)
+        PROG=$(basename $0)
+        ;;
+esac
+
+export CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
+
+. $dir/pbench-base.sh
+###########################################################################
+
+results_full_path=$1
+tarball=$2
+
+# symlink into the TODO state dir
+mkdir -p $results_full_path/TODO
+cd $results_full_path/TODO
+ln -s $results_full_path/$tarball .
+
+# we will get rid of this after a full release cycle,
+# thereby allowing the following code to run. See
+# issue #786.
+exit 0
+
+# add entry to watched file for inotify service
+mkdir -p ${INOTIFY_STATE_DIR}
+watched_file=${INOTIFY_STATE_DIR}/TO-DISPATCH-LIST
+flock -x ${watched_file} echo \"$results_full_path/TODO/$tarball\" >> ${watched_file}
+
+exit 0
+
+
+


### PR DESCRIPTION
Resolves #786.

Implement a result state setting script on the server side. The
script hides the implementation of state from the agent.

Modify pbench-move-results on the agent side to call the script,
so that it does not have to know the details of the state change.