### PR TITLE
Attempt to ensure unit tests pass in all env

### DIFF
--- a/server/pbench/bin/index-pbench
+++ b/server/pbench/bin/index-pbench
@@ -210,7 +210,7 @@ def es_template(es, options, INDEX_PREFIX, INDEX_VERSION, config, dbg=0):
         beg, end, retries = es_put_template(es, name=run_template_name, body=run_template_body)
         successes = 1
         # Pbench Tool Data templates
-        for name, body in tool_templates:
+        for name, body in sorted(tool_templates):
             tool_template_name = '%s.tool-data-%s' % (INDEX_PREFIX,name)
             _, end, retry_count = es_put_template(es, name=tool_template_name, body=body)
             retries += retry_count


### PR DESCRIPTION
It is not sufficient to use an OrderedDict in all cases to get passing
unittests in different environments, because accessing the list of
files via the file system can also yield a non-alphabetical order of
the tool names.

We just have sort the templates by tool name before we invoke the
template creation method.