### PR TITLE
Parallelize archive directory checks; compare file lists

### DIFF
--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -32,5 +32,5 @@
 +++ test-report-status.log file contents
 /var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
 /var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+/var/tmp/pbench-test-server/test-report-status.log:4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 --- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -31,6 +31,6 @@
 --- test-execution.log file contents
 +++ test-report-status.log file contents
 /var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
-/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.
+/var/tmp/pbench-test-server/test-report-status.log:4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 --- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -26,7 +26,6 @@
 --- pbench tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
@@ -34,11 +33,12 @@
 --- test-execution.log file contents
 +++ test-report-status.log file contents
 /var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
-/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: The calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: the calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
 /var/tmp/pbench-test-server/test-report-status.log:
 /var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
-/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
+/var/tmp/pbench-test-server/test-report-status.log:5fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.
+/var/tmp/pbench-test-server/test-report-status.log:4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 --- test-report-status.log file contents

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -26,7 +26,6 @@
 --- pbench tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:start-1900-01-01T00:00:00-UTC
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log:end-1900-01-01T00:00:00-UTC
 --- pbench log file contents
 +++ test-execution.log file contents
@@ -34,11 +33,12 @@
 --- test-execution.log file contents
 +++ test-report-status.log file contents
 /var/tmp/pbench-test-server/test-report-status.log:pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)
-/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive.backup: The calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:* In /var/tmp/pbench-test-server/pbench/archive.backup: the calculated MD5 of the following entries failed to match the stored MD5
+/var/tmp/pbench-test-server/test-report-status.log:md5sum: WARNING: 1 computed checksum did NOT match
 /var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
 /var/tmp/pbench-test-server/test-report-status.log:
 /var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: OK
-/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should not happen.
-/var/tmp/pbench-test-server/test-report-status.log:/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED
+/var/tmp/pbench-test-server/test-report-status.log:4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+/var/tmp/pbench-test-server/test-report-status.log:* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.
+/var/tmp/pbench-test-server/test-report-status.log:3fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
 --- test-report-status.log file contents

--- a/server/pbench/bin/pbench-verify-backup-tarballs
+++ b/server/pbench/bin/pbench-verify-backup-tarballs
@@ -46,38 +46,37 @@ backup=$BDIR
 controllers=$TMP/$PROG/controllers.$$
 files=$TMP/$PROG/files.$$
 allmd5s=$TMP/$PROG/allmd5s.$$
-listp=$TMP/$PROG/primary.$$
-listb=$TMP/$PROG/backup.$$
-tmp=$TMP/$PROG/tmp.$$
-ponly=$TMP/$PROG/primary.only
-bonly=$TMP/$PROG/backup.only
+list=$TMP/$PROG/list.$$
+out=$TMP/$PROG/out.$$
+only=$TMP/$PROG/only.$$
 report=$TMP/$PROG/report.$$
 index_content=$TMP/$PROG/index_mail_contents
 
 # make sure the directory exists
 mkdir -p $TMP/$PROG
 
-trap "rm -f $controllers $files $allmd5s $listp $listp.failed $listb $listb.failed $tmp $ponly $bonly $report $index_content; rmdir $TMP/$PROG" EXIT INT QUIT
+trap "rm -f $controllers.[pb] $files.[pb] $allmd5s.[pb] $list.[pb] $out.[pb] $list.[pb].failed $only.[pb] $report $index_content; rmdir $TMP/$PROG" EXIT INT QUIT
 
 # First argument is the exit code to use when a directory does not exist.
 function checkmd5 {
-    find . -maxdepth 1 -type d | grep -v '^\.$' > $controllers
+    find . -maxdepth 1 -type d | grep -v '^\.$' | sort > $controllers.$1
     while read d ;do
-        pushd $d > /dev/null || exit $1
-        ls | grep md5 | grep -v DUPLICATE__NAME > $files
-        > $allmd5s
+        pushd $d > /dev/null || exit $2
+        ls | grep md5 | grep -v DUPLICATE__NAME > $files.$1
+        > $allmd5s.$1
         while read f ;do
             if [ -s $f ]; then
-                cat $f >> $allmd5s
+                cat $f >> $allmd5s.$1
             else
                 echo "FAIL: Empty .md5 file: $d/$f"
             fi
-        done < $files
-        if [ -s $allmd5s ] ;then
-            md5sum --check --warn $allmd5s | sed 's;^;'$d/';'
+        done < $files.$1
+        if [ -s $allmd5s.$1 ] ;then
+            cat $allmd5s.$1 | sed -r 's;(^[0-9a-f]+)  (.+);\1  '$d/'\2;' >> $list.$1
+            md5sum --check --warn $allmd5s.$1 | sed 's;^;'$d/';'
         fi 
         popd >/dev/null
-    done < $controllers
+    done < $controllers.$1
 }
 
 log_init $(basename $0) $LOGSDIR/$(basename $0)
