### PR TITLE
Add --pbench-pre hook for UB; move wrapper

### DIFF
--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-07.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-07.txt
@@ -7,7 +7,8 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		       --tool-group=str
 		       --sysinfo=str,          str = comma separated values of system information to be collected
 		                                     available: default,none,all,a,b,c,d,e
-                       --pbench-post=str       path to the script which will be executed after postprocess
+                       --pbench-pre=str        path to the script which will be executed before tools are started
+                       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 --- Finished test-07 pbench-user-benchmark (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-08.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-08.txt
@@ -11,7 +11,8 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		       --tool-group=str
 		       --sysinfo=str,          str = comma separated values of system information to be collected
 		                                     available: default,none,all,a,b,c,d,e
-                       --pbench-post=str       path to the script which will be executed after postprocess
+                       --pbench-pre=str        path to the script which will be executed before tools are started
+                       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 --- Finished test-08 pbench-user-benchmark (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -41,11 +41,12 @@ function usage {
 	printf -- "\t\t       --tool-group=str\n"
 	printf -- "\t\t       --sysinfo=str,          str = comma separated values of system information to be collected\n"
 	printf -- "\t\t                                     available: $(pbench-collect-sysinfo --options)\n"
-	printf -- "\t\t       --pbench-post=str       path to the script which will be executed after postprocess\n"
+	printf -- "\t\t       --pbench-pre=str        path to the script which will be executed before tools are started\n"
+	printf -- "\t\t       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete\n"
 }
 
 # Process options and arguments
-opts=$(getopt -q -o C:h --longoptions "config:,help,tool-group:,sysinfo:,pbench-post:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o C:h --longoptions "config:,help,tool-group:,sysinfo:,pbench-post:,pbench-pre:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf -- "$*\n\n"
 	printf "\t${benchmark}: you specified an invalid option\n\n"
@@ -70,17 +71,24 @@ while true; do
 			shift
 		fi
 		;;
-                --sysinfo)
-                shift
-                if [ -n "$1" ]; then
+		--sysinfo)
+		shift
+		if [ -n "$1" ]; then
 			sysinfo="$1"
 			shift
-                fi
-                ;;
+		fi
+		;;
 		--pbench-post)
 		shift
 		if [ -n "$1" ]; then
 			pbench_post="$1"
+			shift
+		fi
+		;;
+		--pbench-pre)
+		shift
+		if [ -n "$1" ]; then
+			pbench_pre="$1"
 			shift
 		fi
 		;;
@@ -147,10 +155,21 @@ record_iteration ${iteration} ${iteration_name} ${benchmark_bin}
 # on abnormal exit, make sure that the metadata log exists and is complete.
 trap "pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir int" INT QUIT
 
+if [[ ! -z $pbench_pre ]]; then
+	log "[$script_name]: Running $pbench_pre"
+	eval $pbench_pre
+	if [[ $? != 0 ]]; then
+		error_log "[$script_name]: the script executed using --pbench-pre flag failed"
+		exit 1
+	fi
+fi
+
 pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
+
 echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"
 echo $iteration >> $benchmark_iterations
+
 SECONDS=0
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
 benchmark_duration=$SECONDS
@@ -158,18 +177,22 @@ benchmark_duration=$SECONDS
 if [[ $_PBENCH_BENCH_TESTS == 1 ]]; then
 	benchmark_duration=0
 fi
-$script_path/postprocess/user-benchmark-wrapper "$benchmark_run_dir" "$benchmark_duration"
 
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end
+
 if [[ ! -z $pbench_post ]]; then
-        log "[$script_name]: Running $pbench_post"
-        eval $pbench_post
+	log "[$script_name]: Running $pbench_post"
+	eval $pbench_post
 	if [[ $? != 0 ]]; then
 		error_log "[$script_name]: the script executed using pbench_post flag failed"
 		exit 1
 	fi
 fi
+
+$script_path/postprocess/user-benchmark-wrapper "$benchmark_run_dir" "$benchmark_duration"
+
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo end
+
 rmdir $benchmark_results_dir/.running


### PR DESCRIPTION
Like `--pbench-post`, we add a hook to be run before tools are
started. This gives us a chance do work knowing the `benchmark_run_dir`
and `benchmark_results_dir` locations, but before tools are started to
avoid disturbing tool data.

We also move the invocation of the `user-benchmark-wrapper` script until
after the `--pbench-post` script is invoked so that we can move work
generating result data outside of the tool data collection.