### PR TITLE
Ensure pbench-move/copy-results only works with metadata.log

### DIFF
--- a/agent/util-scripts/gold/pbench-move-results/test-33.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-33.txt
@@ -2,12 +2,14 @@
 --- setup pbench results dir time stamps
 +++ Running test-33 pbench-move-results
 tar --create --force-local "pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42" | xz -T0 > "/var/tmp/pbench-test-utils/pbench/tmp/pbench-move-results.NNNNN/testhost/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz" 
-[warn][1900-01-01T00:00:00.000000] the run in directory /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43 has an unexpected metadata name, "pbench-user-benchmark__2019.01.01T12.00.43" - skipping
+[warn][1900-01-01T00:00:00.000000] The run in directory /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43 has an unexpected metadata name, "pbench-user-benchmark__2019.01.01T12.00.43" - skipping
 --- Finished test-33 pbench-move-results (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43
 /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43/metadata.log
+/var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44
+/var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44/bad-metadata.log
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/pbench@server.com:
 /var/tmp/pbench-test-utils/pbench/pbench@server.com:/foo
@@ -25,7 +27,9 @@ tar --create --force-local "pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42
 +++ pbench.log file contents
 /var/tmp/pbench-test-utils/pbench/pbench.log:Fake log file contents.
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] preparing to copy 1 MB of data from /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42
-/var/tmp/pbench-test-utils/pbench/pbench.log:[warn][1900-01-01T00:00:00.000000] the run in directory /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43 has an unexpected metadata name, "pbench-user-benchmark__2019.01.01T12.00.43" - skipping
+/var/tmp/pbench-test-utils/pbench/pbench.log:[warn][1900-01-01T00:00:00.000000] The run in directory /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43 has an unexpected metadata name, "pbench-user-benchmark__2019.01.01T12.00.43" - skipping
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] The pbench result pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44 does not appear to be a benchmark directory - skipping
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] The /var/tmp/pbench-test-utils/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44/metadata.log file seems to be missing
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] successfully moved 1 runs, encountered 0 failures
 --- pbench.log file contents
 +++ test-execution.log file contents

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -184,9 +184,16 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
         continue
     fi
 
-    res_name=$(getconf.py --config ${pbench_run_name}/metadata.log name pbench)
+    mdlog=${pbench_run_name}/metadata.log
+    if [ ! -e ${mdlog} ]; then
+        debug_log "The pbench result ${pbench_run_name} does not appear to be a benchmark directory - skipping"
+        debug_log "The ${pbench_run}/${pbench_run_name}/metadata.log file seems to be missing"
+        continue
+    fi
+
+    res_name=$(getconf.py --config ${mdlog} name pbench)
     if [ "${res_name}" != "${pbench_run_name}" ]; then
-        warn_log "the run in directory ${pbench_run}/${pbench_run_name} has an unexpected metadata name, \"${res_name}\" - skipping"
+        warn_log "The run in directory ${pbench_run}/${pbench_run_name} has an unexpected metadata name, \"${res_name}\" - skipping"
         continue
     fi
 
@@ -198,13 +205,11 @@ for dir in `/bin/ls -ort -d */ | awk '{print $8}' | grep -v "^tools-" | grep -v 
 
     # if -u was specified, store the specified user in metadata.log
     if [ ! -z $user ] ;then
-	mdlog=${pbench_run_name}/metadata.log
 	echo $user | pbench-add-metalog-option ${mdlog} run user
     fi
 
     # if -p was specified, store the specified prefix in metadata.log
     if [ ! -z $prefix ] ;then
-	mdlog=${pbench_run_name}/metadata.log
 	echo $prefix | pbench-add-metalog-option ${mdlog} run prefix
     fi
 

--- a/agent/util-scripts/samples/pbench-move-results/test-33/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44/bad-metadata.log
+++ b/agent/util-scripts/samples/pbench-move-results/test-33/pbench/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44/bad-metadata.log
@@ -1,0 +1,31 @@
+[pbench]
+name = pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44
+script = pbench-user-benchmark
+config = ndk-test-1
+date = 2018-05-23T03:21:32
+rpm-version = 0.50-1g799ea025
+iterations = 1, 1
+
+[tools]
+hosts = alphaville
+group = default
+
+[tools/alphaville]
+hostname-s = alphaville
+iostat = --interval=3
+mpstat = --interval=3
+perf = --record-opts=record -a --freq=100
+pidstat = --interval=30
+proc-interrupts = --interval=3
+proc-vmstat = --interval=3
+sar = --interval=3
+turbostat = --interval=3
+
+[run]
+controller = alphaville.usersys.redhat.com
+start_run = 2018-05-23T03:21:32.387628370
+end_run = 2018-05-23T03:22:39.538437410
+
+[iterations/1]
+iteration_name = 1
+user_script = sleep

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -279,7 +279,7 @@ declare -A expected_status=(
 
 declare -A pre_hooks=(
     [test-20]='mkdir -p $_testdir/tmp/tools-default/iostat; touch $_testdir/tmp/tools-default/iostat/iostat-stdout.txt'
-    [test-33]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" $_testdir/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" $_testdir/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; echo "--- setup pbench results dir time stamps") >> $_testout'
+    [test-33]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" $_testdir/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" $_testdir/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; touch --date="2019-01-01 12:00:44" $_testdir/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44; echo "--- setup pbench results dir time stamps") >> $_testout'
 )
 
 declare -A post_hooks=(


### PR DESCRIPTION
Going forward, if a pbench result does not have a metadata.log file
present, then we are not going to try to handle that result. This
will avoid problems that arise from not being able to index the data
from the result to use in various user interfaces (Kibana, Grafana,
and the pbench UI itself).