### PR TITLE
Fix indexing performance and enhance error handling

### DIFF
--- a/server/pbench/bin/gold/test-3.txt
+++ b/server/pbench/bin/gold/test-3.txt
@@ -39,4 +39,8 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad INCOMING=/var/tmp/pbench-test-server/pbench/public_html/incoming
 --- pbench log file contents
 +++ test-execution.log file contents
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-index --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-index.NNNN/pbench-index.run-1900-01-01T00:00:00-UTC.report
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-4.txt
+++ b/server/pbench/bin/gold/test-4.txt
@@ -42,4 +42,8 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad RESULTS=/var/tmp/pbench-test-server/pbench/public_html/results
 --- pbench log file contents
 +++ test-execution.log file contents
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-index --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-index.NNNN/pbench-index.run-1900-01-01T00:00:00-UTC.report
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -44,4 +44,8 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:run-1900-01-01T00:00:00-UTC: Processed 0 tarballs
 --- pbench log file contents
 +++ test-execution.log file contents
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-index --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-index.NNNN/pbench-index.run-1900-01-01T00:00:00-UTC.report
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -3,7 +3,7 @@ len(actions) = 24
 [
     {
         "_id": "22d20eec2affff06976f4abb374b4e13",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -104,7 +104,7 @@ len(actions) = 24
     },
     {
         "_id": "1fd421913c110111a00ba1dc978e13b2",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "22d20eec2affff06976f4abb374b4e13",
         "_source": {
@@ -157,7 +157,7 @@ len(actions) = 24
     },
     {
         "_id": "7be8901181d33e270284c6eb3ed2a14f",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "22d20eec2affff06976f4abb374b4e13",
         "_source": {
@@ -168,7 +168,7 @@ len(actions) = 24
     },
     {
         "_id": "fbc2c34c4feca594465cd410041d1b90",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "22d20eec2affff06976f4abb374b4e13",
         "_source": {
@@ -179,7 +179,7 @@ len(actions) = 24
     },
     {
         "_id": "fe140cb556f8b1ff2ecb7928e6baca2c",
-        "_index": "pbench.result-data.2018-02-02",
+        "_index": "pbench-unittests.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -1127,7 +1127,7 @@ len(actions) = 24
     },
     {
         "_id": "a48b0ae43680b0fd5845f10ad2a97d57",
-        "_index": "pbench.result-data.2018-02-02",
+        "_index": "pbench-unittests.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -2108,7 +2108,7 @@ len(actions) = 24
     },
     {
         "_id": "55b3d02a20e9656350f2f8bc1e9bfdc1",
-        "_index": "pbench.result-data.2018-02-02",
+        "_index": "pbench-unittests.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3056,7 +3056,7 @@ len(actions) = 24
     },
     {
         "_id": "0e1b3660f23bed301965b4c14a0d7d03",
-        "_index": "pbench.result-data.2018-02-02",
+        "_index": "pbench-unittests.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -4037,7 +4037,7 @@ len(actions) = 24
     },
     {
         "_id": "b744ff3690621381c796634a9c7a7848",
-        "_index": "pbench.result-data.2018-02-02",
+        "_index": "pbench-unittests.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -5995,7 +5995,7 @@ len(actions) = 24
     },
     {
         "_id": "850266940e920e25e3bd6c5293aad0d9",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6038,7 +6038,7 @@ len(actions) = 24
     },
     {
         "_id": "8956b5bbcead79c53c5965acf817f7a4",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6081,7 +6081,7 @@ len(actions) = 24
     },
     {
         "_id": "69a74ef46eddcaad8b063a3b0e927a36",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6124,7 +6124,7 @@ len(actions) = 24
     },
     {
         "_id": "c6b9e9a81d43b9ceacb7de9e3a26ef06",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6167,7 +6167,7 @@ len(actions) = 24
     },
     {
         "_id": "b848fc952d0d4f7448142c525d6ea989",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6210,7 +6210,7 @@ len(actions) = 24
     },
     {
         "_id": "22d06eec771528e90f5724323f9066ad",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6253,7 +6253,7 @@ len(actions) = 24
     },
     {
         "_id": "951eaf9993e459a6f9bedfacdc81317a",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6296,7 +6296,7 @@ len(actions) = 24
     },
     {
         "_id": "5e2da34a725e01d15760bce62b47a47b",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6339,7 +6339,7 @@ len(actions) = 24
     },
     {
         "_id": "d30bf2d1ec91cf1ee4cae6b245f08cde",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6382,7 +6382,7 @@ len(actions) = 24
     },
     {
         "_id": "e78536ea58c7436c7b84802576ff30d9",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6425,7 +6425,7 @@ len(actions) = 24
     },
     {
         "_id": "a10ad6b8d91fdfd07dd17aee5eb00aa4",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6468,7 +6468,7 @@ len(actions) = 24
     },
     {
         "_id": "2a1c1789e3dc31819d101e48fc339bd8",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6511,7 +6511,7 @@ len(actions) = 24
     },
     {
         "_id": "69faa6a04c05538c40045215622d736e",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6554,7 +6554,7 @@ len(actions) = 24
     },
     {
         "_id": "c6a1538d322dabe89e31e6164047f91c",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -6597,7 +6597,7 @@ len(actions) = 24
     },
     {
         "_id": "1796e05b78aed007ef229963a53b14f6",
-        "_index": "pbench.tool-data-iostat.2018-02-02",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {

--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -10,7 +10,7 @@ len(actions) = 24
                 "file-date": "2018-02-06",
                 "file-name": "/var/tmp/pbench-test-server/pbench/uperf_uperftest_2018.02.02T20.58.00.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "22d20eec2affff06976f4abb374b4e13",
                 "pbench-agent-version": "0.47-91gb666083"
             },

--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -178,6 +178,7 @@ len(actions) = 24
         "_type": "pbench-run-toc-entry"
     },
     {
+        "_id": "fe140cb556f8b1ff2ecb7928e6baca2c",
         "_index": "pbench.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -1125,6 +1126,7 @@ len(actions) = 24
         "_type": "pbench-result-data"
     },
     {
+        "_id": "a48b0ae43680b0fd5845f10ad2a97d57",
         "_index": "pbench.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -2105,6 +2107,7 @@ len(actions) = 24
         "_type": "pbench-result-data"
     },
     {
+        "_id": "55b3d02a20e9656350f2f8bc1e9bfdc1",
         "_index": "pbench.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -3052,6 +3055,7 @@ len(actions) = 24
         "_type": "pbench-result-data"
     },
     {
+        "_id": "0e1b3660f23bed301965b4c14a0d7d03",
         "_index": "pbench.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -4032,6 +4036,7 @@ len(actions) = 24
         "_type": "pbench-result-data"
     },
     {
+        "_id": "b744ff3690621381c796634a9c7a7848",
         "_index": "pbench.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -5989,6 +5994,7 @@ len(actions) = 24
         "_type": "pbench-result-data"
     },
     {
+        "_id": "850266940e920e25e3bd6c5293aad0d9",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6031,6 +6037,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "8956b5bbcead79c53c5965acf817f7a4",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6073,6 +6080,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "69a74ef46eddcaad8b063a3b0e927a36",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6115,6 +6123,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c6b9e9a81d43b9ceacb7de9e3a26ef06",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6157,6 +6166,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "b848fc952d0d4f7448142c525d6ea989",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6199,6 +6209,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "22d06eec771528e90f5724323f9066ad",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6241,6 +6252,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "951eaf9993e459a6f9bedfacdc81317a",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6283,6 +6295,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "5e2da34a725e01d15760bce62b47a47b",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6325,6 +6338,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "d30bf2d1ec91cf1ee4cae6b245f08cde",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6367,6 +6381,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e78536ea58c7436c7b84802576ff30d9",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6409,6 +6424,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "a10ad6b8d91fdfd07dd17aee5eb00aa4",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6451,6 +6467,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "2a1c1789e3dc31819d101e48fc339bd8",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6493,6 +6510,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "69faa6a04c05538c40045215622d736e",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6535,6 +6553,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c6a1538d322dabe89e31e6164047f91c",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
@@ -6577,6 +6596,7 @@ len(actions) = 24
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "1796e05b78aed007ef229963a53b14f6",
         "_index": "pbench.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {

--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -1,5 +1,10 @@
 +++ Running indexing for test-7.10
-len(actions) = 24
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 514, duplicates: 0, failures: 0)
+Index:  pbench-unittests.result-data.2018-02-02 5
+Index:  pbench-unittests.run.2018-02 47
+Index:  pbench-unittests.tool-data-iostat.2018-02-02 120
+Index:  pbench-unittests.tool-data-pidstat.2018-02-02 342
+len(actions) = 50
 [
     {
         "_id": "22d20eec2affff06976f4abb374b4e13",
@@ -174,6 +179,348 @@ len(actions) = 24
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258607",
             "directory": "/sysinfo/beg/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "9dfbfb0c3c25dff80fa07e0b119caf24",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/sysinfo/beg/dhcp31-44/",
+            "files": [
+                {
+                    "mode": "0o775",
+                    "name": "block-params.log",
+                    "size": 4661
+                },
+                {
+                    "mode": "0o775",
+                    "name": "security-mitigation-data.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o775",
+                    "name": "config-4.13.9-300.fc27.x86_64",
+                    "size": 190476
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180202205801.tar.xz",
+                    "size": 1011040
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180202205801.tar.xz.md5",
+                    "size": 33
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "212dd66fade4ce816ae77d6349f0fac2",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/sysinfo/end/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "028cf6e3c31a3cfcb7e445f884bbb2d3",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/sysinfo/end/dhcp31-44/",
+            "files": [
+                {
+                    "mode": "0o775",
+                    "name": "block-params.log",
+                    "size": 4661
+                },
+                {
+                    "mode": "0o775",
+                    "name": "config-4.13.9-300.fc27.x86_64",
+                    "size": 190476
+                },
+                {
+                    "mode": "0o775",
+                    "name": "security-mitigation-data.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180202210020.tar.xz",
+                    "size": 988652
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180202210020.tar.xz.md5",
+                    "size": 33
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "81d26d8387cceb8f3564c1593e102b9d",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "client::dhcp31-44.perf.lab.eng.bos.redhat.com-server::dhcp31-245.perf.lab.eng.bos.redhat.com:20010--test_config.xml",
+                    "size": 468
+                },
+                {
+                    "mode": "0o755",
+                    "name": "client::dhcp31-44.perf.lab.eng.bos.redhat.com-server::dhcp31-245.perf.lab.eng.bos.redhat.com:20010--server_start.sh",
+                    "size": 33
+                },
+                {
+                    "mode": "0o755",
+                    "name": "client::dhcp31-44.perf.lab.eng.bos.redhat.com-server::dhcp31-245.perf.lab.eng.bos.redhat.com:20010--client_start.sh",
+                    "size": 441
+                },
+                {
+                    "mode": "0o755",
+                    "name": "process-iteration-samples.cmd",
+                    "size": 179
+                },
+                {
+                    "mode": "0o644",
+                    "name": "result.json",
+                    "size": 35057
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "f24a84e7ddc49cd2241d074e2e91ea3b",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "client::dhcp31-44.perf.lab.eng.bos.redhat.com-server::dhcp31-245.perf.lab.eng.bos.redhat.com:20010--client_output.txt",
+                    "size": 7512
+                },
+                {
+                    "mode": "0o755",
+                    "name": "uperf-postprocess.cmd",
+                    "size": 274
+                },
+                {
+                    "mode": "0o644",
+                    "name": "uperf-average.txt",
+                    "size": 476
+                },
+                {
+                    "mode": "0o644",
+                    "name": "uperf.html",
+                    "size": 847
+                },
+                {
+                    "mode": "0o644",
+                    "name": "result.json",
+                    "size": 28961
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "c33e5efc72fe30ccf9b1e17103662e8c",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "9dd47b40473ac89dd655cd4db1fc32e1",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "981961c15ca4c3f96e9c721ba8d75310",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/iostat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "iostat.cmd",
+                    "size": 47
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stdout.txt",
+                    "size": 12498
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk-average.txt",
+                    "size": 1323
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk.html",
+                    "size": 2058
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "7734d4b243268be78cbc1a65f821122d",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/iostat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "disk_IOPS.csv",
+                    "size": 992
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Queue_Size.csv",
+                    "size": 621
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Merges_per_sec.csv",
+                    "size": 982
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Size_in_512_byte_sectors.csv",
+                    "size": 636
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Throughput_MB_per_sec.csv",
+                    "size": 982
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Utilization_percent.csv",
+                    "size": 621
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Wait_Time_msec.csv",
+                    "size": 982
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "2a9f6024a44f4a4fdef9415b38d5a42f",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/mpstat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "mpstat.cmd",
+                    "size": 39
+                },
+                {
+                    "mode": "0o644",
+                    "name": "mpstat-stdout.txt",
+                    "size": 5937
+                },
+                {
+                    "mode": "0o644",
+                    "name": "mpstat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu0-average.txt",
+                    "size": 178
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall-average.txt",
+                    "size": 196
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu0.html",
+                    "size": 654
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall.html",
+                    "size": 662
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "337f475890fd404e0a1187f00409f5eb",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "22d20eec2affff06976f4abb374b4e13",
+        "_source": {
+            "@timestamp": "2018-02-02T20:58:04.723258607",
+            "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/mpstat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "cpu0_cpu0.csv",
+                    "size": 1303
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall_cpuall.csv",
+                    "size": 1303
+                }
+            ]
         },
         "_type": "pbench-run-toc-entry"
     },
@@ -6637,11 +6984,537 @@ len(actions) = 24
             }
         },
         "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "965a7e9b7f229d3e8e0b73960b88c3a2",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/lib/systemd/systemd_--switched-root",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.57",
+                    "cpu_usage": "0.00",
+                    "id": "1-/usr/lib/systemd/systemd_--switched-root",
+                    "io_reads": "59.59",
+                    "io_writes": "0.40",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1",
+                    "rss": "8504",
+                    "vsz": "167264"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "f3149bbcf3f3ad12a983651961d7e016",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22286-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22286",
+                    "rss": "8972",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "d734f556c04ae40d6867e2f1ddc962ee",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22287-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22287",
+                    "rss": "8916",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "fc5b455bb0d3f625c42a983c5872311c",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22288-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22288",
+                    "rss": "8964",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "40c837d073d0c3b61ca33f3dd5f4af9c",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22289-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22289",
+                    "rss": "8936",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "937389e6db1f44e27f47474b30c41e16",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/lib/systemd/systemd_--user",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22298-/usr/lib/systemd/systemd_--user",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22298",
+                    "rss": "7812",
+                    "vsz": "92204"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "1a82d6db45bbb9ad7058549aac0a88d7",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "(sd-pam)",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22300-(sd-pam)",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22300",
+                    "rss": "3196",
+                    "vsz": "221656"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "9b3136f5c99a38495de90f203f8ac79c",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench@notty",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22305-sshd:_pbench@notty",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22305",
+                    "rss": "5220",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "7386468a37fe09e93d53ea5fc04f1b38",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench@notty",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22306-sshd:_pbench@notty",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22306",
+                    "rss": "5256",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "5ed9f2f0fb39ab7bc7082af3f54ed9f7",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench@notty",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22307-sshd:_pbench@notty",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22307",
+                    "rss": "5172",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "a0c9c7d0efc268da0d7380e876df4e24",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench@notty",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22308-sshd:_pbench@notty",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22308",
+                    "rss": "5304",
+                    "vsz": "168776"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "dd187fef9f8a02f17bc515ad87660868",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22309-tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22309",
+                    "rss": "744",
+                    "vsz": "114908"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "75305827f3f5f8b07a7b00801d8a75d9",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22310-tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22310",
+                    "rss": "940",
+                    "vsz": "114908"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "9009e24e62c8835ce597bd7234f81db6",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22311-tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22311",
+                    "rss": "740",
+                    "vsz": "114908"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "f763aa7d686fd8510616219a0c7d2268",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-02",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf_uperftest_2018.02.02T20.58.00",
+                "host": "dhcp31-44",
+                "iteration": "tcp_rr-64B-8i",
+                "iterseqno": "1",
+                "runid": "22d20eec2affff06976f4abb374b4e13",
+                "runtstamp": "2018-02-02T20:58:04.723258607",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-02T20:58:37.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "22312-tail_-n_1000_-f_/pbench-local/logs/pbenc",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "22312",
+                    "rss": "852",
+                    "vsz": "114908"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
     }
 ]
 --- Finished indexing for test-7.10 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/uperf_uperftest_2018.02.02T20.58.00.tar.xz
 /var/tmp/pbench-test-server/pbench/uperf_uperftest_2018.02.02T20.58.00.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -10,7 +10,7 @@ len(actions) = 22
                 "file-date": "2018-02-06",
                 "file-name": "/var/tmp/pbench-test-server/pbench/fio_rw_2018.02.01T22.40.57.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "492a697c9dc7d73d1bd92c98d3fa8b2a",
                 "pbench-agent-version": "0.47-91gb666083"
             },

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -1,5 +1,9 @@
 +++ Running indexing for test-7.11
-len(actions) = 22
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 46, duplicates: 0, failures: 0)
+Index:  pbench-unittests.result-data.2018-02-01 3
+Index:  pbench-unittests.run.2018-02 28
+Index:  pbench-unittests.tool-data-iostat.2018-02-01 15
+len(actions) = 33
 [
     {
         "_id": "492a697c9dc7d73d1bd92c98d3fa8b2a",
@@ -169,6 +173,326 @@ len(actions) = 22
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959021",
             "directory": "/sysinfo/beg/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "9de1e933d83f29360c2903e5ab7b3bbf",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/sysinfo/beg/dhcp31-44/",
+            "files": [
+                {
+                    "mode": "0o775",
+                    "name": "block-params.log",
+                    "size": 4661
+                },
+                {
+                    "mode": "0o775",
+                    "name": "config-4.13.9-300.fc27.x86_64",
+                    "size": 190476
+                },
+                {
+                    "mode": "0o775",
+                    "name": "security-mitigation-data.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180201224057.tar.xz",
+                    "size": 1007264
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180201224057.tar.xz.md5",
+                    "size": 33
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "7d7aed309e6b96668e9b83b9ded12832",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/sysinfo/end/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "44edff26b32fbaf0688107114aed9b9f",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/sysinfo/end/dhcp31-44/",
+            "files": [
+                {
+                    "mode": "0o775",
+                    "name": "block-params.log",
+                    "size": 4661
+                },
+                {
+                    "mode": "0o775",
+                    "name": "config-4.13.9-300.fc27.x86_64",
+                    "size": 190476
+                },
+                {
+                    "mode": "0o775",
+                    "name": "security-mitigation-data.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180201224119.tar.xz",
+                    "size": 1007992
+                },
+                {
+                    "mode": "0o775",
+                    "name": "sosreport-dhcp31-44.perf.lab.eng.bos.redhat.com-pbench-20180201224119.tar.xz.md5",
+                    "size": 33
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "df39338592ad200e5197fbeb1ab68256",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "process-iteration-samples.cmd",
+                    "size": 168
+                },
+                {
+                    "mode": "0o644",
+                    "name": "result.json",
+                    "size": 30267
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "a0701f0ec16172b16b10b9a93de916fe",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "fio.job",
+                    "size": 284
+                },
+                {
+                    "mode": "0o755",
+                    "name": "fio.cmd",
+                    "size": 116
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio-result.txt",
+                    "size": 7988
+                },
+                {
+                    "mode": "0o755",
+                    "name": "fio-postprocess.cmd",
+                    "size": 146
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio-average.txt",
+                    "size": 552
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio.html",
+                    "size": 1207
+                },
+                {
+                    "mode": "0o644",
+                    "name": "result.json",
+                    "size": 24084
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "6a3632aeb1fa00ea342ff5a4c923388c",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/clients/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "4c283b696fafcb4e47fbe6d22d7bb8a0",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/clients/localhost/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "fio_bw.1.log",
+                    "size": 380
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio_clat.1.log",
+                    "size": 424
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio_clat_hist.1.log",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio_iops.1.log",
+                    "size": 362
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio_lat.1.log",
+                    "size": 424
+                },
+                {
+                    "mode": "0o644",
+                    "name": "fio_slat.1.log",
+                    "size": 351
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "fefed367788b933cf6503f93deb56422",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/tools-default/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "5497dcdb6023b0839153c73f1f4a3386",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "b8343687d158aaff3c77da9a17cdb0fa",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/iostat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "iostat.cmd",
+                    "size": 47
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stdout.txt",
+                    "size": 3198
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk-average.txt",
+                    "size": 1341
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk.html",
+                    "size": 2058
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "b97f4ce5aca91eb574272a516a2a7c7d",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
+        "_source": {
+            "@timestamp": "2018-02-01T22:41:00.276959021",
+            "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/iostat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "disk_IOPS.csv",
+                    "size": 362
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Queue_Size.csv",
+                    "size": 186
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Merges_per_sec.csv",
+                    "size": 323
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Size_in_512_byte_sectors.csv",
+                    "size": 206
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Throughput_MB_per_sec.csv",
+                    "size": 358
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Utilization_percent.csv",
+                    "size": 196
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Wait_Time_msec.csv",
+                    "size": 322
+                }
+            ]
         },
         "_type": "pbench-run-toc-entry"
     },
@@ -3525,6 +3849,7 @@ len(actions) = 22
 --- Finished indexing for test-7.11 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/fio_rw_2018.02.01T22.40.57.tar.xz
 /var/tmp/pbench-test-server/pbench/fio_rw_2018.02.01T22.40.57.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -3,7 +3,7 @@ len(actions) = 22
 [
     {
         "_id": "492a697c9dc7d73d1bd92c98d3fa8b2a",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -104,7 +104,7 @@ len(actions) = 22
     },
     {
         "_id": "2f653f8fba9770895d1bf58e50e792a0",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
         "_source": {
@@ -152,7 +152,7 @@ len(actions) = 22
     },
     {
         "_id": "cdc766a729150688a971f347886adfd4",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
         "_source": {
@@ -163,7 +163,7 @@ len(actions) = 22
     },
     {
         "_id": "18a63a7443bcac503814b66250548165",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "492a697c9dc7d73d1bd92c98d3fa8b2a",
         "_source": {
@@ -174,7 +174,7 @@ len(actions) = 22
     },
     {
         "_id": "434134358e6fc19f4f441bfeaab0bdd3",
-        "_index": "pbench.result-data.2018-02-01",
+        "_index": "pbench-unittests.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -1030,7 +1030,7 @@ len(actions) = 22
     },
     {
         "_id": "9f0b9c6b6686267cd54d656409ec9214",
-        "_index": "pbench.result-data.2018-02-01",
+        "_index": "pbench-unittests.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -1951,7 +1951,7 @@ len(actions) = 22
     },
     {
         "_id": "2afa79302c95bcff98e1586affb80cf5",
-        "_index": "pbench.result-data.2018-02-01",
+        "_index": "pbench-unittests.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -2878,7 +2878,7 @@ len(actions) = 22
     },
     {
         "_id": "1a591d45650fdca86b32ff858def62d8",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -2921,7 +2921,7 @@ len(actions) = 22
     },
     {
         "_id": "b52a8671097e7cd9ad57ffdf88017e92",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -2964,7 +2964,7 @@ len(actions) = 22
     },
     {
         "_id": "b2846ec5dc69106b739791cb1a040845",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3007,7 +3007,7 @@ len(actions) = 22
     },
     {
         "_id": "68f7f789dd1d8b08b3205737312ef24a",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3050,7 +3050,7 @@ len(actions) = 22
     },
     {
         "_id": "c77dfa771a9d5aa7e2897c8fbe919056",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3093,7 +3093,7 @@ len(actions) = 22
     },
     {
         "_id": "c36a54fc5f505fce5f9d8594df31d056",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3136,7 +3136,7 @@ len(actions) = 22
     },
     {
         "_id": "bbb4781707acbce83c5de2086c20d55d",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3179,7 +3179,7 @@ len(actions) = 22
     },
     {
         "_id": "e66887f5d41c67e06b98a6dca5a11b11",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3222,7 +3222,7 @@ len(actions) = 22
     },
     {
         "_id": "5823cb854d7bb647515e4ab5d036d6a9",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3265,7 +3265,7 @@ len(actions) = 22
     },
     {
         "_id": "8b8c84b7e183f65d33af72407fc82f60",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3308,7 +3308,7 @@ len(actions) = 22
     },
     {
         "_id": "529c52c7a51d7b965e327a5d23bc333e",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3351,7 +3351,7 @@ len(actions) = 22
     },
     {
         "_id": "5dced12944f56c1d610ab9232ca53c7a",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3394,7 +3394,7 @@ len(actions) = 22
     },
     {
         "_id": "8cc7b57a42d83e3376c2645870304456",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3437,7 +3437,7 @@ len(actions) = 22
     },
     {
         "_id": "3ed92e654e944ef6e6fba87e94c45ad2",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -3480,7 +3480,7 @@ len(actions) = 22
     },
     {
         "_id": "fa9235d3f7036b0c541fb84667343f6a",
-        "_index": "pbench.tool-data-iostat.2018-02-01",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
             "@metadata": {

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -173,6 +173,7 @@ len(actions) = 22
         "_type": "pbench-run-toc-entry"
     },
     {
+        "_id": "434134358e6fc19f4f441bfeaab0bdd3",
         "_index": "pbench.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -1028,6 +1029,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "9f0b9c6b6686267cd54d656409ec9214",
         "_index": "pbench.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -1948,6 +1950,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "2afa79302c95bcff98e1586affb80cf5",
         "_index": "pbench.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -2874,6 +2877,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "1a591d45650fdca86b32ff858def62d8",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -2916,6 +2920,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "b52a8671097e7cd9ad57ffdf88017e92",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -2958,6 +2963,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "b2846ec5dc69106b739791cb1a040845",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3000,6 +3006,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "68f7f789dd1d8b08b3205737312ef24a",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3042,6 +3049,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c77dfa771a9d5aa7e2897c8fbe919056",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3084,6 +3092,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c36a54fc5f505fce5f9d8594df31d056",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3126,6 +3135,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "bbb4781707acbce83c5de2086c20d55d",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3168,6 +3178,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e66887f5d41c67e06b98a6dca5a11b11",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3210,6 +3221,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "5823cb854d7bb647515e4ab5d036d6a9",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3252,6 +3264,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "8b8c84b7e183f65d33af72407fc82f60",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3294,6 +3307,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "529c52c7a51d7b965e327a5d23bc333e",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3336,6 +3350,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "5dced12944f56c1d610ab9232ca53c7a",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3378,6 +3393,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "8cc7b57a42d83e3376c2645870304456",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3420,6 +3436,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "3ed92e654e944ef6e6fba87e94c45ad2",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
@@ -3462,6 +3479,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "fa9235d3f7036b0c541fb84667343f6a",
         "_index": "pbench.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -1,9 +1,11 @@
 +++ Running indexing for test-7.12
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 42397, duplicates: 0, failures: 0)
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 42397, duplicates: 2254, failures: 0)
 Index:  pbench-unittests.run.2018-02 56
 Index:  pbench-unittests.tool-data-iostat.2018-02-05 36
 Index:  pbench-unittests.tool-data-pidstat.2018-02-05 1554
 Index:  pbench-unittests.tool-data-prometheus-metrics.2018-02-05 43005
+Duplicates:  5480 Multiple dupes:  1613
+Index dupes:  pbench-unittests.tool-data-prometheus-metrics.2018-02-05 1613
 len(actions) = 60
 [
     {
@@ -2949,6 +2951,7 @@ len(actions) = 60
 --- Finished indexing for test-7.12 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
 /var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -1,5 +1,10 @@
 +++ Running indexing for test-7.12
-len(actions) = 19
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 42397, duplicates: 0, failures: 0)
+Index:  pbench-unittests.run.2018-02 56
+Index:  pbench-unittests.tool-data-iostat.2018-02-05 36
+Index:  pbench-unittests.tool-data-pidstat.2018-02-05 1554
+Index:  pbench-unittests.tool-data-prometheus-metrics.2018-02-05 43005
+len(actions) = 60
 [
     {
         "_id": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
@@ -271,6 +276,1143 @@ len(actions) = 19
                     "mode": "0o644",
                     "name": "result.txt",
                     "size": 0
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "74848e33fd762d4189dbe511e228d008",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "fdd02f2fb1a11b5652e06bebae921e83",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/disk/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "disk.cmd",
+                    "size": 174
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk-stdout.txt",
+                    "size": 6559
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info-average.txt",
+                    "size": 3182
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info.html",
+                    "size": 1726
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "1cdcfcab7f4f49608d729cc5f6c6ba5f",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/disk/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_blocks.csv",
+                    "size": 927
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_free_space_in_KB.csv",
+                    "size": 696
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_ifree.csv",
+                    "size": 696
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_inodes.csv",
+                    "size": 864
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_iused.csv",
+                    "size": 591
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_info_space_used_in_KB.csv",
+                    "size": 976
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "be527dd1fba0a3503d89cc0a4cadfccb",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "haproxy-ocp.cmd",
+                    "size": 157
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8.csv",
+                    "size": 17618
+                },
+                {
+                    "mode": "0o644",
+                    "name": "haproxy-ocp-stdout.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "haproxy-ocp-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "index.html",
+                    "size": 293
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8.html",
+                    "size": 5502
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-act-average.txt",
+                    "size": 1416
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bck-average.txt",
+                    "size": 1416
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bin-average.txt",
+                    "size": 729
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bout-average.txt",
+                    "size": 755
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_code-average.txt",
+                    "size": 1065
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_duration-average.txt",
+                    "size": 1325
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkdown-average.txt",
+                    "size": 1065
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkfail-average.txt",
+                    "size": 974
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-cli_abrt-average.txt",
+                    "size": 1286
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_byp-average.txt",
+                    "size": 1325
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_in-average.txt",
+                    "size": 1338
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_out-average.txt",
+                    "size": 1403
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_rsp-average.txt",
+                    "size": 1273
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ctime-average.txt",
+                    "size": 1403
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard-average.txt",
+                    "size": 9118
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-downtime-average.txt",
+                    "size": 1039
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dreq-average.txt",
+                    "size": 1208
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dresp-average.txt",
+                    "size": 1234
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-econ-average.txt",
+                    "size": 1702
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ereq-average.txt",
+                    "size": 818
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-eresp-average.txt",
+                    "size": 1091
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hanafail-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_1xx-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_2xx-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_3xx-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_4xx-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_5xx-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_other-average.txt",
+                    "size": 1338
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-iid-average.txt",
+                    "size": 820
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastchg-average.txt",
+                    "size": 1400
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastsess-average.txt",
+                    "size": 1516
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lbtot-average.txt",
+                    "size": 1208
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-pid-average.txt",
+                    "size": 1299
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qcur-average.txt",
+                    "size": 935
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qlimit-average.txt",
+                    "size": 1104
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qmax-average.txt",
+                    "size": 857
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qtime-average.txt",
+                    "size": 1377
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate-average.txt",
+                    "size": 1338
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_lim-average.txt",
+                    "size": 1247
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_max-average.txt",
+                    "size": 1169
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate-average.txt",
+                    "size": 1325
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate_max-average.txt",
+                    "size": 1351
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_tot-average.txt",
+                    "size": 1169
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-scur-average.txt",
+                    "size": 844
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-sid-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-slim-average.txt",
+                    "size": 973
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-smax-average.txt",
+                    "size": 792
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-srv_abrt-average.txt",
+                    "size": 1286
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-stot-average.txt",
+                    "size": 1052
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-throttle-average.txt",
+                    "size": 1234
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-tracked-average.txt",
+                    "size": 1208
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ttime-average.txt",
+                    "size": 1364
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-type-average.txt",
+                    "size": 1312
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-weight-average.txt",
+                    "size": 1268
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wredis-average.txt",
+                    "size": 1351
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wretr-average.txt",
+                    "size": 1325
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-act.html",
+                    "size": 818
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bck.html",
+                    "size": 679
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bin.html",
+                    "size": 712
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bout.html",
+                    "size": 718
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_code.html",
+                    "size": 659
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_duration.html",
+                    "size": 683
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkdown.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkfail.html",
+                    "size": 649
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-cli_abrt.html",
+                    "size": 674
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_byp.html",
+                    "size": 677
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_in.html",
+                    "size": 677
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_out.html",
+                    "size": 683
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_rsp.html",
+                    "size": 673
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ctime.html",
+                    "size": 680
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard.html",
+                    "size": 1374
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-downtime.html",
+                    "size": 655
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dreq.html",
+                    "size": 664
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dresp.html",
+                    "size": 667
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-econ.html",
+                    "size": 702
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ereq.html",
+                    "size": 634
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-eresp.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hanafail.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_1xx.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_2xx.html",
+                    "size": 772
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_3xx.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_4xx.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_5xx.html",
+                    "size": 656
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_other.html",
+                    "size": 680
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-iid.html",
+                    "size": 726
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastchg.html",
+                    "size": 818
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastsess.html",
+                    "size": 691
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lbtot.html",
+                    "size": 665
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-pid.html",
+                    "size": 800
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qcur.html",
+                    "size": 643
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qlimit.html",
+                    "size": 658
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qmax.html",
+                    "size": 637
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qtime.html",
+                    "size": 678
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate.html",
+                    "size": 674
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_lim.html",
+                    "size": 671
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_max.html",
+                    "size": 790
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate.html",
+                    "size": 677
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate_max.html",
+                    "size": 826
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_tot.html",
+                    "size": 788
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-scur.html",
+                    "size": 636
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-sid.html",
+                    "size": 762
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-slim.html",
+                    "size": 748
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-smax.html",
+                    "size": 724
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-srv_abrt.html",
+                    "size": 674
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-stot.html",
+                    "size": 764
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-throttle.html",
+                    "size": 670
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-tracked.html",
+                    "size": 667
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ttime.html",
+                    "size": 677
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-type.html",
+                    "size": 804
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-weight.html",
+                    "size": 800
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wredis.html",
+                    "size": 677
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wretr.html",
+                    "size": 674
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "f3783e6252d70a0a24e7e429b0d8e176",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "cfd14ef2856eacae7487ec5d7b68e9d5",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs/start/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "oc_get_pods-router.log",
+                    "size": 61
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8.log",
+                    "size": 150001
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "5e864ff3d6349ff43812afa7839a29e1",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs/stop/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "oc_get_pods-router.log",
+                    "size": 61
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8.log",
+                    "size": 150001
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "da75bbebcc3b50737b8a24ff4305e335",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "243012042e06b3a0cfae4ad8154aed06",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config/stop/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-haproxy-vv.txt",
+                    "size": 1512
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-haproxy.config",
+                    "size": 9084
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "c131ffb98436e47ea87fefc14de546b7",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config/start/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-haproxy.config",
+                    "size": 9084
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-haproxy-vv.txt",
+                    "size": 1512
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "5cce4328ae8c1382860e11f585043706",
+        "_index": "pbench-unittests.run.2018-02",
+        "_op_type": "create",
+        "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+        "_source": {
+            "@timestamp": "2018-02-05T20:35:36.317245145",
+            "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-act_act: number of active servers (backend), server is active (server).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bck_bck: number of backup servers (backend), server is backup (server).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bin_bin: bytes in.csv",
+                    "size": 711
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-bout_bout: bytes out.csv",
+                    "size": 711
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_code_check_code: layer5-7 code, if available.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-check_duration_check_duration: time in ms took to finish last health check.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkdown_chkdown: number of UP->DOWN transitions.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-chkfail_chkfail: number of failed checks.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-cli_abrt_cli_abrt: number of data transfers aborted by the client.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_byp_comp_byp: number of bytes that bypassed the HTTP compressor.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_in_comp_in: number of HTTP response bytes fed to the compressor.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_out_comp_out: number of HTTP response bytes emitted by the compressor.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-comp_rsp_comp_rsp: number of HTTP responses that were compressed.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ctime_ctime: the average connect time in ms over the 1024 last requests.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_check_duration: time in ms took to finish last health check.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_chkfail: number of failed checks.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_rate: number of sessions per second over last elapsed second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_rate_max: max number of new sessions per second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_req_rate: HTTP requests per second over last elapsed second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_req_rate_max: max number of HTTP requests per second observed.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_scur: current sessions.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dashboard_smax: max sessions.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-downtime_downtime: total downtime (in seconds).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dreq_dreq: requests denied because of security concerns.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-dresp_dresp: responses denied because of security concerns.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-econ_econ: number of requests that encountered an error trying to connect to a backend server.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ereq_ereq: request errors.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-eresp_eresp: response errors including srv_abrt.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hanafail_hanafail: failed health checks details.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_1xx_hrsp_1xx: http responses with 1xx code.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_2xx_hrsp_2xx: http responses with 2xx code.csv",
+                    "size": 700
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_3xx_hrsp_3xx: http responses with 3xx code.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_4xx_hrsp_4xx: http responses with 4xx code.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_5xx_hrsp_5xx: http responses with 5xx code.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-hrsp_other_hrsp_other: http responses with other codes (protocol error).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-iid_iid: unique proxy id.csv",
+                    "size": 711
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastchg_lastchg: number of seconds since the last UP<->DOWN transition.csv",
+                    "size": 915
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lastsess_lastsess: number of seconds since last session assigned to server-backend.csv",
+                    "size": 753
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-lbtot_lbtot: total number of times a server was selected.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-pid_pid: process id (0 for first instance, 1 for second, ...).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qcur_qcur: current queued requests.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qlimit_qlimit: configured maxqueue for the server.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qmax_qmax: max value of qcur.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-qtime_qtime: the average queue time in ms over the 1024 last requests.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_rate: number of sessions per second over last elapsed second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_lim_rate_lim: configured limit on new sessions per second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-rate_max_rate_max: max number of new sessions per second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate_req_rate: HTTP requests per second over last elapsed second.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_rate_max_req_rate_max: max number of HTTP requests per second observed.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-req_tot_req_tot: total number of HTTP requests received.csv",
+                    "size": 700
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-scur_scur: current sessions.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-sid_sid: server id (unique inside a proxy).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-slim_slim: configured session limit.csv",
+                    "size": 849
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-smax_smax: max sessions.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-srv_abrt_srv_abrt: number of data transfers aborted by the server.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-stot_stot: cumulative number of connections.csv",
+                    "size": 700
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-throttle_throttle: current throttle percentage for the server.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-tracked_tracked: id of proxy-server if tracking is enabled.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-ttime_ttime: the average total session time in ms over the 1024 last.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-type_type: (0:frontend, 1:backend, 2:server, 3:socket-listener).csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-weight_weight: total weight (backend), server weight (server).csv",
+                    "size": 747
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wredis_wredis: number of times a request was redispatched to another.csv",
+                    "size": 699
+                },
+                {
+                    "mode": "0o644",
+                    "name": "router-1-wxzk8-wretr_wretr: number of times a connection to a server was retried.csv",
+                    "size": 699
                 }
             ]
         },
@@ -896,6 +2038,912 @@ len(actions) = 19
             }
         },
         "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "f0f65b80c3229416461c0486d6a158a3",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/libexec/postfix/master_-w",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1186-/usr/libexec/postfix/master_-w",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1186",
+                    "rss": "2180",
+                    "vsz": "89608"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "045096629119ae30753e2a50cf94c4ec",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "qmgr_-l_-t_unix_-u",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1190-qmgr_-l_-t_unix_-u",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1190",
+                    "rss": "4080",
+                    "vsz": "89780"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "8a06b439dfe8cc111d08568809f42766",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/bin/openshift_start_master_api_--co",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "4.88",
+                    "id": "12276-/usr/bin/openshift_start_master_api_--co",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "139.14",
+                    "pid": "12276",
+                    "rss": "411460",
+                    "vsz": "1056708"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "448da8725fab95ef869e893699997cb9",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/bin/openshift_start_master_controll",
+                    "context_switches_nonvoluntary_switches": "2.69",
+                    "context_switches_voluntary_switches": "296.12",
+                    "cpu_usage": "3.39",
+                    "id": "12334-/usr/bin/openshift_start_master_controll",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.10",
+                    "pid": "12334",
+                    "rss": "244336",
+                    "vsz": "780212"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "0c9df30a883c99105f8597d0f8aa1ee0",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/bin/etcd_--name=ip-172-31-47-216.us",
+                    "context_switches_nonvoluntary_switches": "12.25",
+                    "context_switches_voluntary_switches": "29.38",
+                    "cpu_usage": "0.90",
+                    "id": "1250-/usr/bin/etcd_--name=ip-172-31-47-216.us",
+                    "io_reads": "0.00",
+                    "io_writes": "62.15",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1250",
+                    "rss": "213324",
+                    "vsz": "5800332"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "7acc68594d0ffc7cd27a05718fc20308",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/sbin/sshd_-D",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.40",
+                    "cpu_usage": "0.00",
+                    "id": "1261-/usr/sbin/sshd_-D",
+                    "io_reads": "0.00",
+                    "io_writes": "0.40",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "1.20",
+                    "pid": "1261",
+                    "rss": "4304",
+                    "vsz": "112788"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "defa945ee8baef6fb8737426527b9ddb",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/sbin/crond_-n",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1266-/usr/sbin/crond_-n",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1266",
+                    "rss": "1692",
+                    "vsz": "126280"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "f349d6021590666400d34eae8ffe560d",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/sbin/agetty_--noclear_tty1_linux",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1269-/sbin/agetty_--noclear_tty1_linux",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1269",
+                    "rss": "864",
+                    "vsz": "110088"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "af0dcb6ed1062e0df26508aae73da059",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/sbin/agetty_--keep-baud_115200_38400_96",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1271-/sbin/agetty_--keep-baud_115200_38400_96",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1271",
+                    "rss": "880",
+                    "vsz": "110088"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "74093556a28b9216a2fe7b7953468699",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "rhnsd",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1310-rhnsd",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1310",
+                    "rss": "572",
+                    "vsz": "107964"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "232f1c99f0d042ff08b9e36f89072d4b",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/bin/dockerd-current_--add-runtime_d",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.40",
+                    "id": "1363-/usr/bin/dockerd-current_--add-runtime_d",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1363",
+                    "rss": "42368",
+                    "vsz": "630848"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "e1756ae812139d173f38a2575c38b317",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/bin/docker-containerd-current_-l_un",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "1460-/usr/bin/docker-containerd-current_-l_un",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1460",
+                    "rss": "8368",
+                    "vsz": "298268"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "9a96ea3dd094a566c2363a00d2d3ecba",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_adds",
+            "type": "COUNTER",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "d280a1583fddad2d0ef213781766c710",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_depth",
+            "type": "GAUGE",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "4a4b18177dc43a8e4aca411ffdcf14ef",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_queue_latency",
+            "quantiles": "0.9",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "0a500076143c63e99dd937abaa477257",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_queue_latency",
+            "quantiles": "0.5",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "c735f889e6dda55f413285a4e5dcb3fd",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_queue_latency",
+            "quantiles": "0.99",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "5c97ce97cb39163b74825f1c558f7114",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_retries",
+            "type": "COUNTER",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "495771af79b034c7e25f1c0e6e1d30be",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_work_duration",
+            "quantiles": "0.9",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "e985960178b0e0c8f36e7156add14186",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_work_duration",
+            "quantiles": "0.5",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "1a138cbf8952472bf98b66c222e43fb4",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 0,
+            "metric": "APIServiceOpenAPIAggregationControllerQueue1_work_duration",
+            "quantiles": "0.99",
+            "sum": 0,
+            "type": "SUMMARY",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "1473e40201a89ba08bb1cbcf1701c4d4",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceRegistrationController_adds",
+            "type": "COUNTER",
+            "value": 2627
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "f7c9a4ab74dfb13406be9f05dd2110cf",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceRegistrationController_depth",
+            "type": "GAUGE",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "9eff532221cd4536739fdb4c3cfdd3ff",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 2627,
+            "metric": "APIServiceRegistrationController_queue_latency",
+            "quantiles": "0.9",
+            "sum": 3197200.0,
+            "type": "SUMMARY",
+            "value": 31
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "6bc3733c10add161ca16aa191b6fb2d4",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 2627,
+            "metric": "APIServiceRegistrationController_queue_latency",
+            "quantiles": "0.5",
+            "sum": 3197200.0,
+            "type": "SUMMARY",
+            "value": 16
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "a72f35090c679a103bc541d40c24d222",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "count": 2627,
+            "metric": "APIServiceRegistrationController_queue_latency",
+            "quantiles": "0.99",
+            "sum": 3197200.0,
+            "type": "SUMMARY",
+            "value": 44
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "76cb872916533445aff29ce4822c31d2",
+        "_index": "pbench-unittests.tool-data-prometheus-metrics.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-211-228-38.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:40.000000",
+            "metric": "APIServiceRegistrationController_retries",
+            "type": "COUNTER",
+            "value": 0
+        },
+        "_type": "pbench-tool-data-prometheus-metrics"
+    },
+    {
+        "_id": "bc1fd6b3b34c1d917ce10ac088c223c6",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-217-11-170.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "iostat": {
+                "disk": {
+                    "id": "xvda",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.30"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "26.67",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.01",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "1.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "c836030f491d375db927c6f3131ea269",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-217-11-170.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:49.000000",
+            "iostat": {
+                "disk": {
+                    "id": "xvdb",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "0.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.00",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "ad7fb3ebb7ee289b685466f42e360fca",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2018.02.05T20.35.36",
+                "host": "ec2-34-217-11-170.us-west-2.compute.amazonaws.com",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
+                "runtstamp": "2018-02-05T20:35:36.317245145",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2018-02-05T20:35:59.000000",
+            "iostat": {
+                "disk": {
+                    "id": "xvda",
+                    "iops": {
+                        "read": "1.40",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "240.00",
+                    "tput": {
+                        "read": "0.16",
+                        "write": "0.00"
+                    },
+                    "util": "0.05",
+                    "wtime": {
+                        "read": "1.93",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
     }
 ]
 --- Finished indexing for test-7.12 (status=0)

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -277,6 +277,7 @@ len(actions) = 19
         "_type": "pbench-run-toc-entry"
     },
     {
+        "_id": "9018d49b51d0a9a127d204cefd0e97aa",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -319,6 +320,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "decc7ad27138d0c1e06dffe612d2074b",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -361,6 +363,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "017c2b6e05f259195d08f1c115395cd9",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -403,6 +406,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e7fa2098b2fd0e37f72d21c458e551d3",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -445,6 +449,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "53ded9e1a9f58ce8d2331dc025785ff6",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -487,6 +492,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "b28ed65513529358a6a95b5774358ce4",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -529,6 +535,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "17de88b0f0f1c65d0689936069adc6b3",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -571,6 +578,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "82383533de1eb0ed4db7c41a49f3508a",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -613,6 +621,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e01072256ceefd8fc270ad1a0869ad9f",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -655,6 +664,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "7b70da12e4dc4b90fed4002aaa8a20e9",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -697,6 +707,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "326d1256997b500c4021b0e802edd901",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -739,6 +750,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e2c36c002edd4cb7ed83c5bfeb832273",
         "_index": "pbench.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -781,6 +793,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "47c62f3d9ace569a9771f2da853889cc",
         "_index": "pbench.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -815,6 +828,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "b302e9c239ad0136d282f2190878bc04",
         "_index": "pbench.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
@@ -849,6 +863,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "e45e9739bcec67140b5e6d3e999877a0",
         "_index": "pbench.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -3,7 +3,7 @@ len(actions) = 19
 [
     {
         "_id": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -216,7 +216,7 @@ len(actions) = 19
     },
     {
         "_id": "f577c3b30f93771ac1e61a7746f782f4",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
         "_source": {
@@ -249,7 +249,7 @@ len(actions) = 19
     },
     {
         "_id": "cdbe6719442ec0387c03d3ba96952b13",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
         "_source": {
@@ -260,7 +260,7 @@ len(actions) = 19
     },
     {
         "_id": "8440fc63c64d24b6c977aa2b18ec12ec",
-        "_index": "pbench.run.2018-02",
+        "_index": "pbench-unittests.run.2018-02",
         "_op_type": "create",
         "_parent": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
         "_source": {
@@ -278,7 +278,7 @@ len(actions) = 19
     },
     {
         "_id": "9018d49b51d0a9a127d204cefd0e97aa",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -321,7 +321,7 @@ len(actions) = 19
     },
     {
         "_id": "decc7ad27138d0c1e06dffe612d2074b",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -364,7 +364,7 @@ len(actions) = 19
     },
     {
         "_id": "017c2b6e05f259195d08f1c115395cd9",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -407,7 +407,7 @@ len(actions) = 19
     },
     {
         "_id": "e7fa2098b2fd0e37f72d21c458e551d3",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -450,7 +450,7 @@ len(actions) = 19
     },
     {
         "_id": "53ded9e1a9f58ce8d2331dc025785ff6",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -493,7 +493,7 @@ len(actions) = 19
     },
     {
         "_id": "b28ed65513529358a6a95b5774358ce4",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -536,7 +536,7 @@ len(actions) = 19
     },
     {
         "_id": "17de88b0f0f1c65d0689936069adc6b3",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -579,7 +579,7 @@ len(actions) = 19
     },
     {
         "_id": "82383533de1eb0ed4db7c41a49f3508a",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -622,7 +622,7 @@ len(actions) = 19
     },
     {
         "_id": "e01072256ceefd8fc270ad1a0869ad9f",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -665,7 +665,7 @@ len(actions) = 19
     },
     {
         "_id": "7b70da12e4dc4b90fed4002aaa8a20e9",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -708,7 +708,7 @@ len(actions) = 19
     },
     {
         "_id": "326d1256997b500c4021b0e802edd901",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -751,7 +751,7 @@ len(actions) = 19
     },
     {
         "_id": "e2c36c002edd4cb7ed83c5bfeb832273",
-        "_index": "pbench.tool-data-iostat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -794,7 +794,7 @@ len(actions) = 19
     },
     {
         "_id": "47c62f3d9ace569a9771f2da853889cc",
-        "_index": "pbench.tool-data-pidstat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -829,7 +829,7 @@ len(actions) = 19
     },
     {
         "_id": "b302e9c239ad0136d282f2190878bc04",
-        "_index": "pbench.tool-data-pidstat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -864,7 +864,7 @@ len(actions) = 19
     },
     {
         "_id": "e45e9739bcec67140b5e6d3e999877a0",
-        "_index": "pbench.tool-data-pidstat.2018-02-05",
+        "_index": "pbench-unittests.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
             "@metadata": {

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -10,7 +10,7 @@ len(actions) = 19
                 "file-date": "2018-02-06",
                 "file-name": "/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "6ba5c95c5cad06e6d0bf5af28d8a4d27",
                 "pbench-agent-version": "0.47-162gb666083"
             },

--- a/server/pbench/bin/gold/test-7.4.txt
+++ b/server/pbench/bin/gold/test-7.4.txt
@@ -3,6 +3,7 @@ Bad hostname in sosreport:  The sosreport did not collect a hostname other than 
 --- Finished indexing for test-7.4 (status=10)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/test-7.4.tar.xz
 /var/tmp/pbench-test-server/pbench/test-7.4.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.5.txt
+++ b/server/pbench/bin/gold/test-7.5.txt
@@ -3,6 +3,7 @@ Bad hostname in sosreport:  The sosreport did not collect a hostname other than 
 --- Finished indexing for test-7.5 (status=10)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/test-7.5.tar.xz
 /var/tmp/pbench-test-server/pbench/test-7.5.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -10,7 +10,7 @@ len(actions) = 4
                 "file-date": "2015-09-28",
                 "file-name": "/var/tmp/pbench-test-server/pbench/test-7.6.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "c71b2c9c961ebd55f61273a6a020bdc6",
                 "pbench-agent-version": "plugins:"
             },

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -3,7 +3,7 @@ len(actions) = 4
 [
     {
         "_id": "c71b2c9c961ebd55f61273a6a020bdc6",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -56,7 +56,7 @@ len(actions) = 4
     },
     {
         "_id": "7712c09ac5c74d34c6702a72a99630f4",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "c71b2c9c961ebd55f61273a6a020bdc6",
         "_source": {
@@ -74,7 +74,7 @@ len(actions) = 4
     },
     {
         "_id": "56c6c2799acd10775b0afbb9d25f0f8b",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "c71b2c9c961ebd55f61273a6a020bdc6",
         "_source": {
@@ -85,7 +85,7 @@ len(actions) = 4
     },
     {
         "_id": "52d58c324725aec09cfabc732be41d5e",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "c71b2c9c961ebd55f61273a6a020bdc6",
         "_source": {

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -1,5 +1,7 @@
 +++ Running indexing for test-7.6
-len(actions) = 4
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 5, duplicates: 0, failures: 0)
+Index:  pbench-unittests.run.2015-09 5
+len(actions) = 5
 [
     {
         "_id": "c71b2c9c961ebd55f61273a6a020bdc6",
@@ -93,11 +95,35 @@ len(actions) = 4
             "directory": "/sysinfo/foo/"
         },
         "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "69b96118335d82179c2ae07b8fc89c4a",
+        "_index": "pbench-unittests.run.2015-09",
+        "_op_type": "create",
+        "_parent": "c71b2c9c961ebd55f61273a6a020bdc6",
+        "_source": {
+            "@timestamp": "2015-09-21T19:31:12.673292621",
+            "directory": "/sysinfo/foo/end/",
+            "files": [
+                {
+                    "mode": "0o664",
+                    "name": "sosreport.tar.xz",
+                    "size": 880
+                },
+                {
+                    "mode": "0o664",
+                    "name": "sosreport.tar.xz.md5",
+                    "size": 51
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
     }
 ]
 --- Finished indexing for test-7.6 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/test-7.6.tar.xz
 /var/tmp/pbench-test-server/pbench/test-7.6.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -3,7 +3,7 @@ len(actions) = 4
 [
     {
         "_id": "3a58d0784827289ecf52b40dbd2d8b05",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -56,7 +56,7 @@ len(actions) = 4
     },
     {
         "_id": "9eab538194ae447786fe5c29559cbd7c",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "3a58d0784827289ecf52b40dbd2d8b05",
         "_source": {
@@ -74,7 +74,7 @@ len(actions) = 4
     },
     {
         "_id": "554a015e90cb3b60dd912707425a4f6d",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "3a58d0784827289ecf52b40dbd2d8b05",
         "_source": {
@@ -85,7 +85,7 @@ len(actions) = 4
     },
     {
         "_id": "01812ea8b446ebab1e9cd13a7be42306",
-        "_index": "pbench.run.2015-09",
+        "_index": "pbench-unittests.run.2015-09",
         "_op_type": "create",
         "_parent": "3a58d0784827289ecf52b40dbd2d8b05",
         "_source": {

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -1,5 +1,7 @@
 +++ Running indexing for test-7.7
-len(actions) = 4
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 5, duplicates: 0, failures: 0)
+Index:  pbench-unittests.run.2015-09 5
+len(actions) = 5
 [
     {
         "_id": "3a58d0784827289ecf52b40dbd2d8b05",
@@ -93,11 +95,35 @@ len(actions) = 4
             "directory": "/sysinfo/foo/"
         },
         "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "ad0b52da742550056964f5762df408f3",
+        "_index": "pbench-unittests.run.2015-09",
+        "_op_type": "create",
+        "_parent": "3a58d0784827289ecf52b40dbd2d8b05",
+        "_source": {
+            "@timestamp": "2015-09-21T19:31:12.673292621",
+            "directory": "/sysinfo/foo/end/",
+            "files": [
+                {
+                    "mode": "0o664",
+                    "name": "sosreport.tar.xz",
+                    "size": 884
+                },
+                {
+                    "mode": "0o664",
+                    "name": "sosreport.tar.xz.md5",
+                    "size": 51
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
     }
 ]
 --- Finished indexing for test-7.7 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/test-7.7.tar.xz
 /var/tmp/pbench-test-server/pbench/test-7.7.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -10,7 +10,7 @@ len(actions) = 4
                 "file-date": "2015-09-28",
                 "file-name": "/var/tmp/pbench-test-server/pbench/test-7.7.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "3a58d0784827289ecf52b40dbd2d8b05",
                 "pbench-agent-version": "plugins:"
             },

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -43764,13 +43764,13 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
-        "_id": "522f1aa5130e6b31b4decc08aa936a73",
+        "_id": "358a3c15e4c98bdee9543fab1d7a4758",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43778,7 +43778,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:13.000000",
+            "@timestamp": "2016-10-06T16:34:14.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-root",
@@ -43807,13 +43807,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "7fa48a4b40ba7bc0202511996b26f570",
+        "_id": "2571e60f9d6e13e8fba23e2fe257017f",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43821,7 +43821,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:13.000000",
+            "@timestamp": "2016-10-06T16:34:14.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-swap",
@@ -43850,13 +43850,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "cb4f65a4b7aa1d086a7b1f79cbf86e75",
+        "_id": "04e89419dd4c868d86c80b283617bdc8",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43864,7 +43864,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:13.000000",
+            "@timestamp": "2016-10-06T16:34:14.000000",
             "iostat": {
                 "disk": {
                     "id": "vda",
@@ -43893,13 +43893,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "6ab0c504a495e1c580018ee776f45565",
+        "_id": "0d9e6c829f6b067fdc7dc86e33825186",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43907,7 +43907,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:16.000000",
+            "@timestamp": "2016-10-06T16:34:17.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-root",
@@ -43936,13 +43936,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8d62b6ec90851e115a9f7e933c92ad1d",
+        "_id": "72758bc18aede35c6522cfb47203cfc4",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43950,7 +43950,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:16.000000",
+            "@timestamp": "2016-10-06T16:34:17.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-swap",
@@ -43979,13 +43979,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "038ce5411758b0c1e9e6c7537b3c3ff0",
+        "_id": "75a5015cdaee2039e9bb3823e30e8a99",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -43993,7 +43993,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:16.000000",
+            "@timestamp": "2016-10-06T16:34:17.000000",
             "iostat": {
                 "disk": {
                     "id": "vda",
@@ -44022,13 +44022,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c8c1705364f63a5cae539a39fb125bc7",
+        "_id": "86759c8e752edcd49c6b8710019e3af8",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44036,7 +44036,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:19.000000",
+            "@timestamp": "2016-10-06T16:34:20.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-root",
@@ -44065,13 +44065,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "1525f60391a03c34dcd8fa89753e1696",
+        "_id": "837322a828d4883bb1b349afaf784ff2",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44079,7 +44079,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:19.000000",
+            "@timestamp": "2016-10-06T16:34:20.000000",
             "iostat": {
                 "disk": {
                     "id": "rhel72_java-swap",
@@ -44108,13 +44108,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "84ba41f9fdff6829f1c212a524923d05",
+        "_id": "c228dbdc36be17e4b88de4378510a6af",
         "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44122,7 +44122,7 @@ len(actions) = 22
                 "sample": "sample1",
                 "toolgroup": "default"
             },
-            "@timestamp": "2016-10-06T16:34:19.000000",
+            "@timestamp": "2016-10-06T16:34:20.000000",
             "iostat": {
                 "disk": {
                     "id": "vda",
@@ -44151,13 +44151,13 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "686218c2a8e949dff92c342a5a774142",
+        "_id": "26f81bbb74ec456b0229e0bb058933bc",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44174,25 +44174,25 @@ len(actions) = 22
                     "cpu_usage": "0.00",
                     "id": "1-/usr/lib/systemd/systemd_--switched-root",
                     "io_reads": "0.00",
-                    "io_writes": "4.00",
+                    "io_writes": "3.99",
                     "memory_faults_major": "0.00",
-                    "memory_faults_minor": "1.00",
+                    "memory_faults_minor": "1.33",
                     "pid": "1",
-                    "rss": "4884",
-                    "vsz": "42508"
+                    "rss": "4552",
+                    "vsz": "42132"
                 }
             }
         },
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "b384394f031d9c9bf68922562f0f838a",
+        "_id": "28f96922fdba4d7827840abf2a6a4968",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44203,31 +44203,31 @@ len(actions) = 22
             "@timestamp": "2016-10-06T16:34:14.000000",
             "pidstat": {
                 "pidstat": {
-                    "command": "rcuob/1",
+                    "command": "/usr/bin/python_-Es_/usr/sbin/tuned_-l_-",
                     "context_switches_nonvoluntary_switches": "0.00",
                     "context_switches_voluntary_switches": "0.00",
                     "cpu_usage": "0.00",
-                    "id": "10-rcuob/1",
+                    "id": "1070-/usr/bin/python_-Es_/usr/sbin/tuned_-l_-",
                     "io_reads": "0.00",
                     "io_writes": "0.00",
                     "memory_faults_major": "0.00",
                     "memory_faults_minor": "0.00",
-                    "pid": "10",
-                    "rss": "0",
-                    "vsz": "0"
+                    "pid": "1070",
+                    "rss": "16636",
+                    "vsz": "553040"
                 }
             }
         },
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "1be92cca2d8f950ff859262facabab66",
+        "_id": "68adf77c04d5e252b963d82d3726c6c7",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44238,31 +44238,31 @@ len(actions) = 22
             "@timestamp": "2016-10-06T16:34:14.000000",
             "pidstat": {
                 "pidstat": {
-                    "command": "SCREEN_-dmS_uperf-server_/var/lib/pbench",
+                    "command": "/usr/sbin/sshd_-D",
                     "context_switches_nonvoluntary_switches": "0.00",
                     "context_switches_voluntary_switches": "0.00",
                     "cpu_usage": "0.00",
-                    "id": "10331-SCREEN_-dmS_uperf-server_/var/lib/pbench",
+                    "id": "1071-/usr/sbin/sshd_-D",
                     "io_reads": "0.00",
                     "io_writes": "0.00",
                     "memory_faults_major": "0.00",
                     "memory_faults_minor": "0.00",
-                    "pid": "10331",
-                    "rss": "1260",
-                    "vsz": "125624"
+                    "pid": "1071",
+                    "rss": "3612",
+                    "vsz": "82548"
                 }
             }
         },
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a3b9eba8311959e713aaf029c0a67345",
+        "_id": "202429a9966c248e8cbd4283cbd9dfda",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44273,31 +44273,31 @@ len(actions) = 22
             "@timestamp": "2016-10-06T16:34:14.000000",
             "pidstat": {
                 "pidstat": {
-                    "command": "/bin/sh_/var/lib/pbench-agent/uperf__201",
+                    "command": "/usr/bin/rhsmcertd",
                     "context_switches_nonvoluntary_switches": "0.00",
                     "context_switches_voluntary_switches": "0.00",
                     "cpu_usage": "0.00",
-                    "id": "10333-/bin/sh_/var/lib/pbench-agent/uperf__201",
+                    "id": "1075-/usr/bin/rhsmcertd",
                     "io_reads": "0.00",
                     "io_writes": "0.00",
                     "memory_faults_major": "0.00",
                     "memory_faults_minor": "0.00",
-                    "pid": "10333",
-                    "rss": "1196",
-                    "vsz": "113116"
+                    "pid": "1075",
+                    "rss": "656",
+                    "vsz": "113336"
                 }
             }
         },
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "7036d305e806eb0089e45a5de27c1398",
+        "_id": "6023d2687f6d972f7ee5b66f3b8d97dd",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44308,31 +44308,31 @@ len(actions) = 22
             "@timestamp": "2016-10-06T16:34:14.000000",
             "pidstat": {
                 "pidstat": {
-                    "command": "/usr/local/bin/uperf_-s_-P_21000",
+                    "command": "rhnsd",
                     "context_switches_nonvoluntary_switches": "0.00",
                     "context_switches_voluntary_switches": "0.00",
                     "cpu_usage": "0.00",
-                    "id": "10336-/usr/local/bin/uperf_-s_-P_21000",
+                    "id": "1080-rhnsd",
                     "io_reads": "0.00",
                     "io_writes": "0.00",
                     "memory_faults_major": "0.00",
                     "memory_faults_minor": "0.00",
-                    "pid": "10336",
-                    "rss": "49340",
-                    "vsz": "60432"
+                    "pid": "1080",
+                    "rss": "284",
+                    "vsz": "107880"
                 }
             }
         },
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "8101acaaa4b9697c460620c7dfe2a2c5",
+        "_id": "cbbdf7a9c9beaf5d67b7f1c106d1a6d4",
         "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
                 "experiment": "uperf__2016-10-06_16:34:03",
-                "host": "master_40gb",
+                "host": "flat7_40gb",
                 "iteration": "tcp_stream-16384B-32i",
                 "iterseqno": "1",
                 "runid": "c5deab694ef0599c3a2315888f8cb847",
@@ -44343,18 +44343,18 @@ len(actions) = 22
             "@timestamp": "2016-10-06T16:34:14.000000",
             "pidstat": {
                 "pidstat": {
-                    "command": "kworker/0:1H",
+                    "command": "pickup_-l_-t_unix_-u",
                     "context_switches_nonvoluntary_switches": "0.00",
                     "context_switches_voluntary_switches": "0.00",
                     "cpu_usage": "0.00",
-                    "id": "1078-kworker/0:1H",
+                    "id": "12249-pickup_-l_-t_unix_-u",
                     "io_reads": "0.00",
                     "io_writes": "0.00",
                     "memory_faults_major": "0.00",
                     "memory_faults_minor": "0.00",
-                    "pid": "1078",
-                    "rss": "0",
-                    "vsz": "0"
+                    "pid": "12249",
+                    "rss": "3924",
+                    "vsz": "93320"
                 }
             }
         },

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -410,6 +410,7 @@ len(actions) = 22
         "_type": "pbench-run-toc-entry"
     },
     {
+        "_id": "fac111bbc020b08a2b36b419c9f10bf6",
         "_index": "pbench.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -14870,6 +14871,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "0d8629a3e0c950396d63011c7ac7c7ab",
         "_index": "pbench.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -29324,6 +29326,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "544e0e12d0ff57a469c4d94a2bcb2c58",
         "_index": "pbench.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43761,6 +43764,7 @@ len(actions) = 22
         "_type": "pbench-result-data"
     },
     {
+        "_id": "522f1aa5130e6b31b4decc08aa936a73",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43803,6 +43807,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "7fa48a4b40ba7bc0202511996b26f570",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43845,6 +43850,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "cb4f65a4b7aa1d086a7b1f79cbf86e75",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43887,6 +43893,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "6ab0c504a495e1c580018ee776f45565",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43929,6 +43936,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "8d62b6ec90851e115a9f7e933c92ad1d",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -43971,6 +43979,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "038ce5411758b0c1e9e6c7537b3c3ff0",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44013,6 +44022,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c8c1705364f63a5cae539a39fb125bc7",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44055,6 +44065,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "1525f60391a03c34dcd8fa89753e1696",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44097,6 +44108,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "84ba41f9fdff6829f1c212a524923d05",
         "_index": "pbench.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44139,6 +44151,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "686218c2a8e949dff92c342a5a774142",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44173,6 +44186,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "b384394f031d9c9bf68922562f0f838a",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44207,6 +44221,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "1be92cca2d8f950ff859262facabab66",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44241,6 +44256,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "a3b9eba8311959e713aaf029c0a67345",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44275,6 +44291,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "7036d305e806eb0089e45a5de27c1398",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
@@ -44309,6 +44326,7 @@ len(actions) = 22
         "_type": "pbench-tool-data-pidstat"
     },
     {
+        "_id": "8101acaaa4b9697c460620c7dfe2a2c5",
         "_index": "pbench.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -3,7 +3,7 @@ len(actions) = 22
 [
     {
         "_id": "c5deab694ef0599c3a2315888f8cb847",
-        "_index": "pbench.run.2016-10",
+        "_index": "pbench-unittests.run.2016-10",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -282,7 +282,7 @@ len(actions) = 22
     },
     {
         "_id": "e1c0ed1631aa464df2a017e69bdb2552",
-        "_index": "pbench.run.2016-10",
+        "_index": "pbench-unittests.run.2016-10",
         "_op_type": "create",
         "_parent": "c5deab694ef0599c3a2315888f8cb847",
         "_source": {
@@ -335,7 +335,7 @@ len(actions) = 22
     },
     {
         "_id": "5910d4015fc1916f15f43def76163ab7",
-        "_index": "pbench.run.2016-10",
+        "_index": "pbench-unittests.run.2016-10",
         "_op_type": "create",
         "_parent": "c5deab694ef0599c3a2315888f8cb847",
         "_source": {
@@ -373,7 +373,7 @@ len(actions) = 22
     },
     {
         "_id": "bc6d9742ae90bfa76ff4daf371653d40",
-        "_index": "pbench.run.2016-10",
+        "_index": "pbench-unittests.run.2016-10",
         "_op_type": "create",
         "_parent": "c5deab694ef0599c3a2315888f8cb847",
         "_source": {
@@ -411,7 +411,7 @@ len(actions) = 22
     },
     {
         "_id": "fac111bbc020b08a2b36b419c9f10bf6",
-        "_index": "pbench.result-data.2016-10-06",
+        "_index": "pbench-unittests.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -14872,7 +14872,7 @@ len(actions) = 22
     },
     {
         "_id": "0d8629a3e0c950396d63011c7ac7c7ab",
-        "_index": "pbench.result-data.2016-10-06",
+        "_index": "pbench-unittests.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -29327,7 +29327,7 @@ len(actions) = 22
     },
     {
         "_id": "544e0e12d0ff57a469c4d94a2bcb2c58",
-        "_index": "pbench.result-data.2016-10-06",
+        "_index": "pbench-unittests.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43765,7 +43765,7 @@ len(actions) = 22
     },
     {
         "_id": "522f1aa5130e6b31b4decc08aa936a73",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43808,7 +43808,7 @@ len(actions) = 22
     },
     {
         "_id": "7fa48a4b40ba7bc0202511996b26f570",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43851,7 +43851,7 @@ len(actions) = 22
     },
     {
         "_id": "cb4f65a4b7aa1d086a7b1f79cbf86e75",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43894,7 +43894,7 @@ len(actions) = 22
     },
     {
         "_id": "6ab0c504a495e1c580018ee776f45565",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43937,7 +43937,7 @@ len(actions) = 22
     },
     {
         "_id": "8d62b6ec90851e115a9f7e933c92ad1d",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -43980,7 +43980,7 @@ len(actions) = 22
     },
     {
         "_id": "038ce5411758b0c1e9e6c7537b3c3ff0",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44023,7 +44023,7 @@ len(actions) = 22
     },
     {
         "_id": "c8c1705364f63a5cae539a39fb125bc7",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44066,7 +44066,7 @@ len(actions) = 22
     },
     {
         "_id": "1525f60391a03c34dcd8fa89753e1696",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44109,7 +44109,7 @@ len(actions) = 22
     },
     {
         "_id": "84ba41f9fdff6829f1c212a524923d05",
-        "_index": "pbench.tool-data-iostat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44152,7 +44152,7 @@ len(actions) = 22
     },
     {
         "_id": "686218c2a8e949dff92c342a5a774142",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44187,7 +44187,7 @@ len(actions) = 22
     },
     {
         "_id": "b384394f031d9c9bf68922562f0f838a",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44222,7 +44222,7 @@ len(actions) = 22
     },
     {
         "_id": "1be92cca2d8f950ff859262facabab66",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44257,7 +44257,7 @@ len(actions) = 22
     },
     {
         "_id": "a3b9eba8311959e713aaf029c0a67345",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44292,7 +44292,7 @@ len(actions) = 22
     },
     {
         "_id": "7036d305e806eb0089e45a5de27c1398",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -44327,7 +44327,7 @@ len(actions) = 22
     },
     {
         "_id": "8101acaaa4b9697c460620c7dfe2a2c5",
-        "_index": "pbench.tool-data-pidstat.2016-10-06",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
             "@metadata": {

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -1,5 +1,10 @@
 +++ Running indexing for test-7.8
-len(actions) = 22
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 11778, duplicates: 0, failures: 0)
+Index:  pbench-unittests.result-data.2016-10-06 3
+Index:  pbench-unittests.run.2016-10 63
+Index:  pbench-unittests.tool-data-iostat.2016-10-06 27
+Index:  pbench-unittests.tool-data-pidstat.2016-10-06 11685
+len(actions) = 48
 [
     {
         "_id": "c5deab694ef0599c3a2315888f8cb847",
@@ -404,6 +409,870 @@ len(actions) = 22
                     "mode": "0o644",
                     "name": "client::10.10.40.15-server::10.10.40.14:20010--client_output.txt",
                     "size": 151168
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "3a321944a0a7e605271e5f997d25f7d1",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "uperf_Gb_sec.csv",
+                    "size": 110294
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "ed3d5f60dd3f715627827d84b5a16a5c",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "dec2dc62257587ff6e1636cc0d5dd49f",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "3eb3a764ea773493fdcbf5e502872917",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/turbostat/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "turbostat-stdout.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "turbostat-stderr.txt",
+                    "size": 70
+                },
+                {
+                    "mode": "0o755",
+                    "name": "turbostat.cmd",
+                    "size": 185
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "342d953aab473768b7646578b3f4af11",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/sar/",
+            "files": [
+                {
+                    "mode": "0o664",
+                    "name": "sar.data",
+                    "size": 49
+                },
+                {
+                    "mode": "0o644",
+                    "name": "system.html",
+                    "size": 876
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu.html",
+                    "size": 3675
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345.html",
+                    "size": 1462
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2.html",
+                    "size": 934
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory.html",
+                    "size": 874
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu.html",
+                    "size": 868
+                },
+                {
+                    "mode": "0o644",
+                    "name": "system-average.txt",
+                    "size": 136
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu-average.txt",
+                    "size": 3408
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345-average.txt",
+                    "size": 1525
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2-average.txt",
+                    "size": 1594
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory-average.txt",
+                    "size": 1217
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu-average.txt",
+                    "size": 992
+                },
+                {
+                    "mode": "0o644",
+                    "name": "sar-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "sar-stdout.txt",
+                    "size": 81460
+                },
+                {
+                    "mode": "0o755",
+                    "name": "sar.cmd",
+                    "size": 143
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "2a34670635bdef65707bd274141489d4",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/sar/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "system_proc_cswch_sec.csv",
+                    "size": 138
+                },
+                {
+                    "mode": "0o644",
+                    "name": "system_interrupts_sec.csv",
+                    "size": 94
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_15.csv",
+                    "size": 263
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_14.csv",
+                    "size": 261
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_13.csv",
+                    "size": 261
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_12.csv",
+                    "size": 263
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_11.csv",
+                    "size": 263
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_10.csv",
+                    "size": 263
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_09.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_08.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_07.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_06.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_05.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_04.csv",
+                    "size": 262
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_03.csv",
+                    "size": 261
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_02.csv",
+                    "size": 261
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_01.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "per_cpu_cpu_00.csv",
+                    "size": 260
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345_udp.csv",
+                    "size": 220
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345_tcp_sockets.csv",
+                    "size": 428
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345_sockets.csv",
+                    "size": 207
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345_nfs_client.csv",
+                    "size": 184
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l345_ip.csv",
+                    "size": 767
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_network_packets_sec.csv",
+                    "size": 213
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_network_multicast_packets_sec.csv",
+                    "size": 122
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_network_Mbits_sec.csv",
+                    "size": 254
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_network_compressed_packets_sec.csv",
+                    "size": 189
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_frame_alignment_errors.csv",
+                    "size": 113
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_fifo_overrun_errors.csv",
+                    "size": 189
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_errors_sec.csv",
+                    "size": 189
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_drops_sec.csv",
+                    "size": 189
+                },
+                {
+                    "mode": "0o644",
+                    "name": "network_l2_carrier_errors.csv",
+                    "size": 113
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_memory_usage.csv",
+                    "size": 649
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_memory_activity.csv",
+                    "size": 381
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_frequency_MHz.csv",
+                    "size": 551
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_all_cpu_busy.csv",
+                    "size": 344
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "49098a3cd98ee9e54c2886d64f5bc1f6",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/proc-vmstat/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat.html",
+                    "size": 3961
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat-average.txt",
+                    "size": 3773
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat-stdout.txt",
+                    "size": 9473
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o755",
+                    "name": "proc-vmstat.cmd",
+                    "size": 191
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "37ac6fb072861aeb5c1f4eadab00a2da",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/proc-vmstat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_zone_delta_sec.csv",
+                    "size": 85
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_workingset_delta_sec.csv",
+                    "size": 111
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_unevictable_delta_sec.csv",
+                    "size": 192
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_thp_delta_sec.csv",
+                    "size": 230
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_slabs_delta_sec.csv",
+                    "size": 78
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_pgsteal_delta_sec.csv",
+                    "size": 218
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_pgscan_delta_sec.csv",
+                    "size": 240
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_pgrefill_delta_sec.csv",
+                    "size": 113
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_pgmigrate_delta_sec.csv",
+                    "size": 89
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_pgalloc_delta_sec.csv",
+                    "size": 203
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_numa_delta_sec.csv",
+                    "size": 334
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_nr_delta_sec.csv",
+                    "size": 1340
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_kswapd_delta_sec.csv",
+                    "size": 138
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_htlb_delta_sec.csv",
+                    "size": 113
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_drop_delta_sec.csv",
+                    "size": 91
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-vmstat_compact_delta_sec.csv",
+                    "size": 157
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "7fd3ac7b901dbd2e9a54ab827e2371bb",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/proc-interrupts/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq.html",
+                    "size": 1339
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu.html",
+                    "size": 4230
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq-average.txt",
+                    "size": 24533
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu-average.txt",
+                    "size": 24533
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-stdout.txt",
+                    "size": 26208
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o755",
+                    "name": "proc-interrupts.cmd",
+                    "size": 203
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "4cb480b5392d7a9f624e78beb0e3e12b",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/proc-interrupts/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_TRM_Thermal_event_interrupts.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_TLB_TLB_shootdowns.csv",
+                    "size": 716
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_THR_Threshold_APIC_interrupts.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_SPU_Spurious_interrupts.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_RTR_APIC_ICR_read_retries.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_RES_Rescheduling_interrupts.csv",
+                    "size": 982
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_PMI_Performance_monitoring_interrupts.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_NMI_Non-maskable_interrupts.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_MIS.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_MCP_Machine_check_polls.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_MCE_Machine_check_exceptions.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_LOC_Local_timer_interrupts.csv",
+                    "size": 1005
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_IWI_IRQ_work_interrupts.csv",
+                    "size": 448
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_ERR.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_CAL_Function_call_interrupts.csv",
+                    "size": 557
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_031_PCI-MSI-edge_virtio1-output.0.csv",
+                    "size": 333
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_030_PCI-MSI-edge_virtio1-input.0.csv",
+                    "size": 333
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_029_PCI-MSI-edge_virtio1-config.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_028_PCI-MSI-edge_virtio0-output.0.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_027_PCI-MSI-edge_virtio0-input.0.csv",
+                    "size": 336
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_026_PCI-MSI-edge_virtio0-config.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_025_PCI-MSI-edge_virtio2-req.0.csv",
+                    "size": 318
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_024_PCI-MSI-edge_virtio2-config.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_015_IO-APIC-edge_ata_piix.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_014_IO-APIC-edge_ata_piix.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_012_IO-APIC-edge_i8042.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_011_IO-APIC-fasteoi_uhci_hcd:usb1_virtio3.csv",
+                    "size": 304
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_009_IO-APIC-fasteoi_acpi.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_008_IO-APIC-edge_rtc0.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_006_IO-APIC-edge_floppy.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_001_IO-APIC-edge_i8042.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq_IRQ_000_IO-APIC-edge_timer.csv",
+                    "size": 288
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_015.csv",
+                    "size": 1363
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_014.csv",
+                    "size": 1379
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_013.csv",
+                    "size": 1364
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_012.csv",
+                    "size": 1428
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_011.csv",
+                    "size": 1366
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_010.csv",
+                    "size": 1381
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_009.csv",
+                    "size": 1379
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_008.csv",
+                    "size": 1363
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_007.csv",
+                    "size": 1438
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_006.csv",
+                    "size": 1410
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_005.csv",
+                    "size": 1411
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_004.csv",
+                    "size": 1351
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_003.csv",
+                    "size": 1460
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_002.csv",
+                    "size": 1379
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_001.csv",
+                    "size": 1380
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu_CPU_000.csv",
+                    "size": 1472
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "4a2e134d22debff6811d00ca3d9dee9a",
+        "_index": "pbench-unittests.run.2016-10",
+        "_op_type": "create",
+        "_parent": "c5deab694ef0599c3a2315888f8cb847",
+        "_source": {
+            "@timestamp": "2016-10-06T16:34:08.098427807",
+            "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat8_40gb/pidstat/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage.html",
+                    "size": 932
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults.html",
+                    "size": 706
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io.html",
+                    "size": 693
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_usage.html",
+                    "size": 693
+                },
+                {
+                    "mode": "0o644",
+                    "name": "context_switches.html",
+                    "size": 724
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage-average.txt",
+                    "size": 103157
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults-average.txt",
+                    "size": 104072
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io-average.txt",
+                    "size": 102807
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_usage-average.txt",
+                    "size": 45725
+                },
+                {
+                    "mode": "0o644",
+                    "name": "context_switches-average.txt",
+                    "size": 122999
+                },
+                {
+                    "mode": "0o644",
+                    "name": "pidstat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "pidstat-stdout.txt",
+                    "size": 48360
+                },
+                {
+                    "mode": "0o755",
+                    "name": "pidstat.cmd",
+                    "size": 60
                 }
             ]
         },
@@ -44359,11 +45228,585 @@ len(actions) = 22
             }
         },
         "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "0dd1eb3e0657e36e623d10e8ceb6f5f3",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "SCREEN_-dmS_uperf-server_/var/lib/pbench",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13028-SCREEN_-dmS_uperf-server_/var/lib/pbench",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13028",
+                    "rss": "1256",
+                    "vsz": "125624"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "a46457e0cb88751b10faf8584a2c7aa3",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/bin/sh_/var/lib/pbench-agent/uperf__201",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13029-/bin/sh_/var/lib/pbench-agent/uperf__201",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13029",
+                    "rss": "1196",
+                    "vsz": "113116"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "0ca989dea06ba699471a86566ccd7e6b",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/local/bin/uperf_-s_-P_20010",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.33",
+                    "cpu_usage": "0.00",
+                    "id": "13030-/usr/local/bin/uperf_-s_-P_20010",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "7.97",
+                    "pid": "13030",
+                    "rss": "744",
+                    "vsz": "11988"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "a4080a6ea0198ccb8cd8eb9a7a452f49",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "SCREEN_-dmS_pbench-tool-iostat-default-1",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13348-SCREEN_-dmS_pbench-tool-iostat-default-1",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13348",
+                    "rss": "1056",
+                    "vsz": "125624"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "b2d96e38c72d8d6c9b9138919c621d4b",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13351-/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13351",
+                    "rss": "1544",
+                    "vsz": "113120"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "870e12bc8d31bdde1461c4ad85604477",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "SCREEN_-dmS_pbench-tool-mpstat-default-1",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13365-SCREEN_-dmS_pbench-tool-mpstat-default-1",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13365",
+                    "rss": "1056",
+                    "vsz": "125624"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "6188ef1182376913105f4e76abe40ae3",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13368-/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13368",
+                    "rss": "1544",
+                    "vsz": "113120"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "a6430d9cb8cfa4f5ac4371ca64f0b269",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "SCREEN_-dmS_pbench-tool-perf-default-1_/",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13383-SCREEN_-dmS_pbench-tool-perf-default-1_/",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13383",
+                    "rss": "1056",
+                    "vsz": "125624"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "8b288d28270b0fc917a5bd67f1a497b6",
+        "_index": "pbench-unittests.tool-data-pidstat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat7_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13387-/bin/bash_/opt/pbench-agent/tool-scripts",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13387",
+                    "rss": "1544",
+                    "vsz": "113120"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "52c0264ed911e374ceac96c38fdefdcd",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "iostat": {
+                "disk": {
+                    "id": "rhel72_java-root",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.67"
+                    },
+                    "qsize": "0.01",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "27.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.01"
+                    },
+                    "util": "0.53",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "8.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "70a5193aa61a54ae10655dfbc5439703",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "iostat": {
+                "disk": {
+                    "id": "rhel72_java-swap",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "0.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.00",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "560712e9dd4c3df7228bd834c70990e7",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:14.000000",
+            "iostat": {
+                "disk": {
+                    "id": "vda",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "1.00"
+                    },
+                    "qsize": "0.01",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "18.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.01"
+                    },
+                    "util": "0.53",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "5.33"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "cb0f1b3b63ad54194173ff7785329da0",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:17.000000",
+            "iostat": {
+                "disk": {
+                    "id": "rhel72_java-root",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "0.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.00",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "0388c559242c08d6643c806db725a520",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:17.000000",
+            "iostat": {
+                "disk": {
+                    "id": "rhel72_java-swap",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "0.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.00",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "976fe2071c76d3ce5d44d7e935d16998",
+        "_index": "pbench-unittests.tool-data-iostat.2016-10-06",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "uperf__2016-10-06_16:34:03",
+                "host": "flat8_40gb",
+                "iteration": "tcp_stream-16384B-32i",
+                "iterseqno": "1",
+                "runid": "c5deab694ef0599c3a2315888f8cb847",
+                "runtstamp": "2016-10-06T16:34:08.098427807",
+                "sample": "sample1",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2016-10-06T16:34:17.000000",
+            "iostat": {
+                "disk": {
+                    "id": "vda",
+                    "iops": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "qsize": "0.00",
+                    "reqmerges": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "reqsize": "0.00",
+                    "tput": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    },
+                    "util": "0.00",
+                    "wtime": {
+                        "read": "0.00",
+                        "write": "0.00"
+                    }
+                }
+            }
+        },
+        "_type": "pbench-tool-data-iostat"
     }
 ]
 --- Finished indexing for test-7.8 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/uperf__2016-10-06_16:34:03.tar.xz
 /var/tmp/pbench-test-server/pbench/uperf__2016-10-06_16:34:03.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -10,7 +10,7 @@ len(actions) = 22
                 "file-date": "2017-02-22",
                 "file-name": "/var/tmp/pbench-test-server/pbench/uperf__2016-10-06_16:34:03.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "c5deab694ef0599c3a2315888f8cb847",
                 "pbench-agent-version": "0.40-2g191b627"
             },

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -1,5 +1,9 @@
 +++ Running indexing for test-7.9
-len(actions) = 19
+	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 3144, duplicates: 0, failures: 0)
+Index:  pbench-unittests.run.2017-04 24
+Index:  pbench-unittests.tool-data-iostat.2017-04-21 60
+Index:  pbench-unittests.tool-data-pidstat.2017-04-21 3060
+len(actions) = 45
 [
     {
         "_id": "dac368cffba8e02c1ecac69dfe46ffcc",
@@ -122,6 +126,430 @@ len(actions) = 19
                     "mode": "0o644",
                     "name": "result.txt",
                     "size": 0
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "1dd23d9668e1d467fadcc8cbc100a3d9",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "8256c6c3d378edaf4e00bdf32301785b",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/"
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "6636466f403564591de8870cef15837a",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/iostat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "iostat.cmd",
+                    "size": 47
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stdout.txt",
+                    "size": 12499
+                },
+                {
+                    "mode": "0o644",
+                    "name": "iostat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk-average.txt",
+                    "size": 1320
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk.html",
+                    "size": 1594
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "3e5871b5792217997b72088311839ead",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/iostat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "disk_IOPS.csv",
+                    "size": 987
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Queue_Size.csv",
+                    "size": 621
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Merges_per_sec.csv",
+                    "size": 982
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Request_Size_in_512_byte_sectors.csv",
+                    "size": 632
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Throughput_MB_per_sec.csv",
+                    "size": 982
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Utilization_percent.csv",
+                    "size": 621
+                },
+                {
+                    "mode": "0o644",
+                    "name": "disk_Wait_Time_msec.csv",
+                    "size": 982
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "db494863a2d7bea0746d8ca28ee62b63",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/mpstat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "mpstat.cmd",
+                    "size": 39
+                },
+                {
+                    "mode": "0o644",
+                    "name": "mpstat-stdout.txt",
+                    "size": 5938
+                },
+                {
+                    "mode": "0o644",
+                    "name": "mpstat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu0-average.txt",
+                    "size": 176
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall-average.txt",
+                    "size": 194
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu0.html",
+                    "size": 654
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall.html",
+                    "size": 662
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "d0d640b059fd4c5f1c0ec99fc6877be9",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/mpstat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "cpu0_cpu0.csv",
+                    "size": 1264
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpuall_cpuall.csv",
+                    "size": 1264
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "ebda6df5e56eb4bf47cb3403228e90ea",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/perf/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "perf.cmd",
+                    "size": 35
+                },
+                {
+                    "mode": "0o644",
+                    "name": "perf-stdout.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "perf-stderr.txt",
+                    "size": 118
+                },
+                {
+                    "mode": "0o644",
+                    "name": "perf.data.xz",
+                    "size": 89828
+                },
+                {
+                    "mode": "0o644",
+                    "name": "perf-report-consolidated.txt",
+                    "size": 2745
+                },
+                {
+                    "mode": "0o644",
+                    "name": "perf-report.txt.xz",
+                    "size": 2428
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "20c43e70095d6c72c06013eab7723ff0",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/perf/perf-percpu/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "perf-report-cpu_0.txt.xz",
+                    "size": 2380
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "dba8a450502155829929e87fee88ff83",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/pidstat/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "pidstat.cmd",
+                    "size": 60
+                },
+                {
+                    "mode": "0o644",
+                    "name": "pidstat-stdout.txt",
+                    "size": 427562
+                },
+                {
+                    "mode": "0o644",
+                    "name": "pidstat-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "context_switches-average.txt",
+                    "size": 19499
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_usage-average.txt",
+                    "size": 7861
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io-average.txt",
+                    "size": 17083
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults-average.txt",
+                    "size": 17240
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage-average.txt",
+                    "size": 17745
+                },
+                {
+                    "mode": "0o644",
+                    "name": "context_switches.html",
+                    "size": 787
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_usage.html",
+                    "size": 693
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io.html",
+                    "size": 693
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults.html",
+                    "size": 706
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage.html",
+                    "size": 932
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "7a3de880d95d37bc3263ee8cee5e7795",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/pidstat/csv/",
+            "files": [
+                {
+                    "mode": "0o644",
+                    "name": "context_switches_nonvoluntary_switches_sec.csv",
+                    "size": 16682
+                },
+                {
+                    "mode": "0o644",
+                    "name": "context_switches_voluntary_switches_sec.csv",
+                    "size": 16683
+                },
+                {
+                    "mode": "0o644",
+                    "name": "cpu_usage_percent_cpu.csv",
+                    "size": 16657
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io_io_reads_KB_sec.csv",
+                    "size": 16657
+                },
+                {
+                    "mode": "0o644",
+                    "name": "file_io_io_writes_KB_sec.csv",
+                    "size": 16663
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults_major_faults_sec.csv",
+                    "size": 16657
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_faults_minor_faults_sec.csv",
+                    "size": 16778
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage_resident_set_size.csv",
+                    "size": 16675
+                },
+                {
+                    "mode": "0o644",
+                    "name": "memory_usage_virtual_size.csv",
+                    "size": 20052
+                }
+            ]
+        },
+        "_type": "pbench-run-toc-entry"
+    },
+    {
+        "_id": "2138fc029c680da45ce46ab9cf3ebb55",
+        "_index": "pbench-unittests.run.2017-04",
+        "_op_type": "create",
+        "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
+        "_source": {
+            "@timestamp": "2017-04-21T20:38:16.618515395",
+            "directory": "/1/reference-result/tools-default/dhcp31-144/proc-interrupts/",
+            "files": [
+                {
+                    "mode": "0o755",
+                    "name": "proc-interrupts.cmd",
+                    "size": 206
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-stderr.txt",
+                    "size": 0
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-stdout.txt",
+                    "size": 29694
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu-average.txt",
+                    "size": 1505
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq-average.txt",
+                    "size": 1505
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-cpu.html",
+                    "size": 721
+                },
+                {
+                    "mode": "0o644",
+                    "name": "proc-interrupts-by-irq.html",
+                    "size": 767
                 }
             ]
         },
@@ -771,11 +1199,537 @@ len(actions) = 19
             }
         },
         "_type": "pbench-tool-data-iostat"
+    },
+    {
+        "_id": "5d368bb144f335f828d0143c366e178a",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "/usr/lib/systemd/systemd_--switched-root",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.65",
+                    "cpu_usage": "0.00",
+                    "id": "1-/usr/lib/systemd/systemd_--switched-root",
+                    "io_reads": "0.00",
+                    "io_writes": "3.90",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "1",
+                    "rss": "10460",
+                    "vsz": "214832"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "5b10ab7ec5b4346296b7525793f63df2",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12567-sshd:_root_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12567",
+                    "rss": "8268",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "0161e6a8f8c1f7e5fe2eb9fc140cd92f",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root@pts/6",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12570-sshd:_root@pts/6",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12570",
+                    "rss": "4468",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "5446475e3e4f57df6bf5734d980ff706",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "-bash",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12580--bash",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12580",
+                    "rss": "4516",
+                    "vsz": "123060"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "b28d816e7732f8f7fd52f641dde72db0",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12602-sshd:_root_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12602",
+                    "rss": "8384",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "ec7502612ac8f4c05b23a84584757d40",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root@pts/7",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12605-sshd:_root@pts/7",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12605",
+                    "rss": "3356",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "d796d4d71029e2c99f46e1ddcf774b37",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "-bash",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12613--bash",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12613",
+                    "rss": "4572",
+                    "vsz": "123060"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "03ace349fc7b034650c3dcae90025a2a",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12725-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12725",
+                    "rss": "8380",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "77905b11ab341b0aed23b2c872734b63",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench@pts/10",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12728-sshd:_pbench@pts/10",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12728",
+                    "rss": "4540",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "df6e66cddb50377e5fabf948f8bbfb95",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "-bash",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "12729--bash",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "12729",
+                    "rss": "4596",
+                    "vsz": "123056"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "31d8bc99fefe529a067e331666652e70",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "less_-S_pbench-index.log",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "13552-less_-S_pbench-index.log",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "13552",
+                    "rss": "2348",
+                    "vsz": "116908"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "0a3fc6a3cee596eaf557ae3e92452175",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "14232-sshd:_root_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "14232",
+                    "rss": "8288",
+                    "vsz": "146840"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "1c31bf557b23db213f43781a3e8a81a2",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_root@pts/3",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "14235-sshd:_root@pts/3",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "14235",
+                    "rss": "4652",
+                    "vsz": "146972"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "569e43a47d0ffdbba9ca7bbfc8c63820",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "-bash",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "14244--bash",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "14244",
+                    "rss": "4676",
+                    "vsz": "123060"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
+    },
+    {
+        "_id": "3b94c151ab915e4cbaf3bf150f88f3e3",
+        "_index": "pbench-unittests.tool-data-pidstat.2017-04-21",
+        "_op_type": "create",
+        "_source": {
+            "@metadata": {
+                "experiment": "pbench-user-benchmark__2017-04-21_20:38:16",
+                "host": "dhcp31-144",
+                "iteration": "1",
+                "iterseqno": "1",
+                "runid": "dac368cffba8e02c1ecac69dfe46ffcc",
+                "runtstamp": "2017-04-21T20:38:16.618515395",
+                "sample": "reference-result",
+                "toolgroup": "default"
+            },
+            "@timestamp": "2017-04-21T20:38:21.000000",
+            "pidstat": {
+                "pidstat": {
+                    "command": "sshd:_pbench_[priv]",
+                    "context_switches_nonvoluntary_switches": "0.00",
+                    "context_switches_voluntary_switches": "0.00",
+                    "cpu_usage": "0.00",
+                    "id": "14266-sshd:_pbench_[priv]",
+                    "io_reads": "0.00",
+                    "io_writes": "0.00",
+                    "memory_faults_major": "0.00",
+                    "memory_faults_minor": "0.00",
+                    "pid": "14266",
+                    "rss": "8216",
+                    "vsz": "146844"
+                }
+            }
+        },
+        "_type": "pbench-tool-data-pidstat"
     }
 ]
 --- Finished indexing for test-7.9 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
 /var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz
 /var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz.md5
 --- pbench tree state

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -10,7 +10,7 @@ len(actions) = 19
                 "file-date": "2017-04-21",
                 "file-name": "/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz",
                 "generated-by": "index-pbench",
-                "generated-by-version": "0.1.0.0",
+                "generated-by-version": "0.2.0.0",
                 "md5": "dac368cffba8e02c1ecac69dfe46ffcc",
                 "pbench-agent-version": "0.42-1gcf7a941"
             },

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -128,6 +128,7 @@ len(actions) = 19
         "_type": "pbench-run-toc-entry"
     },
     {
+        "_id": "e3c2c5676473a43b8523ddbcec616cda",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -170,6 +171,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "0942dcd98df281d3643c3d8f021d3644",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -212,6 +214,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "a2fc9e89f6513708835e4ae6eedb4ecc",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -254,6 +257,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "a9a6d3bd0511fca6618ceee8567c70a4",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -296,6 +300,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "c48f574b8e076c118e783139aefe08de",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -338,6 +343,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "a0b5839f58e5a464570506abce67986d",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -380,6 +386,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "3251049e3fdaa48bb73e3fdee6b42891",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -422,6 +429,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "61157da11424f33e13fb3a46b49485e5",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -464,6 +472,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "e6c80eb6060bb4230de0e199d3886c11",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -506,6 +515,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "7e9074c8745b87c5d17c7fd2fa835e66",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -548,6 +558,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "2c50eef2770fe8a4712ede2e5f3b7029",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -590,6 +601,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "f111580e876e40424ae0156e819e93f8",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -632,6 +644,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "b4754ecf6005dca7bbeb5149e32a92e2",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -674,6 +687,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "9cbb53c51a8e77444ffa6a2f426bceab",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
@@ -716,6 +730,7 @@ len(actions) = 19
         "_type": "pbench-tool-data-iostat"
     },
     {
+        "_id": "aeb9cf05786bbb115e8b8bd6993f5f60",
         "_index": "pbench.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -3,7 +3,7 @@ len(actions) = 19
 [
     {
         "_id": "dac368cffba8e02c1ecac69dfe46ffcc",
-        "_index": "pbench.run.2017-04",
+        "_index": "pbench-unittests.run.2017-04",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -77,7 +77,7 @@ len(actions) = 19
     },
     {
         "_id": "fa8cffef47561755aa976de86eebb960",
-        "_index": "pbench.run.2017-04",
+        "_index": "pbench-unittests.run.2017-04",
         "_op_type": "create",
         "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
         "_source": {
@@ -100,7 +100,7 @@ len(actions) = 19
     },
     {
         "_id": "964dd6e173ad015beabcaaa04d2ea1ea",
-        "_index": "pbench.run.2017-04",
+        "_index": "pbench-unittests.run.2017-04",
         "_op_type": "create",
         "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
         "_source": {
@@ -111,7 +111,7 @@ len(actions) = 19
     },
     {
         "_id": "1335cf153ccff57c51768b5de3d4ff29",
-        "_index": "pbench.run.2017-04",
+        "_index": "pbench-unittests.run.2017-04",
         "_op_type": "create",
         "_parent": "dac368cffba8e02c1ecac69dfe46ffcc",
         "_source": {
@@ -129,7 +129,7 @@ len(actions) = 19
     },
     {
         "_id": "e3c2c5676473a43b8523ddbcec616cda",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -172,7 +172,7 @@ len(actions) = 19
     },
     {
         "_id": "0942dcd98df281d3643c3d8f021d3644",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -215,7 +215,7 @@ len(actions) = 19
     },
     {
         "_id": "a2fc9e89f6513708835e4ae6eedb4ecc",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -258,7 +258,7 @@ len(actions) = 19
     },
     {
         "_id": "a9a6d3bd0511fca6618ceee8567c70a4",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -301,7 +301,7 @@ len(actions) = 19
     },
     {
         "_id": "c48f574b8e076c118e783139aefe08de",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -344,7 +344,7 @@ len(actions) = 19
     },
     {
         "_id": "a0b5839f58e5a464570506abce67986d",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -387,7 +387,7 @@ len(actions) = 19
     },
     {
         "_id": "3251049e3fdaa48bb73e3fdee6b42891",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -430,7 +430,7 @@ len(actions) = 19
     },
     {
         "_id": "61157da11424f33e13fb3a46b49485e5",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -473,7 +473,7 @@ len(actions) = 19
     },
     {
         "_id": "e6c80eb6060bb4230de0e199d3886c11",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -516,7 +516,7 @@ len(actions) = 19
     },
     {
         "_id": "7e9074c8745b87c5d17c7fd2fa835e66",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -559,7 +559,7 @@ len(actions) = 19
     },
     {
         "_id": "2c50eef2770fe8a4712ede2e5f3b7029",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -602,7 +602,7 @@ len(actions) = 19
     },
     {
         "_id": "f111580e876e40424ae0156e819e93f8",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -645,7 +645,7 @@ len(actions) = 19
     },
     {
         "_id": "b4754ecf6005dca7bbeb5149e32a92e2",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -688,7 +688,7 @@ len(actions) = 19
     },
     {
         "_id": "9cbb53c51a8e77444ffa6a2f426bceab",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {
@@ -731,7 +731,7 @@ len(actions) = 19
     },
     {
         "_id": "aeb9cf05786bbb115e8b8bd6993f5f60",
-        "_index": "pbench.tool-data-iostat.2017-04-21",
+        "_index": "pbench-unittests.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
             "@metadata": {

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -22,7 +22,7 @@ from datetime import datetime, timedelta
 from vos.analysis.lib import tstos
 from collections import Counter
 
-_VERSION_ = "0.1.0.0"
+_VERSION_ = "0.2.0.0"
 _NAME_    = "index-pbench"
 _DEBUG    = 9
 
@@ -378,17 +378,18 @@ def convert_to_float(d):
 
 
 class ResultData(object):
-    def __init__(self, tstamp, md5sum, experiment, mdlog, tb, opctx):
+    def __init__(self, ptb, experiment, opctx):
         self.run_metadata = {
-            "runtstamp": tstamp,
-            "runid": md5sum,
+            "runtstamp": ptb.start_run,
+            "runid": ptb.md5sum,
             "experiment": experiment,
         }
+        self.ptb = ptb
         self.counters = Counter()
         opctx.append({ "object": "ResultData", "counters": self.counters })
         self.json_files = None
         try:
-            self.json_files = ResultData.get_json_files(mdlog, tb)
+            self.json_files = ResultData.get_json_files(ptb)
         except KeyError:
             self.json_files = None
 
@@ -396,7 +397,7 @@ class ResultData(object):
         for df in self.json_files:
             try:
                 # Read it once to generate the source_id
-                with open(os.path.join(_tmpdir, df['path']), "rb") as fp:
+                with open(os.path.join(self.ptb.extracted_root, df['path']), "rb") as fp:
                     hash_md5 = hashlib.md5()
                     for chunk in iter(lambda: fp.read(4096), b""):
                         hash_md5.update(chunk)
@@ -409,7 +410,7 @@ class ResultData(object):
 
             try:
                 # Read it a second time to interpret it as a JSON document.
-                with open(os.path.join(_tmpdir, df['path'])) as fp:
+                with open(os.path.join(self.ptb.extracted_root, df['path'])) as fp:
                     results = json.load(fp)
             except Exception as e:
                 print("result-data-indexing: encountered invalid JSON file,"
@@ -438,12 +439,12 @@ class ResultData(object):
         return gen
 
     @staticmethod
-    def get_json_files(mdlog, tb):
+    def get_json_files(ptb):
         """
         Fetch the list of result.json files for this experiment;
         return a list of dicts containing their metadata.
         """
-        paths = [x for x in tb.getnames() if x.find("result.json") >= 0 and tb.getmember(x).isfile()]
+        paths = [x for x in ptb.tb.getnames() if x.find("result.json") >= 0 and ptb.tb.getmember(x).isfile()]
         datafiles = []
         for p in paths:
             fname = os.path.basename(p)
@@ -459,206 +460,224 @@ def _make_source_id(source):
     return hashlib.md5(json.dumps(source, sort_keys=True).encode('utf-8')).hexdigest()
 
 # Handlers data table / dictionary describing how to process a given tool's
-# .csv files.  The outer dictionary holds one dictionary for each tool. Each
-# tool entry has one '@prospectus' entry, which records behavior and handling
-# controls, and then one entry for each .csv file name emitted by the tool.
+# data files to be indexed.  The outer dictionary holds one dictionary for
+# each tool. Each tool entry has one '@prospectus' entry, which records
+# behavior and handling controls for that tool, and a "patterns" list, which
+# contains a handler record for each file that match a given pattern emitted
+# by the tool (can be per file or a pattern to match multiple files).
 #
-# For each .csv file, we record the metric "class", and its name, "metric".
-# E.g. The metadata path hierarchy for iostat disk_IOPS.csv data would be,
-# 'iostat.disk.iops', for disk_Queue_Size.csv it would be 'iostat.disk.qsize',
-# etc.
+# For each data file's handler record, we record the metric "class" (e.g.
+# "disk"), and its "metric" name (e.g. "iops), which are used to contruct the
+# fully qualified namespace for the index field values.  E.g., the metadata
+# path hierarchy for iostat disk_IOPS.csv data would be, 'iostat.disk.iops',
+# for disk_Queue_Size.csv it would be 'iostat.disk.qsize', etc.
 #
-# We record the metrics "display" name (human readable, or really what is
+# We also record the metrics "display" name (human readable, or really what is
 # currently used by pbench today in generated html charts), and the "units"
 # for the metric, but neither field is currently indexed (FIXME!).
 #
 # The "colpat" field, or column pattern, describes as a regular expression the
-# constituent components of the .csv file column header. Currently, the "id"
+# constituent components of the .csv file column header.  Currently, the "id"
 # and "subfield" match groups are the only two expected groups, with
 # "subfield" considered optional.
 #
 # The "subfields" field contents in the handler data structure itself is
 # meant to be a programmatic way to ensure any subfield derived from a column
 # header can be checked, but that is not currently used (FIXME!).
-_known_csv_handlers = {
+#
+# The "metadata" field and "metadata_pat" are option entries which control how
+# to extract metadata from column headers.
+_known_handlers = {
     'iostat': {
         '@prospectus': {
             # For iostat .csv files, we want to merge all columns into one
             # JSON document
-            'handling': 'unify'
+            'handling': 'csv',
+            'method': 'unify'
         },
-        'disk_IOPS.csv': {
-            'class': 'disk',
-            'metric': 'iops',
-            'display': 'IOPS',
-            'units': 'count_per_sec',
-            'subfields': [ 'read', 'write' ],
-            'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
-        },
-        'disk_Queue_Size.csv': {
-            'class': 'disk',
-            'metric': 'qsize',
-            'display': 'Queue_Size',
-            'units': 'count',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)')
-        },
-        'disk_Request_Merges_per_sec.csv': {
-            'class': 'disk',
-            'metric': 'reqmerges',
-            'display': 'Request_Merges',
-            'units': 'count_per_sec',
-            'subfields': [ 'read', 'write' ],
-            'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
-        },
-        'disk_Request_Size_in_512_byte_sectors.csv': {
-            'class': 'disk',
-            'metric': 'reqsize',
-            'display': 'Request_Size',
-            'units': 'count_512b_sectors',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)')
-        },
-        'disk_Throughput_MB_per_sec.csv': {
-            'class': 'disk',
-            'metric': 'tput',
-            'display': 'Throughput',
-            'units': 'MB_per_sec',
-            'subfields': [ 'read', 'write' ],
-            'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
-        },
-        'disk_Utilization_percent.csv': {
-            'class': 'disk',
-            'metric': 'util',
-            'display': 'Utilization',
-            'units': 'percent',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)')
-        },
-        'disk_Wait_Time_msec.csv': {
-            'class': 'disk',
-            'metric': 'wtime',
-            'display': 'Wait_Time',
-            'units': 'msec',
-            'subfields': [ 'read', 'write' ],
-            'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
-        }
-    },
-    'proc-interrupts': {
-        '@prospectus': {
-            # For proc-interrupts .csv files, we want to individually index
-            # each column entry as its own JSON document
-            'handling': 'individual'
-        },
+        'patterns': [
+            {
+                'pattern': re.compile(r'disk_IOPS\.csv'),
+                'class': 'disk',
+                'metric': 'iops',
+                'display': 'IOPS',
+                'units': 'count_per_sec',
+                'subfields': [ 'read', 'write' ],
+                'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
+            }, {
+                'pattern': re.compile(r'disk_Queue_Size\.csv'),
+                'class': 'disk',
+                'metric': 'qsize',
+                'display': 'Queue_Size',
+                'units': 'count',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)')
+            }, {
+                'pattern': re.compile(r'disk_Request_Merges_per_sec\.csv'),
+                'class': 'disk',
+                'metric': 'reqmerges',
+                'display': 'Request_Merges',
+                'units': 'count_per_sec',
+                'subfields': [ 'read', 'write' ],
+                'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
+            }, {
+                'pattern': re.compile(r'disk_Request_Size_in_512_byte_sectors\.csv'),
+                'class': 'disk',
+                'metric': 'reqsize',
+                'display': 'Request_Size',
+                'units': 'count_512b_sectors',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)')
+            }, {
+                'pattern': re.compile(r'disk_Throughput_MB_per_sec\.csv'),
+                'class': 'disk',
+                'metric': 'tput',
+                'display': 'Throughput',
+                'units': 'MB_per_sec',
+                'subfields': [ 'read', 'write' ],
+                'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
+            }, {
+                'pattern': re.compile(r'disk_Utilization_percent\.csv'),
+                'class': 'disk',
+                'metric': 'util',
+                'display': 'Utilization',
+                'units': 'percent',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)')
+            }, {
+                'pattern': re.compile(r'disk_Wait_Time_msec\.csv'),
+                'class': 'disk',
+                'metric': 'wtime',
+                'display': 'Wait_Time',
+                'units': 'msec',
+                'subfields': [ 'read', 'write' ],
+                'colpat': re.compile(r'(?P<id>.+)-(?P<subfield>read|write)')
+            }
+        ]
     },
     'pidstat': {
         '@prospectus': {
             # For pidstat .csv files, we want to individually index
             # each column entry as its own JSON document
-            'handling': 'unify'
+            'handling': 'csv',
+            'method': 'unify'
         },
-        'context_switches_nonvoluntary_switches_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'context_switches_nonvoluntary_switches',
-            'display': 'Context_Switches_Nonvoluntary',
-            'units': 'count_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'context_switches_voluntary_switches_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'context_switches_voluntary_switches',
-            'display': 'Context_Switches_Voluntary',
-            'units': 'count_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'cpu_usage_percent_cpu.csv': {
-            'class': 'pidstat',
-            'metric': 'cpu_usage',
-            'display': 'CPU_Usage',
-            'units': 'percent_cpu',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'file_io_io_reads_KB_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'io_reads',
-            'display': 'IO_Reads',
-            'units': 'KB_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'file_io_io_writes_KB_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'io_writes',
-            'display': 'IO_Writes',
-            'units': 'KB_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'memory_faults_major_faults_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'memory_faults_major',
-            'display': 'Memory_Faults_Major',
-            'units': 'count_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'memory_faults_minor_faults_sec.csv': {
-            'class': 'pidstat',
-            'metric': 'memory_faults_minor',
-            'display': 'Memory_Faults_Minor',
-            'units': 'count_per_sec',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'memory_usage_resident_set_size.csv': {
-            'class': 'pidstat',
-            'metric': 'rss',
-            'display': 'RSS',
-            'units': 'KB',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        },
-        'memory_usage_virtual_size.csv': {
-            'class': 'pidstat',
-            'metric': 'vsz',
-            'display': 'VSZ',
-            'units': 'KB',
-            'subfields': [],
-            'colpat': re.compile(r'(?P<id>.+)'),
-            'metadata': [ 'pid', 'command' ],
-            'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
-        }
+        'patterns': [
+            {
+                'pattern': re.compile(r'context_switches_nonvoluntary_switches_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'context_switches_nonvoluntary_switches',
+                'display': 'Context_Switches_Nonvoluntary',
+                'units': 'count_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'context_switches_voluntary_switches_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'context_switches_voluntary_switches',
+                'display': 'Context_Switches_Voluntary',
+                'units': 'count_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'cpu_usage_percent_cpu\.csv'),
+                'class': 'pidstat',
+                'metric': 'cpu_usage',
+                'display': 'CPU_Usage',
+                'units': 'percent_cpu',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'file_io_io_reads_KB_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'io_reads',
+                'display': 'IO_Reads',
+                'units': 'KB_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'file_io_io_writes_KB_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'io_writes',
+                'display': 'IO_Writes',
+                'units': 'KB_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'memory_faults_major_faults_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'memory_faults_major',
+                'display': 'Memory_Faults_Major',
+                'units': 'count_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'memory_faults_minor_faults_sec\.csv'),
+                'class': 'pidstat',
+                'metric': 'memory_faults_minor',
+                'display': 'Memory_Faults_Minor',
+                'units': 'count_per_sec',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'memory_usage_resident_set_size\.csv'),
+                'class': 'pidstat',
+                'metric': 'rss',
+                'display': 'RSS',
+                'units': 'KB',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }, {
+                'pattern': re.compile(r'memory_usage_virtual_size\.csv'),
+                'class': 'pidstat',
+                'metric': 'vsz',
+                'display': 'VSZ',
+                'units': 'KB',
+                'subfields': [],
+                'colpat': re.compile(r'(?P<id>.+)'),
+                'metadata': [ 'pid', 'command' ],
+                'metadata_pat': re.compile(r'(?P<pid>.+?)-(?P<command>.+)')
+            }
+        ]
     },
-    'sar': {},
-    'turbostat': {},
-}
-
-_known_json_handlers = {
+    'proc-interrupts': {
+        '@prospectus': {
+            # For proc-interrupts .csv files, we want to individually index
+            # each column entry as its own JSON document
+            'handling': 'csv',
+            'method': 'individual'
+        },
+        'patterns': []
+    },
     'prometheus-metrics': {
         '@prospectus': {
             'handling': 'json',
-         },
+            'method': 'json'
+         }
      },
+    'sar': None,
+    'turbostat': None,
+    'mpstat': None,
+    'perf': None,
+    'proc-vmstat': None
 }
+
 # If we need to deal with old .csv file names, place an alias here to map to
 # an existing handler above.
 _aliases = {
@@ -671,8 +690,9 @@ _aliases = {
 
 
 class ToolData(object):
-    def __init__(self, start_run_tstamp, end_run_tstamp, md5sum, experiment,
-                iteration, sample, host, tool, toolgroup, mdlog, tb, opctx):
+    def __init__(self, ptb, experiment, iteration, sample, host, tool,
+                toolgroup, opctx):
+        self.ptb = ptb
         self.toolname = tool
         self.counters = Counter()
         opctx.append({ "object": "ToolData-%s" % (tool), "counters": self.counters })
@@ -681,22 +701,22 @@ class ToolData(object):
         except ValueError:
             iterseqno = itername = iteration
         try:
-            self.start_run_ts = datetime.strptime(start_run_tstamp, "%Y-%m-%dT%H:%M:%S.%f")
+            self.start_run_ts = datetime.strptime(ptb.start_run, "%Y-%m-%dT%H:%M:%S.%f")
         except ValueError:
             try:
-                self.start_run_ts = datetime.strptime(start_run_tstamp, "%Y-%m-%dT%H:%M:%S")
+                self.start_run_ts = datetime.strptime(ptb.start_run, "%Y-%m-%dT%H:%M:%S")
             except ValueError:
                 self.start_run_ts = None
         try:
-            self.end_run_ts = datetime.strptime(end_run_tstamp, "%Y-%m-%dT%H:%M:%S.%f")
+            self.end_run_ts = datetime.strptime(ptb.end_run, "%Y-%m-%dT%H:%M:%S.%f")
         except ValueError:
             try:
-                self.end_run_ts = datetime.strptime(end_run_tstamp, "%Y-%m-%dT%H:%M:%S")
+                self.end_run_ts = datetime.strptime(ptb.end_run, "%Y-%m-%dT%H:%M:%S")
             except ValueError:
                 self.end_run_ts = None
         self.run_metadata = {
-            "runtstamp": start_run_tstamp,
-            "runid": md5sum,
+            "runtstamp": ptb.start_run,
+            "runid": ptb.md5sum,
             "experiment": experiment,
             # FIXME: What are the constituent parts of an iteration name?
             "iteration": itername,
@@ -711,8 +731,8 @@ class ToolData(object):
         # convention used when collecting the results.
 
         # import pdb; pdb.set_trace()
-        label = get_tool_label(host, mdlog)
-        hostname_s = get_tool_hostname_s(host, mdlog)
+        label = get_tool_label(host, ptb.mdconf)
+        hostname_s = get_tool_hostname_s(host, ptb.mdconf)
         if label and hostname_s:
             hostpath = "{}:{}".format(label, hostname_s)
         elif hostname_s:
@@ -720,26 +740,16 @@ class ToolData(object):
         else:
             hostpath = host
 
-        self.csv_files = None
-        self.json_files = None
         try:
-            self.handler = _known_json_handlers[tool]
+            self.handler = _known_handlers[tool]
         except KeyError:
-            try:
-                self.handler = _known_csv_handlers[tool]
-            except KeyError:
-                self.handler = None
-            else:
-                # Fetch all the .csv files as a dictionary containing metadata
-                # about them, a csv reader object, and the header line from each
-                # file.
-                self.csv_files = ToolData.get_csv_files(
-                    self.handler, iteration, sample, hostpath, tool, toolgroup, mdlog, tb)
+            self.handler = None
+            self.files = None
         else:
-            self.json_files = ToolData.get_json_files(self.handler,
-                                                          iteration, sample,
-                                                          hostpath, tool, toolgroup,
-                                                          mdlog, tb)
+            # Fetch all the data files as a dictionary containing metadata
+            # about them.
+            self.files = ToolData.get_files(
+                    self.handler, iteration, sample, hostpath, tool, toolgroup, ptb)
 
     def convert_timestamp(self, orig_ts):
         # Convert the given string timestamp, assumed to be a float in
@@ -761,11 +771,6 @@ class ToolData(object):
         # The metric mapping provides (klass, metric) tuples for a given
         # .csv file.
         metric_mapping = _dict_const()
-        for k,v in self.handler.items():
-            if k.startswith('@'):
-                continue
-            class_list[v['class']] = True
-            metric_mapping[k] = (v['class'], v['metric'])
         # The list of identifiers is generated from the combined headers,
         # parsing out the IDs
         identifiers = _dict_const()
@@ -774,7 +779,7 @@ class ToolData(object):
         field_mapping = _dict_const()
         # Metadata extracted from column header
         metadata = _dict_const()
-        for csv in self.csv_files:
+        for csv in self.files:
             if csv['header'][0] != 'timestamp_ms':
                 print("tool-data-indexing: expected first column of .csv file"
                         " (%s) to be 'timestamp_ms', found %s",
@@ -782,8 +787,10 @@ class ToolData(object):
                 self.counters['first_column_not_timestamp_ms'] += 1
                 continue
             header = csv['header']
-            handler = self.handler[csv['basename']]
-            colpat = handler['colpat']
+            handler_rec = csv['handler_rec']
+            class_list[handler_rec['class']] = True
+            metric_mapping[csv['basename']] = (handler_rec['class'], handler_rec['metric'])
+            colpat = handler_rec['colpat']
             if csv['basename'] not in field_mapping:
                 field_mapping[csv['basename']] = _dict_const()
             for idx,col in enumerate(header):
@@ -798,32 +805,32 @@ class ToolData(object):
                 except IndexError:
                     subfield = None
                 else:
-                    if subfield not in handler['subfields']:
+                    if subfield not in handler_rec['subfields']:
                         print("tool-data-indexing: column header, %r, has an"
                                 " unexpected subfield, %r, expected %r"
                                 " subfields, for .csv %s" % (
-                                    col, subfield, handler['subfields'],
+                                    col, subfield, handler_rec['subfields'],
                                     csv['basename']))
                         self.counters['column_subfields_do_not_match_handler'] += 1
                         subfield = None
                 field_mapping[csv['basename']][idx] = (identifier, subfield)
                 try:
-                    metadata_pat = handler['metadata_pat']
+                    metadata_pat = handler_rec['metadata_pat']
                 except KeyError:
                     pass
                 else:
                     m = metadata_pat.match(col)
                     if m:
                         colmd = {}
-                        for md in handler['metadata']:
+                        for md in handler_rec['metadata']:
                             try:
                                 val = m.group(md)
                             except IndexError:
                                 print("tool-data-indexing: handler metadata,"
                                         " %r, not found in column %r using"
                                         " pattern %r, for .csv %s" % (
-                                            handler['metadata'], col,
-                                            handler['metadata_pat'],
+                                            handler_rec['metadata'], col,
+                                            handler_rec['metadata_pat'],
                                             csv['basename']))
                                 self.counters['expected_column_metadata_not_found'] += 1
                             else:
@@ -832,7 +839,7 @@ class ToolData(object):
         while True:
             # Read a row from each .csv file
             rows = _dict_const()
-            for csv in self.csv_files:
+            for csv in self.files:
                 try:
                     rows[csv['basename']] = next(csv['reader'])
                 except StopIteration:
@@ -911,9 +918,9 @@ class ToolData(object):
         pass
 
     def _make_source_json(self):
-        for df in self.json_files:
+        for df in self.files:
             try:
-                with open(os.path.join(_tmpdir, df['path'])) as fp:
+                with open(os.path.join(self.ptb.extracted_root, df['path'])) as fp:
                     payload = json.load(fp)
             except Exception as e:
                 print("tool-data-indexing: encountered bad JSON file,"
@@ -965,65 +972,89 @@ class ToolData(object):
     def make_source(self):
         """Simple jump method to pick the write source generator based on the
         handler's prospectus."""
-        if not self.csv_files and not self.json_files:
-            # If we do not have any csv or json files for this tool, ignore it.
+        if not self.files:
+            # If we do not have any data files for this tool, ignore it.
             return
-        if self.handler['@prospectus']['handling'] == 'unify':
+        if self.handler['@prospectus']['method'] == 'unify':
             gen = self._make_source_unified()
-        elif self.handler['@prospectus']['handling'] == 'individual':
+        elif self.handler['@prospectus']['method'] == 'individual':
             gen = self._make_source_individual()
-        elif self.handler['@prospectus']['handling'] == 'json':
+        elif self.handler['@prospectus']['method'] == 'json':
             gen = self._make_source_json()
         else:
             raise Exception("Logic bomb!")
         return gen
 
     @staticmethod
-    def get_csv_files(handler, iteration, sample, host, tool, toolgroup, mdlog, tb):
+    def get_csv_files(handler, iteration, sample, host, tool, toolgroup, ptb):
         """
         Fetch the list of .csv files for this tool, fetch their headers, and
         return a dictionary mapping their column headers to their field names.
         """
         path = os.path.join(iteration, sample, "tools-%s" % (toolgroup,), host, tool, "csv")
-        paths = [x for x in tb.getnames() if x.find(path) >= 0 and tb.getmember(x).isfile()]
+        paths = [x for x in ptb.tb.getnames() if x.find(path) >= 0 and ptb.tb.getmember(x).isfile()]
         datafiles = []
         for p in paths:
             fname = os.path.basename(p)
-            try:
-                handler_rec = handler[fname]
-            except KeyError:
+            for rec in handler['patterns']:
+                if rec['pattern'].match(fname):
+                    handler_rec = rec
+                    break
+            else:
                 # Try an alias
-                alias_name = fname
                 try:
-                    fname = _aliases[alias_name]
-                    handler_rec = handler[fname]
+                    alias_name = _aliases[fname]
                 except KeyError:
-                    # Ignore .csv files for which we don't have a handler
-                    #print("WARNING: no .csv handler for %s\n" % (p,), file=sys.stdout)
+                    # Ignore .csv files for which we don't have a handler,
+                    # after checking to see if they might have an alias
+                    # name.
+                    #print("WARNING: no .csv handler for %s (%s)\n" % (fname, p), file=sys.stdout)
                     continue
-            datafile = { "path": p, "basename": fname, 'handler': handler_rec }
+                else:
+                    for rec in handler['patterns']:
+                        if rec['pattern'].match(alias_name):
+                            handler_rec = rec
+                            break
+                    else:
+                        # Ignore .csv files for which we don't have a handler
+                        #print("WARNING: no .csv handler for %s (%s, %s)\n" % (alias_name, fname, p), file=sys.stdout)
+                        continue
+            assert handler_rec is not None
+            datafile = { "path": p, "basename": fname, 'handler_rec': handler_rec }
             # FIXME: we might have to deal with UTF-8 decoding issues
             # reader = csv.reader(codecs.iterdecode(tb.extractfile(dfilepath), 'utf-8'))
-            datafile['reader'] = reader = csv.reader(open(os.path.join(_tmpdir, p)))
+            datafile['reader'] = reader = csv.reader(open(os.path.join(ptb.extracted_root, p)))
             # FIXME: how should we handle .csv files that are empty?
             datafile['header'] = next(reader)
             datafiles.append(datafile)
         return datafiles
 
     @staticmethod
-    def get_json_files(handler, iteration, sample, host, tool, toolgroup, mdlog, tb):
+    def get_json_files(handler, iteration, sample, host, tool, toolgroup, ptb):
         """
         Fetch the list of json files for this tool, and
         return a list of dicts containing their metadata.
         """
         # import pdb; pdb.set_trace()
         path = os.path.join(iteration, sample, "tools-%s" % (toolgroup,), host, tool, "json")
-        paths = [x for x in tb.getnames() if x.find(path) >= 0 and tb.getmember(x).isfile()]
+        paths = [x for x in ptb.tb.getnames() if x.find(path) >= 0 and ptb.tb.getmember(x).isfile()]
         datafiles = []
         for p in paths:
             fname = os.path.basename(p)
-            datafile = { "path": p, "basename": fname, 'handler': handler }
+            datafile = { "path": p, "basename": fname, 'handler_rec': None }
             datafiles.append(datafile)
+        return datafiles
+
+    @staticmethod
+    def get_files(handler, iteration, sample, host, tool, toolgroup, ptb):
+        if handler is None:
+            datafiles = []
+        elif handler['@prospectus']['handling'] == 'csv':
+            datafiles = ToolData.get_csv_files(handler, iteration, sample, host, tool, toolgroup, ptb)
+        elif handler['@prospectus']['handling'] == 'json':
+            datafiles = ToolData.get_json_files(handler, iteration, sample, host, tool, toolgroup, ptb)
+        else:
+            raise Exception("Logic bomb! %s" % (handler['@prospectus']['handling']))
         return datafiles
 
 # tool data are stored in csv files in the tarball.
@@ -1034,9 +1065,9 @@ class ToolData(object):
 # that may not be possible; in the latter case, we fall back to trawling through the
 # tarball and using heuristics.
 
-def get_iterations(mdlog, tb):
+def get_iterations(mdconf, tb):
     try:
-        return mdlog.get("pbench", "iterations").split(', ')
+        return mdconf.get("pbench", "iterations").split(', ')
     except Exception:
         # TBD - trawl through tb with some heuristics
         iterations = []
@@ -1049,7 +1080,7 @@ def get_iterations(mdlog, tb):
                 iterations.append(iter)
         return iterations
 
-def get_samples(iteration, mdlog, tb):
+def get_samples(iteration, mdconf, tb):
     samples = []
     for x in tb.getnames():
         if x.find("{}/".format(iteration)) < 0:
@@ -1064,10 +1095,10 @@ def get_samples(iteration, mdlog, tb):
         samples.append('reference-result')
     return samples
 
-def get_pbench_hosts(iteration, sample, mdlog, tb):
+def get_pbench_hosts(iteration, sample, mdconf, tb):
     try:
         # N.B. Space-separated list
-        return mdlog.get("tools", "hosts").split()
+        return mdconf.get("tools", "hosts").split()
     except ConfigParserError:
         print("ConfigParser error in get_pbench_hosts: tool data will *not* be indexed.")
         print("This is most probably a bug: please open an issue.")
@@ -1079,9 +1110,9 @@ def get_pbench_hosts(iteration, sample, mdlog, tb):
         print("No hosts in [tools] section in metadata log: tool data will *NOT* be indexed.")
         return []
 
-def get_tools(iteration, sample, host, mdlog, tb):
+def get_tools(iteration, sample, host, mdconf, tb):
     try:
-        return mdlog.options("tools/{}".format(host))
+        return mdconf.options("tools/{}".format(host))
     except ConfigParserError:
         print("ConfigParser error in get_tools: tool data will *not* be indexed.")
         print("This is most probably a bug: please open an issue.")
@@ -1093,42 +1124,40 @@ def get_tools(iteration, sample, host, mdlog, tb):
         print("No tools in [tools/{}] section in metadata log: tool data will *NOT* be indexed.".format(host))
         return []
 
-def get_tool_label(host, mdlog):
+def get_tool_label(host, mdconf):
     try:
-        return mdlog.get("tools/" + host, "label")
+        return mdconf.get("tools/" + host, "label")
     except:
         return ""
 
-def get_tool_hostname_s(host, mdlog):
+def get_tool_hostname_s(host, mdconf):
     try:
-        return mdlog.get("tools/" + host, "hostname-s")
+        return mdconf.get("tools/" + host, "hostname-s")
     except:
         return ""
 
-def mk_tool_data(mdlog, md5sum, tb, start_run_tstamp, end_run_tstamp, opctx):
-    experiment = mdlog.get("pbench", "name")
+def mk_tool_data(ptb, opctx):
+    experiment = ptb.mdconf.get("pbench", "name")
     try:
-        toolsgroup = mdlog.get("tools", "group")
+        toolsgroup = ptb.mdconf.get("tools", "group")
     except Exception:
         toolsgroup = "default"
-    iterations = get_iterations(mdlog, tb)
+    iterations = get_iterations(ptb.mdconf, ptb.tb)
     for iteration in iterations:
-        samples = get_samples(iteration, mdlog, tb)
+        samples = get_samples(iteration, ptb.mdconf, ptb.tb)
         for sample in samples:
-            hosts = get_pbench_hosts(iteration, sample, mdlog, tb)
+            hosts = get_pbench_hosts(iteration, sample, ptb.mdconf, ptb.tb)
             for host in hosts:
-                tools = get_tools(iteration, sample, host, mdlog, tb)
+                tools = get_tools(iteration, sample, host, ptb.mdconf, ptb.tb)
                 for tool in tools:
                     yield ToolData(
-                            start_run_tstamp, end_run_tstamp, md5sum,
-                            experiment, iteration, sample, host, tool,
-                            toolsgroup, mdlog, tb, opctx)
+                            ptb, experiment, iteration, sample, host, tool,
+                            toolsgroup, opctx)
     return
 
 def mk_tool_data_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.tool-data-%%s" % INDEX_PREFIX
-    for td in mk_tool_data(ptb.mdconf, ptb.md5sum, ptb.tb, ptb.start_run,
-            ptb.end_run, opctx):
+    for td in mk_tool_data(ptb, opctx):
         # Each ToolData object, td, that is returned here represents how
         # data collected for that tool across all hosts is to be returned.
         # The make_source method returns a generator that will emit each
@@ -1153,9 +1182,8 @@ def mk_tool_data_actions(ptb, options, INDEX_PREFIX, opctx):
 
 def mk_result_data_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.result-data." % INDEX_PREFIX
-    mdlog = ptb.mdconf
-    experiment = mdlog.get("pbench", "name")
-    rd = ResultData(ptb.start_run, ptb.md5sum, experiment, mdlog, ptb.tb, opctx)
+    experiment = ptb.mdconf.get("pbench", "name")
+    rd = ResultData(ptb, experiment, opctx)
     if not rd:
         return
     sources = rd.make_source()
@@ -1231,7 +1259,7 @@ def mk_toc_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.run.%%d-%%02d" % INDEX_PREFIX
     tstamp = ptb.start_run.replace('_', 'T')
     prefix, dirs = mk_toc(ptb.tb, ptb.md5sum, options)
-    assert(prefix == ptb.dirprefix)
+    assert(prefix == ptb.dirname)
     for dname,d in dirs.items():
         d["@timestamp"] = tstamp
         action = {
@@ -1568,7 +1596,7 @@ def fix_date_format(ts):
         # on any other exception, we give up
         return "1900-01-01T00:00:00"
 
-def mk_run_metadata(mdconf, md5sum, dirname, dirprefix):
+def mk_run_metadata(mdconf, md5sum, dirname):
     try:
         d = {}
         d.update(mdconf.items('run'))
@@ -1583,7 +1611,7 @@ def mk_run_metadata(mdconf, md5sum, dirname, dirprefix):
         # it's what ties all of the relevant documents together.
         d['id'] = md5sum
         d['tarball-dirname'] = dirname
-        d['tarball-toc-prefix'] = dirprefix
+        d['tarball-toc-prefix'] = dirname
         del d['rpm-version']
         return d
     except KeyError as e:
@@ -1633,7 +1661,7 @@ def mk_run_action(ptb, options, INDEX_PREFIX, opctx):
     #if debug_time_operations: ts("mk_pbench_metadata")
     #source['pbench'] = mk_pbench_metadata(mdconf)
     if debug_time_operations: ts("mk_run_metadata")
-    source['run'] = mk_run_metadata(ptb.mdconf, ptb.md5sum, ptb.dirname, ptb.dirprefix)
+    source['run'] = mk_run_metadata(ptb.mdconf, ptb.md5sum, ptb.dirname)
     if debug_time_operations: ts("mk_sosreports")
     source['sosreports'] = sos_d = mk_sosreports(ptb.tb)
     if debug_time_operations: ts("mk_tool_info")
@@ -1688,26 +1716,29 @@ class PbenchTarBall(object):
         # compressed with a different compression mechanism from xz?
         self.dirname = dirname[:dirname.rfind('.tar.xz')]
         # ... but let's make sure.
-        # FIXME: how are we making sure it is the first component of every
-        # member of the tar ball?  Here we seem to be only looking at the
-        # first, and not comparing it to self.dirname.
-        self.dirprefix = self.tb.getmembers()[0].name.split(os.path.sep)[0]
+        sampled_prefix = self.tb.getmembers()[0].name.split(os.path.sep)[0]
+        if sampled_prefix != self.dirname:
+            # All members of the tarball should have self.dirname as its
+            # prefix.
+            raise UnsupportedTarballFormat(self.tbname)
 
         # Verify we have a metadata.log file in the tar ball before we
         # start extracting.
         member_name = "%s/metadata.log" % (self.dirname)
         try:
-            self.mdlog = self.tb.getmember(member_name)
+            self.tb.getmember(member_name)
         except KeyError:
             raise UnsupportedTarballFormat(self.tbname)
 
-        # FIXME: Should we have the option of using an already extracted
-        # version of the tar ball?
-        # FIXME: Is this a temporary extraction or permanent? If temporary,
-        # where does it get cleaned up?
+        # The caller of index-pbench is expected to clean up the temporary
+        # directory.
         self.tb.extractall(path=_tmpdir)
+        self.extracted_root = _tmpdir
+        if not os.path.isdir(os.path.join(self.extracted_root, self.dirname)):
+            raise UnsupportedTarballFormat(self.tbname)
         try:
-            self.mdconf = PbenchTarBall.get_mdconfig(os.path.join(_tmpdir, member_name))
+            self.mdconf = PbenchTarBall.get_mdconfig(
+                    os.path.join(self.extracted_root, member_name))
         except Exception:
             raise BadMDLogFormat(self.tbname)
         # We get the start date out of the metadata log.
@@ -1722,7 +1753,6 @@ class PbenchTarBall(object):
             raise BadDate(self.tbname)
         # Open the MD5 file of the tarball and read the MD5 sum from it.
         self.md5sum = open("%s.md5" % (self.tbname)).read().split()[0]
-        # FIXME: at this point, do we assume the MD5 sum of the tar ball is good?
 
     @staticmethod
     def get_mdconfig(mdf):

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -377,12 +377,14 @@ def convert_to_float(d):
         pass
 
 class ResultData(object):
-    def __init__(self, tstamp, md5sum, experiment, mdlog, tb):
+    def __init__(self, tstamp, md5sum, experiment, mdlog, tb, opctx):
         self.run_metadata = {
             "runtstamp": tstamp,
             "runid": md5sum,
             "experiment": experiment,
         }
+        self.counters = Counter()
+        opctx.append({ "object": "ResultData", "counters": self.counters })
         self.json_files = None
         try:
             self.json_files = ResultData.get_json_files(mdlog, tb)
@@ -391,14 +393,38 @@ class ResultData(object):
 
     def _make_source_json(self):
         for df in self.json_files:
-            item = {}
-            results = json.loads(open(os.path.join(_tmpdir, df['path'])).read())
+            try:
+                # Read it once to generate the source_id
+                with open(os.path.join(_tmpdir, df['path']), "rb") as fp:
+                    hash_md5 = hashlib.md5()
+                    for chunk in iter(lambda: fp.read(4096), b""):
+                        hash_md5.update(chunk)
+                    source_id = hash_md5.hexdigest()
+            except Exception as e:
+                print("result-data-indexing: encountered unreadable JSON file,"
+                        " %s: %r" % (df['path'], e))
+                self.counters['unreadable_json_file'] += 1
+                continue
+
+            try:
+                # Read it a second time to interpret it as a JSON document.
+                with open(os.path.join(_tmpdir, df['path'])) as fp:
+                    results = json.load(fp)
+            except Exception as e:
+                print("result-data-indexing: encountered invalid JSON file,"
+                        " %s: %r" % (df['path'], e))
+                self.counters['not_valid_json_file'] += 1
+                continue
+
             convert_to_float(results)
-            item['results'] = results
-            item['@metadata'] = self.run_metadata
+
+            source = {}
+            source['results'] = results
+            source['@metadata'] = self.run_metadata
             ts_str = self.run_metadata['runtstamp']
-            item['@timestamp'] = ts_str
-            yield item
+            source['@timestamp'] = ts_str
+
+            yield source, source_id
         return
 
     def make_source(self):
@@ -422,12 +448,14 @@ class ResultData(object):
             fname = os.path.basename(p)
             datafile = { "path": p, "basename": fname }
             datafiles.append(datafile)
-
         return datafiles
 
 
 ###########################################################################
 # Tool data routines
+
+def _make_source_id(source):
+    return hashlib.md5(json.dumps(source, sort_keys=True).encode('utf-8')).hexdigest()
 
 # Handlers data table / dictionary describing how to process a given tool's
 # .csv files.  The outer dictionary holds one dictionary for each tool. Each
@@ -643,7 +671,7 @@ _aliases = {
 
 class ToolData(object):
     def __init__(self, tstamp, md5sum, experiment, iteration, sample, host, tool, toolgroup,
-                 mdlog, tb):
+                 mdlog, tb, opctx):
         self.toolname = tool
         try:
             (iterseqno, itername) = iteration.split('-', 1)
@@ -657,6 +685,7 @@ class ToolData(object):
             except ValueError:
                 self.start_run_ts = None
         self.counters = Counter()
+        opctx.append({ "object": "ToolData-%s" % (tool), "counters": self.counters })
         self.run_metadata = {
             "runtstamp": tstamp,
             "runid": md5sum,
@@ -737,11 +766,9 @@ class ToolData(object):
         metadata = _dict_const()
         for csv in self.csv_files:
             if csv['header'][0] != 'timestamp_ms':
-                print("Expected first column of .csv file (%s) to be"
-                        " 'timestamp_ms', found %s",
+                print("tool-data-indexing: expected first column of .csv file"
+                        " (%s) to be 'timestamp_ms', found %s",
                         (csv['basename'], csv['header'][0]))
-                # FIXME: consider counting this issue and reporting with a
-                # summary of the indexing work.
                 self.counters['first_column_not_timestamp_ms'] += 1
                 continue
             header = csv['header']
@@ -762,12 +789,11 @@ class ToolData(object):
                     subfield = None
                 else:
                     if subfield not in handler['subfields']:
-                        print("Column header, %r, has an unexpected subfield,"
-                                " %r, expected %r subfields, for .csv %s" % (
+                        print("tool-data-indexing: column header, %r, has an"
+                                " unexpected subfield, %r, expected %r"
+                                " subfields, for .csv %s" % (
                                     col, subfield, handler['subfields'],
                                     csv['basename']))
-                        # FIXME: Consider counting this error and reporting
-                        # with a summary of the indexing work.
                         self.counters['column_subfields_do_not_match_handler'] += 1
                         subfield = None
                 field_mapping[csv['basename']][idx] = (identifier, subfield)
@@ -783,15 +809,12 @@ class ToolData(object):
                             try:
                                 val = m.group(md)
                             except IndexError:
-                                print("Handler metadata, %r, not found in"
-                                        " column %r using pattern %r, for"
-                                        " .csv %s" % (
+                                print("tool-data-indexing: handler metadata,"
+                                        " %r, not found in column %r using"
+                                        " pattern %r, for .csv %s" % (
                                             handler['metadata'], col,
                                             handler['metadata_pat'],
                                             csv['basename']))
-                                # FIXME: Consider counting this error and
-                                # reporting it with a summary of the indexing
-                                # work.
                                 self.counters['expected_column_metadata_not_found'] += 1
                             else:
                                 colmd[md] = val
@@ -821,9 +844,6 @@ class ToolData(object):
                 elif first != tstamp:
                     print("tool-data-indexing: %s csv files have inconsistent"
                             " timestamps per row" % self.toolname)
-                    # FIXME: We should consider counting these inconsistent
-                    # timestamps and reporting them with the summary of the
-                    # indexing work.
                     self.counters['inconsistent_timestamps_across_csv_files'] += 1
                     break
             # Create the base document per identifier; the timestamp is taken
@@ -869,9 +889,10 @@ class ToolData(object):
                         datum[identifier][self.toolname][klass][metric] = val
             # At this point we have fully mapped all data from all .csv files
             # to their proper fields for each identifier. Now we can yield
-            # record for the identifiers.
-            for key,source in datum.items():
-                yield source
+            # records for each of the identifiers.
+            for _id,source in datum.items():
+                source_id = _make_source_id(source)
+                yield source, source_id
         return
 
     def _make_source_individual(self):
@@ -881,31 +902,54 @@ class ToolData(object):
 
     def _make_source_json(self):
         for df in self.json_files:
-            payload = json.loads(open(os.path.join(_tmpdir, df['path'])).read())
-            for item in payload:
-                item['@metadata'] = self.run_metadata
-                # any transformations needed should be done here
+            try:
+                with open(os.path.join(_tmpdir, df['path'])) as fp:
+                    payload = json.load(fp)
+            except Exception as e:
+                print("tool-data-indexing: encountered bad JSON file,"
+                        " %s: %r" % (df['path'], e))
+                self.counters["bad_json_file"] += 1
+                continue
 
-                # timestamp handling.
+            missing_ts = False
+            for source in payload:
                 try:
-                    # unix seconds since epoch timestamp
-                    ts = datetime.utcfromtimestamp(item['@timestamp'])
-                except TypeError:
-                    # assume that item[@timestamp] is already in the expected
-                    # format.
-                    self.counters['json_doc_timestamp_not_validated'] += 1
+                    ts_val = source['@timestamp']
                 except KeyError:
                     # missing timestamps
-                    #
-                    # FIXME: We should consider logging the first record with
-                    # missing timestamps, and then count the rest and report
-                    # the count with the summary of how the indexing went.
+                    if not missing_ts:
+                        # Log the first record with missing timestamps we
+                        # encounter for this file, and then count the rest and
+                        # report the count with the summary of how the
+                        # indexing went.
+                        missing_ts = True
+                        print("tool-data-indexing: encountered JSON file, %s,"
+                                " with missing @timestamp fields" % (
+                                    df['path']))
                     self.counters['json_doc_missing_timestamp'] += 1
+                    continue
+
+                # further timestamp handling
+                try:
+                    # unix seconds since epoch timestamp
+                    ts = datetime.utcfromtimestamp(ts_val)
+                except TypeError:
+                    # the timestamp value is not in seconds since the epoch,
+                    # so assume that source[@timestamp] is already in the
+                    # expected format.
+                    #
+                    # FIXME - Should we validate the expected string format?
+                    self.counters['json_doc_timestamp_not_validated'] += 1
                 else:
                     ts_str = ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
-                    item['@timestamp'] = ts_str
+                    source['@timestamp'] = ts_str
 
-                yield item
+                source['@metadata'] = self.run_metadata
+
+                # any transformations needed should be done here
+
+                source_id = _make_source_id(source)
+                yield source, source_id
         return
 
     def make_source(self):
@@ -970,7 +1014,6 @@ class ToolData(object):
             fname = os.path.basename(p)
             datafile = { "path": p, "basename": fname, 'handler': handler }
             datafiles.append(datafile)
-
         return datafiles
 
 # tool data are stored in csv files in the tarball.
@@ -1052,7 +1095,7 @@ def get_tool_hostname_s(host, mdlog):
     except:
         return ""
 
-def mk_tool_data(mdlog, md5sum, tb, tstamp):
+def mk_tool_data(mdlog, md5sum, tb, tstamp, opctx):
     experiment = mdlog.get("pbench", "name")
     try:
         toolsgroup = mdlog.get("tools", "group")
@@ -1068,12 +1111,12 @@ def mk_tool_data(mdlog, md5sum, tb, tstamp):
                 for tool in tools:
                     yield ToolData(
                         tstamp, md5sum, experiment, iteration, sample,
-                        host, tool, toolsgroup, mdlog, tb)
+                        host, tool, toolsgroup, mdlog, tb, opctx)
     return
 
-def mk_tool_data_actions(ptb, options, INDEX_PREFIX):
+def mk_tool_data_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.tool-data-%%s" % INDEX_PREFIX
-    for td in mk_tool_data(ptb.mdconf, ptb.md5sum, ptb.tb, ptb.start_run):
+    for td in mk_tool_data(ptb.mdconf, ptb.md5sum, ptb.tb, ptb.start_run, opctx):
         # Each ToolData object, td, that is returned here represents how
         # data collected for that tool across all hosts is to be returned.
         # The make_source method returns a generator that will emit each
@@ -1085,39 +1128,36 @@ def mk_tool_data_actions(ptb, options, INDEX_PREFIX):
         asource = td.make_source()
         if not asource:
             continue
-        for source in asource:
+        for source, source_id in asource:
             action = {
                 "_op_type": _op_type,
                 "_index":   index_name_template_for_tool + source['@timestamp'].split('T', 1)[0],
                 "_type":    "pbench-tool-data-%s" % td.toolname,
-                # FIXME: we should generate our own JSON doc ID
-                #"_id":      source_id,
+                "_id":      source_id,
                 "_source":  source
             }
             yield action
     return
 
-def mk_result_data_actions(ptb, options, INDEX_PREFIX):
+def mk_result_data_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.result-data." % INDEX_PREFIX
     mdlog = ptb.mdconf
     experiment = mdlog.get("pbench", "name")
-    rd = ResultData(ptb.start_run, ptb.md5sum, experiment, mdlog, ptb.tb)
+    rd = ResultData(ptb.start_run, ptb.md5sum, experiment, mdlog, ptb.tb, opctx)
     if not rd:
         return
     sources = rd.make_source()
     if not sources:
         return
-    for source in sources:
-            action = {
-                "_op_type": _op_type,
-                "_index":   index_name_template + source['@timestamp'].split('T', 1)[0],
-                "_type":    "pbench-result-data",
-                # FIXME: we should generate our own JSON doc ID
-                #"_id":      source_id,
-                "_source":  source
-            }
-            yield action
-
+    for source, source_id in sources:
+        action = {
+            "_op_type": _op_type,
+            "_index":   index_name_template + source['@timestamp'].split('T', 1)[0],
+            "_type":    "pbench-result-data",
+            "_id":      source_id,
+            "_source":  source
+        }
+        yield action
     return
 
 ###########################################################################
@@ -1172,7 +1212,7 @@ def get_md5sum_of_dir(dir, parentid):
                 h.update(repr(f[k]).encode('utf-8'))
     return h.hexdigest()
 
-def mk_toc_actions(ptb, options, INDEX_PREFIX):
+def mk_toc_actions(ptb, options, INDEX_PREFIX, opctx):
     """Construct Table-of-Contents actions.
 
     These are indexed into the run index along side the runs."""
@@ -1559,8 +1599,7 @@ def mk_metadata(fname, tb, mdconf, md5sum):
     }
     return mddict
 
-def mk_run_action(ptb, options, INDEX_PREFIX):
-    #mk_run_action(hostname, tbname, dirname, dirprefix, tb, mdconf, idxname, md5sum, ts, options):
+def mk_run_action(ptb, options, INDEX_PREFIX, opctx):
     """Extract metadata from the named tarball and create an indexing
        action out of them.
 
@@ -1600,7 +1639,7 @@ def mk_run_action(ptb, options, INDEX_PREFIX):
     if debug_time_operations: ts("Done!", newline=True)
     return action
 
-def make_all_actions(ptb, options, INDEX_PREFIX, INDEX_VERSION):
+def make_all_actions(ptb, options, INDEX_PREFIX, INDEX_VERSION, opctx):
     """Driver for generating all actions on source documents for indexing
     into Elasticsearch. This generator drives the generation of the run
     source document, the table-of-contents tar ball documents, and finally
@@ -1608,15 +1647,15 @@ def make_all_actions(ptb, options, INDEX_PREFIX, INDEX_VERSION):
     """
     debug_time_operations = options.debug_time_operations
     if debug_time_operations: ts("mk_run_action")
-    yield mk_run_action(ptb, options, INDEX_PREFIX)
+    yield mk_run_action(ptb, options, INDEX_PREFIX, opctx)
     if debug_time_operations: ts("mk_toc_actions")
-    for action in mk_toc_actions(ptb, options, INDEX_PREFIX):
+    for action in mk_toc_actions(ptb, options, INDEX_PREFIX, opctx):
         yield action
     if debug_time_operations: ts("mk_result_data_actions")
-    for action in mk_result_data_actions(ptb, options, INDEX_PREFIX):
+    for action in mk_result_data_actions(ptb, options, INDEX_PREFIX, opctx):
         yield action
     if debug_time_operations: ts("mk_tool_data_actions")
-    for action in mk_tool_data_actions(ptb, options, INDEX_PREFIX):
+    for action in mk_tool_data_actions(ptb, options, INDEX_PREFIX, opctx):
         yield action
     if debug_time_operations: ts("", newline=True)
     return
@@ -1720,6 +1759,7 @@ def main(options, args):
     # FileNotFoundError is python 3.3 and the travis-ci hosts still (2015-10-01) run
     # python 3.2
     filenotfounderror = getattr(__builtins__, 'FileNotFoundError', IOError)
+    opctx = []
 
     try:
         config=SafeConfigParser()
@@ -1751,7 +1791,12 @@ def main(options, args):
 
         # prepare the actions - the tarball name is the only argument.
         ptb = PbenchTarBall(args[0])
-        actions = make_all_actions(ptb, options, INDEX_PREFIX, INDEX_VERSION)
+
+        # Construct the generator for emitting all actions.  The `opctx`
+        # dictionary is passed along to each generator so that it can add its
+        # context for error handling to the list.
+        actions = make_all_actions(
+                ptb, options, INDEX_PREFIX, INDEX_VERSION, opctx)
 
         # Create the various index templates
         if options.debug_time_operations: ts("es_template")
@@ -1809,6 +1854,13 @@ def main(options, args):
         res = 12
 
     finally:
+        dump = False
+        for ctx in opctx:
+            if ctx['counters']:
+                dump = True
+        if dump:
+            print("** Errors encountered while indexing:")
+            print(json.dumps(opctx, indent=4, sort_keys=True))
         if options.debug_time_operations: ts("Done", newline=True)
 
     # status codes: these are used by pbench-index to segregate tarballs into

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -376,6 +376,7 @@ def convert_to_float(d):
     else:
         pass
 
+
 class ResultData(object):
     def __init__(self, tstamp, md5sum, experiment, mdlog, tb, opctx):
         self.run_metadata = {
@@ -670,24 +671,31 @@ _aliases = {
 
 
 class ToolData(object):
-    def __init__(self, tstamp, md5sum, experiment, iteration, sample, host, tool, toolgroup,
-                 mdlog, tb, opctx):
+    def __init__(self, start_run_tstamp, end_run_tstamp, md5sum, experiment,
+                iteration, sample, host, tool, toolgroup, mdlog, tb, opctx):
         self.toolname = tool
-        try:
-            (iterseqno, itername) = iteration.split('-', 1)
-        except Exception:
-            iterseqno = itername = iteration
-        try:
-            self.start_run_ts = datetime.strptime(tstamp, "%Y-%m-%dT%H:%M:%S.%f")
-        except ValueError:
-            try:
-                self.start_run_ts = datetime.strptime(tstamp, "%Y-%m-%dT%H:%M:%S")
-            except ValueError:
-                self.start_run_ts = None
         self.counters = Counter()
         opctx.append({ "object": "ToolData-%s" % (tool), "counters": self.counters })
+        try:
+            (iterseqno, itername) = iteration.split('-', 1)
+        except ValueError:
+            iterseqno = itername = iteration
+        try:
+            self.start_run_ts = datetime.strptime(start_run_tstamp, "%Y-%m-%dT%H:%M:%S.%f")
+        except ValueError:
+            try:
+                self.start_run_ts = datetime.strptime(start_run_tstamp, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self.start_run_ts = None
+        try:
+            self.end_run_ts = datetime.strptime(end_run_tstamp, "%Y-%m-%dT%H:%M:%S.%f")
+        except ValueError:
+            try:
+                self.end_run_ts = datetime.strptime(end_run_tstamp, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self.end_run_ts = None
         self.run_metadata = {
-            "runtstamp": tstamp,
+            "runtstamp": start_run_tstamp,
             "runid": md5sum,
             "experiment": experiment,
             # FIXME: What are the constituent parts of an iteration name?
@@ -740,6 +748,8 @@ class ToolData(object):
         ts = datetime.utcfromtimestamp(ts_float)
         if self.start_run_ts is not None and ts < self.start_run_ts:
             self.counters['tool_ts_before_start_run_ts'] += 1
+        if self.end_run_ts is not None and ts > self.end_run_ts:
+            self.counters['tool_ts_after_end_run_ts'] += 1
         return ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
     def _make_source_unified(self):
@@ -1095,7 +1105,7 @@ def get_tool_hostname_s(host, mdlog):
     except:
         return ""
 
-def mk_tool_data(mdlog, md5sum, tb, tstamp, opctx):
+def mk_tool_data(mdlog, md5sum, tb, start_run_tstamp, end_run_tstamp, opctx):
     experiment = mdlog.get("pbench", "name")
     try:
         toolsgroup = mdlog.get("tools", "group")
@@ -1110,13 +1120,15 @@ def mk_tool_data(mdlog, md5sum, tb, tstamp, opctx):
                 tools = get_tools(iteration, sample, host, mdlog, tb)
                 for tool in tools:
                     yield ToolData(
-                        tstamp, md5sum, experiment, iteration, sample,
-                        host, tool, toolsgroup, mdlog, tb, opctx)
+                            start_run_tstamp, end_run_tstamp, md5sum,
+                            experiment, iteration, sample, host, tool,
+                            toolsgroup, mdlog, tb, opctx)
     return
 
 def mk_tool_data_actions(ptb, options, INDEX_PREFIX, opctx):
     index_name_template = "%s.tool-data-%%s" % INDEX_PREFIX
-    for td in mk_tool_data(ptb.mdconf, ptb.md5sum, ptb.tb, ptb.start_run, opctx):
+    for td in mk_tool_data(ptb.mdconf, ptb.md5sum, ptb.tb, ptb.start_run,
+            ptb.end_run, opctx):
         # Each ToolData object, td, that is returned here represents how
         # data collected for that tool across all hosts is to be returned.
         # The make_source method returns a generator that will emit each
@@ -1705,6 +1717,7 @@ class PbenchTarBall(object):
             split_date_str = self.start_run.split('T')
             # List of constituent date components, year [0], month [1], day [2]
             self.date = [ int(x) for x in split_date_str[0].split("-") ]
+            self.end_run = fix_date_format(self.mdconf.get('run', 'end_run'))
         except Exception:
             raise BadDate(self.tbname)
         # Open the MD5 file of the tarball and read the MD5 sum from it.

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -8,29 +8,30 @@
 
 from __future__ import print_function
 
-import sys, os, time, re, stat, copy
-import hashlib, json, glob, csv, tarfile
+import sys, os, time, re, stat, copy, math
+import hashlib, json, glob, csv, tarfile, logging
 
+from random import SystemRandom
+from urllib3 import exceptions as ul_excs, Timeout
+from datetime import datetime, timedelta
+from collections import Counter, deque
+from optparse import OptionParser, make_option
 try:
     from configparser import SafeConfigParser, Error as ConfigParserError, NoSectionError, NoOptionError
 except ImportError:
     from ConfigParser import SafeConfigParser, Error as ConfigParserError, NoSectionError, NoOptionError
-from optparse import OptionParser, make_option
-from elasticsearch import VERSION, Elasticsearch, helpers, exceptions as es_excs
-from urllib3 import exceptions as ul_excs, Timeout
-from datetime import datetime, timedelta
+try:
+    from elasticsearch1 import VERSION as es_VERSION, Elasticsearch, helpers, exceptions as es_excs
+except ImportError:
+    from elasticsearch import VERSION as es_VERSION, Elasticsearch, helpers, exceptions as es_excs
 from vos.analysis.lib import tstos
-from collections import Counter
 
 _VERSION_ = "0.2.0.0"
 _NAME_    = "index-pbench"
-_DEBUG    = 9
+_DEBUG    = 0
 
 # global - defaults to normal dict, ordered dict for unittests
 _dict_const = dict
-
-# global - passed in through environment by pbench-index
-_tmpdir = None
 
 
 class MappingFileError(Exception):
@@ -219,142 +220,180 @@ def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config):
 ###########################################################################
 # FIXME: this is cribbed from the vos sosreport index stuff and should be
 # made generic and imported.
+_r = SystemRandom()
+
+_MAX_SLEEP_TIME = 120
+
+def calc_backoff_sleep(backoff):
+    global _r
+    b = math.pow(2, backoff)
+    return _r.uniform(0, min(b, _MAX_SLEEP_TIME))
+
 _read_timeout = 30
+_request_timeout = 100000*60.0
 _op_type = "create"
 
-def es_index(es, actions, dbg=0):
+
+class MockStreamingBulk(object):
+    def __init__(self, max_actions):
+        self.max_actions = max_actions
+        self.actions_l = []
+        self.duplicates_tracker = Counter()
+        self.index_tracker = Counter()
+        self.dupes_by_index_tracker = Counter()
+
+    def our_streaming_bulk(self, es, actions, **kwargs):
+        assert es == None
+
+        global options
+        if options.debug_time_operations: ts("streaming bulk start")
+
+        for action in actions:
+            self.duplicates_tracker[action['_id']] += 1
+            dcnt = self.duplicates_tracker[action['_id']]
+            if dcnt == 2:
+                self.dupes_by_index_tracker[action['_index']] += 1
+            self.index_tracker[action['_index']] += 1
+            if self.index_tracker[action['_index']] <= self.max_actions:
+                self.actions_l.append(action)
+            resp = {}
+            resp[action['_op_type']] = { '_id': action['_id'] }
+            if dcnt > 2:
+                # Report each duplicate
+                resp[action['_op_type']]['status'] = 409
+                ok = False
+            else:
+                # For now, all other docs are considered successful
+                ok = True
+            yield ok, resp
+
+        if options.debug_time_operations: ts("streaming bulk end")
+
+    def report(self):
+        for idx in sorted(self.index_tracker.keys()):
+            print("Index: ", idx, self.index_tracker[idx])
+        total_dupes = 0
+        total_multi_dupes = 0
+        for docid in self.duplicates_tracker:
+            total_dupes += self.duplicates_tracker[docid] if self.duplicates_tracker[docid] > 1 else 0
+            if self.duplicates_tracker[docid] >= 2:
+                total_multi_dupes += 1
+        if total_dupes > 0:
+            print("Duplicates: ", total_dupes, "Multiple dupes: ", total_multi_dupes)
+        for idx in sorted(self.dupes_by_index_tracker.keys()):
+            print("Index dupes: ", idx, self.dupes_by_index_tracker[idx])
+        print("len(actions) = {}".format(len(self.actions_l)))
+        print(json.dumps(self.actions_l, indent=4, sort_keys=True))
+
+
+def es_index(es, actions, errorsfp, dbg=0):
     """
     Now do the indexing specified by the actions.
     """
     if not es:
-        # If we don't have an actual ES client object, just emit a sample of
-        # the actions we have been given.
-        global options
-        if options.debug_time_operations: ts("dumps")
-        actions_l = []
-        tocs = 3
-        tods = 15
-        for action in actions:
-            if action['_type'] == 'pbench-run-toc-entry':
-                tocs -= 1
-                if tocs >= 0:
-                    actions_l.append(action)
-            elif action['_type'].startswith('pbench-tool-data'):
-                tods -= 1
-                if tods >= 0:
-                    actions_l.append(action)
-            else:
-                actions_l.append(action)
-        print("len(actions) = {}".format(len(actions_l)))
-        print(json.dumps(actions_l, indent=4, sort_keys=True))
-        if options.debug_time_operations: ts("Done", newline=True)
-        return 0
+        # If we don't have an Elasticsearch client object, we assume this is
+        # for unit tests or debugging, so we'll use our mocked out streaming
+        # bulk method.
+        mock = MockStreamingBulk(15)
+        streaming_bulk = mock.our_streaming_bulk
+        def tstos(arg):
+            return "1900-01-01T00:00:00-UTC"
+        def ts():
+            return 0
+        _do_ts = ts
+    else:
+        mock = None
+        streaming_bulk = helpers.streaming_bulk
+        _do_ts = time.time
 
-    delay = _read_timeout
-    tries = 20
+    # FIXME: we should just change these two loggers to write to a
+    # file instead of setting the logging level up so high.
+    logging.getLogger("urllib3").setLevel(logging.FATAL)
+    logging.getLogger("elasticsearch1").setLevel(logging.FATAL)
 
-    beg, end = time.time(), None
-    start = beg
+    actions_deque = deque()
+    actions_retry_deque = deque()
+
+    def actions_tracking_closure(cl_actions):
+        for cl_action in cl_actions:
+            assert '_id' in cl_action
+            assert '_index' in cl_action
+            assert '_type' in cl_action
+            assert _op_type == cl_action['_op_type']
+
+            actions_deque.append((0, cl_action))   # Append to the right side ...
+            yield cl_action
+            # if after yielding an action some actions appear on the retry deque
+            # start yielding those actions until we drain the retry queue.
+            backoff = 1
+            while len(actions_retry_deque) > 0:
+                time.sleep(calc_backoff_sleep(backoff))
+                retry_actions = []
+                # First drain the retry deque entirely so that we know when we
+                # have cycled through the entire list to be retried.
+                while len(actions_retry_deque) > 0:
+                    retry_actions.append(actions_retry_deque.popleft())
+                for retry_count, retry_action in retry_actions:
+                    actions_deque.append((retry_count, retry_action))   # Append to the right side ...
+                    yield retry_action
+                # if after yielding all the actions to be retried, some show up
+                # on the retry deque again, we extend our sleep backoff to avoid
+                # pounding on the ES instance.
+                backoff += 1
+
+    beg, end = _do_ts(), None
+
     if dbg > 0:
         print("\tbulk index (beg ts: %s) ..." % tstos(beg))
         sys.stdout.flush()
-    # FIXME: Switch below to streaming_bulk() to not do this!
-    all_actions = list(actions)
-    while True:
-        try:
-            # FIXME: if action is a generator, then we are not going to work
-            # well in the face of retrying on errors.  Switch to using
-            # streaming_bulk() and retry using the full action in the error
-            # payload.
-            res = helpers.bulk(es, all_actions)
-        except es_excs.ConnectionError as err:
-            end = time.time()
-            if isinstance(err.info, ul_excs.ReadTimeoutError):
-                tries -= 1
-                if tries > 0:
-                    print("\t\tWARNING (end ts: %s, duration: %.2fs):"
-                          " read timeout, delaying %d seconds before"
-                          " retrying (%d attempts remaining)..." % (
-                              tstos(end), end - beg, delay, tries),
-                          file=sys.stderr)
-                    time.sleep(delay)
-                    delay *= 2
-                    beg, end = time.time(), None
-                    print("\t\tWARNING (beg ts: %s): retrying..." % (
-                        tstos(beg)), file=sys.stderr)
-                    if _DEBUG > 8:
-                        import pdb; pdb.set_trace()
-                    continue
-                print("\tERROR(%s) (end ts: %s, duration: %.2fs): %s" % (
-                    _NAME_, tstos(end), end - start, err), file=sys.stderr)
-                return 1
-        except helpers.BulkIndexError as err:
-            end = time.time()
-            len_errors = len(err.errors)
-            error_idx = 0
-            lcl_successes = 0
-            lcl_duplicates = 0
-            lcl_errors = 0
-            for e in err.errors:
-                sts = e[_op_type]['status']
-                if sts not in (200, 201):
-                    if _op_type == 'create' and sts == 409:
-                        lcl_duplicates += 1
-                    else:
-                        if _DEBUG > 8:
-                            import pdb; pdb.set_trace()
-                        print("\t\tERRORS (%d of %d): %r" % \
-                              (error_idx, len_errors, e[_op_type]['error']),
-                              file=sys.stderr)
-                        lcl_errors += 1
-                else:
-                    lcl_successes += 1
-            if _DEBUG > 0 or lcl_errors > 0:
-                print("\tdone (end ts: %s, duration: %.2fs,"
-                      " success: %d, duplicates: %d, errors: %d)" % (
-                          tstos(end), end - start, lcl_successes,
-                          lcl_duplicates, lcl_errors))
-                sys.stdout.flush()
-            break
-        except Exception as err:
-            end = time.time()
-            print("\tERROR(%s) (end ts: %s, duration: %.2fs): %s" % (
-                _NAME_, tstos(end), end - start, err), file=sys.stderr)
-            return 1
+
+    successes = 0
+    duplicates = 0
+    failures = 0
+
+    # Create the generator that closes over the external generator, "actions"
+    generator = actions_tracking_closure(actions)
+
+    streaming_bulk_generator = streaming_bulk(
+            es, generator, raise_on_error=False,
+            raise_on_exception=False, request_timeout=_request_timeout)
+
+    for ok, resp in streaming_bulk_generator:
+        retry_count, action = actions_deque.popleft()
+        assert action['_id'] == resp[_op_type]['_id']
+        if ok:
+            successes += 1
         else:
-            end = time.time()
-            successes = res[0]
-            duplicates = 0
-            errors = 0
-            len_res1 = len(res[1])
-            for idx, ires in enumerate(res[1]):
-                sts = ires[_op_type]['status']
-                if sts not in (200, 201):
-                    if _op_type == 'create' and sts == 409:
-                        duplicates += 1
-                    else:
-                        print("\t\tERROR (%d of %d): %r" % (
-                            idx, len_res1, ires[_op_type]['error']),
-                            file=sys.stderr)
-                        errors += 1
+            if resp[_op_type]['status'] == 409:
+                if retry_count == 0:
+                    # Only count duplicates if the retry count is 0 ...
+                    duplicates += 1
                 else:
+                    # ... otherwise consider it successful.
                     successes += 1
-            if dbg > 0 or errors > 0:
-                print("\tdone (end ts: %s, duration: %.2fs,"
-                    " success: %d, duplicates: %d, errors: %d)" % (
-                        tstos(end), end - start, successes, duplicates,
-                        errors))
-                sys.stdout.flush()
-            if errors > 0:
-                if successes > 0:
-                    modifier = "some "
-                else:
-                    modifier = ""
-                    print("\tERROR(%s) %serrors encountered during indexing" % (
-                        _NAME_, modifier), file=sys.stderr)
-                    return 1
-            break
-    return 0
+            elif resp[_op_type]['status'] == 400:
+                jsonstr = json.dumps({ "action": action, "ok": ok, "resp": resp, "retry_count": retry_count, "timestamp": tstos(_do_ts()) }, indent=4, sort_keys=True)
+                print(jsonstr, file=errorsfp)
+                errorsfp.flush()
+                failures += 1
+            else:
+                # Retry all other errors
+                actions_retry_deque.append((retry_count + 1, action))
+
+    end = _do_ts()
+
+    assert len(actions_deque) == 0
+    assert len(actions_retry_deque) == 0
+
+    print("\tdone (end ts: %s, duration: %.2fs,"
+            " success: %d, duplicates: %d, failures: %d)" % (
+        tstos(end), end - beg, successes, duplicates, failures))
+    sys.stdout.flush()
+
+    if mock:
+        mock.report()
+
+    return failures
 
 ###########################################################################
 # Benchmark result data: json files only
@@ -763,9 +802,39 @@ class ToolData(object):
         return ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
     def _make_source_unified(self):
-        """Process each .csv file at the same time, reading one row from each,
-        unifying them into one record per column identifier when the
-        timestamps match."""
+        """Create one JSON document per identifier, per timestamp from
+        the data found in multiple csv files.
+
+        This algorithm is only applicable to 2 or more csv files which
+        contain data about 1 or more identifiers.
+
+        The approach is to process each .csv file at the same time,
+        reading one row from each in lock step. The field data found
+        in each column across all files for a given identifier at the
+        same timestamp are unified into one JSON document.
+
+        For example, given 2 csv files:
+
+          * file0.csv
+            * timestamp_ms,id0_foo,id1_foo,id2_foo
+              * 00000, 1.0, 2.0, 3.0
+              * 00001, 1.1, 2.1, 3.1
+          * file1.csv
+            * timestamp_ms,id0_bar,id1_bar,id2_bar
+              * 00000, 4.0, 5.0, 6.0
+              * 00001, 4.1, 5.1, 6.1
+
+        The output would be 6 JSON records, one for each 3 identifiers
+        at each of two timestamps, with the fields "foo" and "bar" in
+        each:
+
+          [ { "@timestamp": 00000, "id": "id0", "foo": 1.0, "bar": 4.0 },
+            { "@timestamp": 00000, "id": "id1", "foo": 2.0, "bar": 5.0 },
+            { "@timestamp": 00000, "id": "id2", "foo": 3.0, "bar": 6.0 },
+            { "@timestamp": 00001, "id": "id0", "foo": 1.1, "bar": 4.1 },
+            { "@timestamp": 00001, "id": "id1", "foo": 2.1, "bar": 5.1 },
+            { "@timestamp": 00001, "id": "id2", "foo": 3.1, "bar": 6.1 } ]
+        """
         # Class list is generated from the handler data
         class_list = _dict_const()
         # The metric mapping provides (klass, metric) tuples for a given
@@ -774,19 +843,25 @@ class ToolData(object):
         # The list of identifiers is generated from the combined headers,
         # parsing out the IDs
         identifiers = _dict_const()
-        # The field mapping provides (identifier, subfield, metadata)
-        # tuples for all columns of all files.
+        # Records the association between the column number of a given
+        # .csv file and the identifier / subfield tuple.
         field_mapping = _dict_const()
         # Metadata extracted from column header
         metadata = _dict_const()
+
+        # To begin the unification process, we have to generate a data
+        # structure to drive processing of the rows from all csv files
+        # by deriving data from the header rows of all the csv files,
+        # first. This is driven by the data provided in the handler.
         for csv in self.files:
-            if csv['header'][0] != 'timestamp_ms':
+            # Each csv file dictionary provides its header row.
+            header = csv['header']
+            if header[0] != 'timestamp_ms':
                 print("tool-data-indexing: expected first column of .csv file"
                         " (%s) to be 'timestamp_ms', found %s",
-                        (csv['basename'], csv['header'][0]))
+                        (csv['basename'], header[0]))
                 self.counters['first_column_not_timestamp_ms'] += 1
                 continue
-            header = csv['header']
             handler_rec = csv['handler_rec']
             class_list[handler_rec['class']] = True
             metric_mapping[csv['basename']] = (handler_rec['class'], handler_rec['metric'])
@@ -795,16 +870,26 @@ class ToolData(object):
                 field_mapping[csv['basename']] = _dict_const()
             for idx,col in enumerate(header):
                 if idx == 0:
+                    # No field mapping necessary for the timestamp
                     field_mapping[csv['basename']][idx] = None
                     continue
+                # First pull out the identifier of the target from the column
+                # header and record it in the list of identifiers.
                 m = colpat.match(col)
                 identifier = m.group('id')
                 identifiers[identifier] = True
                 try:
+                    # Pull out any sub-field names found in the column
+                    # header.
                     subfield = m.group('subfield')
                 except IndexError:
+                    # Columns do not have to have sub-fields, so we can
+                    # safely use None.
                     subfield = None
                 else:
+                    # Ensure the name of the subfield found in the
+                    # column is in the list of expected subfields from
+                    # "known handlers" table.
                     if subfield not in handler_rec['subfields']:
                         print("tool-data-indexing: column header, %r, has an"
                                 " unexpected subfield, %r, expected %r"
@@ -813,15 +898,30 @@ class ToolData(object):
                                     csv['basename']))
                         self.counters['column_subfields_do_not_match_handler'] += 1
                         subfield = None
+                # Record the association between the column number
+                # ('idx') of a given .csv file ('basename') and the
+                # identifier / subfield tuple.
                 field_mapping[csv['basename']][idx] = (identifier, subfield)
                 try:
+                    # Some identifiers are constructed by combining
+                    # pieces of metadata to make a unique ID.  Pull
+                    # out of the handler the pattern that can extract
+                    # that metadata.
                     metadata_pat = handler_rec['metadata_pat']
                 except KeyError:
+                    # We can safely ignore handlers which do not
+                    # provide metadata handlers.
                     pass
                 else:
+                    # Parse out the metadata name(s) from the column
+                    # header.
                     m = metadata_pat.match(col)
                     if m:
                         colmd = {}
+                        # We matched one or more names, loop through
+                        # the list of expected metadata regex group
+                        # names to build up the mapping of regex
+                        # group names to actual metadata field names.
                         for md in handler_rec['metadata']:
                             try:
                                 val = m.group(md)
@@ -835,22 +935,36 @@ class ToolData(object):
                                 self.counters['expected_column_metadata_not_found'] += 1
                             else:
                                 colmd[md] = val
+                        # Store the association between the identifier
+                        # and the metadata mapping for field names.
                         metadata[identifier] = colmd
-        while True:
-            # Read a row from each .csv file
-            rows = _dict_const()
-            for csv in self.files:
-                try:
-                    rows[csv['basename']] = next(csv['reader'])
-                except StopIteration:
-                    # This should handle the case of mismatched number of
-                    # rows across all .csv files. All readers which have
-                    # finished will emit a StopIteration.
-                    pass
-            if not rows:
-                # None of the csv file readers returned any rows to process,
-                # so we're done.
-                break
+        # At this point, we have processed all the data about csv files
+        # and are ready to start reading the contents of all the csv
+        # files and building the unified records.
+        def rows_generator():
+            # We use this generator to highlight the process of reading from
+            # all the csv files, reading one row from each of the csv files,
+            # returning that as a dictionary of csv file to row read, which
+            # in turn is yielded by the generator.
+            while True:
+                # Read a row from each .csv file
+                rows = _dict_const()
+                for csv in self.files:
+                    try:
+                        rows[csv['basename']] = next(csv['reader'])
+                    except StopIteration:
+                        # This should handle the case of mismatched number of
+                        # rows across all .csv files. All readers which have
+                        # finished will emit a StopIteration.
+                        pass
+                if not rows:
+                    # None of the csv file readers returned any rows to
+                    # process, so we're done.
+                    break
+                # Yield the one dictionary that contains each newly read row
+                # from all the csv files.
+                yield rows
+        for rows in rows_generator():
             # Verify timestamps are all the same
             tstamp = None
             first = None
@@ -863,15 +977,37 @@ class ToolData(object):
                             " timestamps per row" % self.toolname)
                     self.counters['inconsistent_timestamps_across_csv_files'] += 1
                     break
-            # Create the base document per identifier; the timestamp is taken
-            # from the "first" timestamp, converted to a floating point
-            # seconds value, and then formatted as a string.
+            # We are now ready to create a base document per identifier to
+            # hold all the fields from the various columns. Given the two
+            # input dictionaries, "identifiers" and "metadata", we create
+            # an output dictionary, "datum", which has keys for all the
+            # identifiers and a base dictionary for forming the JSON docs.
+
+            # For example, given these inputs:
+            #   * identifiers = { "id0": True, "id1": True }
+            #   * metadata = { "id0": { "f1": "foo", "f2": "bar" },
+            #                  "id1": { "f1": "faz", "f2": "baz" } }
+            # The for loop below would generate the following dictionary:
+            #   * datum = { "id0": { "@timestamp": ts_str,
+            #                        "@metadata": self.run_metadata,
+            #                        self.toolname: { "id": "id0",
+            #                                         "f1": "foo",
+            #                                         "f2": "bar" } },
+            #               "id1": { "@timestamp": ts_str,
+            #                        "@metadata": self.run_metadata,
+            #                        self.toolname: { "id": "id1",
+            #                                         "f1": "faz",
+            #                                         "f2": "baz" } },
+
+            # The timestamp is taken from the "first" timestamp, converted
+            # to a floating point value in seconds, and then formatted as a
+            # string.
             ts_str = self.convert_timestamp(first)
             datum = _dict_const()
             for identifier in identifiers.keys():
                 datum[identifier] = _dict_const([
-                    # Since they are all the same, we use the first to generate the
-                    # real timestamp.
+                    # Since they are all the same, we use the first to
+                    # generate the real timestamp.
                     ('@timestamp', ts_str),
                     ('@metadata', self.run_metadata)
                 ])
@@ -1719,9 +1855,7 @@ def make_all_actions(ptb, options, INDEX_PREFIX, INDEX_VERSION, opctx):
 
 
 class PbenchTarBall(object):
-    def __init__(self, tbarg):
-        global _tmpdir
-
+    def __init__(self, tbarg, tmpdir):
         self.tbname = tbarg
         self.hostname = os.path.basename(os.path.dirname(self.tbname))
         self.tb = tarfile.open(self.tbname)
@@ -1749,8 +1883,8 @@ class PbenchTarBall(object):
 
         # The caller of index-pbench is expected to clean up the temporary
         # directory.
-        self.tb.extractall(path=_tmpdir)
-        self.extracted_root = _tmpdir
+        self.tb.extractall(path=tmpdir)
+        self.extracted_root = tmpdir
         if not os.path.isdir(os.path.join(self.extracted_root, self.dirname)):
             raise UnsupportedTarballFormat(self.tbname)
         try:
@@ -1813,8 +1947,6 @@ def get_es_hosts(config):
 # it to ES for indexing.
 
 def main(options, args):
-    global _tmpdir
-
     # ^$!@!#%# compatibility
     # FileNotFoundError is python 3.3 and the travis-ci hosts still (2015-10-01) run
     # python 3.2
@@ -1823,11 +1955,8 @@ def main(options, args):
 
     try:
         config=SafeConfigParser()
-        try:
-            cfg_name = options.cfg_name
-        except Exception:
-            cfg_name = os.environ.get("ES_CONFIG_PATH")
 
+        cfg_name = options.cfg_name
         if not cfg_name:
             raise ConfigFileNotSpecified("No config file specified: set ES_CONFIG_PATH env variable or use --config <file> on the command line")
 
@@ -1838,7 +1967,8 @@ def main(options, args):
         except Exception as e:
             raise ConfigFileError(e)
 
-        _tmpdir = os.environ['TMPDIR']
+        if not options.tmpdir:
+            raise Exception("No temporary directory specified")
 
         if options.debug_unittest:
             es = None
@@ -1850,7 +1980,7 @@ def main(options, args):
             es = Elasticsearch(hosts, max_retries=0)
 
         # prepare the actions - the tarball name is the only argument.
-        ptb = PbenchTarBall(args[0])
+        ptb = PbenchTarBall(args[0], options.tmpdir)
 
         # Construct the generator for emitting all actions.  The `opctx`
         # dictionary is passed along to each generator so that it can add its
@@ -1863,8 +1993,13 @@ def main(options, args):
         es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config)
 
         # returns 0 or 1
-        if options.debug_time_operations: ts("es_index")
-        res = es_index(es, actions)
+        if options.indexing_errors:
+            ie_filename = options.indexing_errors
+        else:
+            ie_filename = os.path.join(options.tmpdir, "index-pbench.error-log.json")
+        with open(ie_filename, "w") as fp:
+            if options.debug_time_operations: ts("es_index")
+            res = es_index(es, actions, fp, dbg=_DEBUG)
 
     except ConfigFileNotSpecified as e:
         print(e, file=sys.stderr)
@@ -1903,7 +2038,7 @@ def main(options, args):
         res = 10
 
     except tarfile.TarError as e:
-        print("Can't unpack tarball into {}: {}".format(_tmpdir, e), file=sys.stderr)
+        print("Can't unpack tarball into {}: {}".format(options.tmpdir, e), file=sys.stderr)
         res = 11
 
     # this is Spinal Tap
@@ -1947,16 +2082,20 @@ def main(options, args):
 
 prog_options = [
     make_option("-C", "--config", dest="cfg_name", help="Specify config file"),
-    make_option("-M", "--metadata", dest="metadata_string", help="Specify additional metadata (e.g. for browbeat) as a JSON document"),
+    make_option("-E", "--indexing-errors", dest="indexing_errors", help="Name of a file to write JSON documents that fail to index"),
+    make_option("-D", "--temp-directory", dest="tmpdir", help="Temporary directory to use while indexing"),
+    make_option("-M", "--metadata", dest="metadata_string", help="Specify additional metadata (e.g. for browbeat) as a JSON document string"),
     # options for debuggging and unit testing
     make_option("-U", "--unittest", action="store_true", dest="debug_unittest", help="Run in unittest mode"),
     make_option("-T", "--time-ops", action="store_true", dest="debug_time_operations", help="Time action making routines"),
 ]
 
 if __name__ == '__main__':
-    parser = OptionParser("Usage: index-pbench [--config <path-to-config-file>] <path-to-tarball>")
+    parser = OptionParser("Usage: index-pbench [--config <path-to-config-file>] [--metadata \"<JSON doc>\"] [--working-directory <dir>] <path-to-tarball>")
     for o in prog_options:
         parser.add_option(o)
+    parser.set_defaults(cfg_name = os.environ.get("ES_CONFIG_PATH"))
+    parser.set_defaults(tmpdir = os.environ.get("TMPDIR"))
 
     (options, args) = parser.parse_args()
 

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -1067,7 +1067,8 @@ class ToolData(object):
 
 def get_iterations(mdconf, tb):
     try:
-        return mdconf.get("pbench", "iterations").split(', ')
+        # N.B. Comma-separated list
+        iterations_str = mdconf.get("pbench", "iterations")
     except Exception:
         # TBD - trawl through tb with some heuristics
         iterations = []
@@ -1078,7 +1079,12 @@ def get_iterations(mdconf, tb):
             iter = l[1]
             if re.search('^[1-9][0-9]*-', iter):
                 iterations.append(iter)
-        return iterations
+    else:
+        iterations = iterations_str.split(', ')
+    iterations_set = set(iterations)
+    iterations = list(iterations_set)
+    iterations.sort()
+    return iterations
 
 def get_samples(iteration, mdconf, tb):
     samples = []
@@ -1093,14 +1099,17 @@ def get_samples(iteration, mdconf, tb):
             samples.append(sample)
     if len(samples) == 0:
         samples.append('reference-result')
+    samples_set = set(samples)
+    samples = list(samples_set)
+    samples.sort()
     return samples
 
-def get_pbench_hosts(iteration, sample, mdconf, tb):
+def get_hosts(iteration, sample, mdconf, tb):
     try:
         # N.B. Space-separated list
-        return mdconf.get("tools", "hosts").split()
+        hosts = mdconf.get("tools", "hosts")
     except ConfigParserError:
-        print("ConfigParser error in get_pbench_hosts: tool data will *not* be indexed.")
+        print("ConfigParser error in get_hosts: tool data will *not* be indexed.")
         print("This is most probably a bug: please open an issue.")
         return []
     except NoSectionError:
@@ -1109,10 +1118,14 @@ def get_pbench_hosts(iteration, sample, mdconf, tb):
     except NoOptionError:
         print("No hosts in [tools] section in metadata log: tool data will *NOT* be indexed.")
         return []
+    hosts_set = set(hosts.split())
+    hosts = list(hosts_set)
+    hosts.sort()
+    return hosts
 
 def get_tools(iteration, sample, host, mdconf, tb):
     try:
-        return mdconf.options("tools/{}".format(host))
+        tools = mdconf.options("tools/{}".format(host))
     except ConfigParserError:
         print("ConfigParser error in get_tools: tool data will *not* be indexed.")
         print("This is most probably a bug: please open an issue.")
@@ -1123,6 +1136,10 @@ def get_tools(iteration, sample, host, mdconf, tb):
     except NoOptionError:
         print("No tools in [tools/{}] section in metadata log: tool data will *NOT* be indexed.".format(host))
         return []
+    tools_set = set(tools)
+    tools = list(tools_set)
+    tools.sort()
+    return tools
 
 def get_tool_label(host, mdconf):
     try:
@@ -1146,7 +1163,7 @@ def mk_tool_data(ptb, opctx):
     for iteration in iterations:
         samples = get_samples(iteration, ptb.mdconf, ptb.tb)
         for sample in samples:
-            hosts = get_pbench_hosts(iteration, sample, ptb.mdconf, ptb.tb)
+            hosts = get_hosts(iteration, sample, ptb.mdconf, ptb.tb)
             for host in hosts:
                 tools = get_tools(iteration, sample, host, ptb.mdconf, ptb.tb)
                 for tool in tools:
@@ -1771,7 +1788,7 @@ class PbenchTarBall(object):
         return mdfconfig
 
 
-def get_hosts(config):
+def get_es_hosts(config):
     """
     Return list of dicts (a single dict for now) -
     that's what ES is expecting.
@@ -1829,7 +1846,7 @@ def main(options, args):
             global _dict_const
             _dict_const = collections.OrderedDict
         else:
-            hosts = get_hosts(config)
+            hosts = get_es_hosts(config)
             es = Elasticsearch(hosts, max_retries=0)
 
         # prepare the actions - the tarball name is the only argument.

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -801,14 +801,15 @@ class ToolData(object):
                     ('@metadata', self.run_metadata)
                 ])
                 datum[identifier][self.toolname] = _dict_const()
-                for klass in class_list.keys():
-                    datum[identifier][self.toolname][klass] = _dict_const([('id',identifier)])
                 try:
                     md = metadata[identifier]
                 except KeyError:
-                    pass
-                else:
-                    datum[identifier][self.toolname][klass].update(md)
+                    md = None
+                for klass in class_list.keys():
+                    d = _dict_const([('id',identifier)])
+                    if md:
+                        d.update(md)
+                    datum[identifier][self.toolname][klass] = d
             # Now we can perform the mapping from multiple .csv files to JSON
             # documents using a known field hierarchy (no identifiers in field
             # names) with the identifiers as additional metadata. Note that we

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -20,6 +20,7 @@ from elasticsearch import VERSION, Elasticsearch, helpers, exceptions as es_excs
 from urllib3 import exceptions as ul_excs, Timeout
 from datetime import datetime, timedelta
 from vos.analysis.lib import tstos
+from collections import Counter
 
 _VERSION_ = "0.1.0.0"
 _NAME_    = "index-pbench"
@@ -648,6 +649,14 @@ class ToolData(object):
             (iterseqno, itername) = iteration.split('-', 1)
         except Exception:
             iterseqno = itername = iteration
+        try:
+            self.start_run_ts = datetime.strptime(tstamp, "%Y-%m-%dT%H:%M:%S.%f")
+        except ValueError:
+            try:
+                self.start_run_ts = datetime.strptime(tstamp, "%Y-%m-%dT%H:%M:%S")
+            except ValueError:
+                self.start_run_ts = None
+        self.counters = Counter()
         self.run_metadata = {
             "runtstamp": tstamp,
             "runid": md5sum,
@@ -695,6 +704,15 @@ class ToolData(object):
                                                           hostpath, tool, toolgroup,
                                                           mdlog, tb)
 
+    def convert_timestamp(self, orig_ts):
+        # Convert the given string timestamp, assumed to be a float in
+        # milliseconds since the epoch, to the expected string timestamp format.
+        ts_float = float(orig_ts)/1000
+        ts = datetime.utcfromtimestamp(ts_float)
+        if self.start_run_ts is not None and ts < self.start_run_ts:
+            self.counters['tool_ts_before_start_run_ts'] += 1
+        return ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
+
     def _make_source_unified(self):
         """Process each .csv file at the same time, reading one row from each,
         unifying them into one record per column identifier when the
@@ -718,7 +736,14 @@ class ToolData(object):
         # Metadata extracted from column header
         metadata = _dict_const()
         for csv in self.csv_files:
-            assert csv['header'][0] == 'timestamp_ms'
+            if csv['header'][0] != 'timestamp_ms':
+                print("Expected first column of .csv file (%s) to be"
+                        " 'timestamp_ms', found %s",
+                        (csv['basename'], csv['header'][0]))
+                # FIXME: consider counting this issue and reporting with a
+                # summary of the indexing work.
+                self.counters['first_column_not_timestamp_ms'] += 1
+                continue
             header = csv['header']
             handler = self.handler[csv['basename']]
             colpat = handler['colpat']
@@ -737,10 +762,14 @@ class ToolData(object):
                     subfield = None
                 else:
                     if subfield not in handler['subfields']:
-                        raise Exception(
-                            "Handler subfields, %r, do not match header"
-                            " subfield name %s" % (
-                                handler['subfields'], subfield))
+                        print("Column header, %r, has an unexpected subfield,"
+                                " %r, expected %r subfields, for .csv %s" % (
+                                    col, subfield, handler['subfields'],
+                                    csv['basename']))
+                        # FIXME: Consider counting this error and reporting
+                        # with a summary of the indexing work.
+                        self.counters['column_subfields_do_not_match_handler'] += 1
+                        subfield = None
                 field_mapping[csv['basename']][idx] = (identifier, subfield)
                 try:
                     metadata_pat = handler['metadata_pat']
@@ -754,11 +783,16 @@ class ToolData(object):
                             try:
                                 val = m.group(md)
                             except IndexError:
-                                raise Exception(
-                                    "Handler metadata, %r, not found in column"
-                                    " %r using pattern %r" % (
-                                        handler['metadata'], col,
-                                        handler['metadata_pat']))
+                                print("Handler metadata, %r, not found in"
+                                        " column %r using pattern %r, for"
+                                        " .csv %s" % (
+                                            handler['metadata'], col,
+                                            handler['metadata_pat'],
+                                            csv['basename']))
+                                # FIXME: Consider counting this error and
+                                # reporting it with a summary of the indexing
+                                # work.
+                                self.counters['expected_column_metadata_not_found'] += 1
                             else:
                                 colmd[md] = val
                         metadata[identifier] = colmd
@@ -782,16 +816,20 @@ class ToolData(object):
             first = None
             for fname in rows.keys():
                 tstamp = rows[fname][0]
-                if not first:
+                if first is None:
                     first = tstamp
-                else:
-                    assert(first == tstamp)
+                elif first != tstamp:
+                    print("tool-data-indexing: %s csv files have inconsistent"
+                            " timestamps per row" % self.toolname)
+                    # FIXME: We should consider counting these inconsistent
+                    # timestamps and reporting them with the summary of the
+                    # indexing work.
+                    self.counters['inconsistent_timestamps_across_csv_files'] += 1
+                    break
             # Create the base document per identifier; the timestamp is taken
             # from the "first" timestamp, converted to a floating point
             # seconds value, and then formatted as a string.
-            first = int(first)/1000
-            ts = datetime.utcfromtimestamp(first)
-            ts_str = ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
+            ts_str = self.convert_timestamp(first)
             datum = _dict_const()
             for identifier in identifiers.keys():
                 datum[identifier] = _dict_const([
@@ -852,11 +890,20 @@ class ToolData(object):
                 try:
                     # unix seconds since epoch timestamp
                     ts = datetime.utcfromtimestamp(item['@timestamp'])
+                except TypeError:
+                    # assume that item[@timestamp] is already in the expected
+                    # format.
+                    self.counters['json_doc_timestamp_not_validated'] += 1
+                except KeyError:
+                    # missing timestamps
+                    #
+                    # FIXME: We should consider logging the first record with
+                    # missing timestamps, and then count the rest and report
+                    # the count with the summary of how the indexing went.
+                    self.counters['json_doc_missing_timestamp'] += 1
+                else:
                     ts_str = ts.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
                     item['@timestamp'] = ts_str
-                except Exception:
-                    # assume that item[@timestamp] is already in %Y-%m-%dT%H:%M:%S.%f%z format
-                    pass
 
                 yield item
         return
@@ -1437,7 +1484,7 @@ def _to_utc(l, u):
     ISO format date.
     """
     lts = datetime.strptime(l, "%Y-%m-%dT%H:%M:%S")
-    uts = datetime.strptime(u[:u.rfind('.')] , "%Y-%m-%dT%H:%M:%S")
+    uts = datetime.strptime(u[:u.rfind('.')], "%Y-%m-%dT%H:%M:%S")
 
     offset = lts - uts
     res = round(float(offset.seconds) / 60 / 60 + offset.days * 24, 1)

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -85,8 +85,8 @@ typeset -i nerrs=0
 erred=$TMPDIR/$PROG.$TS.erred
 typeset -i nskip=0
 skipped=$TMPDIR/$PROG.$TS.skipped
-mail_body=$TMPDIR/$PROG.$TS.mail
-index_content=$TMPDIR/$PROG.$TS.index_mail_contents
+report_body=$TMPDIR/$PROG.$TS.report
+errors_json=$TMPDIR/$PROJ.$TS.indexing-errors.json
 
 mkdir -p $TMPDIR
 trap "rm -rf $TMPDIR" EXIT QUIT INT
@@ -94,8 +94,7 @@ trap "rm -rf $TMPDIR" EXIT QUIT INT
 > $indexed
 > $erred
 > $skipped
-> $mail_body
-> $index_content
+> $errors_json
 
 list=$TMPDIR/list
 find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' -printf "%s\t%p\n" 2>/dev/null | sort -n > $list
@@ -136,25 +135,31 @@ while read size result ;do
         # running unittests: assume that we are in the bin directory
         PROGLOC=$dir
         PYTHONPATH=${PROGLOC}/../lib:$PYTHONPATH eval\
-             "python3 ${PROGLOC}/index-pbench -U --config ${PROGLOC}/../lib/config/pbench-index.cfg $link"
+             "python3 ${PROGLOC}/index-pbench -U --config ${PROGLOC}/../lib/config/pbench-index.cfg -E $errors_json $link"
         status=$?
     else
         PROGLOC=$(getconf.py install-dir pbench-server)
         if which python3 > /dev/null 2>&1 ;then
             # we have a python3 here
             PYTHONPATH=${PROGLOC}/lib:$PYTHONPATH eval\
-                "python3 ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
+                "python3 ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg -E $errors_json $link"
             status=$?
         elif which scl > /dev/null 2>&1 ;then
             # we fall back to SCL
             PYTHONPATH=${PROGLOC}/lib:$PYTHONPATH scl enable rh-python36 \
-                "python ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg $link"
+                "python ${PROGLOC}/bin/index-pbench --config ${PROGLOC}/lib/config/pbench-index.cfg -E $errors_json $link"
             status=$?
         else
             echo "index-pbench needs python3, either directly or through SCL" >&4
             # this is fatal
             exit 127
         fi
+    fi
+
+    if [ -s $errors_json ]; then
+        echo $link > $errors_json.report
+        cat $errors_json >> $errors_json.report
+        pbench-report-status --name $PROG.errors --timestamp $TS --type status $errors_json.report
     fi
     
     if [ $status -ne 0 ] ;then
@@ -196,54 +201,47 @@ while read size result ;do
     echo "   $(timestamp): Finished $result (size $size)"
 done < $list
 
-
 echo "$TS: ending at $(timestamp), indexed $nidx (skipped $nskip) results, $nerrs errors"
 
 log_finish
 
-if [[ $nidx -gt 0 || $nskip -gt 0 || $nerrs -gt 0 ]]; then
-    # Tricky quoting: variables are not expanded until the final eval.
-    # That solved the problem of embedded parens - in the meantime, we got rid of the
-    # parens, so it has become moot.
-    if [[ $nerrs > 0 && $nskip > 0 ]] ;then
-        subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results, w/ $nerrs errors"
-    elif [[ $nskip > 0 ]] ;then
-        subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results"
-    elif [[ $nerrs > 0 ]] ;then
-        subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results, w/ $nerrs errors"
-    else
-        subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results"
-    fi
-    if [[ "$_PBENCH_SERVER_TEST" != 1 ]] ;then
-        # send mail if not unit testing
-        cat << EOF > $index_content
+> $report_body
+
+# Tricky quoting: variables are not expanded until the final eval.
+# That solved the problem of embedded parens - in the meantime, we got rid of the
+# parens, so it has become moot.
+if [[ $nerrs > 0 && $nskip > 0 ]] ;then
+    subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results, w/ $nerrs errors"
+elif [[ $nskip > 0 ]] ;then
+    subj="$PROG.$TS - Indexed $nidx results, skipped $nskip results"
+elif [[ $nerrs > 0 ]] ;then
+    subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results, w/ $nerrs errors"
+else
+    subj="$PROG.$TS($PBENCH_ENV) - Indexed $nidx results"
+fi
+
+cat << EOF > $report_body
 $subj
 EOF
-        cat $mail_body >> $index_content
-        mailcmd="pbench-report-status --name $PROG --timestamp $TS --type status $index_content"
-    else
-        # otherwise store the output in the log
-        mailcmd="echo \"$subj\"; cat $mail_body"
-    fi
-    if [[ $nerrs -gt 0 ]]; then
-        echo "Results producing errors"
-        echo "========================"
-        cat $erred
-        echo
-    fi  >> $mail_body
-    if [[ $nskip -gt 0 ]]; then
-        echo "Skipped Results"
-        echo "==============="
-        cat $skipped
-        echo
-    fi  >> $mail_body
-    if [[ $nidx -gt 0 ]]; then
-        echo "Indexed Results"
-        echo "==============="
-        cat $indexed
-    fi  >> $mail_body
+if [[ $nidx -gt 0 ]]; then
+    echo
+    echo "Indexed Results"
+    echo "==============="
+    cat $indexed
+fi  >> $report_body
+if [[ $nerrs -gt 0 ]]; then
+    echo
+    echo "Results producing errors"
+    echo "========================"
+    cat $erred
+fi  >> $report_body
+if [[ $nskip -gt 0 ]]; then
+    echo
+    echo "Skipped Results"
+    echo "==============="
+    cat $skipped
+fi  >> $report_body
 
-    eval $mailcmd
-fi
+pbench-report-status --name $PROG --timestamp $TS --type status $report_body
 
 exit 0

--- a/server/pbench/bin/state/config/pbench-index.cfg
+++ b/server/pbench/bin/state/config/pbench-index.cfg
@@ -4,8 +4,8 @@
 server = elasticsearch.example.com:9280
 
 [Settings]
-index_prefix = pbench
-index_version = 1
+index_prefix = pbench-unittests
+index_version = 2
 bulk_action_count = 2000
 # Uncomment the settings below if you need to override the Elasticsearch
 # defaults for shards per index or replica count per index.

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -239,6 +239,7 @@ declare -A cmds=(
     [test-7.10]="_run_index"
     [test-7.11]="_run_index"
     [test-7.12]="_run_index"
+
     # activation test
     [test-8]="_run_activate"
 

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -43,7 +43,7 @@ function _run {
 
 function _run_index {
     echo "+++ Running indexing for $test" >> $_testout
-    cmd="TMPDIR=$_testtmp PYTHONPATH=${_tlib}:$PYTHONPATH $_tdir/index-pbench -U -C ${_testopt}/config/pbench-index.cfg $(readlink -f $_testdir/*.tar.xz)"
+    cmd="TMPDIR=$_testtmp PYTHONPATH=${_tlib}:$PYTHONPATH $_tdir/index-pbench -U -C ${_testopt}/config/pbench-index.cfg -E $_testdir/errors-json-unittests.json $(readlink -f $_testdir/*.tar.xz)"
     if which python3 > /dev/null 2>&1 ;then
 	eval $cmd >> $_testout 2>&1
     elif which scl > /dev/null 2>&1 ;then


### PR DESCRIPTION
The performance problem with indexing is two-fold:

 * we accumulate all generated records into one big list before we start indexing, which is really bad
  * we have observed 10s of GBs of memory used when indexing large amounts of data
  * to fix, we just need to use the streaming bulk methods and improve the error handling
 * in order to ensure error handling for Elasticsearch is good, we need source IDs for all documents ahead of time to make it easier to handle retrying operations when an ES instance is overloaded

Along the way, we have attempted to improve the error handling so that we index as much as possible, report errors better, and report them succinctly.