### PR TITLE
Remove pandas-related stuff.

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -194,12 +194,7 @@ if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
 
 else
     function check_install_rpm {
-        # this deals with python-pandas/python2-pandas dichotomy - see bench-scripts/pbench-fio
-        if [ -z "$3" ] ;then
-            echo $1
-        else
-            echo $3
-        fi
+        echo $1
         #$2 is the version which will vary
         return 0
     }

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -463,7 +463,6 @@ function fio_install() {
 			debug_log "[$script_name]$benchmark_rpm $ver installation failed, exiting"
 			exit 1
 		fi
-                
 	fi
 	if [ ! -z "$clients" ] ; then
 		debug_log "verifying clients have fio installed"

--- a/agent/bench-scripts/samples/pbench-agent.cfg
+++ b/agent/bench-scripts/samples/pbench-agent.cfg
@@ -1,5 +1,4 @@
 [packages]
-pandas-package = python2-pandas
 
 [pbench-fio]
 version = 3.3

--- a/agent/config/pbench-agent-default.cfg.example
+++ b/agent/config/pbench-agent-default.cfg.example
@@ -25,7 +25,6 @@ interval = 3
 interval = 30
 
 [packages]
-pandas-package = depends
 
 [pbench-fio]
 version = 3.3

--- a/agent/config/pbench-agent.cfg.example
+++ b/agent/config/pbench-agent.cfg.example
@@ -33,14 +33,6 @@ interval = 30
 # take care of installing the right package, depending
 # on the distro.
 
-# If you are copying this example file to create the "real"
-# pbench-agent.cfg file, you need to uncomment one of the
-# following pandas-package lines.
-# RHEL has python-pandas
-# pandas-package = python-pandas
-# Fedora has python2-pandas and python3-pandas
-# pandas-package = python2-pandas
-
 [config]
 path = %(pbench_install_dir)s/config
 files = pbench-agent.cfg

--- a/agent/util-scripts/samples/pbench-copy-results/test-31/opt/pbench-agent/config/pbench-agent.cfg
+++ b/agent/util-scripts/samples/pbench-copy-results/test-31/opt/pbench-agent/config/pbench-agent.cfg
@@ -29,7 +29,6 @@ interval = 3
 interval = 30
 
 [packages]
-pandas-package = python2-pandas
 
 [config]
 path = %(pbench_install_dir)s/config


### PR DESCRIPTION
Fixes issue #1005.

Pandas handling has been previously removed from pbench-fio.

This commit removes all the other traces of pandas that were left
over.