### PR TITLE
Query prefix field in run document for summary visualization

### DIFF
--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -36,7 +36,6 @@
     "jschart": "^1.0.2",
     "lodash": "^4.17.10",
     "lodash-decorators": "^6.0.0",
-    "moment": "^2.19.3",
     "numeral": "^2.0.6",
     "omit.js": "^1.0.0",
     "path-to-regexp": "^2.1.0",

--- a/web-server/v0.4/src/components/GlobalHeader/index.js
+++ b/web-server/v0.4/src/components/GlobalHeader/index.js
@@ -1,19 +1,12 @@
 import { PureComponent } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import moment from 'moment';
-import { Icon, Divider, Tooltip, DatePicker, Button, notification, Spin } from 'antd';
+import { Icon, Divider, Tooltip } from 'antd';
 import Debounce from 'lodash-decorators/debounce';
 import { Link } from 'dva/router';
 import styles from './index.less';
 
-const { MonthPicker } = DatePicker;
-
-@connect(({ global, dashboard, routing }) => ({
-  startMonth: dashboard.startMonth,
-  endMonth: dashboard.endMonth,
-  indices: dashboard.indices,
-  datastoreConfig: global.datastoreConfig,
+@connect(({ routing }) => ({
   location: routing.location.pathname,
 }))
 class GlobalHeader extends PureComponent {
@@ -27,62 +20,6 @@ class GlobalHeader extends PureComponent {
     this.triggerResizeEvent();
   };
 
-  openErrorNotification = (month) => {
-    notification.error({
-      message: 'Index Unavailable',
-      description: month + ' does not contain any documents. Please select a different month.',
-    });
-  }
-
-  changeStartMonth = month => {
-    const { dispatch, indices } = this.props;
-    let selectedMonth = month.format('YYYY-MM').toString();
-
-    if (indices.includes(selectedMonth)) {
-      dispatch({
-        type: 'dashboard/modifyControllerStartMonth',
-        payload: month.toString(),
-      });
-    } else {
-      this.openErrorNotification(selectedMonth)
-    }
-  };
-
-  changeEndMonth = month => {
-    const { dispatch, indices } = this.props;
-    let selectedMonth = month.format('YYYY-MM').toString();
-
-    if (indices.includes(selectedMonth)) {
-      dispatch({
-        type: 'dashboard/modifyControllerEndMonth',
-        payload: month.toString(),
-      });
-    } else {
-      this.openErrorNotification(selectedMonth)
-    }
-  };
-
-  handleDateChange = () => {
-    const { dispatch, datastoreConfig, startMonth, endMonth } = this.props;
-
-    dispatch({
-      type: 'dashboard/fetchControllers',
-      payload: { datastoreConfig: datastoreConfig, startMonth: moment(startMonth), endMonth: moment(endMonth) },
-    });
-  };
-
-  disabledStartMonth = (current) => {
-    const { endMonth } = this.props;
-
-    return current && current > moment(endMonth);
-  }
-
-  disabledEndMonth = (current) => {
-    const { startMonth } = this.props;
-
-    return current && current < moment(startMonth); 
-  }
-
   /* eslint-disable*/
   @Debounce(600)
   triggerResizeEvent() {
@@ -92,7 +29,7 @@ class GlobalHeader extends PureComponent {
   }
 
   render() {
-    const { collapsed, isMobile, logo, indices, startMonth, endMonth, location, dispatch } = this.props;
+    const { collapsed, isMobile, logo, location, dispatch } = this.props;
     console.log('header rendered');
 
     return (
@@ -109,51 +46,19 @@ class GlobalHeader extends PureComponent {
             type={collapsed ? 'menu-unfold' : 'menu-fold'}
             onClick={this.toggle}
           />
-          {location == '/dashboard/controllers' ? (
-            <Spin spinning={indices.length == 0}>
-              <div>
-                <MonthPicker
-                  style={{ marginBottom: 16 }}
-                  placeholder={'Start month'}
-                  value={moment(startMonth)}
-                  disabledDate={this.disabledStartMonth}
-                  onChange={this.changeStartMonth}
-                  allowClear={false}
-                  renderExtraFooter={() =>
-                    'Select the start month to adjust the time range for controllers to query.'
-                  }
-                />
-                <MonthPicker
-                  style={{ marginLeft: 16, marginRight: 8 }}
-                  placeholder={'End month'}
-                  value={moment(endMonth)}
-                  disabledDate={this.disabledEndMonth}
-                  onChange={this.changeEndMonth}
-                  allowClear={false}
-                  renderExtraFooter={() =>
-                    'Select the end month to adjust the time range for controllers to query.'
-                  }
-                />
-                <Button type="primary" onClick={this.handleDateChange}>
-                  {'Filter Months'}
-                </Button>
-              </div>
-            </Spin>
-          ) : (
-            <div />
-          )}
         </div>
         <div className={styles.right}>
-          <Tooltip title="Search" onClick={() => {
-              dispatch (
+          <Tooltip
+            title="Search"
+            onClick={() => {
+              dispatch(
                 routerRedux.push({
                   pathname: '/search',
                 })
-              )
-              }}>
-            <a
-              className={styles.action}
-            >
+              );
+            }}
+          >
+            <a className={styles.action}>
               <Icon type="search" />
             </a>
           </Tooltip>

--- a/web-server/v0.4/src/index.js
+++ b/web-server/v0.4/src/index.js
@@ -5,7 +5,6 @@ import createHistory from 'history/createHashHistory';
 // user BrowserHistory
 // import createHistory from 'history/createBrowserHistory';
 import createLoading from 'dva-loading';
-import 'moment/locale/zh-cn';
 
 import './index.less';
 import 'ant-design-pro/dist/ant-design-pro.css';

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -1,123 +1,109 @@
-import {
-    queryIndexMapping,
-    searchQuery
-} from '../services/search';
+import { queryIndexMapping, searchQuery } from '../services/search';
 
 export default {
-    namespace: 'search',
+  namespace: 'search',
 
-    state: {
-        mapping: {},
-        searchResults: [],
-        fields: [],
-        selectedFields: [],
-        selectedIndices: [],
-        loading: false
-    },
+  state: {
+    mapping: {},
+    searchResults: [],
+    fields: [],
+    selectedFields: [],
+    loading: false,
+  },
 
-    effects: {
-        *fetchIndexMapping({ payload }, { call, put }) {
-            let response = yield call(queryIndexMapping, payload);
-            const { datastoreConfig, indices } = payload;
+  effects: {
+    *fetchIndexMapping({ payload }, { call, put }) {
+      let response = yield call(queryIndexMapping, payload);
+      const { datastoreConfig, indices } = payload;
 
-            let index = datastoreConfig.prefix + datastoreConfig.run_index + indices[0];
-            let mapping = response[index].mappings['pbench-run'].properties;
-            let fields = [];
-            let filters = {};
+      let index = datastoreConfig.prefix + datastoreConfig.run_index + indices[0];
+      let mapping = response[index].mappings['pbench-run'].properties;
+      let fields = [];
+      let filters = {};
 
-            for (const [key, value] of Object.entries(mapping)) {
-                if (typeof value.properties !== "undefined") {
-                    filters[key] = Object.keys(value.properties);
-                    fields.concat(Object.keys(value.properties));
-                }
-            }
-
-            yield put({
-                type: 'getIndexMapping',
-                payload: filters
-            })
-            yield put({
-                type: 'getIndexFields',
-                payload: fields
-            })
-            yield put({
-                type: 'modifySelectedFields',
-                payload: ['run.name', 'run.config', 'run.controller']
-            })
-            yield put({
-                type: 'modifySelectedIndices',
-                payload: [indices[0]]
-            })
-        },
-        *fetchSearchResults({ payload }, { call, put }) {
-            try {
-                let response = yield call(searchQuery, payload);
-                const { selectedFields } = payload;
-                
-                let searchResults = {};
-                searchResults['resultCount'] = response.hits.total;
-                let parsedResults = [];
-                response.hits.hits.map((result) => {
-                    let parsedResult = {};
-                    selectedFields.map(field => {
-                        parsedResult[field] = result._source[field.split('.')[0]][field.split('.')[1]];
-                    });
-                    parsedResults.push(parsedResult);
-                })
-                searchResults['results'] = parsedResults;
-
-                yield put({
-                    type: 'getSearchResults',
-                    payload: searchResults
-                })
-            } catch (e) {
-                console.log(e.message)
-            }
-        },
-        *updateSelectedFields({ payload }, { select, put }) {
-            yield put({
-                type: 'modifySelectedFields',
-                payload: payload
-            })
-        },
-        *updateSelectedIndices({ payload }, { select, put }) {
-            yield put({
-                type: 'modifySelectedIndices',
-                payload: payload
-            })
+      for (const [key, value] of Object.entries(mapping)) {
+        if (typeof value.properties !== 'undefined') {
+          filters[key] = Object.keys(value.properties);
+          fields.concat(Object.keys(value.properties));
         }
-    },
+      }
 
-    reducers: {
-        getIndexMapping(state, { payload }) {
-            return {
-                ...state,
-                mapping: payload
-            }
-        },
-        getIndexFields(state, { payload }) {
-            return {
-                ...state,
-                fields: payload
-            }
-        },
-        getSearchResults(state, { payload }) {
-            return {
-                ...state,
-                searchResults: payload
-            }
-        },
-        modifySelectedFields(state, { payload }) {
-            return {
-                ...state,
-                selectedFields: payload
-            }
-        },
-        modifySelectedIndices(state, { payload }) {
-            return {
-                ...state,
-                selectedIndices: payload
-            }
-        }
-    }
-}
+      yield put({
+        type: 'getIndexMapping',
+        payload: filters,
+      });
+      yield put({
+        type: 'getIndexFields',
+        payload: fields,
+      });
+      yield put({
+        type: 'modifySelectedFields',
+        payload: ['run.name', 'run.config', 'run.controller'],
+      });
+      yield put({
+        type: 'modifySelectedIndices',
+        payload: [indices[0]],
+      });
+    },
+    *fetchSearchResults({ payload }, { call, put }) {
+      try {
+        let response = yield call(searchQuery, payload);
+        let { selectedFields } = payload;
+
+        let searchResults = {};
+        searchResults['resultCount'] = response.hits.total;
+        let parsedResults = [];
+        response.hits.hits.map(result => {
+          let parsedResult = {};
+          selectedFields.map(field => {
+            parsedResult[field] = result._source[field.split('.')[0]][field.split('.')[1]];
+          });
+          parsedResult['run.prefix'] =
+            result._source['run.prefix'.split('.')[0]]['run.prefix'.split('.')[1]];
+          parsedResults.push(parsedResult);
+        });
+        searchResults['results'] = parsedResults;
+
+        yield put({
+          type: 'getSearchResults',
+          payload: searchResults,
+        });
+      } catch (e) {
+        console.log(e.message);
+      }
+    },
+    *updateSelectedFields({ payload }, { select, put }) {
+      yield put({
+        type: 'modifySelectedFields',
+        payload: payload,
+      });
+    },
+  },
+
+  reducers: {
+    getIndexMapping(state, { payload }) {
+      return {
+        ...state,
+        mapping: payload,
+      };
+    },
+    getIndexFields(state, { payload }) {
+      return {
+        ...state,
+        fields: payload,
+      };
+    },
+    getSearchResults(state, { payload }) {
+      return {
+        ...state,
+        searchResults: payload,
+      };
+    },
+    modifySelectedFields(state, { payload }) {
+      return {
+        ...state,
+        selectedFields: payload,
+      };
+    },
+  },
+};

--- a/web-server/v0.4/src/routes/Dashboard/ComparisonSelect.js
+++ b/web-server/v0.4/src/routes/Dashboard/ComparisonSelect.js
@@ -14,8 +14,6 @@ import { queryIterations } from '../../services/dashboard';
   iterations: dashboard.iterations,
   results: dashboard.results,
   controllers: dashboard.controllers,
-  startMonth: dashboard.startMonth,
-  endMonth: dashboard.endMonth,
   datastoreConfig: global.datastoreConfig,
   loading: loading.effects['dashboard/fetchIterations'],
 }))
@@ -268,7 +266,7 @@ class ComparisonSelect extends ReactJS.Component {
           <Card style={{ marginBottom: 16 }}>
             <Card
               type="inner"
-              title={<h3 style={{marginTop: 8}}>{'Selected Iterations'}</h3>}
+              title={<h3 style={{ marginTop: 8 }}>{'Selected Iterations'}</h3>}
               extra={
                 <div>
                   <Button
@@ -289,31 +287,35 @@ class ComparisonSelect extends ReactJS.Component {
                   </Button>
                 </div>
               }
-            > 
-              {selectedRowNames.length > 0 ?
+            >
+              {selectedRowNames.length > 0 ? (
                 <div>
                   {selectedRowNames.map((row, i) => (
-                    <Tag style={{fontSize: 16}} key={i} id={i}>
+                    <Tag style={{ fontSize: 16 }} key={i} id={i}>
                       {row}
                     </Tag>
                   ))}
                 </div>
-                :
-                <Card.Meta
-                  description="Start by comparing all iterations or selecting specific iterations from the result tables below."
-                />
-              }
+              ) : (
+                <Card.Meta description="Start by comparing all iterations or selecting specific iterations from the result tables below." />
+              )}
             </Card>
             <Card
               type="inner"
-              title={<h3 style={{marginTop: 8}}>{'Iteration Filters'}</h3>}
+              title={<h3 style={{ marginTop: 8 }}>{'Iteration Filters'}</h3>}
               style={{ marginTop: 16 }}
               extra={
-                <Button style={{ marginLeft: 8 }} type="primary" onClick={this.clearFilters} loading={loadingButton}>
+                <Button
+                  style={{ marginLeft: 8 }}
+                  type="primary"
+                  onClick={this.clearFilters}
+                  loading={loadingButton}
+                >
                   {'Clear Filters'}
                 </Button>
-              }>
-                {/*<Select
+              }
+            >
+              {/*<Select
                   allowClear={true}
                   placeholder={'Filter Hostname & Port'}
                   style={{ marginTop: 16, width: 160 }}
@@ -324,22 +326,22 @@ class ComparisonSelect extends ReactJS.Component {
                     <Select.Option value={port}>{port}</Select.Option>
                   ))}
                   </Select>*/}
-                {Object.keys(configData).map((category, i) => (
-                  <Select
-                    key={i}
-                    allowClear={true}
-                    placeholder={category}
-                    style={{ marginLeft: 8, width: 160 }}
-                    value={selectedConfig[category]}
-                    onChange={value => this.configChange(value, category)}
-                  >
-                    {configData[category].map((categoryData, i) => (
-                      <Select.Option key={i} value={categoryData}>
-                        {categoryData}
-                      </Select.Option>
-                    ))}
-                  </Select>
-                ))}
+              {Object.keys(configData).map((category, i) => (
+                <Select
+                  key={i}
+                  allowClear={true}
+                  placeholder={category}
+                  style={{ marginLeft: 8, width: 160 }}
+                  value={selectedConfig[category]}
+                  onChange={value => this.configChange(value, category)}
+                >
+                  {configData[category].map((categoryData, i) => (
+                    <Select.Option key={i} value={categoryData}>
+                      {categoryData}
+                    </Select.Option>
+                  ))}
+                </Select>
+              ))}
             </Card>
           </Card>
           {responseDataCopy.map((response, i) => {

--- a/web-server/v0.4/src/routes/Dashboard/RunComparison.js
+++ b/web-server/v0.4/src/routes/Dashboard/RunComparison.js
@@ -15,7 +15,7 @@ const { Description } = DescriptionList;
 const TabPane = Tabs.TabPane;
 
 @connect(({ global }) => ({
-  datastoreConfig: global.datastoreConfig
+  datastoreConfig: global.datastoreConfig,
 }))
 export default class RunComparison extends ReactJS.Component {
   static propTypes = {
@@ -165,7 +165,8 @@ export default class RunComparison extends ReactJS.Component {
         for (var iteration in clusteredIterations[primaryMetric][cluster]) {
           iterationRequests.push(
             axios.get(
-              datastoreConfig.results + '/results/' +
+              datastoreConfig.results +
+                '/results/' +
                 encodeURIComponent(
                   clusteredIterations[primaryMetric][cluster][iteration].controller_name
                 ) +
@@ -288,7 +289,9 @@ export default class RunComparison extends ReactJS.Component {
 
     return {
       __html:
-        '<iframe style="overflow: hidden; overflow-y: hidden; height: 650px; border: none; margin: 0; padding: 0; scrolling: none" src="' + datastoreConfig.production + '/results/' +
+        '<iframe style="overflow: hidden; overflow-y: hidden; height: 650px; border: none; margin: 0; padding: 0; scrolling: none" src="' +
+        datastoreConfig.production +
+        '/results/' +
         controllerName +
         '/' +
         resultName +
@@ -387,7 +390,7 @@ export default class RunComparison extends ReactJS.Component {
           <Description term="Controller">{<Tag>{controller}</Tag>}</Description>
           <Description term="Results">
             {selectedResults.map(result => (
-              <Tag>{result.result}</Tag>
+              <Tag>{result['run.name']}</Tag>
             ))}
           </Description>
           <Description term="Clustering Config">

--- a/web-server/v0.4/src/services/global.js
+++ b/web-server/v0.4/src/services/global.js
@@ -2,7 +2,17 @@ import request from '../utils/request';
 
 export async function queryDatastoreConfig() {
   // Note that window.location.pathname should have a trailing slash already.
-  return request(window.location.pathname + 'config.json', {
+  return request('http://localhost:8000/dev.config.json', {
+    method: 'GET',
+  });
+}
+
+export async function queryMonthIndices(params) {
+  const { datastoreConfig } = params;
+
+  const endpoint = datastoreConfig.elasticsearch + '/_cat/indices?format=json&pretty=true';
+
+  return request(endpoint, {
     method: 'GET',
   });
 }


### PR DESCRIPTION
The dashboard redux service will query the prefix value for a run before building the url to fetch result.json docs from the production environment.

This also improves the index selection workflow by removing ranges and allowing users to select specific indices to query run documents. This required a restructuring of redux services by moving specific dispatched actions to the `global` service in order to provide data at the appropriate scope throughout the dashboard.  