### PR TITLE
Reduce overhead for local dev by using node environment vars

### DIFF
--- a/web-server/v0.4/.webpackrc.js
+++ b/web-server/v0.4/.webpackrc.js
@@ -1,6 +1,9 @@
 const path = require('path');
 
 export default {
+  define: {
+    'process.env': process.env.NODE_ENV
+  },
   entry: 'src/index.js',
   extraBabelPlugins: [['import', { libraryName: 'antd', libraryDirectory: 'es', style: true }]],
   env: {
@@ -20,6 +23,6 @@ export default {
     javascriptEnabled: true,
   },
   disableDynamicImport: true,
-  publicPath: '/dashboard/',
+  publicPath: process.env.NODE_ENV === 'development' ? '/' : '/dashboard/',
   hash: true,
 };

--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -40,7 +40,7 @@ Pbench Dashboard is a web-based platform for consuming indexed performance bench
 
 Assets placed in the `public` directory are copied to the `dist` directory for reference in the generated `index.html` file during the build process.
 
-Assets placed in the `src/assets/` directory are only referenced within components or layouts definitions and is packaged in the generated `***.js` file during the build process.
+Assets placed in the `src/assets/` directory are only referenced within component or layout definitions and are packaged in the generated `***.js` file during the build process.
 
 
 ## Installation
@@ -61,13 +61,7 @@ This will automatically open the application on [http://localhost:8000](http://l
 
 ## Local Development
 
-Both the production and development builds of the dashboard require specific configurations in order to run on their respective environment. For local development, modify the following configuration definitions:
-
-`.webpackrc.js`
-
-```Javascript
-publicPath: '/'
-```
+Both the production and development builds of the dashboard require specific configurations in order to run on their respective environment.
 
 Create and include a JSON config file in the root directory. Please reference the following example for required configuration fields.
 
@@ -79,18 +73,6 @@ Create and include a JSON config file in the root directory. Please reference th
    "results": "http://results.example.com",
    "prefix": "example.prefix",
    "run_index": "example.index"
-}
-```
-
-For local development, reference `dev.config.json` on localhost through the `global` service.
-
-`/src/services/global.js`
-
-```Javascript
-export async function queryDatastoreConfig() {
-  return request('http://localhost:8000/dev.config.json', {
-    method: 'GET',
-  });
 }
 ```
 

--- a/web-server/v0.4/src/services/global.js
+++ b/web-server/v0.4/src/services/global.js
@@ -1,8 +1,33 @@
 import request from '../utils/request';
 
+/**
+ * This service references the node environment for retrieval of 
+ * the API config file. Node specifies two types of environments
+ * depending on how the dashboard has been run: 
+ * 
+ * `development` - the dashboard is referencing `dev.config.json`
+ * and has been executed from the root directory using the `start`
+ * script. 
+ * 
+ * `production` - the dashboard has been bundled to minimized
+ * js, css, and html files using the `build` script and is 
+ * deployed on a web server.
+ */
 export async function queryDatastoreConfig() {
-  // Note that window.location.pathname should have a trailing slash already.
-  return request('http://localhost:8000/dev.config.json', {
+  let configEndpoint = '';
+  let environment = process.env || 'development';
+  
+  switch(environment) {
+    case 'development':
+      configEndpoint = 'http://localhost:8000/dev.config.json'
+      break
+    case 'production':
+      // Note that window.location.pathname should already have a trailing slash.
+      configEndpoint = window.location.pathname + 'config.json'
+      break
+  }
+
+  return request(configEndpoint, {
     method: 'GET',
   });
 }


### PR DESCRIPTION
Reference the node environment status in order to configure
appropriate endpoints and public paths for development and
production environments.