### PR TITLE
pbench-report-status: fix it and make it findable for execution.

### DIFF
--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -33,6 +33,16 @@ TOP=$(getconf.py pbench-top-dir pbench-files)
 BDIR=$(getconf.py pbench-backup-dir pbench-files)
 export LOGSDIR=$(getconf.py pbench-logs-dir pbench-files)
 
+if [[ -z "$_PBENCH_SERVER_TEST" ]]; then
+    # the real thing
+    BINDIR=$(getconf.py script-dir pbench-server)
+else
+    # running unit tests
+    BINDIR=.
+fi
+# need this to find pbench-report-status
+PATH=$BINDIR:$PATH
+
 ARCHIVE=${TOP}/archive/fs-version-001
 INOTIFY_STATE_DIR=${ARCHIVE}/inotify_state
 INCOMING=${TOP}/public_html/incoming

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -206,13 +206,13 @@ if [[ $nidx -gt 0 || $nskip -gt 0 || $nerrs -gt 0 ]]; then
     # That solved the problem of embedded parens - in the meantime, we got rid of the
     # parens, so it has become moot.
     if [[ $nerrs > 0 && $nskip > 0 ]] ;then
-        subj='$PROG.$TS - Indexed $nidx results, skipped $nskip results, w/ $nerrs errors'
+        subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results, w/ $nerrs errors"
     elif [[ $nskip > 0 ]] ;then
-        subj='$PROG.$TS - Indexed $nidx results, skipped $nskip results'
+        subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results"
     elif [[ $nerrs > 0 ]] ;then
-        subj='$PROG.$TS($PBENCH_ENV) - Indexed $nidx results, w/ $nerrs errors'
+        subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results, w/ $nerrs errors"
     else
-        subj='$PROG.$TS($PBENCH_ENV) - Indexed $nidx results'
+        subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results"
     fi
     if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
         # send mail if not unit testing

--- a/server/pbench/bin/pbench-report-status
+++ b/server/pbench/bin/pbench-report-status
@@ -21,6 +21,7 @@ while true; do
             ;;
         -t|--timestamp)
             timestamp="${2#run-}"
+            timestamp="${timestamp%-UTC}"
             shift 2
             ;;
         -T|--type)
@@ -72,7 +73,7 @@ CONFIG=/opt/pbench-server/lib/config/pbench-index.cfg
 
 server=$(getconf.py server Server)
 datestamp=${timestamp%-*}
-index=$(getconf.py index_prefix Settings)-"$name"-"$datestamp"
+index=$(getconf.py index_prefix Settings)."$name"."$datestamp"
 md5=$(md5sum $file | cut -d' ' -f1)
 
 # Translate newlines to spaces and translate tildes which are used as

