### PR TITLE
Fix indexing work to improve error handling

### DIFF
--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.10
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 514, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.result-data.2018-02-02 5
 Index:  pbench-unittests.run.2018-02 47
 Index:  pbench-unittests.tool-data-iostat.2018-02-02 120
@@ -7511,6 +7514,7 @@ len(actions) = 50
         "_type": "pbench-tool-data-pidstat"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 514, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.10 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.11
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 46, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.result-data.2018-02-01 3
 Index:  pbench-unittests.run.2018-02 28
 Index:  pbench-unittests.tool-data-iostat.2018-02-01 15
@@ -3846,6 +3849,7 @@ len(actions) = 33
         "_type": "pbench-tool-data-iostat"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 46, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.11 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.12
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 42397, duplicates: 2254, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.run.2018-02 56
 Index:  pbench-unittests.tool-data-iostat.2018-02-05 36
 Index:  pbench-unittests.tool-data-pidstat.2018-02-05 1554
@@ -2948,6 +2951,7 @@ len(actions) = 60
         "_type": "pbench-tool-data-iostat"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 42397, duplicates: 2254, failures: 0, retries: 0)
 --- Finished indexing for test-7.12 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.4.txt
+++ b/server/pbench/bin/gold/test-7.4.txt
@@ -1,4 +1,8 @@
 +++ Running indexing for test-7.4
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+      done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Bad hostname in sosreport:  The sosreport did not collect a hostname other than 'localhost'
 --- Finished indexing for test-7.4 (status=10)
 +++ pbench tree state

--- a/server/pbench/bin/gold/test-7.5.txt
+++ b/server/pbench/bin/gold/test-7.5.txt
@@ -1,4 +1,8 @@
 +++ Running indexing for test-7.5
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+      done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Bad hostname in sosreport:  The sosreport did not collect a hostname other than 'localhost'
 --- Finished indexing for test-7.5 (status=10)
 +++ pbench tree state

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.6
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 5, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.run.2015-09 5
 len(actions) = 5
 [
@@ -120,6 +123,7 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 5, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.6 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.7
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 5, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.run.2015-09 5
 len(actions) = 5
 [
@@ -120,6 +123,7 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 5, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.7 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.8
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 11778, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.result-data.2016-10-06 3
 Index:  pbench-unittests.run.2016-10 63
 Index:  pbench-unittests.tool-data-iostat.2016-10-06 27
@@ -45803,6 +45806,7 @@ len(actions) = 48
         "_type": "pbench-tool-data-iostat"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 11778, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.8 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -1,5 +1,8 @@
 +++ Running indexing for test-7.9
-	done (end ts: 1900-01-01T00:00:00-UTC, duration: 0.00s, success: 3144, duplicates: 0, failures: 0)
+Template:  pbench-unittests.run
+Template:  pbench-unittests.tool-data-iostat
+Template:  pbench-unittests.tool-data-pidstat
+	done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3, retries: 0)
 Index:  pbench-unittests.run.2017-04 24
 Index:  pbench-unittests.tool-data-iostat.2017-04-21 60
 Index:  pbench-unittests.tool-data-pidstat.2017-04-21 3060
@@ -1726,6 +1729,7 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     }
 ]
+	done indexing (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 3144, duplicates: 0, failures: 0, retries: 0)
 --- Finished indexing for test-7.9 (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-server/pbench

--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from elasticsearch import VERSION as es_VERSION, Elasticsearch
 
-from pbench import es_index
+from pbench import tstos, es_index, es_put_template
 
 
 _VERSION_ = "0.2.0.0"
@@ -33,8 +33,10 @@ _DEBUG    = 0
 # global - defaults to normal dict, ordered dict for unittests
 _dict_const = dict
 
-# 30 second timeout talking to Elasticsearch
-_read_timeout = 30
+# 100,000 minute timeout talking to Elasticsearch; basically we just don't
+# want to timeout waiting for Elasticsearch and then have to retry, as that
+# can add undue burden to the Elasticsearch cluster.
+_read_timeout = 100000*60
 
 # All indexing uses "create" (instead of "index") to avoid updating
 # existing records, allowing us to detect duplicates.
@@ -112,16 +114,12 @@ def fetch_mapping(mapping_fn):
         raise MappingFileError("Invalid mapping file: %s" % mapping_fn)
     return keys[0], mapping
 
-def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config):
+def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config, dbg=0):
     """Load the various Elasticsearch index templates required by pbench.
 
     We first load the pbench-run index templates, and then we construct and
     load the templates for each tool data index.
     """
