### PR TITLE
Replace use of sed with a JSON payload generator

### DIFF
--- a/server/pbench/bin/pbench-gen-json-payload
+++ b/server/pbench/bin/pbench-gen-json-payload
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import sys
+import json
+
+with open(sys.argv[4], "r") as fp:
+    text = fp.read()
+
+doc = {
+    "@timestamp": sys.argv[1],
+    "name": sys.argv[2],
+    "doctype": sys.argv[3],
+    "text": text
+}
+
+json.dump(doc, sys.stdout, indent=4)
+
+sys.exit(0)

--- a/server/pbench/bin/pbench-report-status
+++ b/server/pbench/bin/pbench-report-status
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 prog=$(basename $0)
+dir=$(dirname $0)
 
 function usage() {
     echo "Usage: $prog --name <name> --timestamp <ts> --type status|error <file-to-index>"
@@ -76,31 +77,13 @@ datestamp=${timestamp%-*}
 index=$(getconf.py index_prefix Settings)."$name"."$datestamp"
 md5=$(md5sum $file | cut -d' ' -f1)
 
-# Translate newlines to spaces and translate tildes which are used as
-# sed delimiters below to double underscores - otherwise the sed below
-# gets very confused.  It would be ideal if we could send the textfile
-# as an attachment. Recent ES versions have a plugin for that, but the
-# production ES is old and does not support it. We'll revisit this
-# when we update ES.
-text=$(cat $file | sed 's/~/__/g' | tr '\n' ' ')
-
 tmp=/tmp/$prog.$$
 
 trap "rm -rf $tmp" EXIT QUIT INT
 
 mkdir $tmp
 
-echo '
-{
-    "@timestamp": %timestamp%,
-    "name": %name%,
-    "doctype": %type%,
-    "text": %text%
-}' |
-sed 's/%timestamp%/"'$timestamp'"/
-     s/%name%/"'$name'"/
-     s/%type%/"'$doctype'"/
-     s~%text%~"'"$text"'"~' > ${tmp}/payload
+$dir/pbench-gen-json-payload $timestamp $name $doctype $file > ${tmp}/payload
 
 curl -XPOST -H 'Content-Type: application/json' "http://$server/$index/$doctype/$md5" --data @"${tmp}/payload" >> ${tmp}/log 2>&1
 status=$?


### PR DESCRIPTION
Ran into:

```
    /opt/pbench-server/bin/pbench-report-status: line 103:        /bin/sed: Argument list too long
```

We use a simple python script to properly generate the JSON payload, escaping the file contents so that we always have valid data.