### PR TITLE
Fix the agent conf files

### DIFF
--- a/agent/config/pbench-agent-default.cfg.example
+++ b/agent/config/pbench-agent-default.cfg.example
@@ -1,0 +1,33 @@
+[DEFAULT]
+pbench_install_dir = /opt/pbench-agent
+version = 002
+
+[results]
+user = pbench
+dir = /pbench/public_html/incoming
+ssh_opts = -o StrictHostKeyChecking=no
+
+[pbench-agent]
+install-dir = %(pbench_install_dir)s
+pbench_user = pbench
+pbench_group = pbench
+pbench_run = /var/lib/pbench-agent
+pbench_log = %(pbench_run)s/pbench.log
+
+[pbench-agent-internal]
+install-dir = /opt/pbench-agent-internal
+
+[pbench/tools]
+default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat
+interval = 3
+
+[tools/pidstat]
+interval = 30
+
+[packages]
+pandas-package = depends
+
+[pbench-fio]
+version = 3.3
+histogram_interval_msec = 10000
+

--- a/agent/config/pbench-agent.cfg.example
+++ b/agent/config/pbench-agent.cfg.example
@@ -18,7 +18,7 @@ host_path = http://%(pbench_result_redirector)s/pbench-archive-host
 ssh_opts = -o StrictHostKeyChecking=no
 scp_opts = -o StrictHostKeyChecking=no
 webserver = %(pbench_web_server)s
-host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL001
+host_info_url = http://%(webserver)s/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 dir = /pbench/public_html/incoming
 
 [pbench/tools]


### PR DESCRIPTION
Fixes #961 #960 

This PR will fix the following conf file issues:
1. Fix the current agent config file which uses the wrong results host version.
2. Fix the missing pbench agent config default example file.