### PR TITLE
Fixes: #700 parse pidstat in chunks.

### DIFF
--- a/agent/tool-scripts/postprocess/GenData.pm
+++ b/agent/tool-scripts/postprocess/GenData.pm
@@ -42,7 +42,7 @@ sub gen_data {
 	my %counts;
 	my $filename;
 	my $timestamp_ms;
-	
+
 	# Generate the CSV file, and don't filter out anything based on a
 	# threshold, and generate the averages for each series.
 	my $csv;
@@ -61,7 +61,7 @@ sub gen_data {
 			#printf "\tchart = $chart\n";
 
 			$filename = $csv . "/" . $htmlpage. "_" .$chart . ".csv";
-			open(TOOL_CSV, ">$filename") || die "$script: could not open $filename\n";
+			open(TOOL_CSV, ">>$filename") || die "$script: could not open $filename\n";
 
 			# first check whether the timestamps in the different series agree: if so,
 			# we'll generate a normal (type-1) csv file:  each row will have the form
@@ -135,7 +135,7 @@ sub gen_data {
 							if ( not defined $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms} ) {
 								die "$script: timestamp $timestamp_ms missing for ($htmlpage, $chart, $series_key)";
 							}
-							$value = $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms}; 
+							$value = $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms};
 							$totals{$chart}{$series_key} += $value;
 							if ($value > $maxval{$htmlpage}{$chart}{$series_key}) {
 								$maxval{$htmlpage}{$chart}{$series_key} = $value;
@@ -175,7 +175,7 @@ sub gen_data {
 					for $series_key (@series_keys) {
 						# this should not happen any more, but paranoid checking doesn't hurt.
 						if ( defined $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms} ) {
-							$value = $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms}; 
+							$value = $stats{$htmlpage}{$chart}{$series_key}{$timestamp_ms};
 							$totals{$chart}{$series_key} += $value;
 							if ($value > $maxval{$htmlpage}{$chart}{$series_key}) {
 								$maxval{$htmlpage}{$chart}{$series_key} = $value;

--- a/agent/tool-scripts/postprocess/pidstat-postprocess
+++ b/agent/tool-scripts/postprocess/pidstat-postprocess
@@ -40,6 +40,8 @@ my $line;
 my $line2;
 my $tid;
 my @stats;
+my $lines_limit = 10000;
+my $lines_scanned = 0;
 
 my @virsh_list;
 my @virsh_vcpus;
@@ -69,6 +71,17 @@ if ( (($? >> 8) == 0) && (! -e "/usr/bin/vdsClient") && (-e "/usr/bin/virsh") ) 
 		}
 	}
 }
+
+$graph_type{cpu_usage}{percent_cpu} = "stackedAreaChart";
+$graph_threshold{cpu_usage}{percent_cpu} = 1;
+$graph_threshold{file_io}{io_reads_KB_sec} = 50;
+$graph_threshold{file_io}{io_writes_KB_sec} = 50;
+$graph_threshold{memory_faults}{minor_faults_sec} = 150;
+$graph_threshold{memory_faults}{major_faults_sec} = 150;
+$graph_threshold{context_switches}{voluntary_switches_sec} = 100;
+$graph_threshold{context_switches}{nonvoluntary_switches_sec} = 100;
+$graph_threshold{memory_usage}{virtual_size} = 100;
+$graph_threshold{memory_usage}{resident_set_size} = 100;
 
 # read the pidstat.txt and collect stats for all non dm-* devices
 open(PIDSTAT_TXT, "$dir/pidstat-stdout.txt") || die "could not find $dir/pidstat-stdout.txt\n";
@@ -149,35 +162,35 @@ while ($line = <PIDSTAT_TXT>) {
 		$pidstat{memory_usage}{virtual_size}{$pid}{$timestamp_ms} = $vsz;
 		$pidstat{memory_usage}{resident_set_size}{$pid}{$timestamp_ms} = $rss;
 		$timestamps{$timestamp_ms}++;
+
+                # parse data every 10,000 lines.
+                if ($lines_scanned % $lines_limit == 0) {
+                  # TODO: this code shold be multithreaded in order to speed up the process.
+                
+                  # fill in any missing data with zeros
+                  my $htmlpage;
+                  my $graph;
+                  my $pid;
+                  my $timestamp_ms;
+                  foreach  $htmlpage ( keys %pidstat ) {
+                  	foreach  $graph ( keys %{ $pidstat{$htmlpage} } ) {
+                  		foreach $pid ( keys %{ $pidstat{$htmlpage}{$graph} } ) {
+                  			foreach $timestamp_ms ( sort {$a <=> $b} (keys %timestamps ) ) {
+                  				if (! defined($pidstat{$htmlpage}{$graph}{$pid}{$timestamp_ms})) {
+                  					$pidstat{$htmlpage}{$graph}{$pid}{$timestamp_ms} = 0;
+                  				}
+                  			}
+                  		}
+                  	}
+                  }
+                
+                  # dump data into csv.
+                  gen_data(\%pidstat, \%graph_type, \%graph_threshold, $dir);
+                
+                  # reset pidstat in order to reduce memory.
+                  %pidstat = ();
+                }
+		$lines_scanned += 1; # count lines.
 	}
 }
 close(PIDSTAT_TXT);
-
-# fill in any missing data with zeros
-my $htmlpage;
-my $graph;
-my $pid;
-my $timestamp_ms;
-foreach  $htmlpage ( keys %pidstat ) {
-	foreach  $graph ( keys %{ $pidstat{$htmlpage} } ) {
-		foreach $pid ( keys %{ $pidstat{$htmlpage}{$graph} } ) {
-			foreach $timestamp_ms ( sort {$a <=> $b} (keys %timestamps ) ) {
-				if (! defined($pidstat{$htmlpage}{$graph}{$pid}{$timestamp_ms})) {
-					$pidstat{$htmlpage}{$graph}{$pid}{$timestamp_ms} = 0;
-				}
-			}
-		}
-	}
-}
-
-$graph_type{cpu_usage}{percent_cpu} = "stackedAreaChart";
-$graph_threshold{cpu_usage}{percent_cpu} = 1;
-$graph_threshold{file_io}{io_reads_KB_sec} = 50;
-$graph_threshold{file_io}{io_writes_KB_sec} = 50;
-$graph_threshold{memory_faults}{minor_faults_sec} = 150;
-$graph_threshold{memory_faults}{major_faults_sec} = 150;
-$graph_threshold{context_switches}{voluntary_switches_sec} = 100;
-$graph_threshold{context_switches}{nonvoluntary_switches_sec} = 100;
-$graph_threshold{memory_usage}{virtual_size} = 100;
-$graph_threshold{memory_usage}{resident_set_size} = 100;
-gen_data(\%pidstat, \%graph_type, \%graph_threshold, $dir);


### PR DESCRIPTION
When scanning large pidstat-stdout.txt file, we might face OOM kill, because we try to load the entire file into pidstat [1].
in order to avoid that, we should work in chunks, and pidstat
should hold just some buffer and not the entire file.

This patch will hold a buffer of 10,000 lines, and will use gen_data  func to dump into a csv format and reset the pidstat each iteration.

this is a short term solution and it might take longer because we do the parsing phase while scanning.
this way we'll make sure we'll not hit any OOM kills.

[1]
https://github.com/distributed-system-analysis/pbench/blob/19fa2ad408214df97fab06da1d03aea020590299/agent/tool-scripts/postprocess/pidstat-postprocess#L31