### PR TITLE
Add a proper log environment for verify-backup-tarballs

### DIFF
--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -51,3 +51,6 @@
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-backup-tarballs.NNNN/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -41,3 +41,6 @@
 /var/tmp/pbench-test-server/test-execution.log:
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-backup-tarballs.NNNN/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.1.txt
+++ b/server/pbench/bin/gold/test-9.1.txt
@@ -15,12 +15,18 @@
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/logs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
 --- pbench tree state
 +++ pbench log file contents
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents

--- a/server/pbench/bin/gold/test-9.1.txt
+++ b/server/pbench/bin/gold/test-9.1.txt
@@ -25,3 +25,6 @@
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -13,12 +13,18 @@
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/logs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
 --- pbench tree state
 +++ pbench log file contents
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents

--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -23,3 +23,8 @@
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -13,12 +13,18 @@
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/logs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
 --- pbench tree state
 +++ pbench log file contents
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -23,3 +23,8 @@
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -1,5 +1,4 @@
 +++ Running pbench-verify-backup-tarballs
-md5sum: WARNING: 1 computed checksum did NOT match
 --- Finished pbench-verify-backup-tarballs (status=0}
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
@@ -16,12 +15,19 @@ md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/logs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
 --- pbench tree state
 +++ pbench log file contents
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:md5sum: WARNING: 1 computed checksum did NOT match
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -26,3 +26,13 @@ md5sum: WARNING: 1 computed checksum did NOT match
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: The calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
+/var/tmp/pbench-test-server/test-report-status.log:
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+--- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -1,5 +1,4 @@
 +++ Running pbench-verify-backup-tarballs
-md5sum: WARNING: 1 computed checksum did NOT match
 --- Finished pbench-verify-backup-tarballs (status=0}
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench
@@ -16,12 +15,19 @@ md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+/var/tmp/pbench-test-server/pbench/logs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 /var/tmp/pbench-test-server/pbench/public_html
 /var/tmp/pbench-test-server/pbench/public_html/incoming
 /var/tmp/pbench-test-server/pbench/public_html/results
 /var/tmp/pbench-test-server/pbench/tmp
 --- pbench tree state
 +++ pbench log file contents
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:md5sum: WARNING: 1 computed checksum did NOT match
+/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -26,3 +26,13 @@ md5sum: WARNING: 1 computed checksum did NOT match
 +++ test-execution.log file contents
 /var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/pbench-report-status --name pbench-verify-backup-tarballs --timestamp run-1900-01-01T00:00:00-UTC --type status /var/tmp/pbench-test-server/pbench/tmp/pbench-verify-backup-tarballs/index_mail_contents
 --- test-execution.log file contents
++++ test-report-status.log file contents
+/var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
+/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive.backup: The calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
+/var/tmp/pbench-test-server/test-report-status.log:
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
+/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
+--- test-report-status.log file contents

--- a/server/pbench/bin/pbench-report-status
+++ b/server/pbench/bin/pbench-report-status
@@ -88,6 +88,8 @@ tmp=/tmp/$prog.$$
 
 trap "rm -rf $tmp" EXIT QUIT INT
 
