### PR TITLE
Bug fixes.

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -43,13 +43,13 @@ function collect_mitigation_data {
 	> $dir/security-mitigation-data.txt
 	# check the generic vulnerabilities files first
 	if [ -d  /sys/devices/system/cpu/vulnerabilities ] ;then
-		grep -H . /sys/devices/system/cpu/vulnerabilities/* >> $dir/security-mitigation-data.txt
+		grep -Hs . /sys/devices/system/cpu/vulnerabilities/* >> $dir/security-mitigation-data.txt
 	fi 
 	# then check the RHEL-specific flag settings files - only
 	# applicable on x86_64
 	if [ -d /sys/kernel/debug/x86 ] ;then
 		echo >> $dir/security-mitigation-data.txt
-		grep -H . /sys/kernel/debug/x86/*enabled >> $dir/security-mitigation-data.txt
+		grep -Hs . /sys/kernel/debug/x86/*enabled >> $dir/security-mitigation-data.txt
 	fi
 }
 

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -86,6 +86,7 @@ erred=$TMPDIR/$PROG.$TS.erred
 typeset -i nskip=0
 skipped=$TMPDIR/$PROG.$TS.skipped
 mail_body=$TMPDIR/$PROG.$TS.mail
+index_content=$TMPDIR/$PROG.$TS.index_mail_contents
 
 mkdir -p $TMPDIR
 trap "rm -rf $TMPDIR" EXIT QUIT INT
@@ -94,6 +95,7 @@ trap "rm -rf $TMPDIR" EXIT QUIT INT
 > $erred
 > $skipped
 > $mail_body
+> $index_content
 
 list=$TMPDIR/list
 find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' -printf "%s\t%p\n" 2>/dev/null | sort -n > $list


### PR DESCRIPTION
pbench-sysinfo-dump: silence the grep if no files are found by the glob.
pbench-index: initialize index_content.