### PR TITLE
Scripts to facilitate restoring results from tarballs

### DIFF
--- a/server/pbench/scripts/tarballs-from-prefix
+++ b/server/pbench/scripts/tarballs-from-prefix
@@ -1,0 +1,40 @@
+#! /bin/bash
+
+# we asssume that these scripts are installed in /opt/pbench-server/scripts
+# on the server.
+
+###########################################################################
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))/../bin
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)/../bin
+        PROG=$(basename $0)
+        ;;
+esac
+
+# TOP, ARCHIVE, INCOMING, RESULTS, USERS are all defined by the base file
+. $dir/pbench-base.sh
+###########################################################################
+ 
+controller=$1
+if [ -z "$controller" ] ;then
+   exit 1
+fi
+shift
+prefix=$1
+
+cd $ARCHIVE/$controller || exit 1
+
+# find all the prefix files that contain the given prefix
+# and return the list (slightly munged)
+
+grep -H $prefix .prefix/prefix.* |
+    sed 's/^.prefix\/prefix.//
+         s/:.*/.tar.xz/'
+
+exit 0

--- a/server/pbench/scripts/tarballs-from-prefix
+++ b/server/pbench/scripts/tarballs-from-prefix
@@ -30,11 +30,13 @@ prefix=$1
 
 cd $ARCHIVE/$controller || exit 1
 
-# find all the prefix files that contain the given prefix
-# and return the list (slightly munged)
+# find all the prefix files that contain the given prefix and return
+# the list (slightly munged to contain just the result name) - we
+# assume that the prefix files follow the current convention
+# (<resultname>.prefix) rather than the old one (prefix.<resultname>).
 
-grep -H $prefix .prefix/prefix.* |
-    sed 's/^.prefix\/prefix.//
-         s/:.*/.tar.xz/'
+grep -H $prefix .prefix/*.prefix |
+    sed 's/^.prefix\///
+         s/\.prefix:.*/.tar.xz/'
 
 exit 0

--- a/server/pbench/scripts/tarballs-from-prefix
+++ b/server/pbench/scripts/tarballs-from-prefix
@@ -35,7 +35,8 @@ cd $ARCHIVE/$controller || exit 1
 # assume that the prefix files follow the current convention
 # (<resultname>.prefix) rather than the old one (prefix.<resultname>).
 
-grep -H $prefix .prefix/*.prefix |
+# match the prefix exactly
+grep -H "^${prefix}$" .prefix/*.prefix |
     sed 's/^.prefix\///
          s/\.prefix:.*/.tar.xz/'
 

--- a/server/pbench/scripts/tarballs-from-prefix
+++ b/server/pbench/scripts/tarballs-from-prefix
@@ -35,8 +35,8 @@ cd $ARCHIVE/$controller || exit 1
 # assume that the prefix files follow the current convention
 # (<resultname>.prefix) rather than the old one (prefix.<resultname>).
 
-# match the prefix exactly
-grep -H "^${prefix}$" .prefix/*.prefix |
+# match the prefix exactly and literally, not as a regexp
+grep -xHF "${prefix}" .prefix/*.prefix |
     sed 's/^.prefix\///
          s/\.prefix:.*/.tar.xz/'
 

--- a/server/pbench/scripts/unpack-tarballs
+++ b/server/pbench/scripts/unpack-tarballs
@@ -84,7 +84,12 @@ while read tb ;do
     fi
 
     # Let it be processed by pbench-unpack-tarballs
-    mv $linksrc/$tb $linkdest/
+    if [ -L "$linksrc/$tb" ] ;then
+        mv $linksrc/$tb $linkdest/
+    else
+        echo "Link does not exist: $linksrc/$tb - creating a new link in $linkdest/"
+        ln -s $PWD/$tb $linkdest/
+    fi
 
 done < $tblist
 

--- a/server/pbench/scripts/unpack-tarballs
+++ b/server/pbench/scripts/unpack-tarballs
@@ -32,7 +32,7 @@ cd $ARCHIVE/$controller || exit 1
 
 incoming=$INCOMING/$controller
 
-linksrc=MOVE_UNPACKED
+linksrc=MOVE-UNPACKED
 linkdest=TO-UNPACK
 
 tblist=/tmp/unpack-tarballs.$$
@@ -78,14 +78,7 @@ while read tb ;do
     fi
 
     # Let it be processed by pbench-unpack-tarballs
-
-    # Check that the prefix file is named properly
-    # and rename it if necessary (like shim-001 does).
-    if [ -f ".prefix/prefix.$resultname" ] ;then
-        mv .prefix/prefix.$resultname .prefix/$resultname.prefix
-        # pbench-unpack-tarballs will deal with the prefix now.
-    fi
-    mv $linksrc/$tb $linkdest
+    mv $linksrc/$tb $linkdest/
 
 done < $tblist
 

