### PR TITLE
fio-postprocess: fix Perl syntax bug

### DIFF
--- a/agent/bench-scripts/postprocess/fio-postprocess
+++ b/agent/bench-scripts/postprocess/fio-postprocess
@@ -186,7 +186,7 @@ if (defined $jobs_stats) {
 	my %all_job_params;
 	for my $job (@{ $$jobs_stats }) {
 		if (defined $$job{"job options"}) {
-			for my $job_param (keys $$job{"job options"} ) {
+			for my $job_param (keys (%{ $$job{"job options"} }) ) {
 				$all_job_params{$job_param} = "";
 			}
 		}


### PR DESCRIPTION
- In newer versions of Perl the existing syntax results in the
  following error:

  "Experimental keys on scalar is now forbidden at <file> line <line #>"