### PR TITLE
Modify pbench-ansible to monitor nodes under infra group

### DIFF
--- a/contrib/ansible/openshift/README.md
+++ b/contrib/ansible/openshift/README.md
@@ -17,6 +17,8 @@ lb - sar, pidstat, iostat, disk, perf
 
 glusterfs - sar, pidstat, iostat, pprof, disk, perf
 
+infra - sar, pidstat, iostat, disk, perf, pprof
+
 ### Sample inventory
 Your inventory should have groups of hosts describing the roles they play in the OpenShift cluster. This playbook looks for the following groups in the inventory file:
 ```
@@ -31,6 +33,8 @@ Your inventory should have groups of hosts describing the roles they play in the
 [lb]
 
 [glusterfs]
+
+[infra]
 
 [prometheus-metrics]
 <host> port=8443 cert=<cert> key=<key>

--- a/contrib/ansible/openshift/pbench_register.yml
+++ b/contrib/ansible/openshift/pbench_register.yml
@@ -34,15 +34,21 @@
     - name: add nodes to the file
       shell: echo -e {{ item.1 }} node {{ item.0 }} >> {{ file }}
       with_indexed_items: 
-       - "{{ groups['nodes'][-1] }}" 
-       - "{{ groups['nodes'][-2] }}"
+       - "{{ groups['nodes'][0] }}" 
+       - "{{ groups['nodes'][1] }}"
       when: groups['nodes']|default([]) and not ( register_all_nodes | default(False) | bool )
     
     #  registers tools on the nodes with the following label openshift_node_labels="{'region': 'infra'} in the inventory
     #  along with the last two nodes when register_all_nodes is set to False in the inventory
+    #- name: add infra nodes to the file
+    #  shell: index=1; for infra in $(cat {{ inventory_file }} | grep -w "'region'":" 'infra'" | cut -d ' ' -f1); do echo -e $infra infra $index >> {{ file }} && ((index+=1)); done
+    #  when: groups['nodes']|default([]) and not ( register_all_nodes | default(False) | bool )
+
     - name: add infra nodes to the file
-      shell: index=1; for infra in $(cat {{ inventory_file }} | grep -w "'region'":" 'infra'" | cut -d ' ' -f1); do echo -e $infra infra $index >> {{ file }} && ((index+=1)); done
-      when: groups['nodes']|default([]) and not ( register_all_nodes | default(False) | bool )
+      shell: echo -e {{ item.1 }} infra {{ item.0 }} >> {{ file }}
+      with_indexed_items:
+       - "{{ groups['infra'] }}"
+      when: groups['infra]|default([])
 
     - name: add cns nodes to file
       shell: echo -e {{ item.1 }} cns {{ item.0 }} >> {{ file }}

--- a/contrib/ansible/openshift/register.sh
+++ b/contrib/ansible/openshift/register.sh
@@ -79,7 +79,7 @@ while read -u 11 line;do
       prometheus_metrics_status=registered
     fi
   fi
-  if [ "$group" == "node" ] || [ "$group" == "cns" ]; then
+  if [ "$group" == "node" ] || [ "$group" == "cns" ] || [ "$group" == "infra" ]; then
     pbench-register-tool --label=$label --name=pprof --remote $remote -- --osecomponent=node --interval=$ose_node_interval
   fi
 done 11< $hosts


### PR DESCRIPTION
- Openshift-labeler had been modified to determine the role a node plays
  in the openshift cluster by looking at the labels on the nodes instead
  of inventory. So instead of looking for the infra label in the inventory
  we can have a infra group.
- Also modifies to monitor first two nodes by default instead of last two
  nodes.