### PR TITLE
Copy two files instead of move two files

### DIFF
--- a/server/pbench/bin/pbench-server-prep-shim-001
+++ b/server/pbench/bin/pbench-server-prep-shim-001
@@ -230,14 +230,26 @@ while read tblink ;do
         continue
     fi
 
-    mv ${tb} ${tb}.md5 ${dest}/
+    cp ${tb} ${tb}.md5 ${dest}/
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Error: \"mv ${tb} ${tb}.md5 ${dest}/\", status $sts" |
+        echo "$TS: Error: \"cp ${tb} ${tb}.md5 ${dest}/\", status $sts" |
             tee -a $status >&4
+        rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5
+        sts=$?
+        if [ $sts -ne 0]; then
+            echo "$TS: Warning: cleanup of copy failure failed itself: \"rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5\", status $sts" |
+                tee -a $status >&4
+        fi
         quarantine ${errors}/${controller} ${tb} ${tb}.md5 ${dest}/.prefix/${resultname}.prefix
         nerrs=$nerrs+1
         continue
+    fi
+    rm -f ${tb} ${tb}.md5
+    sts=$?
+    if [ $sts -ne 0 ] ;then
+        echo "$TS: Warning: cleanup of successful copy operation failed: \"rm -f ${tb} ${tb}.md5\", status $sts" |
+            tee -a $status >&4
     fi
 
     # Remove the link from the reception area.  rm -f returns the same

--- a/server/pbench/bin/pbench-server-prep-shim-002
+++ b/server/pbench/bin/pbench-server-prep-shim-002
@@ -178,13 +178,26 @@ while read ck ;do
         continue
     fi
 
-    mv ${tb} ${tb}.md5 $dest
+    cp ${tb} ${tb}.md5 ${dest}/
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Error: \"mv ${tb} ${tb}.md5 $dest\", status $sts" |
+        echo "$TS: Error: \"cp ${tb} ${tb}.md5 ${dest}/\", status $sts" |
             tee -a $status >&4
+        rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5
+        sts=$?
+        if [ $sts -ne 0]; then
+            echo "$TS: Warning: cleanup of copy failure failed itself: \"rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5\", status $sts" |
+                tee -a $status >&4
+        fi
         quarantine ${errors}/${controller} ${tb} ${tb}.md5
         nerrs=$nerrs+1
+        continue
+    fi
+    rm -f ${tb} ${tb}.md5
+    sts=$?
+    if [ $sts -ne 0 ] ;then
+        echo "$TS: Warning: cleanup of successful copy operation failed: \"rm -f ${tb} ${tb}.md5\", status $sts" |
+            tee -a $status >&4
     fi
 
     pushd $dest/TODO > /dev/null >/dev/null 2>&1


### PR DESCRIPTION
If a `mv` of 2 files fails, it is possible for the move to have successfully
moved the first file, but not the second one.  We change to using `cp` instead
so that we can consistently clean up during the error handling.