### PR TITLE
Fix Inconsistent reporting of missing ARCHIVE directory

### DIFF
--- a/server/pbench/bin/gold/test-2.txt
+++ b/server/pbench/bin/gold/test-2.txt
@@ -3,7 +3,6 @@
 +++ Running pbench-copy-sosreports
 --- Finished pbench-copy-sosreports (status=1)
 +++ Running pbench-index
-pbench-index: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- Finished pbench-index (status=1)
 +++ Running pbench-clean-up-dangling-results-links
 --- Finished pbench-clean-up-dangling-results-links (status=1)
@@ -21,6 +20,9 @@ pbench-index: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-
 /var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
 /var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
 /var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+/var/tmp/pbench-test-server/pbench/logs/pbench-index
+/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
+/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
@@ -30,6 +32,7 @@ pbench-index: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-
 /var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log:pbench-clean-up-dangling-results-links: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 /var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log:pbench-copy-sosreports: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 /var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log:pbench-edit-prefixes: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
+/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log:pbench-index: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:pbench-unpack-tarballs: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- pbench log file contents
 +++ test-execution.log file contents

--- a/server/pbench/bin/pbench-index
+++ b/server/pbench/bin/pbench-index
@@ -55,13 +55,15 @@ esac
 . $dir/pbench-base.sh
 ###########################################################################
 
+log_init $(basename $0) $LOGSDIR/$(basename $0)
+
 # check that all the directories exist
 test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"
 
 # make sure only one copy is running.
 # Use 'flock -n $LOCKFILE /home/pbench/bin/pbench-index' in the
 # crontab to ensure that only one copy is running. The script itself
-# does not use any locking. 
+# does not use any locking.
 
 # the link source and destination for this script
 linksrc=TO-INDEX
@@ -74,8 +76,6 @@ linkerrdest=WONT-INDEX
 TMPDIR=$TMP/pbench-index.$$
 # index-pbench need to get at it
 export TMPDIR
-
-log_init $(basename $0) $LOGSDIR/$(basename $0)
 
 echo "$TS: starting at $(timestamp)"
 
@@ -108,7 +108,7 @@ while read size result ;do
         echo $result >> $erred
         continue
     fi
-       
+
     resultname=$(basename $result)
     resultname=${resultname%.tar.xz}
     hostname=$(basename $(dirname $link))
@@ -161,7 +161,7 @@ while read size result ;do
         cat $errors_json >> $errors_json.report
         pbench-report-status --name $PROG.errors --timestamp $TS --type status $errors_json.report
     fi
-    
+
     if [ $status -ne 0 ] ;then
         # Distinguish failure cases, so we can retry the indexing easily if possible.
         # Different WONT-INDEX directories for different failures:
@@ -179,7 +179,7 @@ while read size result ;do
         fi
         continue
     fi
-    
+
     # move the link to $linkdest directory
     # echo mv $result $(echo $result | sed "s/$linksrc/$linkdest/")
     mv $result $(echo $result | sed "s/$linksrc/$linkdest/")


### PR DESCRIPTION
Fixes #870 

`pbench-index` does

`test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"`

before calling log_init; everybody else does it after calling `log_init`. This PR will fix the inconsistency.