### PR TITLE
Require TOP & LOGSDIR in addition to TMP

### DIFF
--- a/server/pbench/bin/gold/test-0.1.txt
+++ b/server/pbench/bin/gold/test-0.1.txt
@@ -1,0 +1,53 @@
++++ Running pbench-unpack-tarballs
+pbench-unpack-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-unpack-tarballs (status=1)
++++ Running pbench-move-unpacked
+pbench-move-unpacked: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-move-unpacked (status=1)
++++ Running pbench-copy-sosreports
+pbench-copy-sosreports: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-copy-sosreports (status=1)
++++ Running pbench-index
+pbench-index: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-index (status=1)
++++ Running pbench-clean-up-dangling-results-links
+pbench-clean-up-dangling-results-links: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-clean-up-dangling-results-links (status=1)
++++ Running pbench-edit-prefixes
+pbench-edit-prefixes: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
+--- Finished pbench-edit-prefixes (status=1)
++++ var/www/html tree state
+/var/tmp/pbench-test-server/var-www-html
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+--- var/www/html tree state
++++ pbench tree state
+/var/tmp/pbench-test-server/pbench
+/var/tmp/pbench-test-server/pbench/archive
+/var/tmp/pbench-test-server/pbench/archive/fs-version-001
+/var/tmp/pbench-test-server/pbench/bad-logs
+/var/tmp/pbench-test-server/pbench/public_html
+/var/tmp/pbench-test-server/pbench/public_html/incoming
+/var/tmp/pbench-test-server/pbench/public_html/results
+/var/tmp/pbench-test-server/pbench/public_html/users
+/var/tmp/pbench-test-server/pbench/tmp
+--- pbench tree state
++++ pbench-local tree state
+/var/tmp/pbench-test-server/pbench-local
+/var/tmp/pbench-test-server/pbench-local/fs-version-001
+/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
+/var/tmp/pbench-test-server/pbench-local/fs-version-002
+/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
+/var/tmp/pbench-test-server/pbench-local/quarantine
+/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
+/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
+/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
+--- pbench-local tree state
++++ pbench log file contents
+--- pbench log file contents

--- a/server/pbench/bin/gold/test-0.txt
+++ b/server/pbench/bin/gold/test-0.txt
@@ -1,0 +1,44 @@
++++ Running pbench-unpack-tarballs
+pbench-unpack-tarballs: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-unpack-tarballs (status=1)
++++ Running pbench-move-unpacked
+pbench-move-unpacked: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-move-unpacked (status=1)
++++ Running pbench-copy-sosreports
+pbench-copy-sosreports: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-copy-sosreports (status=1)
++++ Running pbench-index
+pbench-index: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-index (status=1)
++++ Running pbench-clean-up-dangling-results-links
+pbench-clean-up-dangling-results-links: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-clean-up-dangling-results-links (status=1)
++++ Running pbench-edit-prefixes
+pbench-edit-prefixes: Bad TOP=/var/tmp/pbench-test-server/pbench
+--- Finished pbench-edit-prefixes (status=1)
++++ var/www/html tree state
+/var/tmp/pbench-test-server/var-www-html
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+--- var/www/html tree state
++++ pbench tree state
+--- pbench tree state
++++ pbench-local tree state
+/var/tmp/pbench-test-server/pbench-local
+/var/tmp/pbench-test-server/pbench-local/fs-version-001
+/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
+/var/tmp/pbench-test-server/pbench-local/fs-version-002
+/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
+/var/tmp/pbench-test-server/pbench-local/quarantine
+/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
+/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
+/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
+/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
+--- pbench-local tree state
++++ pbench log file contents
+--- pbench log file contents

--- a/server/pbench/bin/pbench-base.sh
+++ b/server/pbench/bin/pbench-base.sh
@@ -27,14 +27,20 @@ else
     exit 2
 fi
 
-TMP=$(getconf.py pbench-tmp-dir pbench-files)
-PBENCH_ENV=$(getconf.py pbench-environment results)
+# Required
+TOP=$(getconf.py pbench-top-dir pbench-files)
+test -d $TOP || doexit "Bad TOP=$TOP"
 
+# Required
+TMP=$(getconf.py pbench-tmp-dir pbench-files)
 test -d $TMP || doexit "Bad TMP=$TMP"
 
-TOP=$(getconf.py pbench-top-dir pbench-files)
-BDIR=$(getconf.py pbench-backup-dir pbench-files)
 export LOGSDIR=$(getconf.py pbench-logs-dir pbench-files)
+test -d $LOGSDIR || doexit "Bad LOGSDIR=$LOGSDIR"
+
+# Optional
+BDIR=$(getconf.py pbench-backup-dir pbench-files)
+PBENCH_ENV=$(getconf.py pbench-environment results)
 
 if [[ -z "$_PBENCH_SERVER_TEST" ]]; then
     # the real thing

--- a/server/pbench/bin/state/test-0.1.setup
+++ b/server/pbench/bin/state/test-0.1.setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Move the logs tree to the side
+mv pbench/logs pbench/bad-logs
+exit $?

--- a/server/pbench/bin/state/test-0.reset
+++ b/server/pbench/bin/state/test-0.reset
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Move the pbench tree back
+mv pbench-bad pbench
+exit $?

--- a/server/pbench/bin/state/test-0.setup
+++ b/server/pbench/bin/state/test-0.setup
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Move the pbench tree to the side
+mv pbench pbench-bad
+exit $?

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -118,8 +118,10 @@ function _save_tree {
         echo "--- var/www/html tree state" >> $_testout
     fi
     echo "+++ pbench tree state" >> $_testout
-    find $_testdir | sort |
-        sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
+    if [ -d ${_testdir} ] ;then
+        find $_testdir | sort |
+            sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
+    fi
     echo "--- pbench tree state" >> $_testout
     if [ -d ${_testdir_local} ] ;then
         echo "+++ pbench-local tree state" >> $_testout
@@ -272,6 +274,16 @@ function _setup_state {
 }
 
 function _reset_state {
+    # Run per-test state reset
+    _state_reset=$_tdir/state/${1}.reset
+    if [ -f ${_state_reset} ]; then
+        (cd $_testroot; $_state_reset)
+        if [[ $? -gt 0 ]]; then
+            echo "ERROR: unable to run per-test state reset for $1" >&2
+            exit 1
+        fi
+    fi
+
     export PATH=${_orig_PATH}
     unset CONFIG
     unset IDXCONFIG
@@ -313,6 +325,10 @@ function _reset_state {
 }
 
 declare -A cmds=(
+    # check for no TOP directory
+    [test-0]="_run_allscripts"
+    # check for no LOGSDIR directory
+    [test-0.1]="_run_allscripts"
     # check for no TMP directory
     [test-1]="_run_allscripts"
     # check for no ARCHIVE directory
@@ -421,6 +437,6 @@ for test in $tests ;do
         let failures=failures+1
     fi
 
-    _reset_state
+    _reset_state ${test}
 done
 exit $failures


### PR DESCRIPTION
`TOP`, `TMP`, and `LOGSDIR` are now required for all scripts, since all
of them rely on their existence.  `TOP` is checked first because often
`TMP` and `LOGSDIR` are defined in relation to `TOP`.  All three checks
happen in `pbench-base.sh`.