@@ -88,38 +87,40 @@ echo "start-$(timestamp)"
 > $index_content
 
 # primary archive
-> $listp
+> $out.p
 if cd $primary ;then
-    checkmd5 5 | sort > $listp
+    checkmd5 p 5 > $out.p 2>&1 &
 fi
 
 # backup location
-> $listb
+> $out.b
 if cd $backup ;then
-    checkmd5 6 | sort > $listb
+    checkmd5 b 6 > $out.b 2>&1 &
 fi
+
+wait
 
 let ret=0
 
 # Construct the report file
 > $report
 
-grep FAIL $listp > $listp.failed
-if [ -s $listp.failed ] ;then
-    (echo "* In $primary: The calculated MD5 of the following entries failed to match the stored MD5"
-     cat $listp.failed | sed 's;^\.;'$primary';'; echo) >> $report
-elif [ -s $listp -a ! -s $listp.failed ] ;then
+grep -E "(^md5sum: |FAIL)" $out.p > $list.p.failed
+if [ -s $list.p.failed ] ;then
+    (echo "* In $primary: the calculated MD5 of the following entries failed to match the stored MD5"
+     cat $list.p.failed | sed 's;^\.;'$primary';'; echo) >> $report
+elif [ -s $out.p -a ! -s $list.p.failed ] ;then
     :
 else
     echo "Primary list is empty - is $primary mounted?" >> $report
     ret=7
 fi
 
-grep FAIL $listb > $listb.failed
-if [ -s $listb.failed ] ;then
-    (echo "* In $backup: The calculated MD5 of the following entries failed to match the stored MD5"
-     cat $listb.failed | sed 's;^\.;'$backup';'; echo) >> $report
-elif [ -s $listb -a ! -s $listb.failed ] ;then
+grep -E "(^md5sum: |FAIL)" $out.b > $list.b.failed
+if [ -s $list.b.failed ] ;then
+    (echo "* In $backup: the calculated MD5 of the following entries failed to match the stored MD5"
+     cat $list.b.failed | sed 's;^\.;'$backup';'; echo) >> $report
+elif [ -s $out.b -a ! -s $list.b.failed ] ;then
     :
 else
     echo "Backup list is empty - is $backup mounted?" >> $report
@@ -133,17 +134,17 @@ fi
 # will be empty.
 
 if [[ $ret == 0 ]] ;then
-    comm -13 $listp $listb > $bonly
-    comm -23 $listp $listb > $ponly
+    comm -23 --nocheck-order $list.p $list.b > $only.p
+    comm -13 --nocheck-order $list.p $list.b > $only.b
 
-    if [ -s $ponly ] ;then
+    if [ -s $only.p ] ;then
         (echo "* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.";
-         cat $ponly | sed 's;^\.;'$primary';') >> $report
+         cat $only.p | sed 's;^\.;'$primary';') >> $report
     fi
 
-    if [ -s $bonly ] ;then
-        (echo "* Files that exist only in backup directory - this should not happen.";
-         cat $bonly | sed 's;^\.;'$backup';') >> $report
+    if [ -s $only.b ] ;then
+        (echo "* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.";
+         cat $only.b | sed 's;^\.;'$backup';') >> $report
     fi
 fi
 


### PR DESCRIPTION
In an attempt to speed up the verification process we have parallelized
the checks of the archive (primary) and the backup directories.

In addition, instead of comparing the output of the md5sum commands, we
compare the content of the combined md5sum files (which are kept in
sorted order by making sure the list of controllers is sorted before
processing, and leveraging "ls"'s sorted output.