### PR TITLE
Add support to run stockpile along with collect sysinfo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "agent/stockpile"]
+	path = agent/stockpile
+	url = https://github.com/redhat-performance/stockpile

--- a/agent/base
+++ b/agent/base
@@ -266,10 +266,19 @@ function verify_common_bench_script_options {
 
 # generate inventory file with controller and remotes
 function generate_inventory {
-    echo "[controller]"
-    echo $HOSTNAME
-    echo "[remote]"
-    ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+	local component=$1
+	if [[ $component == "stockpile" ]]; then
+		echo "[stockpile]"
+		echo $HOSTNAME
+		echo "[all]"
+		echo $HOSTNAME
+		ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+	else
+		echo "[controller]"
+		echo $HOSTNAME
+		echo "[remote]"
+		ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+	fi
 }
 
 if [[ "${_PBENCH_BENCH_TESTS}" == 1 ]] ;then

--- a/agent/bench-scripts/gold/test-benchmark-clis/test-CL.txt
+++ b/agent/bench-scripts/gold/test-benchmark-clis/test-CL.txt
@@ -10,7 +10,7 @@ Bench Script: pbench-cyclictest --help
 		-s --stress                                   run stress process on the same cpu as --cpu
 		--tool-group=str
 		--sysinfo=str,                                str= comma separated values of sysinfo to be collected
-		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-cyclictest --tool-group=bad --sysinfo=bad
 ------------
@@ -26,7 +26,7 @@ Bench Script: pbench-cyclictest --tool-group=bad --sysinfo=bad
 		-s --stress                                   run stress process on the same cpu as --cpu
 		--tool-group=str
 		--sysinfo=str,                                str= comma separated values of sysinfo to be collected
-		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-cyclictest --bad-to-the-bone 
 ------------
@@ -42,7 +42,7 @@ pbench-cyclictest --bad-to-the-bone
 		-s --stress                                   run stress process on the same cpu as --cpu
 		--tool-group=str
 		--sysinfo=str,                                str= comma separated values of sysinfo to be collected
-		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                   available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-dbench --help 
 ------------
@@ -77,7 +77,7 @@ Bench Script: pbench-dbench --help
 		                                        part of the label, just use --tool-label-pattern= to tell this script
 		                                        the prefix pattern to use for CPU information.
 		             --sysinfo=str,             str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-dbench --tool-group=bad --sysinfo=bad
 ------------
@@ -116,7 +116,7 @@ Bench Script: pbench-dbench --tool-group=bad --sysinfo=bad
 		                                        part of the label, just use --tool-label-pattern= to tell this script
 		                                        the prefix pattern to use for CPU information.
 		             --sysinfo=str,             str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-dbench --bad-to-the-bone 
 ------------
@@ -155,7 +155,7 @@ pbench-dbench --bad-to-the-bone
 		                                        part of the label, just use --tool-label-pattern= to tell this script
 		                                        the prefix pattern to use for CPU information.
 		             --sysinfo=str,             str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-fio --help 
 ------------
@@ -241,7 +241,7 @@ The following options are available:
 		set the histogram logging interval in seconds (default 10)
 
 	--sysinfo=str            str= comma separated values of sysinfo to be collected
-		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-fio --tool-group=bad --sysinfo=bad
 ------------
@@ -331,7 +331,7 @@ The following options are available:
 		set the histogram logging interval in seconds (default 10)
 
 	--sysinfo=str            str= comma separated values of sysinfo to be collected
-		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-fio --bad-to-the-bone 
 ------------
@@ -421,7 +421,7 @@ The following options are available:
 		set the histogram logging interval in seconds (default 10)
 
 	--sysinfo=str            str= comma separated values of sysinfo to be collected
-		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-iozone --help 
 ------------
@@ -438,7 +438,7 @@ Bench Script: pbench-iozone --help
 			number of iozone runs - default is 10 runs
 		--tool-group=str
 		--sysinfo=str, str= comma separated values of sysinfo to be collected
-		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-iozone --tool-group=bad --sysinfo=bad
 ------------
@@ -459,7 +459,7 @@ Bench Script: pbench-iozone --tool-group=bad --sysinfo=bad
 			number of iozone runs - default is 10 runs
 		--tool-group=str
 		--sysinfo=str, str= comma separated values of sysinfo to be collected
-		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-iozone --bad-to-the-bone 
 ------------
@@ -480,7 +480,7 @@ pbench-iozone --bad-to-the-bone
 			number of iozone runs - default is 10 runs
 		--tool-group=str
 		--sysinfo=str, str= comma separated values of sysinfo to be collected
-		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-linpack --help 
 ------------
@@ -490,7 +490,7 @@ Bench Script: pbench-linpack --help
 	       --threads=int[,int]  number of threads to use (default is num_cpus)
 	       --tool-group=str
 	       --sysinfo=str,       str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-linpack --tool-group=bad --sysinfo=bad
 ------------
@@ -504,7 +504,7 @@ Bench Script: pbench-linpack --tool-group=bad --sysinfo=bad
 	       --threads=int[,int]  number of threads to use (default is num_cpus)
 	       --tool-group=str
 	       --sysinfo=str,       str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-linpack --bad-to-the-bone 
 ------------
@@ -518,7 +518,7 @@ pbench-linpack --bad-to-the-bone
 	       --threads=int[,int]  number of threads to use (default is num_cpus)
 	       --tool-group=str
 	       --sysinfo=str,       str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-migrate --help 
 ------------
@@ -542,7 +542,7 @@ Bench Script: pbench-migrate --help
 		                                        0 = 1 migration, just to dest-host (no round-trip migration, VM ends up on dest-host).
 		                                        1 = 2 migrations, 2 = 4 migrations, etc.  VM ends up on src-host
 		--sysinfo=str,                          str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-migrate --tool-group=bad --sysinfo=bad
 ------------
@@ -570,7 +570,7 @@ Bench Script: pbench-migrate --tool-group=bad --sysinfo=bad
 		                                        0 = 1 migration, just to dest-host (no round-trip migration, VM ends up on dest-host).
 		                                        1 = 2 migrations, 2 = 4 migrations, etc.  VM ends up on src-host
 		--sysinfo=str,                          str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-migrate --bad-to-the-bone 
 ------------
@@ -598,7 +598,7 @@ pbench-migrate --bad-to-the-bone
 		                                        0 = 1 migration, just to dest-host (no round-trip migration, VM ends up on dest-host).
 		                                        1 = 2 migrations, 2 = 4 migrations, etc.  VM ends up on src-host
 		--sysinfo=str,                          str= comma separated values of sysinfo to be collected
-		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                             available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-moongen --help 
 ------------
@@ -646,7 +646,7 @@ Bench Script: pbench-moongen --help
 		             --queues-per-task=int      how many tasks queues to bind to each task (default 3)
 		             --dst-macs=mac[,mac]       list of destination mac addresses, each mac in the list corresponds to a port from the port list
 		             --sysinfo=str,             str= comma separated values of system information to be collected
-		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-moongen --tool-group=bad --sysinfo=bad
 ------------
@@ -698,7 +698,7 @@ Bench Script: pbench-moongen --tool-group=bad --sysinfo=bad
 		             --queues-per-task=int      how many tasks queues to bind to each task (default 3)
 		             --dst-macs=mac[,mac]       list of destination mac addresses, each mac in the list corresponds to a port from the port list
 		             --sysinfo=str,             str= comma separated values of system information to be collected
-		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-moongen --bad-to-the-bone 
 ------------
@@ -750,7 +750,7 @@ pbench-moongen --bad-to-the-bone
 		             --queues-per-task=int      how many tasks queues to bind to each task (default 3)
 		             --dst-macs=mac[,mac]       list of destination mac addresses, each mac in the list corresponds to a port from the port list
 		             --sysinfo=str,             str= comma separated values of system information to be collected
-		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                              available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-netperf --help 
 ------------
@@ -787,7 +787,7 @@ Bench Script: pbench-netperf --help
 		             --server-label=str             provide the pbench netperf-server tool label and postprocessing will
 		                                            compute a netperf-server result/CPU metric
 		             --sysinfo=str,                 str= comma separated values of sysinfo to be collected
-		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-netperf --tool-group=bad --sysinfo=bad
 ------------
@@ -828,7 +828,7 @@ Bench Script: pbench-netperf --tool-group=bad --sysinfo=bad
 		             --server-label=str             provide the pbench netperf-server tool label and postprocessing will
 		                                            compute a netperf-server result/CPU metric
 		             --sysinfo=str,                 str= comma separated values of sysinfo to be collected
-		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-netperf --bad-to-the-bone 
 ------------
@@ -869,7 +869,7 @@ pbench-netperf --bad-to-the-bone
 		             --server-label=str             provide the pbench netperf-server tool label and postprocessing will
 		                                            compute a netperf-server result/CPU metric
 		             --sysinfo=str,                 str= comma separated values of sysinfo to be collected
-		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                                 available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-specjbb2005 --help 
 ------------
@@ -887,7 +887,7 @@ Bench Script: pbench-specjbb2005 --help
 		-d str --dir=<str>               directory to run the test
 		       --tool-group=<str>        tool group to use during test
 		       --sysinfo=<str,>          comma separated values of sysinfo to be collected
-		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --specjbb2005-dir=<str>   the location of the install directory for SPECjbb2005
 		                                      (default is /usr/local/share/specjbb2005)
 
@@ -911,7 +911,7 @@ Bench Script: pbench-specjbb2005 --tool-group=bad --sysinfo=bad
 		-d str --dir=<str>               directory to run the test
 		       --tool-group=<str>        tool group to use during test
 		       --sysinfo=<str,>          comma separated values of sysinfo to be collected
-		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --specjbb2005-dir=<str>   the location of the install directory for SPECjbb2005
 		                                      (default is /usr/local/share/specjbb2005)
 
@@ -935,7 +935,7 @@ pbench-specjbb2005 --bad-to-the-bone
 		-d str --dir=<str>               directory to run the test
 		       --tool-group=<str>        tool group to use during test
 		       --sysinfo=<str,>          comma separated values of sysinfo to be collected
-		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                      available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --specjbb2005-dir=<str>   the location of the install directory for SPECjbb2005
 		                                      (default is /usr/local/share/specjbb2005)
 
@@ -1169,7 +1169,7 @@ options common in most pbench benchmark scripts
 
 --sysinfo=str,
   comma separated values of sysinfo to be collected, default="none"
-    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 --tool-period=str
   str = [binary-search|repeat-final-validation]
@@ -1410,7 +1410,7 @@ options common in most pbench benchmark scripts
 
 --sysinfo=str,
   comma separated values of sysinfo to be collected, default="none"
-    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 --tool-period=str
   str = [binary-search|repeat-final-validation]
@@ -1651,7 +1651,7 @@ options common in most pbench benchmark scripts
 
 --sysinfo=str,
   comma separated values of sysinfo to be collected, default="none"
-    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+    available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 --tool-period=str
   str = [binary-search|repeat-final-validation]
@@ -1703,7 +1703,7 @@ Bench Script: pbench-uperf --help
 				   part of the label, just use --tool-label-pattern= to tell this script
 				   the prefix pattern to use for CPU information.
 	--sysinfo=str,             str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-uperf --tool-group=bad --sysinfo=bad
 ------------
@@ -1754,7 +1754,7 @@ Bench Script: pbench-uperf --tool-group=bad --sysinfo=bad
 				   part of the label, just use --tool-label-pattern= to tell this script
 				   the prefix pattern to use for CPU information.
 	--sysinfo=str,             str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-uperf --bad-to-the-bone 
 ------------
@@ -1805,7 +1805,7 @@ pbench-uperf --bad-to-the-bone
 				   part of the label, just use --tool-label-pattern= to tell this script
 				   the prefix pattern to use for CPU information.
 	--sysinfo=str,             str= comma separated values of sysinfo to be collected
-	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                                available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 Bench Script: pbench-user-benchmark --help 
 ------------
@@ -1816,7 +1816,7 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		-C str --config=str            name of the test config
 		       --tool-group=str
 		       --sysinfo=str,          str = comma separated values of system information to be collected
-		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --pbench-pre=str        path to the script which will be executed before tools are started
 		       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 		       --use-tool-triggers     use tool triggers instead of normal start/stop around script
@@ -1835,7 +1835,7 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		-C str --config=str            name of the test config
 		       --tool-group=str
 		       --sysinfo=str,          str = comma separated values of system information to be collected
-		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --pbench-pre=str        path to the script which will be executed before tools are started
 		       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 		       --use-tool-triggers     use tool triggers instead of normal start/stop around script
@@ -1854,7 +1854,7 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		-C str --config=str            name of the test config
 		       --tool-group=str
 		       --sysinfo=str,          str = comma separated values of system information to be collected
-		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+		                                     available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 		       --pbench-pre=str        path to the script which will be executed before tools are started
 		       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 		       --use-tool-triggers     use tool triggers instead of normal start/stop around script

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -29,3 +29,15 @@ interval = 30
 [pbench-fio]
 version = 3.3
 histogram_interval_msec = 10000
+
+[stockpile]
+# stockpile_path, stockpile_log and stockpile_output_path are 
+# optional variables. stockpile_path is set to $pbench_install_dir defined 
+# in the config, stockpile_log and stockpile_output_path are set to 
+# sysinfo dir being used for that particular run.
+stockpile_user = root
+local_remote_user = root
+host_remote_user = root
+stockpile_path =
+stockpile_log =
+stockpile_output_path =

--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-23.txt
@@ -9,7 +9,7 @@ Options specified can be one of:
 	                            (the default group is 'default')
 
 	       --sysinfo=str, str = comma separated values of system information to be collected
-	                            available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+	                            available: default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 
 	       --check,       checks if sysinfo is set to one of the accepted values
 --- Finished test-23 pbench-collect-sysinfo (status=0)

--- a/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
+++ b/agent/util-scripts/gold/pbench-collect-sysinfo/test-24.txt
@@ -1,5 +1,5 @@
 +++ Running test-24 pbench-collect-sysinfo --options
-default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara
+default, none, all, block, libvirt, kernel_config, security_mitigations, sos, topology, ara, stockpile
 --- Finished test-24 pbench-collect-sysinfo (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -18,13 +18,13 @@ group=default
 dir="/tmp"
 # array containing all the possible sysinfo options
 sysinfo_opts_default=( block libvirt kernel_config security_mitigations sos topology )
-sysinfo_opts_available=( block libvirt kernel_config security_mitigations sos topology ara )
+sysinfo_opts_available=( block libvirt kernel_config security_mitigations sos topology ara stockpile )
 # get comma separated values
 sysinfo_opts_default_comma_separated=$(IFS=,; echo "${sysinfo_opts_default[*]}")
 sysinfo_opts_available_comma_separated=$(IFS=,; echo "${sysinfo_opts_available[*]}")
 check=false
 
-# Display sysinfo options 
+# Display sysinfo options
 function display_sysinfo_opts {
 	printf "default, none, all"
 	for item in ${sysinfo_opts_available[*]}; do printf ", %s" $item ; done
@@ -106,7 +106,7 @@ fi
 
 # check if the input sysinfo parameter passed by the user is a valid option or not
 if $check; then
-	debug_log "[$script_name]: sysinfo option is set to $sysinfo" 
+	debug_log "[$script_name]: sysinfo option is set to $sysinfo"
 	if [ "$sysinfo" == "all" ] || [ "$sysinfo" == "default" ] || [ "$sysinfo" == "none" ]; then
 		:
 	else

--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -48,7 +48,7 @@ function collect_mitigation_data {
 	# check the generic vulnerabilities files first
 	if [ -d  /sys/devices/system/cpu/vulnerabilities ] ;then
 		grep -Hs . /sys/devices/system/cpu/vulnerabilities/* >> $dir/security-mitigation-data.txt
-	fi 
+	fi
 	# then check the RHEL-specific flag settings files - only
 	# applicable on x86_64
 	if [ -d /sys/kernel/debug/x86 ] ;then
@@ -134,6 +134,42 @@ function collect_ara_data {
 	fi
 }
 
+function collect_stockpile_data {
+	# parse config
+	stockpile_path=$(getconf.py stockpile_path stockpile)
+	stockpile_user=$(getconf.py stockpile_user stockpile)
+	stockpile_local_remote_user=$(getconf.py local_remote_user stockpile)
+	stockpile_host_remote_user=$(getconf.py host_remote_user stockpile)
+	stockpile_output_path=$(getconf.py stockpile_output_path stockpile)
+	stockpile_log=$(getconf.py stockpile_log stockpile)
+
+	if [[ -z "$stockpile_path" ]]; then
+		stockpile_path=$(getconf.py pbench_install_dir pbench-agent)
+	fi
+
+	# set stockpile log file and output paths
+	if [[ -z "$stockpile_log" ]]; then
+                stockpile_log=$dir/stockpile.log
+        fi
+	if [[ -z "$stockpile_output_path" ]]; then
+        	stockpile_output_path=$dir/stockpile.json
+	fi
+
+	# generate inventory and run stockpile
+	generate_inventory stockpile > $INVENTORY
+	debug_log "[$script_name]Collecting stockpile data"
+	stockpile_opts="stockpile_user=$stockpile_user local_remote_user=$stockpile_local_remote_user host_remote_user=$stockpile_host_remote_user stockpile_output_path=$stockpile_output_path"
+	stockpile_playbook="$stockpile_path/stockpile/stockpile.yml"
+	echo "ansible-playbook -vv --extra-vars '"$stockpile_opts"' -i $INVENTORY $stockpile_playbook" > ${benchmark_run_dir}/stockpile.cmd
+	chmod +x ${benchmark_run_dir}/stockpile.cmd
+	debug_log "Running stockpile with options: $stockpile_opts"
+	${benchmark_run_dir}/stockpile.cmd 2>&1 >$stockpile_log
+	if [[ $? != 0 ]]; then
+        	error_log "[$script_name] Stockpile run failed"
+		exit 1
+	fi
+}
+
 for item in ${sysinfo//,/ };do
 	debug_log "[$script_name]: collecting $item"
 	if [[ "$item" == "kernel_config" ]]; then
@@ -150,6 +186,8 @@ for item in ${sysinfo//,/ };do
 		collect_block &
 	elif [[ "$item" == "ara" ]]; then
 		collect_ara_data &> $pbench_log
+	elif [[ "$item" == "stockpile" ]]; then
+		collect_stockpile_data &
 	else
 		error_log "[$script_name]bad sysinfo value"
 	fi


### PR DESCRIPTION
Stockpile is as part of collect sysinfo to gather system information
about controller and registered remotes. Eventually, collect sysinfo
will be replaced with stockpile once it has support to gather all
the info that it's collecting.

Fixes #915 