--- a/server/pbench/scripts/unpack-tarballs
+++ b/server/pbench/scripts/unpack-tarballs
@@ -74,7 +74,13 @@ while read tb ;do
         if [ -d "$tmpdir" ] ;then
             echo "skipping $resultdir: it is a link to $tmpdir"
             continue
+        else
+            echo "Cannot happen: $resultdir points to $tmpdir which is not a directory."
+            continue
         fi
+    else
+        echo "Cannot happen: $resultdir is neither a directory, nor a link."
+        continue
     fi
 
     # Let it be processed by pbench-unpack-tarballs

--- a/server/pbench/scripts/unpack-tarballs
+++ b/server/pbench/scripts/unpack-tarballs
@@ -1,0 +1,92 @@
+#! /bin/bash
+
+# we asssume that these scripts are installed in /opt/pbench-server/scripts
+# on the server.
+
+###########################################################################
+# load common things
+opts=$SHELLOPTS
+case $opts in
+    *xtrace*)
+        dir=$(dirname $(which $0))/../bin
+        PROG=$(basename $(which $0))
+        ;;
+    *)
+        dir=$(dirname $0)/../bin
+        PROG=$(basename $0)
+        ;;
+esac
+
+# TOP, ARCHIVE, INCOMING, RESULTS, USERS are all defined by the base file
+. $dir/pbench-base.sh
+###########################################################################
+ 
+controller=$1
+if [ -z "$controller" ] ;then
+   exit 1
+fi
+shift
+tarballs="$@"
+
+cd $ARCHIVE/$controller || exit 1
+
+incoming=$INCOMING/$controller
+
+linksrc=MOVE_UNPACKED
+linkdest=TO-UNPACK
+
+tblist=/tmp/unpack-tarballs.$$
+
+trap "rm -f $tblist" EXIT QUIT INT
+
+> $tblist
+if [ -z "$tarballs" ] ;then
+    ls *.tar.xz > $tblist
+else
+    for tb in $tarballs ;do
+        echo $tb >> $tblist
+    done
+fi
+
+while read tb ;do
+    # tb is a simple name: foo.tar.xz, not a path.
+    resultname=${tb%.tar.xz}
+
+    if [ ! -f "$resultname.tar.xz.md5" ] ;then
+        echo "MD5 file does not exist: $resultname"
+        continue
+    fi
+
+    md5sum --check $resultname.tar.xz.md5 > /dev/null
+    sts=$?
+    if [ "$sts" != "0" ] ;then
+        echo "MD5 check failed: $resultname"
+        continue
+    fi
+
+    resultdir=$incoming/$resultname
+    if [ -d "$resultdir" ] ;then
+        # unpacked already
+        echo "skipping $resultdir: unpacked already"
+        continue
+    elif [ -L "$resultdir" ] ;then
+        tmpdir=$(readlink -f "$resultdir")
+        if [ -d "$tmpdir" ] ;then
+            echo "skipping $resultdir: it is a link to $tmpdir"
+            continue
+        fi
+    fi
+
+    # Let it be processed by pbench-unpack-tarballs
+
+    # Check that the prefix file is named properly
+    # and rename it if necessary (like shim-001 does).
+    if [ -f ".prefix/prefix.$resultname" ] ;then
+        mv .prefix/prefix.$resultname .prefix/$resultname.prefix
+        # pbench-unpack-tarballs will deal with the prefix now.
+    fi
+    mv $linksrc/$tb $linkdest
+
+done < $tblist
+
+exit 0


### PR DESCRIPTION
WARNING: these are *completely* untested. This is meant as a starting
point for discussion.

These scripts are meant to be interactively used.

Most of the requests we've had so far have been prefix requests, not
individual tarballs. The scripts tarballs-from-prefix and
unpack-tarballs are meant to address this situation:

 - tarballs-from-prefix <controller> <prefix>

   This script takes two arguments, the controller and the prefix and
   returns a list of tarballs for that controller that should be under
   that prefix.  Each element of the list is just a tarball name, not
   a path.

 - unpack-tarballs <controller> <tarball> ...

   This script takes as arguments the controller and a list of tarball
   names (as returned by tarballs-from-prefix). It checks each tarball
   and if conditions are right, it changes its state to TO-UNPACK,
   thereby notifying the pbench-unpack-tarballs script to unpack the
   tarball.

   The intended workflow is:

   unpack-tarballs <controller> $(tarballs-from-prefix <controller> <prefix>)

   But unpack-tarballs can also deal with a bunch of individual
   tarballs (whether they have a prefix or not). If the tarball does
   have an old-style prefix (prefix.<resultname>), it is renamed
   to the new style, <resultname>.prefix before the state of the
   tarball is changed. When pbench-unpack-tarballs processes it,
   it will DTRT wrt the prefix.