### PR TITLE
Properly initialize the benchmark iteration file

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-20.txt
@@ -8,6 +8,7 @@ python-pandas
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/fio_test-06_1900.01.01T00.00.00.iterations
 /var/tmp/pbench-test-bench/pbench/tools-default
 /var/tmp/pbench-test-bench/pbench/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench/tools-default/sar

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -416,6 +416,7 @@ function fio_process_options() {
 		benchmark_run_dir="$run_dir"
 	fi
 	benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
+	> ${benchmark_iterations}
 
 	verify_tool_group $tool_group
 }

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -405,6 +405,7 @@ else
 fi
 # we'll record the iterations in this file
 benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
+> ${benchmark_iterations}
 mdlog=${benchmark_run_dir}/metadata.log
 
 function record_iteration {

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -122,6 +122,7 @@ benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 
 # we'll record the iterations in this file
 benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
+> ${benchmark_iterations}
 mdlog=${benchmark_run_dir}/metadata.log
 
 # make the run dir available to the user script
@@ -168,7 +169,6 @@ pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_r
 
 echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"
-echo $iteration >> $benchmark_iterations
 
 SECONDS=0
 $benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt


### PR DESCRIPTION
We also ensure that only one iteration is tracked for user-benchmark.

Fixes #879.