--- a/server/pbench/lib/config/pbench-server-default.cfg.example
+++ b/server/pbench/lib/config/pbench-server-default.cfg.example
@@ -1,0 +1,108 @@
+# Do not change anything in this file: anything in here can be overridden
+# by including the section/option with the correct value in pbench-server.cfg.
+
+# This file describes the elements of deploying the pbench background tools.
+[DEFAULT]
+mailto = perf-dept-admins@example.com
+version = 001
+
+default-host = perf.example.com
+default-user = pbench
+default-group = pbench
+
+default-deploy-dir = /opt/pbench-server
+default-script-dir = %(default-deploy-dir)s/bin
+default-lib-dir = %(default-deploy-dir)s/lib
+default-crontab-dir = %(default-lib-dir)s/crontab
+default-lock-dir = %(default-lib-dir)s/locks
+
+deploy-script-dir = %(default-script-dir)s
+deploy-lib-dir = %(default-lib-dir)s
+deploy-crontab-dir=%(default-crontab-dir)s
+deploy-lock-dir = %(default-lock-dir)s
+
+## See pbench-server-setup documentation for filesystem setup
+deploy-pbench-dir = /pbench
+deploy-archive-dir = %(deploy-pbench-dir)s/archive/fs-version-%(version)s
+deploy-unpack-dir = %(deploy-pbench-dir)s/public_html/incoming
+deploy-pbench-local-dir = /pbench-local
+deploy-pbench-logs-dir = %(deploy-pbench-local-dir)s/logs
+deploy-pbench-backup-dir = %(deploy-pbench-local-dir)s/archive.backup
+deploy-pbench-tmp-dir = %(deploy-pbench-local-dir)s/tmp
+
+[pbench-files]
+pbench-top-dir = %(deploy-pbench-dir)s
+pbench-backup-dir = %(deploy-pbench-backup-dir)s
+pbench-logs-dir = %(deploy-pbench-logs-dir)s
+pbench-tmp-dir = %(deploy-pbench-tmp-dir)s
+pbench-unpack-dir = %(deploy-unpack-dir)s
+
+###########################################################################
+## deployment section
+###########################################################################
+[pbench-server]
+user=%(default-user)s
+group=%(default-group)s
+install-dir = %(default-deploy-dir)s
+script-dir = %(deploy-script-dir)s
+crontabdir = %(deploy-crontab-dir)s
+roles = pbench-results pbench-backup
+# when a tarball comes in to this server, what processing should it undergo?
+# production-like servers do at least the first two and possibly more of these:
+#dispatch-states = TO-UNPACK, TO-INDEX, TO-COPY-SOS, TO-BACKUP
+
+# satellite servers do these:
+#dispatch-states = TO-UNPACK, TO-SYNC
+
+###########################################################################
+# we need to install some stuff in the apache document root
+# so we either get it directly or look in the config file.
+# N.B. Different distros use different config files.
+# The following works on Fedora, RHEL, CentOS.
+[apache]
+# configfile = /etc/httpd/conf/httpd.conf
+documentroot = g/var/www/html
+
+# this *has* to agree with the setting in the pbench-agent config file
+[results]
+webserver = pbench.example.com
+host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL%(version)s
+
+###########################################################################
+# crontab roles
+[pbench-results]
+host = %(default-host)s
+mailfrom = %(default-user)s@%(host)s
+tasks = pbench-dispatch, pbench-unpack-tarballs, pbench-copy-sosreports, pbench-edit-prefixes, pbench-index
+
+[pbench-backup]
+host = %(default-host)s
+mailfrom = %(default-user)s@%(host)s
+tasks = pbench-backup-tarballs, pbench-verify-backup-tarballs
+
+###########################################################################
+# crontab tasks
+[pbench-dispatch]
+crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-dispatch.lock %(deploy-script-dir)s/pbench-dispatch
+
+[pbench-backup-tarballs]
+crontab = 41 4 * * *  flock -n %(deploy-lock-dir)s/pbench-backup-tarballs.lock %(deploy-script-dir)s/pbench-backup-tarballs  %(deploy-pbench-backup-dir)s
+
+[pbench-verify-backup-tarballs]
+crontab = 59 4 * * Sunday  flock -n %(deploy-lock-dir)s/pbench-verify-backup-tarballs.lock %(deploy-script-dir)s/pbench-verify-backup-tarballs %(deploy-archive-dir)s %(deploy-pbench-backup-dir)s
+
+[pbench-unpack-tarballs]
+crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-unpack-tarballs.lock %(deploy-script-dir)s/pbench-unpack-tarballs %(deploy-unpack-dir)s
+
+[pbench-move-unpacked]
+njobs = 1
+crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-move-unpacked.lock %(deploy-script-dir)s/pbench-move-unpacked %(deploy-unpack-dir)s
+
+[pbench-copy-sosreports]
+crontab = 41 * * * *  flock -n %(deploy-lock-dir)s/pbench-copy-sosreports.lock %(deploy-script-dir)s/pbench-copy-sosreports
+
+[pbench-edit-prefixes]
+crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-edit-prefixes.lock %(deploy-script-dir)s/pbench-edit-prefixes 
+
+[pbench-index]
+crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-index.lock %(deploy-script-dir)s/pbench-index

--- a/server/pbench/lib/config/pbench-server.cfg.example
+++ b/server/pbench/lib/config/pbench-server.cfg.example
@@ -1,134 +1,23 @@
-# this file describes the elements of deploying the pbench background tools
+# This file describes the elements of deploying the pbench background tools.
 [DEFAULT]
-# CHANGE ME!
+# cvalues here override those in pbench-server-default.cfg.
+# An installation will want to override at least the following:
 mailto = admins@example.com
-version = 001
-
-# CHANGE ME!
 default-host = pbench.example.com
-default-user = pbench
-default-group = pbench
-default-deploy-dir = /opt/pbench-server
 
-default-script-dir = %(default-deploy-dir)s/bin
-default-lib-dir = %(default-deploy-dir)s/lib
-default-crontab-dir = %(default-lib-dir)s/crontab
-default-lock-dir = %(default-lib-dir)s/locks
-
-deploy-script-dir = %(default-script-dir)s
-deploy-lib-dir = %(default-lib-dir)s
-deploy-crontab-dir=%(default-crontab-dir)s
-deploy-lock-dir = %(default-lock-dir)s
-
-## See pbench server setup documentation for filesystem setup
-# TOP and ARCHIVE are on pbench volume
-deploy-pbench-dir = /pbench
-deploy-archive-dir = %(deploy-pbench-dir)s/archive/fs-version-%(version)s
-# CHANGE ME!
-# LOGSDIR is local - XXX TBD
-deploy-pbench-logs-dir = /srv/tmp/logs
-# CHANGE ME!
-# BDIR may be remote
+# Backup dir may be remote
 deploy-backup-host = pbench-backup.example.com
 deploy-pbench-backup-dir = %(default-user)s@%(deploy-backup-host)s:/pbench-local/archive.backup
-# CHANGE ME!
-# TMP is local
-deploy-pbench-tmp-dir = /srv/tmp
-
-[pbench-files]
-pbench-top-dir = %(deploy-pbench-dir)s
-pbench-backup-dir = %(deploy-pbench-backup-dir)s
-pbench-logs-dir = %(deploy-pbench-logs-dir)s
-pbench-tmp-dir = %(deploy-pbench-tmp-dir)s
-
-###########################################################################
-## runtime section
-###########################################################################
-[sosreport]
-user = %(default-user)s
-# CHANGE ME!
-host = pbench-sosreports.example.com
-dir = /path/to/sosreport/dir
-# CHANGE ME!
-mailto=admins@example.com
 
 ###########################################################################
 ## deployment section
 ###########################################################################
 [pbench-server]
-user = %(default-user)s
-group = %(default-group)s
+# we now index status into ES, but in some cases we might still want to use mail.
 use-mail-for-status = yes
-install-dir = %(default-deploy-dir)s
-# CHANGE ME!
 roles = pbench-results, pbench-backup
-# roles = pbench-results, pbench-backup, pbench-rsync-satellites
 
-# we need to install some stuff in the apache document root
-# so we either get it directly or look in the config file.
-# N.B. Different distros use different config files.
-# The following works on Fedora, RHEL, CentOS.
-[apache]
-# configfile = /etc/httpd/conf/httpd.conf
-documentroot = /var/www/html
-
-# this *has* to agree with the setting in the pbench-agent config file
-[results]
-
-# CHANGE ME!
-webserver = pbench.example.com
-host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL%(version)s
-
-###########################################################################
-# crontab roles
-[pbench-results]
-host = %(default-host)s
-mailfrom = %(default-user)s@%(host)s
-# CHANGE ME!
-tasks = pbench-unpack-tarballs, pbench-copy-sosreports, pbench-edit-prefixes, pbench-index
-
-[pbench-backup]
-host = %(default-host)s
-mailfrom = %(default-user)s@%(host)s
-tasks = pbench-backup-tarballs, pbench-verify-backup-tarballs
-
-[pbench-rsync-satellites]
-# tasks = pbench-rsync-satellite, pbench-age-out-satellite
-tasks = pbench-rsync-satellite
-satellites = EC2
-
-# the crontab making script will loop over satellites, creating rsync and age-out entries for each.
-# satellites
-[EC2]
-prefix = EC2
-satellite-host = host.ec2.example.com
-satellite-archive = /path/to/pbench/archive/fs-version-001
-
-###########################################################################
-# crontab tasks
-[pbench-backup-tarballs]
-crontab = 41 4 * * *  flock -n %(deploy-lock-dir)s/pbench-backup-tarballs.lock %(deploy-script-dir)s/pbench-backup-tarballs
-
-[pbench-verify-backup-tarballs]
-crontab = 59 4 * * Sunday  flock -n %(deploy-lock-dir)s/pbench-verify-backup-tarballs.lock %(deploy-script-dir)s/pbench-verify-backup-tarballs %(deploy-pbench-backup-dir)s
-
-[pbench-unpack-tarballs]
-crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-unpack-tarballs.lock %(deploy-script-dir)s/pbench-unpack-tarballs
-
-[pbench-copy-sosreports]
-crontab = 41 * * * *  flock -n %(deploy-lock-dir)s/pbench-copy-sosreports.lock %(deploy-script-dir)s/pbench-copy-sosreports
-
-[pbench-edit-prefixes]
-crontab = * * * * *  flock -n %(deploy-lock-dir)s/pbench-edit-prefixes.lock %(deploy-script-dir)s/pbench-edit-prefixes
-
-[pbench-index]
-crontab = 26 * * * *  flock -n %(deploy-lock-dir)s/pbench-index.lock %(deploy-script-dir)s/pbench-index
-
-[pbench-clean-up-dangling-results]
-crontab = 51 3 * * *  flock -n %(deploy-lock-dir)s/pbench-clean-up-dangling-results-links.lock %(deploy-script-dir)s/pbench-clean-up-dangling-results-links
-
-[pbench-rsync-satellite]
-crontab = 51 23 * * *  flock -n %(deploy-lock-dir)s/pbench-rsync-satellite.lock.$PREFIX %(deploy-script-dir)s/pbench-rsync-satellite $PREFIX $SATELLITE_HOST $SATELLITE_ARCHIVE
-
-[pbench-age-out-satellite]
-crontab = 51 1 * * 0  flock -n %(deploy-lock-dir)s/pbench-age-out-satellite.lock.$PREFIX %(deploy-script-dir)s/pbench-age-out-satellite $PREFIX $SATELLITE_HOST $SATELLITE_ARCHIVE
+# the rest will come from the default config file.
+[config]
+paths = /opt/pbench-server/lib/config
+files = pbench-server-default.cfg


### PR DESCRIPTION
Fixes for pbench-report-status:
- get rid of timezone in timestamp - ES did not like it.
- use dots instead of dashes in the index name.

Modify example config files: split into pbench-server-default.cfg and pbench-server.cfg.
Add script-dir to config file.

pbench-base.sh: add script-dir to PATH, so that all the scripts can execute pbench-report-status.

pbench-index: when setting subj, use double quotes so the variables inside the strings will be
expanded.