### PR TITLE
pbench-copy-sosreports: fix the wrong state transition name

### DIFF
--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -48,7 +48,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-UNPACK --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=TO-BACKUP --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=BAD-MD5 --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=TO-COPY-SOS --exclude=COPIED-SOS --exclude=TO-BACKUP --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 --- test-execution.log file contents
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{

--- a/server/pbench/bin/gold/test-6.5.txt
+++ b/server/pbench/bin/gold/test-6.5.txt
@@ -53,7 +53,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-UNPACK --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=TO-BACKUP --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=BAD-MD5 --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=TO-COPY-SOS --exclude=COPIED-SOS --exclude=TO-BACKUP --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 --- test-execution.log file contents
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{

--- a/server/pbench/bin/gold/test-6.6.txt
+++ b/server/pbench/bin/gold/test-6.6.txt
@@ -48,7 +48,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-UNPACK --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=TO-BACKUP --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=BAD-MD5 --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=TO-COPY-SOS --exclude=COPIED-SOS --exclude=TO-BACKUP --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 --- test-execution.log file contents
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -39,7 +39,7 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:
 --- pbench log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=TO-UNPACK --exclude=TO-COPY-SOS --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=TO-BACKUP --exclude=INDEXED --exclude=WONT-INDEX --exclude=DONE --exclude=BAD-MD5 --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
+/var/tmp/pbench-test-server/test-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/rsync -va --stats --exclude=TODO --exclude=BAD-MD5 --exclude=TO-UNPACK --exclude=UNPACKED --exclude=MOVED-UNPACKED --exclude=TO-SYNC --exclude=SYNCED --exclude=TO-LINK --exclude=TO-INDEX --exclude=INDEXED --exclude=WONT-INDEX --exclude=TO-COPY-SOS --exclude=COPIED-SOS --exclude=TO-BACKUP --exclude=SATELLITE-MD5-PASSED --exclude=SATELLITE-MD5-FAILED --exclude=TO-DELETE --exclude=SATELLITE-DONE /var/tmp/pbench-test-server/pbench/archive/fs-version-001/ /var/tmp/pbench-test-server/pbench/archive.backup
 --- test-execution.log file contents
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -89,9 +89,17 @@ fi
 export mail_recipients=$(getconf.py mailto pbench-server)
 
 # make all the state directories for the pipeline and any others needed
-LINKDIRS="TODO TO-UNPACK TO-COPY-SOS TO-SYNC SYNCED TO-LINK TO-INDEX TO-BACKUP \
-	INDEXED WONT-INDEX DONE BAD-MD5 SATELLITE-MD5-PASSED SATELLITE-MD5-FAILED \
-	TO-DELETE SATELLITE-DONE TO-UNPACK UNPACKED MOVED-UNPACKED"
+# every related state directories are paired together with their
+# final state at the end
+LINKDIRS="TODO BAD-MD5 \
+    TO-UNPACK UNPACKED MOVED-UNPACKED  \
+    TO-SYNC SYNCED \
+    TO-LINK \
+    TO-INDEX INDEXED WONT-INDEX \
+    TO-COPY-SOS COPIED-SOS \
+    TO-BACKUP \
+    SATELLITE-MD5-PASSED SATELLITE-MD5-FAILED \
+    TO-DELETE SATELLITE-DONE"
 
 # list of the state directories which will be excluded during rsync
 EXCLUDE_DIRS="$LINKDIRS WONT-INDEX*"

--- a/server/pbench/bin/pbench-copy-sosreports
+++ b/server/pbench/bin/pbench-copy-sosreports
@@ -62,11 +62,11 @@ test -d $INCOMING || doexit "Bad INCOMING=$INCOMING"
 # make sure only one copy is running.
 # Use 'flock -n $LOCKFILE /home/pbench/bin/pbench-unpack-tarballs' in the
 # crontab to ensure that only one copy is running. The script itself
-# does not use any locking. 
+# does not use any locking.
 
 # the link source and destination for this script
 linksrc=TO-COPY-SOS
-linkdest=TO-INDEX
+linkdest=COPIED-SOS
 
 if [ "$SOSREPORTDEST" == "" ]; then
     _sosrpt_user=$(getconf.py user sosreports)
@@ -100,7 +100,7 @@ for result in $list ;do
         nerrs=$nerrs+1
         continue
     fi
-       
+
     resultname=$(basename $result)
     resultname=${resultname%.tar.xz}
     hostname=$(basename $(dirname $link))
@@ -166,7 +166,7 @@ for result in $list ;do
         fi
         popd > /dev/null
     fi
-    
+
     # move the link to $linkdest directory
     mv $result $(echo $result | sed "s/$linksrc/$linkdest/")
     sts=$?


### PR DESCRIPTION
Fixes #907 

This PR will add the missing state transition for copy-sos-reports
i.e `COPIED-SOS`. 

It will also remove the `DONE` state transition because it is not being used by any server scripts, not anymore. There was a duplicate `TO-UNPACK` state transition name, that is also removed now.
