### PR TITLE
Pbench-move-results: New versioning mechanism.

### DIFF
--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -123,7 +123,6 @@ if [ -z "$results_path_prefix" ]; then
     debug_log "expected the results_host_info to have the form: <results_user>@<results_host(FQDN)>:<results_path_prefix>"
     exit 1
 fi
-results_full_path="$results_path_prefix/$hostname"
 
 if [[ ! -z "$show_server" ]] ;then
     echo ${results_repo}
@@ -135,11 +134,6 @@ ssh -q -i $pbench_bin/id_rsa $ssh_opts $results_repo exit
 if [ $? -ne 0 ]; then
     error_log "ERROR: results host unreachable: $results_repo"
     debug_log "the following ssh command failed: \"ssh -q -i $pbench_bin/id_rsa $ssh_opts $results_repo exit\""
-    exit 1
-fi
-ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "mkdir -p $results_full_path"
-if [ $? -ne 0 ]; then
-    error_log "ERROR: unable to create remote results path, $results_repo:$results_full_path"
     exit 1
 fi
 
@@ -206,8 +200,28 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
         echo "$prefix" > $prefixfile
     fi
 
-    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "mkdir -p $results_full_path"
+    echo $hostname > $tarball.hostname
 
+    # pack everything in one tarball
+    tar czf complete-$tarball $tarball $tarball.md5 $prefixfile $tarball.hostname
+    
+    hash=$(md5sum "$tarball" | awk '{ print $1 }')
+    hash_path=$(echo $hash | cut -b 1-2)/$(echo $hash | cut -b 3-4)/$(echo $hash | cut -b 5-)
+
+    results_full_path="$results_path_prefix/$hash_path"
+    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "mkdir -p $results_full_path"
+    if [ $? -ne 0 ]; then
+        error_log "ERROR: unable to create remote results path, $results_repo:$results_full_path"
+        exit 1
+    fi
+
+    hostnames_full_path="$results_path_prefix/hostnames/$hostname"
+    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "mkdir -p $hostnames_full_path"
+    if [ $? -ne 0 ]; then
+        error_log "ERROR: unable to create remote hostnames path, $results_repo:$hostnames_full_path"
+        exit 1
+    fi 
+    
     # check if there is a name collision and resolve it
     typeset -i i=1
     rtarball=$tarball
@@ -251,7 +265,7 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
     fi
 
     # finally do the copy
-    scp $scp_opts -i $pbench_bin/id_rsa $ssh_opts ./$tarball ./$tarball.md5 $prefixfile $results_repo:$results_full_path
+    scp $scp_opts -i $pbench_bin/id_rsa $ssh_opts ./complete-$tarball $results_repo:$results_full_path
     if [ $? -ne 0 ]; then
         error_log "ERROR: unable to copy results tarball, $tarball, to $results_repo:$results_full_path"
         rm -f $tarball $tarball.md5
@@ -265,9 +279,9 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
     fi
 
     # Verify the bits copied are good
-    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "cd $results_full_path; md5sum --check $pbench_run_name.tar.xz.md5"
+    ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo "cd $results_full_path; tar xf complete-$tarball; rm -f complete-$tarball; md5sum --check $pbench_run_name.tar.xz.md5"
     chk_res=$?
-    rm -f $tarball $tarball.md5
+    rm -f $tarball $tarball.md5 complete-$tarball $tarball.hostname
     if [ $chk_res -ne 0 ]; then
         error_log "ERROR: remote copy failed, remote tarball MD5 does not match original"
         rm -f $tarball $tarball.md5
@@ -284,7 +298,7 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
     # set the state of the result appropriately so that it will be processed
     # by the server scripts.
     ssh -i $pbench_bin/id_rsa $ssh_opts $results_repo \
-	/opt/pbench-server/bin/pbench-server-set-result-state $results_full_path $tarball
+	/opt/pbench-server/bin/pbench-server-set-result-state $hostnames_full_path $results_full_path/$tarball
 
     let runs_copied=runs_copied+1
 done
@@ -301,3 +315,4 @@ if [ $anything -gt 0 ]; then
     debug_log "successfully $op $runs_copied runs, encountered $failures failures"
 fi
 exit $failures
