### PR TITLE
Remove `--directory` option from pbench-fio.

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-17.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-17.txt
@@ -40,7 +40,7 @@ The following options are available:
 	--iodepth=<int>		Set the iodepth config variable in the fio job file
 
 	-c str[,str] --clients=str[,str]      str= one or more remote systems to run fio
-	                         If no clients are specified, fio is run locally
+		If no clients are specified, fio is run locally
 
 	--client-file=str        str= file (with absolute path) which contains 1 client per line
 
@@ -55,9 +55,6 @@ The following options are available:
 
 	--run-dir=<path>
 		provide the path of an existig result (typically somewhere in /var/tmp/pbench-test-bench/pbench
-
-	--directory=<path>
-		provide the path to an existing directory where fio operations will be performed
 
 	--numjobs=<int>
 		number of jobs to run, if not given then fio default of numjobs=1 will be used

--- a/agent/bench-scripts/gold/pbench-fio/test-18.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-18.txt
@@ -36,7 +36,7 @@ The following options are available:
 	--iodepth=<int>		Set the iodepth config variable in the fio job file
 
 	-c str[,str] --clients=str[,str]      str= one or more remote systems to run fio
-	                         If no clients are specified, fio is run locally
+		If no clients are specified, fio is run locally
 
 	--client-file=str        str= file (with absolute path) which contains 1 client per line
 
@@ -51,9 +51,6 @@ The following options are available:
 
 	--run-dir=<path>
 		provide the path of an existig result (typically somewhere in /var/tmp/pbench-test-bench/pbench
-
-	--directory=<path>
-		provide the path to an existing directory where fio operations will be performed
 
 	--numjobs=<int>
 		number of jobs to run, if not given then fio default of numjobs=1 will be used

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -51,7 +51,6 @@ rate_iops=""
 test_types="read,randread"		# default is -non- destructive
 block_sizes="4,64,1024"
 targets="/tmp/fio"
-directory=""
 numjobs=""
 runtime=""
 ramptime=""
@@ -129,9 +128,6 @@ function fio_usage() {
 		printf -- "\t--run-dir=<path>\n"
 		printf "\t\tprovide the path of an existig result (typically somewhere in $pbench_run\n"
 		printf "\n"
-		printf -- "\t--directory=<path>\n"
-		printf "\t\tprovide the path to an existing directory where fio operations will be performed\n"
-		printf "\n"
 		printf -- "\t--numjobs=<int>\n"
 		printf "\t\tnumber of jobs to run, if not given then fio default of numjobs=1 will be used\n"
 		printf "\n"
@@ -165,7 +161,7 @@ function fio_usage() {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,directory:,numjobs:,job-file:,sysinfo:,pre-iteration-script:,histogram-interval-sec:,histogram-interval-msec:" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o jic:t:b:s:d:r: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,numjobs:,job-file:,sysinfo:,pre-iteration-script:,histogram-interval-sec:,histogram-interval-msec:" -n "getopt.sh" -- "$@");
 
 	if [ $? -ne 0 ]; then
 		printf "\t${benchmark}: you specified an invalid option\n\n"
@@ -352,13 +348,6 @@ function fio_process_options() {
 				shift;
 			fi
 			;;
-			--directory)
-			shift;
-			if [ -n "$1" ]; then 
-				directory="$1"
-				shift;
-			fi
-			;; 
 			--numjobs)
 			shift;
 			if [ -n "$1" ]; then

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -212,6 +212,8 @@ declare -A pre=(
     [test-04]="cp $_tdir/samples/test-04.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
     [test-05]="cp $_tdir/samples/test-05.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
     [test-06]="cp $_tdir/samples/test-06.tar.xz $_testdir/samples; mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg; echo foo bar baz | tr ' ' '\n' > /tmp/foo"
+    [test-17]="mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
+    [test-18]="mkdir -p $_testopt/config;cp $_tdir/samples/pbench-agent.cfg $_testopt/config; export CONFIG=$_testopt/config/pbench-agent.cfg"
     [test-22]="tar xf $_tdir/samples/test-22.tar.xz -C $_testdir/"
 )
 


### PR DESCRIPTION
Fixes #872

The `--directory` option does nothing: it has been subsumed
by the `--targets` option. Remove it completely.