+mkdir $tmp
+
 echo '
 {
     "@timestamp": %timestamp%,
@@ -98,12 +100,15 @@ echo '
 sed 's/%timestamp%/"'$timestamp'"/
      s/%name%/"'$name'"/
      s/%type%/"'$doctype'"/
-     s~%text%~"'"$text"'"~' > $tmp
+     s~%text%~"'"$text"'"~' > ${tmp}/payload
 
-curl -XPOST -H 'Content-Type: application/json' "http://$server/$index/$doctype/$md5" --data @"${tmp}" >> $LOGSDIR/$name/$name.log 2>&1
+curl -XPOST -H 'Content-Type: application/json' "http://$server/$index/$doctype/$md5" --data @"${tmp}/payload" >> ${tmp}/log 2>&1
 status=$?
 
-echo >> $LOGSDIR/$name/$name.log
+echo >> ${tmp}/log
+
+if [ -f "$LOGSDIR/$name/$name.log" ]; then
+    cat ${tmp}/log >> $LOGSDIR/$name/$name.log
+fi
 
 exit $status
-

--- a/server/pbench/bin/pbench-verify-backup-tarballs
+++ b/server/pbench/bin/pbench-verify-backup-tarballs
@@ -43,6 +43,9 @@ primary=$ARCHIVE
 backup=$BDIR
 
 # work files
+controllers=$TMP/$PROG/controllers.$$
+files=$TMP/$PROG/files.$$
+allmd5s=$TMP/$PROG/allmd5s.$$
 listp=$TMP/$PROG/primary.$$
 listb=$TMP/$PROG/backup.$$
 tmp=$TMP/$PROG/tmp.$$
@@ -54,42 +57,53 @@ index_content=$TMP/$PROG/index_mail_contents
 # make sure the directory exists
 mkdir -p $TMP/$PROG
 
-controllers=$TMP/$PROG/controllers.$$
-trap "rm -f $controllers $listp $listp.failed $listb $listb.failed $tmp $ponly $bonly $report $index_content; rmdir $TMP/$PROG" EXIT INT QUIT
+trap "rm -f $controllers $files $allmd5s $listp $listp.failed $listb $listb.failed $tmp $ponly $bonly $report $index_content; rmdir $TMP/$PROG" EXIT INT QUIT
+
+# First argument is the exit code to use when a directory does not exist.
+function checkmd5 {
+    find . -maxdepth 1 -type d | grep -v '^\.$' > $controllers
+    while read d ;do
+        pushd $d > /dev/null || exit $1
+        ls | grep md5 | grep -v DUPLICATE__NAME > $files
+        > $allmd5s
+        while read f ;do
+            if [ -s $f ]; then
+                cat $f >> $allmd5s
+            else
+                echo "FAIL: Empty .md5 file: $d/$f"
+            fi
+        done < $files
+        if [ -s $allmd5s ] ;then
+            md5sum --check --warn $allmd5s | sed 's;^;'$d/';'
+        fi 
+        popd >/dev/null
+    done < $controllers
+}
+
+log_init $(basename $0) $LOGSDIR/$(basename $0)
+
+echo "start-$(timestamp)"
 
 # Initialize index mail content
 > $index_content
 
+# primary archive
 > $listp
 if cd $primary ;then
-    find . -maxdepth 1 -type d | grep -v '^\.$' > $controllers
-    while read d ;do
-        pushd $d > /dev/null || exit 5
-        files=$(ls | grep md5 | grep -v DUPLICATE__NAME)
-        if [ ! -z "${files}" ] ;then
-            md5sum -c ${files} | sed 's;^;'$d/';'
-        fi 
-        popd >/dev/null
-    done < $controllers | sort > $listp
+    checkmd5 5 | sort > $listp
 fi
 
 # backup location
 > $listb
 if cd $backup ;then
-    find . -maxdepth 1 -type d | grep -v '^\.$' > $controllers
-    while read d ;do
-        pushd $d > /dev/null || exit 6
-        files=$(ls | grep md5 | grep -v DUPLICATE__NAME)
-        if [ ! -z "${files}" ] ;then
-            md5sum -c ${files} | sed 's;^;'$d/';'
-        fi 
-        popd >/dev/null
-    done < $controllers | sort > $listb
+    checkmd5 6 | sort > $listb
 fi
 
-# construct the report
-> $report
 let ret=0
+
+# Construct the report file
+> $report
+
 grep FAIL $listp > $listp.failed
 if [ -s $listp.failed ] ;then
     (echo "* In $primary: The calculated MD5 of the following entries failed to match the stored MD5"
@@ -133,6 +147,10 @@ if [[ $ret == 0 ]] ;then
     fi
 fi
 
+echo "end-$(timestamp)"
+
+log_finish
+
 # send it
 subj="$PROG.$TS($PBENCH_ENV)"
 cat << EOF > $index_content
@@ -143,4 +161,3 @@ cat $report >> $index_content
 pbench-report-status --name $PROG --timestamp $TS --type status $index_content
 
 exit $ret
-

--- a/server/pbench/bin/test-bin/pbench-report-status
+++ b/server/pbench/bin/test-bin/pbench-report-status
@@ -1,3 +1,31 @@
 #!/bin/bash
 
 echo "$0 $*" >> $_testlog
+
+opts=$(getopt -q -o hn:t:T: --longoptions "help,name:,timestamp:,type:" -n "getopt.sh" -- "$@");
+
+eval set -- "$opts"
+while true; do
+    case "$1" in
+        -h|--help)
+            shift
+            ;;
+        -n|--name)
+            shift 2
+            ;;
+        -t|--timestamp)
+            shift 2
+            ;;
+        -T|--type)
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+    esac
+done
+
+file=$1
+
+cat $file >> $_testreportstatus

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -14,8 +14,10 @@ if [[ $? -gt 0 ]]; then
     echo "ERROR: failed to empty test root directory, \"$_testroot\"" >&2
     exit 1
 fi
+
 _testout=$_testroot/output.txt
 export _testlog=$_testroot/test-execution.log
+export _testreportstatus=$_testroot/test-report-status.log
 _testdir=$_testroot/pbench
 mkdir -p $_testdir
 if [[ ! -d $_testdir ]]; then
@@ -108,11 +110,20 @@ function _dump_logs {
             done
     fi
     echo "--- pbench log file contents" >> $_testout
+
     echo "+++ test-execution.log file contents" >> $_testout
     grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-execution.log 2>/dev/null |
          sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*/;tmp/pbench-\1.NNNN/;' >> $_testout>> $_testout 2>&1
     echo "--- test-execution.log file contents" >> $_testout
     rm -f $_testroot/test-execution.log
+
+    if [ -s $_testroot/test-report-status.log ]; then
+        echo "+++ test-report-status.log file contents" >> $_testout
+        grep -HvF "\-\-should-n0t-ex1st--" $_testroot/test-report-status.log 2>/dev/null |
+             sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*/;tmp/pbench-\1.NNNN/;' >> $_testout>> $_testout 2>&1
+        echo "--- test-report-status.log file contents" >> $_testout
+    fi
+    rm -f $_testroot/test-report-status.log
 }
 
 function _verify_output {


### PR DESCRIPTION
The base problem with `pbench-verify-backup-tarballs` is actually with `pbench-report-status` which fails to work because the directory path to the log file is not created when a script does not invoke, `log_init`.  The first patch addresses this problem.

The second patch adds to the unit tests the contents of the report-status payload itself.

The third patch adds proper logging to the `pbench-verify-backup-tarballs` command so that we don't get a cron job email with the output of stderr and the report status email.