+

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -77,14 +77,14 @@ function mk_dirs {
     hostname=$1
 
     for d in $LINKDIRS ;do
-        thedir=$ARCHIVE/$hostname/$d
+        thedir=$ARCHIVE/hostnames/$hostname/$d
         mkdir -p $thedir
         if [[ $? -ne 0 || ! -d "$thedir" ]]; then
             return 1
         fi
     done
     # to accommodate different exit codes from index-pbench
-    mkdir -p $ARCHIVE/$hostname/WONT-INDEX.{1..12}
+    mkdir -p $ARCHIVE/hostnames/$hostname/WONT-INDEX.{1..12}
     if [[ $? -ne 0 ]]; then
         return 2
     fi

--- a/server/pbench/bin/pbench-dispatch
+++ b/server/pbench/bin/pbench-dispatch
@@ -76,7 +76,7 @@ else
 
     # get the list of files we'll be operating on - sort them by size
     list=$TMP/$PROG.$$
-    find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' 2>/dev/null | grep -v DUPLICATE > $list
+    find -L $ARCHIVE/hostnames/*/$linksrc -name '*.tar.xz' 2>/dev/null | grep -v DUPLICATE > $list
 
     trap 'rm -f $list' EXIT INT QUIT
 
@@ -92,7 +92,7 @@ else
 
         resultname=$(basename $result)
         resultname=${resultname%.tar.xz}
-        hostname=$(basename $(dirname $link))
+        hostname=$(basename $(echo $result | cut -d'/' -f-6))
 
         # echo $link
         # echo $resultname

--- a/server/pbench/bin/pbench-server-set-result-state
+++ b/server/pbench/bin/pbench-server-set-result-state
@@ -19,13 +19,13 @@ export CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
 . $dir/pbench-base.sh
 ###########################################################################
 
-results_full_path=$1
-tarball=$2
+hostnames_full_path=$1
+result_tarball=$2
 
 # symlink into the TODO state dir
-mkdir -p $results_full_path/TODO
-cd $results_full_path/TODO
-ln -s $results_full_path/$tarball .
+mkdir -p $hostnames_full_path/TODO
+cd $hostnames_full_path/TODO
+ln -s $result_tarball .
 
 # we will get rid of this after a full release cycle,
 # thereby allowing the following code to run. See
@@ -35,7 +35,7 @@ exit 0
 # add entry to watched file for inotify service
 mkdir -p ${INOTIFY_STATE_DIR}
 watched_file=${INOTIFY_STATE_DIR}/TO-DISPATCH-LIST
-flock -x ${watched_file} echo \"$results_full_path/TODO/$tarball\" >> ${watched_file}
+flock -x ${watched_file} echo \"$hostnames_full_path/TODO/$tarball\" >> ${watched_file}
 
 exit 0
 

--- a/server/pbench/bin/pbench-sync-package-tarballs
+++ b/server/pbench/bin/pbench-sync-package-tarballs
@@ -18,7 +18,7 @@ esac
 # TOP, TMP, LOGSDIR, ARCHIVE, TS are all defined in pbench-base.sh
 . $dir/pbench-base.sh
 
-remotearchive=$ARCHIVE
+remotearchive=$ARCHIVE/hostnames
 
 files=$(if cd $remotearchive;then find . -path '*/TO-SYNC/*.tar.xz' -printf '%P\n' ;else exit 1 ;fi)
 
@@ -66,29 +66,33 @@ calculate_md5_prefix () {
 
     tar_list="$@"
     for tar in ${tar_list[@]}; do
-        if [ -s $remotearchive/$tar ]; then
-            if [[ -s $remotearchive/$tar.md5 ]]; then
-                echo "$tar"
-                echo "$tar.md5"
+        tarball=$(readlink -e $remotearchive/$tar)
+        if [ -s "$tarball" ]; then
+            if [[ -s "$tarball.md5" ]]; then
+                tarball_name=$(echo $tarball | cut -d'/' -f5-)
+                echo "$tarball_name"
+                echo "$tarball_name.md5"
+                echo "$tarball_name.hostname"
             else
-                echo Failed: "$remotearchive/$tar" exist but "$remotearchive/$tar.md5" not exist >> $tmp/mail.log
+                echo Failed: "$tarball" exist but "$$tarball.md5" not exist >> $tmp/mail.log
             fi
-            prefix=$(calculate_prefixname $tar)
-            if [ -s $remotearchive/$prefix ]; then
-                echo "$prefix"
+            prefix=$(calculate_prefixname $tarball)
+            if [ -s $prefix ]; then
+                prefix_name=$(echo $prefix | cut -d'/' -f5-)
+                echo "$prefix_name"
             fi
         else
-            echo Failed: "$remotearchive/$tar" not exist >> $tmp/mail.log
+            echo Failed: "$tarball" not exist >> $tmp/mail.log
         fi
     done
 }
 
-tar_list=$(echo $files | sed 's/\/TO-SYNC//g')
+tar_list=$(echo $files)
 calculate_md5_prefix $tar_list > $tmp/files-to-sync
 
-pushd $remotearchive >/dev/null || exit 2
-if [ ! -d $remotearchive ] ;then
-    mkdir -p $remotearchive
+pushd $ARCHIVE >/dev/null || exit 2
+if [ ! -d $ARCHIVE ] ;then
+    mkdir -p $ARCHIVE
 fi
 
 # package everything and use the saved stdout (see log_init)

--- a/server/pbench/bin/pbench-sync-satellite
+++ b/server/pbench/bin/pbench-sync-satellite
@@ -128,8 +128,6 @@ fi
 
 # unpack the tarball into tmp directory
 tar -xf $tmp/satellite.$prefix.tar -C $unpack
-files=$(find $unpack -path '*.tar.xz' -printf '%P\n')
-hosts="$(for host in $files;do echo ${host%%/*};done | sort -u )"
 
 # initialize change state log and mail content
 > $LOGSDIR/change-state.$prefix.log
@@ -138,32 +136,30 @@ hosts="$(for host in $files;do echo ${host%%/*};done | sort -u )"
 let start_time=$(timestamp-seconds-since-epoch)
 echo "$TS: start - $(timestamp)"
 
-for host in $hosts ;do
+mv $unpack/* $ARCHIVE
+
+files=$(find $ARCHIVE -path '*.tar.xz.hostname' -printf '%P\n')
+#hosts="$(for host in $files;do cat $host;done | sort -u )"
+
+for i in files ;do
     typeset -i processed=0
     typeset -i failed_md5=0
-    localdir=$ARCHIVE/$prefix::$host
+    pushd ${i%/*} >/dev/null || exit 2
+    host=$(cat $i)
+    localdir=$ARCHIVE/hostnames/$prefix::$host
     if [ ! -d $localdir ] ;then
-        mkdir -p $localdir || exit 1
+        mkdir -p $localdir
     fi
-    pushd $localdir >/dev/null || exit 2
+
     if [ ! -d $logdir/$host ] ;then
         mkdir -p $logdir/$host
     fi
 
     # get the tarball list for this host
-    flist=$(find $unpack/$host -type f -name '*.tar.xz.md5' | sed 's;'$unpack/$host/';;')
+    flist=$(find . -type f -name '*.tar.xz.md5' -printf '%P\n')
 
     echo $flist
-    
-    # move the unpacked files from tmp directory to archive
-    mv $unpack/$host/* .
 
-    # move prefix files if present
-    if [[ -d $unpack/$host/.prefix ]] ;then
-        mkdir -p ./.prefix
-        mv $unpack/$host/.prefix/* ./.prefix
-    fi
-    
     # make the state dirs: TODO, TO-INDEX, TO-COPY-SOS etc.
     mk_dirs $prefix::$host
 
@@ -176,16 +172,17 @@ for host in $hosts ;do
     if [ -s $logdir/$host/ok-checks.log ] ;then
         md5_pass=$(cat $logdir/$host/ok-checks.log | sed -n 's/: OK//p')
         for x in $md5_pass; do
-            ln -sf $PWD/$x SATELLITE-MD5-PASSED/$x
+            ln -sf $PWD/$x $localdir/SATELLITE-MD5-PASSED/$x
             status=$?
             if [[ $status != 0 ]] ;then
                 nerrs=$nerrs+1
                 echo "Failed to create the symlink for md5 check passed tarballs: ln -sf \
-                $PWD/$x SATELLITE-MD5-PASSED/$x" | tee -a $mail_content >&4 
+                $PWD/$x $localdir/SATELLITE-MD5-PASSED/$x" | tee -a $mail_content >&4 
                 continue
             fi
         done
     fi
+    
     grep 'FAIL' $logdir/$host/md5-checks.log > $logdir/$host/fail-checks.log
     cat $logdir/$host/fail-checks.log >> $mail_content
     failed_md5=$(wc -l < $logdir/$host/fail-checks.log)
@@ -193,39 +190,41 @@ for host in $hosts ;do
     if [ -s $logdir/$host/fail-checks.log ] ;then
         md5_fail=$(cat $logdir/$host/fail-checks.log | sed -n 's/: FAIL//p')
         for x in $md5_fail; do
-            ln -sf $PWD/$x SATELLITE-MD5-FAILED/$x
+            ln -sf $PWD/$x $localdir/SATELLITE-MD5-FAILED/$x
             status=$?
             if [[ $status != 0 ]] ;then
                 nerrs=$nerrs+1
                 echo "Failed to create the symlink for md5 check failed tarballs: ln -sf \
-                $PWD/$x SATELLITE-MD5-FAILED/$x" | tee -a $mail_content >&4 
+                $PWD/$x $localdir/SATELLITE-MD5-FAILED/$x" | tee -a $mail_content >&4 
                 continue
             fi
         done
     fi
+
     # create symlinks for the synced tarballs in TODO
     if [ -s $logdir/$host/ok-checks.log ] ;then
         for x in $md5_pass; do
-            ln -sf $PWD/$x TODO/$x
+            ln -sf $PWD/$x $localdir/TODO/$x
             status=$?
             if [[ $status != 0 ]] ;then
                 nerrs=$nerrs+1
                 echo "Failed to create the symlink for TODO state directory: ln -sf \
-                $PWD/$x TODO/$x" | tee -a $mail_content >&4 
+                $PWD/$x $localdir/TODO/$x" | tee -a $mail_content >&4 
                 continue
             fi
             # For the synced tarballs, add an entry to the dispatch
             # list watching by inotify script.  
-            flock -x $INOTIFY_STATE_DIR/TO-DISPATCH-LIST echo $PWD/TODO/$x >> $INOTIFY_STATE_DIR/TO-DISPATCH-LIST
+            flock -x $INOTIFY_STATE_DIR/TO-DISPATCH-LIST echo $localdir/TODO/$x >> $INOTIFY_STATE_DIR/TO-DISPATCH-LIST
         done
     fi
+
     # save the contents of ok checks to further use it for state change
     if [ -s $logdir/$host/ok-checks.log ] ;then
         state_list=$(cat $logdir/$host/ok-checks.log | sed -n 's/: OK//p')
         for x in $state_list; do
-            echo "$host/TO-SYNC/$x" >> $LOGSDIR/change_state.$prefix.log
+            echo "hostnames/$host/TO-SYNC/$x" >> $LOGSDIR/change_state.$prefix.log
         done
-    fi 
+    fi
     popd > /dev/null
 done
 

--- a/server/pbench/bin/pbench-unpack-tarballs
+++ b/server/pbench/bin/pbench-unpack-tarballs
@@ -90,7 +90,7 @@ list=$tmp/$PROG.list
 # find command will not generate any result if the linksrc is empty, and because of that du will not get any result 
 # to calculate the size. In that scenario du generates the size of the current directory as output, to handle
 # that exclude the current directory.
-find $ARCHIVE/*/$linksrc -type l -name '*.tar.xz' -printf "%l\n" 2>/dev/null | grep -v DUPLICATE | xargs du -b --exclude "." 2>/dev/null | sort -n > $list
+find $ARCHIVE/hostanmes/*/$linksrc -type l -name '*.tar.xz' -printf "%l\n" 2>/dev/null | grep -v DUPLICATE | xargs du -b --exclude "." 2>/dev/null | sort -n > $list
 
 typeset -i ntb=0
 typeset -i ntotal=0
@@ -109,9 +109,10 @@ while read size result ;do
         nerrs=$nerrs+1
         continue
     fi
+
     resultname=$(basename $result)
     resultname=${resultname%.tar.xz}
-    hostname=$(basename $(dirname $link))
+    hostname=$(cat $link.hostname)
 
     # echo "Link=$link"
     # echo "Resultname=$resultname"
@@ -227,7 +228,7 @@ while read size result ;do
         fi
     fi
 
-    mv $ARCHIVE/$hostname/$linksrc/$resultname.tar.xz $ARCHIVE/$hostname/$linkdest/$resultname.tar.xz
+    mv $ARCHIVE/hostnames/$hostname/$linksrc/$resultname.tar.xz $ARCHIVE/hostnames/$hostname/$linkdest/$resultname.tar.xz
     status=$?
     if [[ $status -ne 0 ]] ;then
         echo "$TS: Cannot move $ARCHIVE/$hostname/$resultname from $linksrc to $linkdest: code $status" | tee -a $mail_content >&4


### PR DESCRIPTION
Fixes #797 

This PR will do the following changes:
1. `pbench-move-results` will create a new versioning mechanism on the server side to deal with the incompatibility: old clients will remain unchanged and the data will be processed exactly as they are processed today; new clients will use the new mechanism.

2. `pbench-move-results` will copy one tarball per result to the server. The tarball will package up a few pieces that are currently copied separately: the compressed tarball of the results, its MD5 sum, and the (optional) prefix file. In addition, the controller hostname will be added as additional information (currently it's encoded as part of the pathname of the tarball).

3. This PR will change the archive directory structure to make it deeper and not as wide, by using the MD5 string of the tarball to implement an (on-disk) trie (like git, or gluster): e.g. the MD5 sum 7341243af6d9af1025cbec71023dbff7 will generate a pathname of 73/41/7341243af6d9af1025cbec71023dbff7 to a directory that will hold the unpacked "container" tarball.