### PR TITLE
pbench-report-status: snip off the -UTC part of the timestamp

### DIFF
--- a/server/pbench/bin/gold/test-12.txt
+++ b/server/pbench/bin/gold/test-12.txt
@@ -43,7 +43,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "run-1900-01-01T00:00:00-UTC: processed /var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz\nrun-1900-01-01T00:00:00-UTC: Processed 1 entries, 1 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-server-prep-shim-001", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-13.txt
+++ b/server/pbench/bin/gold/test-13.txt
@@ -39,7 +39,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "run-1900-01-01T00:00:00-UTC: processed /var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz\nrun-1900-01-01T00:00:00-UTC: Processed 1 entries, 1 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-server-prep-shim-002", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-14.txt
+++ b/server/pbench/bin/gold/test-14.txt
@@ -40,7 +40,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "run-1900-01-01T00:00:00-UTC: Processed 1 entries, 0 tarballs successful, 1 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-server-prep-shim-001", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-15.txt
+++ b/server/pbench/bin/gold/test-15.txt
@@ -39,7 +39,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "run-1900-01-01T00:00:00-UTC: Processed 1 entries, 0 tarballs successful, 1 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-server-prep-shim-002", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-3.txt
+++ b/server/pbench/bin/gold/test-3.txt
@@ -45,7 +45,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-index", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-4.txt
+++ b/server/pbench/bin/gold/test-4.txt
@@ -48,7 +48,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-index", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -50,7 +50,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-index.run-1900-01-01T00:00:00-UTC(unit-test) - Indexed 0 results\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-index", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -53,7 +53,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n\nNumber of files: 6\nNumber of files transferred: 0\nTotal file size: # bytes\nTotal transferred file size: # bytes\nLiteral data: # bytes\nMatched data: # bytes\nFile list size: #\nFile list generation time: #.### seconds\nFile list transfer time: #.### seconds\nTotal bytes sent: #\nTotal bytes received: #\n\nsent # bytes  received # bytes  #.### bytes/sec\ntotal size is #  speedup is #.##\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-6.5.txt
+++ b/server/pbench/bin/gold/test-6.5.txt
@@ -58,7 +58,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n\nNumber of files: 6\nNumber of files transferred: 4\nTotal file size: # bytes\nTotal transferred file size: # bytes\nLiteral data: # bytes\nMatched data: # bytes\nFile list size: #\nFile list generation time: #.### seconds\nFile list transfer time: #.### seconds\nTotal bytes sent: #\nTotal bytes received: #\n\nsent # bytes  received # bytes  #.### bytes/sec\ntotal size is #  speedup is #.##\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-6.6.txt
+++ b/server/pbench/bin/gold/test-6.6.txt
@@ -53,7 +53,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n\nNumber of files: 6\nNumber of files transferred: 0\nTotal file size: # bytes\nTotal transferred file size: # bytes\nLiteral data: # bytes\nMatched data: # bytes\nFile list size: #\nFile list generation time: #.### seconds\nFile list transfer time: #.### seconds\nTotal bytes sent: #\nTotal bytes received: #\n\nsent # bytes  received # bytes  #.### bytes/sec\ntotal size is #  speedup is #.##\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -44,7 +44,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n\nNumber of files: 1\nNumber of files transferred: 0\nTotal file size: # bytes\nTotal transferred file size: # bytes\nLiteral data: # bytes\nMatched data: # bytes\nFile list size: #\nFile list generation time: #.### seconds\nFile list transfer time: #.### seconds\nTotal bytes sent: #\nTotal bytes received: #\n\nsent # bytes  received # bytes  #.### bytes/sec\ntotal size is #  speedup is #.##\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-9.1.txt
+++ b/server/pbench/bin/gold/test-9.1.txt
@@ -35,7 +35,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-verify-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -33,7 +33,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.\n4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-verify-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -33,7 +33,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.\n4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-verify-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -35,7 +35,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n* In /var/tmp/pbench-test-server/pbench/archive/fs-version-001: the calculated MD5 of the following entries failed to match the stored MD5\nmd5sum: WARNING: 1 computed checksum did NOT match\n/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED\n\n* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.\n5fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.\n4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-verify-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -35,7 +35,7 @@
 +++ test-curl-payload.log file contents
 /var/tmp/pbench-test-server/test-curl-payload.log:{
 /var/tmp/pbench-test-server/test-curl-payload.log:    "text": "pbench-verify-backup-tarballs.run-1900-01-01T00:00:00-UTC(unit-test)\n* In /var/tmp/pbench-test-server/pbench/archive.backup: the calculated MD5 of the following entries failed to match the stored MD5\nmd5sum: WARNING: 1 computed checksum did NOT match\n/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz: FAILED\n\n* Files that exist only in primary directory - extra files in this list are probably OK: they just have not been backed up yet.\n4fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n* Files that exist only in backup directory - this should only happen if a backup or primary tar ball becomes corrupted.\n3fe570aea2be3dab96b328da5a8cfcc9  ./controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz\n", 
-/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00-UTC", 
+/var/tmp/pbench-test-server/test-curl-payload.log:    "@timestamp": "1900-01-01T00:00:00", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "name": "pbench-verify-backup-tarballs", 
 /var/tmp/pbench-test-server/test-curl-payload.log:    "doctype": "status"
 /var/tmp/pbench-test-server/test-curl-payload.log:}

--- a/server/pbench/bin/pbench-report-status
+++ b/server/pbench/bin/pbench-report-status
@@ -104,7 +104,8 @@ fi
 
 md5=$(md5sum $file | cut -d' ' -f1)
 
-$dir/pbench-gen-json-payload $timestamp $name $doctype $file > ${tmp}/payload
+# drop the -UTC spec from the timestamp: the ES date parser does not like it
+$dir/pbench-gen-json-payload ${timestamp%-*} $name $doctype $file > ${tmp}/payload
 
 curl -XPOST -H 'Content-Type: application/json' "http://$server/$index/$doctype/$md5" --data @"${tmp}/payload" >> ${tmp}/log 2>&1
 status=$?


### PR DESCRIPTION
 The ES  date parser does not like it.