### PR TITLE
Restore normal ln behavior for unit tests

### DIFF
--- a/server/pbench/bin/gold/test-0.1.txt
+++ b/server/pbench/bin/gold/test-0.1.txt
@@ -19,38 +19,40 @@ pbench-edit-prefixes: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
 +++ Running unit test audit
 pbench-audit-archive: Bad LOGSDIR=/var/tmp/pbench-test-server/pbench/logs
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/bad-logs
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - bad-logs
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 --- pbench log file contents

--- a/server/pbench/bin/gold/test-0.txt
+++ b/server/pbench/bin/gold/test-0.txt
@@ -19,29 +19,32 @@ pbench-edit-prefixes: Bad TOP=/var/tmp/pbench-test-server/pbench
 +++ Running unit test audit
 pbench-audit-archive: Bad TOP=/var/tmp/pbench-test-server/pbench
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 --- pbench log file contents

--- a/server/pbench/bin/gold/test-1.txt
+++ b/server/pbench/bin/gold/test-1.txt
@@ -19,38 +19,40 @@ pbench-edit-prefixes: Bad TMP=/var/tmp/pbench-test-server/pbench/tmp
 +++ Running unit test audit
 pbench-audit-archive: Bad TMP=/var/tmp/pbench-test-server/pbench/tmp
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/bad-tmp
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - bad-tmp
+drwxrwxr-x          - logs
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 --- pbench log file contents

--- a/server/pbench/bin/gold/test-10.txt
+++ b/server/pbench/bin/gold/test-10.txt
@@ -2,57 +2,59 @@
 --- Finished pbench-sync-satellite (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/change-state.TEST.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+-rw-rw-r--          0 logs/change-state.TEST.log
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-sync-satellite
+drwxrwxr-x          - logs/pbench-sync-satellite/TEST
+-rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
+-rw-rw-r--        354 logs/pbench-sync-satellite/pbench-sync-satellite.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-11.txt
+++ b/server/pbench/bin/gold/test-11.txt
@@ -2,68 +2,70 @@
 --- Finished pbench-sync-satellite (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=2)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/change-state.TEST2.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/controller
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/controller/rsync.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/pbench-rsync-satellite.wq.trimmed
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/TEST2
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-sync-satellite/pbench-sync-satellite.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/TEST2::controller
+-rw-r--r--    1558168 archive/fs-version-001/TEST2::controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/TEST2::controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/TEST2::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+-rw-rw-r--          0 logs/change-state.TEST2.log
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-rsync-satellite
+drwxrwxr-x          - logs/pbench-rsync-satellite/TEST2
+drwxrwxr-x          - logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC
+drwxrwxr-x          - logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/controller
+-rw-rw-r--        553 logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/controller/rsync.log
+-rw-rw-r--         12 logs/pbench-rsync-satellite/TEST2/run-1900-01-01T00:00:00-UTC/pbench-rsync-satellite.wq.trimmed
+drwxrwxr-x          - logs/pbench-sync-satellite
+drwxrwxr-x          - logs/pbench-sync-satellite/TEST2
+-rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
+-rw-rw-r--        354 logs/pbench-sync-satellite/pbench-sync-satellite.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/897d86470f84c04f5f871d687c4c3140 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-12.txt
+++ b/server/pbench/bin/gold/test-12.txt
@@ -2,56 +2,59 @@
 --- Finished pbench-server-prep-shim-001 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/duplicates
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/.prefix/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/quarantine
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/duplicates
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/Controller
+drwxrwxr-x          - archive/fs-version-001/Controller/.prefix
+-rw-rw-r--         12 archive/fs-version-001/Controller/.prefix/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.prefix
+drwxrwxr-x          - archive/fs-version-001/Controller/TODO
+lrwxrwxrwx        128 archive/fs-version-001/Controller/TODO/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz -> /var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--    2129128 archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--         94 archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
+drwxrwxr-x          - archive/quarantine
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-server-prep-shim-001
+-rw-rw-r--          0 logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.error
+-rw-rw-r--        454 logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/TODO
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/logs
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
-/var/tmp/pbench-test-server/pbench-local/tmp
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive/Controller
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive/Controller/TODO
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - logs
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload
@@ -62,9 +65,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-server-prep-shim-001.1900-01/status/227ffae433a2b2eec2b38ec93d84f5a2 --data @/tmp/pbench-report-status.NNNN/payload
 /var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log:
 --- pbench log file contents
-+++ test-execution.log file contents
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz .
---- test-execution.log file contents
 +++ test-curl-payload.log file contents
 {
     "text": "run-1900-01-01T00:00:00-UTC: processed /var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz\nrun-1900-01-01T00:00:00-UTC: Processed 1 entries, 1 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 

--- a/server/pbench/bin/gold/test-13.txt
+++ b/server/pbench/bin/gold/test-13.txt
@@ -2,51 +2,54 @@
 --- Finished pbench-server-prep-shim-002 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/duplicates
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/quarantine
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/duplicates
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/Controller
+drwxrwxr-x          - archive/fs-version-001/Controller/TODO
+lrwxrwxrwx        128 archive/fs-version-001/Controller/TODO/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz -> /var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--    2129128 archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--         94 archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
+drwxrwxr-x          - archive/quarantine
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-server-prep-shim-002
+-rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
+-rw-rw-r--        454 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive/Controller
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive/Controller
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload
@@ -57,9 +60,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-server-prep-shim-002.1900-01/status/6c47622853ffc8d0ca9cddbc1238f35a --data @/tmp/pbench-report-status.NNNN/payload
 /var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log:
 --- pbench log file contents
-+++ test-execution.log file contents
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/archive/fs-version-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz .
---- test-execution.log file contents
 +++ test-curl-payload.log file contents
 {
     "text": "run-1900-01-01T00:00:00-UTC: processed /var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz\nrun-1900-01-01T00:00:00-UTC: Processed 1 entries, 1 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.\n", 

--- a/server/pbench/bin/gold/test-14.txt
+++ b/server/pbench/bin/gold/test-14.txt
@@ -2,52 +2,54 @@
 --- Finished pbench-server-prep-shim-001 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/duplicates
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/quarantine
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/duplicates
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/quarantine
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-server-prep-shim-001
+-rw-rw-r--        214 logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.error
+-rw-rw-r--        509 logs/pbench-server-prep-shim-001/pbench-server-prep-shim-001.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/TODO
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive/Controller/TODO/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001/Controller
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive/Controller
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive/Controller/TODO
+lrwxrwxrwx         62 fs-version-001/pbench-move-results-receive/Controller/TODO/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz -> ../pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-001/Controller
+-rw-rw-r--    2129128 quarantine/md5-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--         94 quarantine/md5-001/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-15.txt
+++ b/server/pbench/bin/gold/test-15.txt
@@ -2,51 +2,53 @@
 --- Finished pbench-server-prep-shim-002 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/duplicates
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/quarantine
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
-/var/tmp/pbench-test-server/pbench/mv
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/duplicates
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/quarantine
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-server-prep-shim-002
+-rw-rw-r--        214 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
+-rw-rw-r--        509 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+drwxrwxr-x          - mv
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive/Controller
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002/Controller
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive/Controller
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - quarantine/md5-002/Controller
+-rw-rw-r--    2129128 quarantine/md5-002/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz
+-rw-rw-r--         94 quarantine/md5-002/Controller/pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-16.txt
+++ b/server/pbench/bin/gold/test-16.txt
@@ -2,171 +2,177 @@
 --- Finished pbench-unpack-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-UNPACK/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00/lines.10.txt
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/results/controller00
-/var/tmp/pbench-test-server/pbench/public_html/results/controller01
-/var/tmp/pbench-test-server/pbench/public_html/results/controller01/prefix01
-/var/tmp/pbench-test-server/pbench/public_html/results/controller02
-/var/tmp/pbench-test-server/pbench/public_html/results/controller02/prefix02
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/public_html/users/user01
-/var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01
-/var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01/prefix01
-/var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/tmp/README.pbench-unpack-tarballs.sorting
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller00
+drwxrwxr-x          - archive/fs-version-001/controller00/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller00/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller00/MOVED-UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller00/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-UNPACK
+lrwxrwxrwx         52 archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller00/TODO
+drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.9
+-rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01
+drwxrwxr-x          - archive/fs-version-001/controller01/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller01/COPIED-SOS
+-rw-rw-r--       3120 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller01/MOVED-UNPACKED
+lrwxrwxrwx         53 archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller01/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-UNPACK
+lrwxrwxrwx         71 archive/fs-version-001/controller01/TO-UNPACK/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/TODO
+drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.9
+-rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller02
+drwxrwxr-x          - archive/fs-version-001/controller02/.prefix
+-rw-rw-r--          9 archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
+drwxrwxr-x          - archive/fs-version-001/controller02/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller02/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller02/MOVED-UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller02/MOVED-UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller02/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller02/TODO
+drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.9
+-rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--        194 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--       1670 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+drwxrwxr-x          - public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+-rw-rw-r--       7300 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
+drwxrwxr-x          - public_html/incoming/controller01
+drwxrwxr-x          - public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+-rw-rw-r--       3650 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
+-rw-rw-r--         38 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
+drwxrwxr-x          - public_html/incoming/controller02
+drwxrwxr-x          - public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+-rw-rw-r--        730 public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00/lines.10.txt
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/results/controller00
+lrwxrwxrwx        111 public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results/controller01
+drwxrwxr-x          - public_html/results/controller01/prefix01
+lrwxrwxrwx        112 public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results/controller02
+drwxrwxr-x          - public_html/results/controller02/prefix02
+lrwxrwxrwx        111 public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - public_html/users/user01
+drwxrwxr-x          - public_html/users/user01/controller01
+drwxrwxr-x          - public_html/users/user01/controller01/prefix01
+lrwxrwxrwx        112 public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - tmp
+-rw-rw-r--        442 tmp/README.pbench-unpack-tarballs.sorting
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload
@@ -184,12 +190,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-unpack-tarballs.1900-01/status/65acd420d4a5bac8c4df9eee8d85dc4c --data @/tmp/pbench-report-status.NNNN/payload
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:
 --- pbench log file contents
-+++ test-execution.log file contents
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
---- test-execution.log file contents
 +++ test-curl-payload.log file contents
 {
     "text": "pbench-unpack-tarballs.run-1900-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1900-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n", 

--- a/server/pbench/bin/gold/test-17.txt
+++ b/server/pbench/bin/gold/test-17.txt
@@ -2,176 +2,185 @@
 --- Finished pbench-unpack-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-UNPACK/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/results/controller00
-/var/tmp/pbench-test-server/pbench/public_html/results/controller01
-/var/tmp/pbench-test-server/pbench/public_html/results/controller01/prefix01
-/var/tmp/pbench-test-server/pbench/public_html/results/controller02
-/var/tmp/pbench-test-server/pbench/public_html/results/controller02/prefix02
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/public_html/users/user01
-/var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01
-/var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01/prefix01
-/var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/tmp/README.pbench-unpack-tarballs.sorting
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller00
+drwxrwxr-x          - archive/fs-version-001/controller00/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller00/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller00/MOVED-UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller00/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-UNPACK
+lrwxrwxrwx         52 archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller00/TODO
+drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.9
+-rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01
+drwxrwxr-x          - archive/fs-version-001/controller01/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller01/COPIED-SOS
+-rw-rw-r--       3120 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller01/MOVED-UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller01/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-UNPACK
+lrwxrwxrwx         71 archive/fs-version-001/controller01/TO-UNPACK/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/TODO
+drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
+lrwxrwxrwx         53 archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.9
+-rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller02
+drwxrwxr-x          - archive/fs-version-001/controller02/.prefix
+-rw-rw-r--          9 archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
+drwxrwxr-x          - archive/fs-version-001/controller02/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller02/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller02/MOVED-UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller02/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller02/TODO
+drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.9
+-rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--        194 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--       2380 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+lrwxrwxrwx        117 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/incoming/controller01
+lrwxrwxrwx        118 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/incoming/controller02
+lrwxrwxrwx        117 public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/results/controller00
+lrwxrwxrwx        111 public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results/controller01
+drwxrwxr-x          - public_html/results/controller01/prefix01
+lrwxrwxrwx        112 public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results/controller02
+drwxrwxr-x          - public_html/results/controller02/prefix02
+lrwxrwxrwx        111 public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - public_html/users/user01
+drwxrwxr-x          - public_html/users/user01/controller01
+drwxrwxr-x          - public_html/users/user01/controller01/prefix01
+lrwxrwxrwx        112 public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00 -> /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - tmp
+-rw-rw-r--        442 tmp/README.pbench-unpack-tarballs.sorting
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/public_html
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00/lines.10.txt
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+drwxrwxr-x          - public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+-rw-rw-r--       7300 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
+drwxrwxr-x          - public_html/incoming/controller01
+drwxrwxr-x          - public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+-rw-rw-r--       3650 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
+-rw-rw-r--         38 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
+drwxrwxr-x          - public_html/incoming/controller02
+drwxrwxr-x          - public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+-rw-rw-r--        730 public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00/lines.10.txt
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload
@@ -192,15 +201,6 @@
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-unpack-tarballs.1900-01/status/65acd420d4a5bac8c4df9eee8d85dc4c --data @/tmp/pbench-report-status.NNNN/payload
 /var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log:
 --- pbench log file contents
-+++ test-execution.log file contents
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
---- test-execution.log file contents
 +++ test-curl-payload.log file contents
 {
     "text": "pbench-unpack-tarballs.run-1900-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1900-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n", 

--- a/server/pbench/bin/gold/test-18.txt
+++ b/server/pbench/bin/gold/test-18.txt
@@ -2,74 +2,76 @@
 --- Finished pbench-move-unpacked (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller00
+drwxrwxr-x          - archive/fs-version-001/controller00/MOVED-UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01
+-rw-rw-r--       3120 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01/MOVED-UNPACKED
+lrwxrwxrwx         71 archive/fs-version-001/controller01/MOVED-UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+lrwxrwxrwx         53 archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller02
+drwxrwxr-x          - archive/fs-version-001/controller02/.prefix
+-rw-rw-r--          9 archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
+drwxrwxr-x          - archive/fs-version-001/controller02/MOVED-UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller02/MOVED-UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-UNPACK
+-rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--        208 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+drwxrwxr-x          - public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+-rw-rw-r--       7300 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
+drwxrwxr-x          - public_html/incoming/controller01
+drwxrwxr-x          - public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+-rw-rw-r--       3650 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
+-rw-rw-r--         38 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
+drwxrwxr-x          - public_html/incoming/controller02
+drwxrwxr-x          - public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-19.txt
+++ b/server/pbench/bin/gold/test-19.txt
@@ -2,164 +2,166 @@
 --- Finished pbench-move-unpacked (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/BAD-MD5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/COPIED-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/INDEXED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/MOVED-UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-DONE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/SYNCED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-BACKUP
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-COPY-SOS
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-DELETE
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-LINK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-SYNC
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TODO
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller00
+drwxrwxr-x          - archive/fs-version-001/controller00/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller00/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller00/MOVED-UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller00/MOVED-UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller00/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller00/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller00/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller00/TODO
+drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX.9
+-rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01
+drwxrwxr-x          - archive/fs-version-001/controller01/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller01/COPIED-SOS
+-rw-rw-r--       3120 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller01/MOVED-UNPACKED
+lrwxrwxrwx         53 archive/fs-version-001/controller01/MOVED-UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller01/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller01/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller01/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller01/TODO
+drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
+lrwxrwxrwx         71 archive/fs-version-001/controller01/UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX.9
+-rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller02
+drwxrwxr-x          - archive/fs-version-001/controller02/.prefix
+-rw-rw-r--          9 archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
+drwxrwxr-x          - archive/fs-version-001/controller02/BAD-MD5
+drwxrwxr-x          - archive/fs-version-001/controller02/COPIED-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/INDEXED
+drwxrwxr-x          - archive/fs-version-001/controller02/MOVED-UNPACKED
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-DONE
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-FAILED
+drwxrwxr-x          - archive/fs-version-001/controller02/SATELLITE-MD5-PASSED
+drwxrwxr-x          - archive/fs-version-001/controller02/SYNCED
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-BACKUP
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-COPY-SOS
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-DELETE
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-LINK
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-SYNC
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller02/TODO
+drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX.9
+-rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--        330 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--        809 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+drwxrwxr-x          - public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
+-rw-rw-r--       7300 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
+drwxrwxr-x          - public_html/incoming/controller01
+drwxrwxr-x          - public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
+-rw-rw-r--       3650 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
+-rw-rw-r--         38 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
+drwxrwxr-x          - public_html/incoming/controller02
+drwxrwxr-x          - public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/public_html
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+drwxrwxr-x          - public_html/incoming/controller01
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-2.txt
+++ b/server/pbench/bin/gold/test-2.txt
@@ -13,56 +13,58 @@
 +++ Running unit test audit
 pbench-audit-archive: Bad archive: /var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-index
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/no-archive
-/var/tmp/pbench-test-server/pbench/no-archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
+-rw-rw-r--        110 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
+drwxrwxr-x          - logs/pbench-copy-sosreports
+-rw-rw-r--          0 logs/pbench-copy-sosreports/pbench-copy-sosreports.error
+-rw-rw-r--         94 logs/pbench-copy-sosreports/pbench-copy-sosreports.log
+drwxrwxr-x          - logs/pbench-edit-prefixes
+-rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
+-rw-rw-r--         92 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+drwxrwxr-x          - logs/pbench-index
+-rw-rw-r--          0 logs/pbench-index/pbench-index.error
+-rw-rw-r--         84 logs/pbench-index/pbench-index.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--         92 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--         94 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - no-archive
+drwxrwxr-x          - no-archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log:pbench-clean-up-dangling-results-links: Bad ARCHIVE=/var/tmp/pbench-test-server/pbench/archive/fs-version-001

--- a/server/pbench/bin/gold/test-20.txt
+++ b/server/pbench/bin/gold/test-20.txt
@@ -3,125 +3,127 @@ audit archive hierarchy
 --- Finished echo (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=6)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/a-wayward-file.txt
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.empty
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.unexp_state_dirs
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.unexp_state_dirs/TO-INDEX
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.unexp_state_dirs/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.unexp_state_dirs/an-unexpected
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.unexp_state_dirs/unexpected
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.0
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.1
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.10
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.11
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.12
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.13
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.14
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.15
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.16
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.17
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.18
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.19
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.2
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.20
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.21
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.22
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.23
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.24
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.25
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.26
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.27
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.28
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.29
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.3
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.30
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.4
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.6
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.7
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.8
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller.wont_index/WONT-INDEX.9
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/an-unexpected-symlink
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/unexpected-file
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller00/unexpected-symlink
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix/a-unexpected
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix/prefix.DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix/prefix.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/.prefix/unexpected
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/TO-UNPACK
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/wayward-file.txt
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02
-/var/tmp/pbench-test-server/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/tmp/controller00
-/var/tmp/pbench-test-server/pbench/tmp/controller00/benchmark-result-large_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/tmp/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
-/var/tmp/pbench-test-server/pbench/tmp/controller01
-/var/tmp/pbench-test-server/pbench/tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00
-/var/tmp/pbench-test-server/pbench/tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
-/var/tmp/pbench-test-server/pbench/tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 archive/fs-version-001/a-wayward-file.txt
+drwxrwxr-x          - archive/fs-version-001/controller.empty
+drwxrwxr-x          - archive/fs-version-001/controller.unexp_state_dirs
+drwxrwxr-x          - archive/fs-version-001/controller.unexp_state_dirs/TO-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller.unexp_state_dirs/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller.unexp_state_dirs/an-unexpected
+drwxrwxr-x          - archive/fs-version-001/controller.unexp_state_dirs/unexpected
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.0
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.1
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.10
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.11
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.12
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.13
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.14
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.15
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.16
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.17
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.18
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.19
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.2
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.20
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.21
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.22
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.23
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.24
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.25
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.26
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.27
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.28
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.29
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.3
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.30
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.4
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.5
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.6
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.7
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.8
+drwxrwxr-x          - archive/fs-version-001/controller.wont_index/WONT-INDEX.9
+drwxrwxr-x          - archive/fs-version-001/controller00
+-rw-rw-r--          0 archive/fs-version-001/controller00/.prefix
+drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
+lrwxrwxrwx          9 archive/fs-version-001/controller00/an-unexpected-symlink -> /dev/null
+-rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
+-rw-rw-r--          0 archive/fs-version-001/controller00/unexpected-file
+lrwxrwxrwx          9 archive/fs-version-001/controller00/unexpected-symlink -> /dev/null
+drwxrwxr-x          - archive/fs-version-001/controller01
+drwxrwxr-x          - archive/fs-version-001/controller01/.prefix
+-rw-rw-r--          0 archive/fs-version-001/controller01/.prefix/a-unexpected
+-rw-rw-r--         12 archive/fs-version-001/controller01/.prefix/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.prefix
+-rw-rw-r--         13 archive/fs-version-001/controller01/.prefix/prefix.DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--          0 archive/fs-version-001/controller01/.prefix/prefix.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--          0 archive/fs-version-001/controller01/.prefix/unexpected
+-rw-rw-r--       3120 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
+lrwxrwxrwx         71 archive/fs-version-001/controller01/UNPACKED/DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../DUPLICATE__NAME.1.benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+lrwxrwxrwx         53 archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001/controller02
+drwxrwxr-x          - archive/fs-version-001/controller02/.prefix
+-rw-rw-r--          9 archive/fs-version-001/controller02/.prefix/benchmark-result-small_1900-01-01T00:00:00.prefix
+drwxrwxr-x          - archive/fs-version-001/controller02/TO-UNPACK
+drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
+lrwxrwxrwx         52 archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
+-rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
+-rw-rw-r--          0 archive/fs-version-001/wayward-file.txt
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/incoming/controller00
+lrwxrwxrwx         68 public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 -> ../../../tmp/controller00/benchmark-result-large_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/incoming/controller01
+lrwxrwxrwx         69 public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 -> ../../../tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/incoming/controller02
+drwxrwxr-x          - public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
+drwxrwxr-x          - tmp/controller00
+drwxrwxr-x          - tmp/controller00/benchmark-result-large_1900-01-01T00:00:00
+-rw-rw-r--       7300 tmp/controller00/benchmark-result-large_1900-01-01T00:00:00/lines.100.txt
+drwxrwxr-x          - tmp/controller01
+drwxrwxr-x          - tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00
+-rw-rw-r--       3650 tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00/lines.50.txt
+-rw-rw-r--         38 tmp/controller01/benchmark-result-medium_1900-01-01T00:00:00/metadata.log
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/270b662e76be70e22735b042fc336b60 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-3.txt
+++ b/server/pbench/bin/gold/test-3.txt
@@ -12,59 +12,61 @@
 --- Finished pbench-edit-prefixes (status=1)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-index
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/no-incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
+drwxrwxr-x          - logs/pbench-copy-sosreports
+-rw-rw-r--          0 logs/pbench-copy-sosreports/pbench-copy-sosreports.error
+-rw-rw-r--         93 logs/pbench-copy-sosreports/pbench-copy-sosreports.log
+drwxrwxr-x          - logs/pbench-edit-prefixes
+-rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
+-rw-rw-r--         91 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+drwxrwxr-x          - logs/pbench-index
+-rw-rw-r--          0 logs/pbench-index/pbench-index.error
+-rw-rw-r--        379 logs/pbench-index/pbench-index.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--         91 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--         93 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/no-incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-4.txt
+++ b/server/pbench/bin/gold/test-4.txt
@@ -12,59 +12,61 @@
 --- Finished pbench-edit-prefixes (status=1)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-index
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/no-results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
+-rw-rw-r--        107 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
+drwxrwxr-x          - logs/pbench-copy-sosreports
+-rw-rw-r--          0 logs/pbench-copy-sosreports/pbench-copy-sosreports.error
+-rw-rw-r--        192 logs/pbench-copy-sosreports/pbench-copy-sosreports.log
+drwxrwxr-x          - logs/pbench-edit-prefixes
+-rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
+-rw-rw-r--         89 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+drwxrwxr-x          - logs/pbench-index
+-rw-rw-r--          0 logs/pbench-index/pbench-index.error
+-rw-rw-r--        379 logs/pbench-index/pbench-index.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--         89 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--         91 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/no-results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-5.1.txt
+++ b/server/pbench/bin/gold/test-5.1.txt
@@ -12,63 +12,65 @@
 --- Finished pbench-edit-prefixes (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-index
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
+drwxrwxr-x          - logs/pbench-copy-sosreports
+-rw-rw-r--          0 logs/pbench-copy-sosreports/pbench-copy-sosreports.error
+-rw-rw-r--        192 logs/pbench-copy-sosreports/pbench-copy-sosreports.log
+drwxrwxr-x          - logs/pbench-edit-prefixes
+-rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
+-rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+drwxrwxr-x          - logs/pbench-index
+-rw-rw-r--          0 logs/pbench-index/pbench-index.error
+-rw-rw-r--        379 logs/pbench-index/pbench-index.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--         78 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--         78 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/public_html
-/var/tmp/pbench-test-server/pbench-local/public_html/incoming
-/var/tmp/pbench-test-server/pbench-local/public_html/results
-/var/tmp/pbench-test-server/pbench-local/public_html/users
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-5.txt
+++ b/server/pbench/bin/gold/test-5.txt
@@ -12,59 +12,61 @@
 --- Finished pbench-edit-prefixes (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-copy-sosreports/pbench-copy-sosreports.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-edit-prefixes/pbench-edit-prefixes.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-index
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-index/pbench-index.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-move-unpacked/pbench-move-unpacked.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
+-rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
+drwxrwxr-x          - logs/pbench-copy-sosreports
+-rw-rw-r--          0 logs/pbench-copy-sosreports/pbench-copy-sosreports.error
+-rw-rw-r--        192 logs/pbench-copy-sosreports/pbench-copy-sosreports.log
+drwxrwxr-x          - logs/pbench-edit-prefixes
+-rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
+-rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
+drwxrwxr-x          - logs/pbench-index
+-rw-rw-r--          0 logs/pbench-index/pbench-index.error
+-rw-rw-r--        379 logs/pbench-index/pbench-index.log
+drwxrwxr-x          - logs/pbench-move-unpacked
+-rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
+-rw-rw-r--        208 logs/pbench-move-unpacked/pbench-move-unpacked.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs
+-rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
+-rw-rw-r--         78 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-6.1.txt
+++ b/server/pbench/bin/gold/test-6.1.txt
@@ -3,41 +3,43 @@
 +++ Running unit test audit
 pbench-audit-archive: Bad archive: /var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/not-the-archive
-/var/tmp/pbench-test-server/pbench/not-the-archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        171 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - not-the-archive
+drwxrwxr-x          - not-the-archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC

--- a/server/pbench/bin/gold/test-6.2.txt
+++ b/server/pbench/bin/gold/test-6.2.txt
@@ -3,41 +3,43 @@
 +++ Running unit test audit
 pbench-audit-archive: Bad archive: /var/tmp/pbench-test-server/pbench/archive/fs-version-001
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+-rw-rw-r--          0 archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        167 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log:start-1900-01-01T00:00:00-UTC

--- a/server/pbench/bin/gold/test-6.3.txt
+++ b/server/pbench/bin/gold/test-6.3.txt
@@ -2,45 +2,47 @@
 --- Finished pbench-backup-tarballs (status=1)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/backup
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - backup
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        164 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-6.4.txt
+++ b/server/pbench/bin/gold/test-6.4.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/foo
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/foo
+-rw-r--r--    3242068 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/foo
+-rw-r--r--    3242068 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        692 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/4e6a327801a9294313dd343fa3f0f8e7 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-6.5.txt
+++ b/server/pbench/bin/gold/test-6.5.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/foo
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/foo
+-rw-r--r--    3242068 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/foo
+-rw-r--r--    3242068 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        885 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/4e6a327801a9294313dd343fa3f0f8e7 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-6.6.txt
+++ b/server/pbench/bin/gold/test-6.6.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/foo
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/foo
+-rw-r--r--    3242068 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive.backup/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive.backup/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/foo
+-rw-r--r--    3242068 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz
+-rw-r--r--         66 archive/fs-version-001/foo/fio__2016-08-18_15:47:09.tar.xz.md5
+-rw-r--r--    1610896 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz
+-rw-r--r--         84 archive/fs-version-001/foo/pbench-user-benchmark__2016-08-24_21:32:01.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        692 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/4e6a327801a9294313dd343fa3f0f8e7 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-6.txt
+++ b/server/pbench/bin/gold/test-6.txt
@@ -2,46 +2,48 @@
 --- Finished pbench-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/backup
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-backup-tarballs/pbench-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - backup
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-backup-tarballs
+-rw-rw-r--          0 logs/pbench-backup-tarballs/pbench-backup-tarballs.error
+-rw-rw-r--        692 logs/pbench-backup-tarballs/pbench-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.0.txt
+++ b/server/pbench/bin/gold/test-7.0.txt
@@ -23,41 +23,43 @@ Daily tool data for all tools land in indices named by tool; e.g. prefix.tool-da
 --- Finished indexing for test-7.0 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.1.txt
+++ b/server/pbench/bin/gold/test-7.1.txt
@@ -3,43 +3,45 @@ The metadata.log file is curdled in tarball:  /var/tmp/pbench-test-server/pbench
 --- Finished indexing for test-7.1 (status=7)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.1.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.1.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1232 test-7.1.tar.xz
+-rw-rw-r--         50 test-7.1.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.10.txt
+++ b/server/pbench/bin/gold/test-7.10.txt
@@ -10295,44 +10295,46 @@ len(actions) = 80
 --- Finished indexing for test-7.10 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/uperf_uperftest_2018.02.02T20.58.00.tar.xz
-/var/tmp/pbench-test-server/pbench/uperf_uperftest_2018.02.02T20.58.00.tar.xz.md5
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
+-rw-r--r--    2359300 uperf_uperftest_2018.02.02T20.58.00.tar.xz
+-rw-r--r--         77 uperf_uperftest_2018.02.02T20.58.00.tar.xz.md5
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.11.txt
+++ b/server/pbench/bin/gold/test-7.11.txt
@@ -5097,44 +5097,46 @@ len(actions) = 49
 --- Finished indexing for test-7.11 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/fio_rw_2018.02.01T22.40.57.tar.xz
-/var/tmp/pbench-test-server/pbench/fio_rw_2018.02.01T22.40.57.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+-rw-r--r--    2166628 fio_rw_2018.02.01T22.40.57.tar.xz
+-rw-r--r--         68 fio_rw_2018.02.01T22.40.57.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.12.txt
+++ b/server/pbench/bin/gold/test-7.12.txt
@@ -2955,44 +2955,46 @@ len(actions) = 60
 --- Finished indexing for test-7.12 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+-rw-r--r--    5264916 pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
+-rw-r--r--         84 pbench-user-benchmark__2018.02.05T20.35.36.tar.xz.md5
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.13.txt
+++ b/server/pbench/bin/gold/test-7.13.txt
@@ -5750,44 +5750,46 @@ len(actions) = 30
 --- Finished indexing for test-7.13 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+-rw-rw-r--    3320548 pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
+-rw-rw-r--         98 pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.14.txt
+++ b/server/pbench/bin/gold/test-7.14.txt
@@ -5025,44 +5025,46 @@ len(actions) = 30
 --- Finished indexing for test-7.14 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+-rw-rw-r--    3331324 pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
+-rw-rw-r--         98 pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.2.txt
+++ b/server/pbench/bin/gold/test-7.2.txt
@@ -3,43 +3,45 @@ Unsupported Tarball Format - no metadata.log:  /var/tmp/pbench-test-server/pbenc
 --- Finished indexing for test-7.2 (status=4)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.2.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.2.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1204 test-7.2.tar.xz
+-rw-rw-r--         50 test-7.2.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.3.txt
+++ b/server/pbench/bin/gold/test-7.3.txt
@@ -3,43 +3,45 @@ The metadata.log file is curdled in tarball:  /var/tmp/pbench-test-server/pbench
 --- Finished indexing for test-7.3 (status=7)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.3.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.3.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1472 test-7.3.tar.xz
+-rw-rw-r--         50 test-7.3.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.4.txt
+++ b/server/pbench/bin/gold/test-7.4.txt
@@ -7,44 +7,46 @@ Bad hostname in sosreport:  The sosreport did not collect a hostname other than 
 --- Finished indexing for test-7.4 (status=10)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.4.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.4.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1460 test-7.4.tar.xz
+-rw-rw-r--         50 test-7.4.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.5.txt
+++ b/server/pbench/bin/gold/test-7.5.txt
@@ -7,44 +7,46 @@ Bad hostname in sosreport:  The sosreport did not collect a hostname other than 
 --- Finished indexing for test-7.5 (status=10)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.5.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.5.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1476 test-7.5.tar.xz
+-rw-rw-r--         50 test-7.5.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.6.txt
+++ b/server/pbench/bin/gold/test-7.6.txt
@@ -127,44 +127,46 @@ len(actions) = 5
 --- Finished indexing for test-7.6 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.6.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.6.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1476 test-7.6.tar.xz
+-rw-rw-r--         50 test-7.6.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.7.txt
+++ b/server/pbench/bin/gold/test-7.7.txt
@@ -127,44 +127,46 @@ len(actions) = 5
 --- Finished indexing for test-7.7 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/test-7.7.tar.xz
-/var/tmp/pbench-test-server/pbench/test-7.7.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+-rw-rw-r--       1480 test-7.7.tar.xz
+-rw-rw-r--         50 test-7.7.tar.xz.md5
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.8.txt
+++ b/server/pbench/bin/gold/test-7.8.txt
@@ -47951,44 +47951,46 @@ len(actions) = 75
 --- Finished indexing for test-7.8 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
-/var/tmp/pbench-test-server/pbench/uperf__2016-10-06_16:34:03.tar.xz
-/var/tmp/pbench-test-server/pbench/uperf__2016-10-06_16:34:03.tar.xz.md5
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
+-rw-rw-r--    5823584 uperf__2016-10-06_16:34:03.tar.xz
+-rw-r--r--         68 uperf__2016-10-06_16:34:03.tar.xz.md5
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-7.9.txt
+++ b/server/pbench/bin/gold/test-7.9.txt
@@ -4450,44 +4450,46 @@ len(actions) = 75
 --- Finished indexing for test-7.9 (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/errors-json-unittests.json
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz
-/var/tmp/pbench-test-server/pbench/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+-rw-rw-r--          0 errors-json-unittests.json
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+-rw-r--r--    1136808 pbench-user-benchmark__2017-04-21_20:38:16.tar.xz
+-rw-r--r--         84 pbench-user-benchmark__2017-04-21_20:38:16.tar.xz.md5
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-8.txt
+++ b/server/pbench/bin/gold/test-8.txt
@@ -22,52 +22,51 @@ MAILFROM=pbench@pbench.example.com
 59 4 * * 0  flock -n /var/tmp/pbench-test-server/opt/pbench-server/lib/locks/pbench-verify-backup-tarballs.lock /var/tmp/pbench-test-server/opt/pbench-server/bin/pbench-verify-backup-tarballs /var/tmp/pbench-test-server/pbench/archive.backup
 ---- /var/tmp/pbench-test-server/opt/pbench-server/lib/crontab/crontab
 ++++ test-activation-execution.log file contents
-/var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -sf pbench-results-host-info.URL001.active pbench-results-host-info.URL001
-/var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -sf pbench-results-host-info.URL002.active pbench-results-host-info.URL002
 /var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/systemctl enable httpd.service
 /var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/systemctl start httpd.service
 /var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/firewall-cmd --add-service=http
 /var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/firewall-cmd --permanent --add-service=http
-/var/tmp/pbench-test-server/test-activation-execution.log:/var/tmp/pbench-test-server/opt/pbench-server/unittest-scripts/ln -s /var/tmp/pbench-test-server/pbench/public_html/incoming /var/tmp/pbench-test-server/pbench/public_html/results /var/tmp/pbench-test-server/pbench/public_html/users /var/tmp/pbench-test-server/var-www-html
 ---- test-activation-execution.log file contents
 --- Finished verifying server activation (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=0)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/d5ee68b33a845dac49792935d85c10ce --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-9.1.txt
+++ b/server/pbench/bin/gold/test-9.1.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-verify-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-verify-backup-tarballs
+-rw-rw-r--          0 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+-rw-rw-r--        285 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-9.2.txt
+++ b/server/pbench/bin/gold/test-9.2.txt
@@ -2,53 +2,55 @@
 --- Finished pbench-verify-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-verify-backup-tarballs
+-rw-rw-r--          0 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+-rw-rw-r--        285 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-9.3.txt
+++ b/server/pbench/bin/gold/test-9.3.txt
@@ -2,53 +2,55 @@
 --- Finished pbench-verify-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-verify-backup-tarballs
+-rw-rw-r--          0 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+-rw-rw-r--        285 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-9.4.txt
+++ b/server/pbench/bin/gold/test-9.4.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-verify-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-verify-backup-tarballs
+-rw-rw-r--          0 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+-rw-rw-r--        285 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/gold/test-9.5.txt
+++ b/server/pbench/bin/gold/test-9.5.txt
@@ -2,55 +2,57 @@
 --- Finished pbench-verify-backup-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=1)
-+++ var/www/html tree state
-/var/tmp/pbench-test-server/var-www-html
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
-/var/tmp/pbench-test-server/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
++++ var/www/html tree state (/var/tmp/pbench-test-server/var-www-html)
+lrwxrwxrwx         55 incoming -> /var/tmp/pbench-test-server/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL001 -> pbench-results-host-info.URL001.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL001.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL001.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        110 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         87 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         54 results -> /var/tmp/pbench-test-server/pbench/public_html/results
+lrwxrwxrwx         52 users -> /var/tmp/pbench-test-server/pbench/public_html/users
 --- var/www/html tree state
-+++ pbench tree state
-/var/tmp/pbench-test-server/pbench
-/var/tmp/pbench-test-server/pbench/archive
-/var/tmp/pbench-test-server/pbench/archive.backup
-/var/tmp/pbench-test-server/pbench/archive.backup/controller
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
-/var/tmp/pbench-test-server/pbench/archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
-/var/tmp/pbench-test-server/pbench/logs
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
-/var/tmp/pbench-test-server/pbench/logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
-/var/tmp/pbench-test-server/pbench/public_html
-/var/tmp/pbench-test-server/pbench/public_html/incoming
-/var/tmp/pbench-test-server/pbench/public_html/results
-/var/tmp/pbench-test-server/pbench/public_html/users
-/var/tmp/pbench-test-server/pbench/tmp
++++ pbench tree state (/var/tmp/pbench-test-server/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive.backup
+drwxrwxr-x          - archive.backup/controller
+-rw-r--r--    1558168 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive.backup/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive.backup/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - archive/fs-version-001/controller
+-rw-r--r--    1558168 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz
+-rw-r--r--         66 archive/fs-version-001/controller/fio__2016-08-16_22:03:11.tar.xz.md5
+-rw-r--r--       7028 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz
+-rw-r--r--         86 archive/fs-version-001/controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz.md5
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-archive
+-rw-rw-r--          0 logs/pbench-audit-archive/pbench-audit-archive.error
+-rw-rw-r--        218 logs/pbench-audit-archive/pbench-audit-archive.log
+drwxrwxr-x          - logs/pbench-verify-backup-tarballs
+-rw-rw-r--          0 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.error
+-rw-rw-r--        285 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/users
+drwxrwxr-x          - tmp
 --- pbench tree state
-+++ pbench-local tree state
-/var/tmp/pbench-test-server/pbench-local
-/var/tmp/pbench-test-server/pbench-local/fs-version-001
-/var/tmp/pbench-test-server/pbench-local/fs-version-001/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/fs-version-002
-/var/tmp/pbench-test-server/pbench-local/fs-version-002/pbench-move-results-receive
-/var/tmp/pbench-test-server/pbench-local/quarantine
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/duplicates-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/errors-002
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-001
-/var/tmp/pbench-test-server/pbench-local/quarantine/md5-002
++++ pbench-local tree state (/var/tmp/pbench-test-server/pbench-local)
+drwxrwxr-x          - fs-version-001
+drwxrwxr-x          - fs-version-001/pbench-move-results-receive
+drwxrwxr-x          - fs-version-002
+drwxrwxr-x          - fs-version-002/pbench-move-results-receive
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-001
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-001
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-001
+drwxrwxr-x          - quarantine/md5-002
 --- pbench-local tree state
 +++ pbench log file contents
 /var/tmp/pbench-test-server/pbench/logs/pbench-audit-archive/pbench-audit-archive.log:curl -XPOST -H Content-Type: application/json http://elasticsearch.example.com:9280/pbench-unittests.pbench-audit-archive.1900-01/status/220da1f3bf4d0b3f092de018ea819ba1 --data @/tmp/pbench-report-status.NNNN/payload

--- a/server/pbench/bin/test-bin/ln
+++ b/server/pbench/bin/test-bin/ln
@@ -1,3 +1,0 @@
-#! /bin/bash
-
-echo "$0 $*" >> $_testlog

--- a/server/pbench/bin/unittests
+++ b/server/pbench/bin/unittests
@@ -109,23 +109,34 @@ function _run_allscripts {
     _run pbench-edit-prefixes
 }
 
+function _local_find {
+    # We create our own local find command so that we don't emit the size
+    # information for directories.  This is due to the fact that on different
+    # file systems empty directories, or directories with small numbers of
+    # files, can be handled differently.  E.g. on Ext4 directories have a
+    # minimum size of 4096, while on XFS only after a certain size do they
+    # grow to multiples of 4096 [1].  We only care about the sizes of files and
+    # links in our tests.
+    #
+    # [1] https://superuser.com/questions/585844/why-directories-size-are-different-in-ls-l-output-on-xfs-file-system
+    find ${1} ! -name $(basename ${1}) -type d -printf '%M          - %P\n' , \( ! -type d ! -type l -printf '%M %10s %P\n' \) , -type l -printf '%M %10s %P -> %l\n' | sort -k 3
+}
+
 function _save_tree {
     # Save state of the tree
     if [ -d ${_testhtml} ] ;then
-        echo "+++ var/www/html tree state" >> $_testout
-        find ${_testhtml} | sort >> $_testout
+        echo "+++ var/www/html tree state (${_testhtml})" >> $_testout
+        _local_find ${_testhtml} >> $_testout
         echo "--- var/www/html tree state" >> $_testout
     fi
-    echo "+++ pbench tree state" >> $_testout
+    echo "+++ pbench tree state (${_testdir})" >> $_testout
     if [ -d ${_testdir} ] ;then
-        find $_testdir | sort |
-            sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
+        _local_find ${_testdir} | sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
     fi
     echo "--- pbench tree state" >> $_testout
     if [ -d ${_testdir_local} ] ;then
-        echo "+++ pbench-local tree state" >> $_testout
-        find ${_testdir_local} | sort |
-            sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
+        echo "+++ pbench-local tree state (${_testdir_local})" >> $_testout
+        _local_find ${_testdir_local} | sed 's;tmp/pbench-\([-a-zA-Z]*\)\.[0-9][0-9]*$;tmp/pbench-\1.NNNN;' >> $_testout
         echo "--- pbench-local tree state" >> $_testout
     fi
 }


### PR DESCRIPTION
We also emit the unit test state directories with mode, size, and the
symlink (present), shortening the path to reduce the volume of output.