-    if not es:
-        # Don't do anything if we don't have an Elasticsearch client object.
-        return
-
     index_settings = _dict_const(
         gateway=_dict_const(
             local=_dict_const(
@@ -181,7 +179,7 @@ def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config):
     for toolname,frag in tool_mapping_frags.items():
         tool_skel = copy.deepcopy(skel)
         tool_skel['properties'][toolname] = frag
-        tool_mapping = _dict_const(("pbench-tool-data-%s" % toolname, tool_skel))
+        tool_mapping = _dict_const([("pbench-tool-data-%s" % toolname, tool_skel)])
         tool_template_body = _dict_const(
             template='%s.tool-data-%s.*' % (INDEX_PREFIX, toolname),
             settings=index_settings,
@@ -192,7 +190,7 @@ def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config):
     results_mappings = _dict_const()
     for mapping_fn in glob.iglob(os.path.join(MAPPING_DIR, "result-*.json")):
         key, mapping = fetch_mapping(mapping_fn)
-        if options.debug_unittest:
+        if dbg > 0:
             print("fetch_mapping: {}".format(key))
             from pprint import pprint;
             pprint(mapping)
@@ -204,25 +202,26 @@ def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config):
         settings=index_settings,
         mappings=results_mappings)
 
-    if not es:
-        # Don't do anything if we don't have an Elasticsearch client object.
-        print(run_template_name, json.dumps(run_template_body, indent=4, sort_keys=True))
-        for name, body in tool_templates:
-            print(name, json.dumps(body, indent=4, sort_keys=True))
-        return
-
     # FIXME: We should query to see if a template exists, and only
     # create it if it does not, or if the version of it is older than
     # expected.
     try:
         # Pbench Run template
-        res = es.indices.put_template(name=run_template_name, body=run_template_body)
+        beg, end, retries = es_put_template(es, name=run_template_name, body=run_template_body)
+        successes = 1
         # Pbench Tool Data templates
         for name, body in tool_templates:
             tool_template_name = '%s.tool-data-%s' % (INDEX_PREFIX,name)
-            res = es.indices.put_template(name=tool_template_name, body=body)
+            _, end, retry_count = es_put_template(es, name=tool_template_name, body=body)
+            retries += retry_count
+            successes += 1
     except Exception as e:
         raise TemplateError(e)
+    else:
+        print("\tdone templates (end ts: %s, duration: %.2fs,"
+                " successes: %d, retries: %d)" % (
+            tstos(end), end - beg, successes, retries))
+        sys.stdout.flush()
 
 
 ###########################################################################
@@ -1821,7 +1820,7 @@ def main(options, args):
 
         # Create the various index templates
         if options.debug_time_operations: ts("es_template")
-        es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config)
+        es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config, dbg=_DEBUG)
 
         # returns 0 or 1
         if options.indexing_errors:
@@ -1831,6 +1830,12 @@ def main(options, args):
         with open(ie_filename, "w") as fp:
             if options.debug_time_operations: ts("es_index")
             res = es_index(es, actions, fp, dbg=_DEBUG)
+            beg, end, successes, duplicates, failures, retries = res
+            print("\tdone indexing (end ts: %s, duration: %.2fs,"
+                    " successes: %d, duplicates: %d, failures: %d, retries: %d)" % (
+                tstos(end), end - beg, successes, duplicates, failures, retries))
+            sys.stdout.flush()
+            res = 1 if failures > 0 else 0
 
     except ConfigFileNotSpecified as e:
         print(e, file=sys.stderr)

