### PR TITLE
Fixes for two bugs discovered when deploying the server

### DIFF
--- a/server/pbench/bin/gold/test-12.txt
+++ b/server/pbench/bin/gold/test-12.txt
@@ -23,7 +23,6 @@
 /var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
 /var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller
 /var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/TODO
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/TODO/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
 /var/tmp/pbench-test-server/pbench-local/logs
 /var/tmp/pbench-test-server/pbench-local/quarantine
 /var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001

--- a/server/pbench/bin/pbench-server-prep-shim-001
+++ b/server/pbench/bin/pbench-server-prep-shim-001
@@ -229,6 +229,19 @@ while read tblink ;do
         continue
     fi
 
+    # Remove the link from the reception area.  rm -f returns the same
+    # exit status as rm, except in the case when $tblink does not
+    # exist.
+    rm -f $tblink
+    sts=$?
+    if [ $sts -ne 0 ] ;then
+        echo "$TS: Error: \"rm -f $tblink\", status $sts" |
+            tee -a $status >&4
+        nerrs=$nerrs+1
+        # this will continue to give errors every time through
+        # so we need a better solution
+    fi
+
     pushd $dest/TODO > /dev/null
     ln -s $dest/$(basename $tb) .
     sts=$?

--- a/server/pbench/bin/pbench-sync-package-tarballs
+++ b/server/pbench/bin/pbench-sync-package-tarballs
@@ -5,7 +5,12 @@
 # WARNING; Do not put anything in here that will pollute the
 # standard output!
 
-export CONFIG=${CONFIG:-/opt/pbench-server/lib/config/pbench-server.cfg}
+# This script is invoked remotely from a master server. Since it is
+# not invoked from cron, it can not get access to the server config
+# file through the CONFIG setting in the crontab.  But it does need
+# access to the server config file, so make sure that CONFIG is set
+# here and points to the server config file.
+export CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
 
 # load common things
 opts=$SHELLOPTS


### PR DESCRIPTION
Fixes issue #875.

Deploying v0.51 servers uncovered two bugs:

- pbench-server-prep-shim-001: the script processes tarballs that are
  sent by a version-001 agent. The latter creates a
  TODO/tarball.tar.xz link to signal that the tarball is ready to be
  processed. The shim should remove that link after processing, but it
  does not. Consequently, it encounters that link on every future
  iteration and complains about it.

  The fix is to remove the link. The only problem that might arise is
  if the link removal fails: in that case, the script complains but
  since it cannot remove it, it will continue encountering it and
  complaining about it.

- pbench-sync-package-tarballs: this script is called (remotely on a
  satellite server) by pbench-sync-satellite. The script set its
  config file like this:

    export CONFIG=${CONFIG:-/opt/pbench-server/lib/config/pbench-server.cfg}

  If CONFIG is not set when the script is invoked, this will do the
  right thing. Unfortunately, if an agent has been installed, the
  /etc/profile.d that it installed is sourced and it sets CONFIG to
  point to the agent config file, which breaks things.

  The fix is to set it unconditionally in pbench-sync-package-tarballs:

    export CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg