### PR TITLE
Stop creating the unnecessary log directory

### DIFF
--- a/server/pbench/bin/pbench-sync-package-tarballs
+++ b/server/pbench/bin/pbench-sync-package-tarballs
@@ -57,13 +57,6 @@ mkdir -p "$tmp"
 > $index_content
 
 log_init $(basename $0) $LOGSDIR/$(basename $0)
-logdir=$LOGSDIR/$(basename $0)/$prefix/$TS
-mkdir -p "$logdir"
-rc=$?
-if [[ $rc != 0 ]] ;then
-    echo "$TS: Failed: mkdir -p $logdir" >&4
-    exit 2
-fi
 
 calculate_prefixname () {
     local prefix

--- a/server/pbench/bin/pbench-sync-package-tarballs
+++ b/server/pbench/bin/pbench-sync-package-tarballs
@@ -121,7 +121,7 @@ $PROG: Processed $nprocessed result tar balls, with $nerrs errors
 
 EOF
     cat $tmp/mail.log >> $index_content
-    pbench-report-status --name $PROG --timestamp $TS --type status $index_content
+    $dir/pbench-report-status --name $PROG --timestamp $TS --type status $index_content
 fi
 
 exit 0


### PR DESCRIPTION
We remove the unused and unnecessary log directory creation step since it ends up creating thousands of directories, 1,440 to exact, every day.  This will eventually reek havoc with a file system.