--- a/server/pbench/lib/pbench/__init__.py
+++ b/server/pbench/lib/pbench/__init__.py
@@ -2,14 +2,15 @@
 Simple module level convenience functions.
 """
 
-import sys, os, time, json, errno, logging
+import sys, os, time, json, errno, logging, math
 
 from random import SystemRandom
 from collections import Counter, deque
+from urllib3 import exceptions as ul_excs
 try:
-    from elasticsearch1 import VERSION as es_VERSION, helpers
+    from elasticsearch1 import VERSION as es_VERSION, helpers, exceptions as es_excs
 except ImportError:
-    from elasticsearch import VERSION as es_VERSION, helpers
+    from elasticsearch import VERSION as es_VERSION, helpers, exceptions as es_excs
 
 
 def tstos(ts=None):
@@ -23,6 +24,69 @@ def calc_backoff_sleep(backoff):
     global _r
     b = math.pow(2, backoff)
     return _r.uniform(0, min(b, _MAX_SLEEP_TIME))
+
+
+class MockPutTemplate(object):
+    def __init__(self):
+        self.name = None
+
+    def put_template(self, *args, **kwargs):
+        assert 'name' in kwargs and 'body' in kwargs
+        name = kwargs['name']
+        if self.name is None:
+            self.name = name
+        else:
+            assert self.name == name
+        #print(name, json.dumps(kwargs['body'], indent=4, sort_keys=True))
+        return None
+
+    def report(self):
+        print("Template: ", self.name)
+
+
+def es_put_template(es, name=None, body=None):
+    assert name is not None and body is not None
+    if not es:
+        mock = MockPutTemplate()
+        def _ts():
+            return 0
+        _do_ts = _ts
+        _put_template = mock.put_template
+    else:
+        mock = None
+        _do_ts = time.time
+        _put_template = es.indices.put_template
+        # FIXME: we should just change these two loggers to write to a
+        # file instead of setting the logging level up so high.
+        logging.getLogger("urllib3").setLevel(logging.FATAL)
+        logging.getLogger("elasticsearch1").setLevel(logging.FATAL)
+
+    retry = True
+    retry_count = 0
+    backoff = 1
+    beg, end = _do_ts(), None
+    while retry:
+        try:
+            _put_template(name=name, body=body)
+        except es_excs.TransportError as exc:
+            # Only retry on certain 500 errors
+            if not exc.status in [500, 503, 504]:
+                raise
+            time.sleep(calc_backoff_sleep(backoff))
+            backoff += 1
+            retry_count += 1
+        except es_excs.ConnectionError as exc:
+            # We retry all connection errors
+            time.sleep(calc_backoff_sleep(backoff))
+            backoff += 1
+            retry_count += 1
+        else:
+            retry = False
+    end = _do_ts()
+
+    if mock:
+        mock.report()
+    return beg, end, retry_count
 
 
 class MockStreamingBulk(object):
@@ -51,6 +115,7 @@ class MockStreamingBulk(object):
                 ok = False
             else:
                 # For now, all other docs are considered successful
+                resp[action['_op_type']]['status'] = 200
                 ok = True 
             yield ok, resp
 
@@ -71,21 +136,29 @@ class MockStreamingBulk(object):
         print(json.dumps(self.actions_l, indent=4, sort_keys=True))
 
 
+# Always use "create" operations, as we also ensure each JSON document being
+# indexed has an "_id" field, so we can tell when we are indexing duplicate
+# data.
 _op_type = "create"
+# 100,000 minute timeout talking to Elasticsearch; basically we just don't
+# want to timeout waiting for Elasticsearch and then have to retry, as that
+# can add undue burden to the Elasticsearch cluster.
 _request_timeout = 100000*60.0
 
 def es_index(es, actions, errorsfp, dbg=0):
     """
     Now do the indexing specified by the actions.
     """
+    global tstos
     if not es:
         # If we don't have an Elasticsearch client object, we assume this is
         # for unit tests or debugging, so we'll use our mocked out streaming
         # bulk method.
         mock = MockStreamingBulk(15)
         streaming_bulk = mock.our_streaming_bulk
-        def tstos(*args):
-            return "1900-01-01T00:00:00-UTC"
+        def _tstos(*args):
+            return "1970-01-01T00:00:00-UTC"
+        tstos = _tstos
         def _ts():
             return 0
         _do_ts = _ts
@@ -93,14 +166,20 @@ def es_index(es, actions, errorsfp, dbg=0):
         mock = None
         streaming_bulk = helpers.streaming_bulk
         _do_ts = time.time
+        # FIXME: we should just change these two loggers to write to a
+        # file instead of setting the logging level up so high.
+        logging.getLogger("urllib3").setLevel(logging.FATAL)
+        logging.getLogger("elasticsearch1").setLevel(logging.FATAL)
 
-    # FIXME: we should just change these two loggers to write to a
-    # file instead of setting the logging level up so high.
-    logging.getLogger("urllib3").setLevel(logging.FATAL)
-    logging.getLogger("elasticsearch1").setLevel(logging.FATAL)
-
+    # These need to be defined before the closure below. These work because
+    # a closure remembers the binding of a name to an object. If integer
+    # objects were used, the name would be bound to that integer value only
+    # so for the retries, incrementing the integer would change the outer
+    # scope's view of the name.  By using a Counter object, the name to
+    # object binding is maintained, but the object contents are changed.
     actions_deque = deque()
     actions_retry_deque = deque()
+    retries_tracker = Counter()
 
     def actions_tracking_closure(cl_actions):
         for cl_action in cl_actions:
@@ -116,6 +195,7 @@ def es_index(es, actions, errorsfp, dbg=0):
             backoff = 1
             while len(actions_retry_deque) > 0:
                 time.sleep(calc_backoff_sleep(backoff))
+                retries_tracker['retries'] += 1
                 retry_actions = []
                 # First drain the retry deque entirely so that we know when we
                 # have cycled through the entire list to be retried.
@@ -130,11 +210,6 @@ def es_index(es, actions, errorsfp, dbg=0):
                 backoff += 1
 
     beg, end = _do_ts(), None
-
-    if dbg > 0:
-        print("\tbulk index (beg ts: %s) ..." % tstos(beg))
-        sys.stdout.flush()
-
     successes = 0
     duplicates = 0
     failures = 0
@@ -146,26 +221,36 @@ def es_index(es, actions, errorsfp, dbg=0):
             es, generator, raise_on_error=False,
             raise_on_exception=False, request_timeout=_request_timeout)
 
-    for ok, resp in streaming_bulk_generator:
+    for ok, resp_payload in streaming_bulk_generator:
         retry_count, action = actions_deque.popleft()
-        assert action['_id'] == resp[_op_type]['_id']
+        try:
+            resp = resp_payload[_op_type]
+            status = resp['status']
+        except KeyError as e:
+            assert not ok
+            # resp is not of expected form
+            print(resp)
+            status = 999
+        else:
+            assert action['_id'] == resp['_id']
         if ok:
             successes += 1
         else:
-            if resp[_op_type]['status'] == 409:
+            if status == 409:
                 if retry_count == 0:
                     # Only count duplicates if the retry count is 0 ...
                     duplicates += 1
                 else:
                     # ... otherwise consider it successful.
                     successes += 1
-            elif resp[_op_type]['status'] == 400:
+            elif status == 400:
                 jsonstr = json.dumps({ "action": action, "ok": ok, "resp": resp, "retry_count": retry_count, "timestamp": tstos(_do_ts()) }, indent=4, sort_keys=True)
                 print(jsonstr, file=errorsfp)
                 errorsfp.flush()
                 failures += 1
             else:
                 # Retry all other errors
+                print(resp)
                 actions_retry_deque.append((retry_count + 1, action))
 
     end = _do_ts()
@@ -173,13 +258,7 @@ def es_index(es, actions, errorsfp, dbg=0):
     assert len(actions_deque) == 0
     assert len(actions_retry_deque) == 0
 
-    print("\tdone (end ts: %s, duration: %.2fs,"
-            " success: %d, duplicates: %d, failures: %d)" % (
-        tstos(end), end - beg, successes, duplicates, failures))
-    sys.stdout.flush()
-
     if mock:
         mock.report()
 
-    return failures
-
+    return (beg, end, successes, duplicates, failures, retries_tracker['retries'])


### PR DESCRIPTION
We fix the default "read timeout" to be very large so that we don't
timeout prematurely and retry needlessly for template operations.

We have enhanced the error handling so that we don't always assume we
get a response object, and we dump out error messages that are
unexpected for now.

We also add the new es_put_template wrapper which properly handles the
retries.