### PR TITLE
Add --no-stderr-capture flag to pbench-user-benchmark

### DIFF
--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-07.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-07.txt
@@ -10,6 +10,7 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		       --pbench-pre=str        path to the script which will be executed before tools are started
 		       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 		       --use-tool-triggers     use tool triggers instead of normal start/stop around script
+		       --no-stderr-capture     do not capture stderr of the script to the result.txt file
 --- Finished test-07 pbench-user-benchmark (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-08.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-08.txt
@@ -14,6 +14,7 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 		       --pbench-pre=str        path to the script which will be executed before tools are started
 		       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete
 		       --use-tool-triggers     use tool triggers instead of normal start/stop around script
+		       --no-stderr-capture     do not capture stderr of the script to the result.txt file
 --- Finished test-08 pbench-user-benchmark (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
@@ -14,6 +14,7 @@ Running user-benchmark-script no-file
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
@@ -16,6 +16,7 @@ Running user-benchmark-script no-duration
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
@@ -16,6 +16,7 @@ Running user-benchmark-script with-duration
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
@@ -27,6 +27,7 @@ ValueError: Expecting object: line 3 column 25 (char 50)
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary-debug.json
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-23.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-23.txt
@@ -23,6 +23,7 @@ STOP DEFAULT
 [pbench-tool-trigger]pbench-stop-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
 sud
 --- Finished test-23 pbench-user-benchmark (status=0)
+tool-trigger-example 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/result.txt | pbench-tool-trigger 1 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00 default
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00
@@ -39,6 +40,7 @@ sud
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/result.txt
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/user-benchmark-summary-debug.json
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/user-benchmark.cmd
 /var/tmp/pbench-test-bench/pbench/pbench.log
 /var/tmp/pbench-test-bench/pbench/samples
 /var/tmp/pbench-test-bench/pbench/tmp

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-24.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-24.txt
@@ -1,0 +1,36 @@
++++ Running test-24 pbench-user-benchmark
+Running user-benchmark-script no-file
+--- Finished test-24 pbench-user-benchmark (status=0)
+user-benchmark-script no-file 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/result.txt
++++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/user-benchmark.cmd
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/samples
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark_test-24_1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script no-file
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-25.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-25.txt
@@ -1,0 +1,36 @@
++++ Running test-25 pbench-user-benchmark
+Running user-benchmark-script no-file
+--- Finished test-25 pbench-user-benchmark (status=0)
+user-benchmark-script no-file | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/result.txt
++++ pbench tree state
+/var/tmp/pbench-test-bench/pbench
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/metadata.log
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/user-benchmark-summary-debug.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/user-benchmark-summary.json
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/user-benchmark.cmd
+/var/tmp/pbench-test-bench/pbench/pbench.log
+/var/tmp/pbench-test-bench/pbench/samples
+/var/tmp/pbench-test-bench/pbench/tmp
+/var/tmp/pbench-test-bench/pbench/tmp/pbench-user-benchmark_test-25_1900.01.01T00.00.00.iterations
+/var/tmp/pbench-test-bench/pbench/tools-default
+/var/tmp/pbench-test-bench/pbench/tools-default/mpstat
+/var/tmp/pbench-test-bench/pbench/tools-default/sar
+--- pbench tree state
++++ pbench.log file contents
+/var/tmp/pbench-test-bench/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-user-benchmark] processing options
+/var/tmp/pbench-test-bench/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] [pbench-user-benchmark] Running user-benchmark-script no-file
+--- pbench.log file contents
++++ test-execution.log file contents
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00 --sysinfo=default end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00 beg
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00 end
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
+--- test-execution.log file contents

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -34,6 +34,7 @@ config=""
 tool_group=default
 sysinfo=default
 use_tool_triggers=0
+capture_stderr=" 2>&1"
 
 function usage {
 	printf "Usage: $script_name [options] -- <script to run>\n\n"
@@ -45,10 +46,11 @@ function usage {
 	printf -- "\t\t       --pbench-pre=str        path to the script which will be executed before tools are started\n"
 	printf -- "\t\t       --pbench-post=str       path to the script which will be executed after tools are stopped and postprocessing is complete\n"
 	printf -- "\t\t       --use-tool-triggers     use tool triggers instead of normal start/stop around script\n"
+	printf -- "\t\t       --no-stderr-capture     do not capture stderr of the script to the result.txt file\n"
 }
 
 # Process options and arguments
-opts=$(getopt -q -o C:h --longoptions "config:,help,tool-group:,sysinfo:,pbench-post:,pbench-pre:,use-tool-triggers" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o C:h --longoptions "config:,help,tool-group:,sysinfo:,pbench-post:,pbench-pre:,use-tool-triggers,no-stderr-capture" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf -- "$*\n\n"
 	printf "\t${benchmark}: you specified an invalid option\n\n"
@@ -97,6 +99,10 @@ while true; do
 		--use-tool-triggers)
 		shift
 		use_tool_triggers=1
+		;;
+		--no-stderr-capture)
+		shift
+		capture_stderr=""
 		;;
 		-h|--help)
 		usage
@@ -171,6 +177,25 @@ if [[ ! -z $pbench_pre ]]; then
 	fi
 fi
 
+benchmark_run_cmd="${benchmark_run_dir}/user-benchmark.cmd"
+if [ $use_tool_triggers -eq 0 ]; then
+	# We are not using tool triggers, so we'll only have one iteration,
+	# "1/reference-result/", so for compatibility we'll place the results
+	# output file there.
+	_final_results_dir="${benchmark_results_dir}"
+else
+	# We are using tool triggers, so we'll potentially have more than
+	# one iteration, so just place the results output file in the run
+	# directory.
+	_final_results_dir="${benchmark_run_dir}"
+fi
+printf "%s%s | tee %s/result.txt" "${benchmark_bin}" "${capture_stderr}" "${_final_results_dir}" > $benchmark_run_cmd
+if [ $use_tool_triggers -ne 0 ]; then
+	printf " | pbench-tool-trigger ${iteration} ${benchmark_run_dir} ${tool_group}" >> $benchmark_run_cmd
+fi
+printf "\n" >> $benchmark_run_cmd
+chmod +x $benchmark_run_cmd
+
 if [ $use_tool_triggers -eq 0 ]; then
 	pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 fi
@@ -179,11 +204,7 @@ echo "Running $benchmark_bin"
 log "[$script_name] Running $benchmark_bin"
 
 SECONDS=0
-if [ $use_tool_triggers -eq 0 ]; then
-	$benchmark_bin 2>&1 | tee $benchmark_results_dir/result.txt
-else
-	$benchmark_bin 2>&1 | tee $benchmark_run_dir/result.txt     | pbench-tool-trigger ${iteration} ${benchmark_run_dir} ${tool_group}
-fi
+$benchmark_run_cmd
 benchmark_duration=$SECONDS
 # make it predictable in the unittest environment
 if [[ $_PBENCH_BENCH_TESTS == 1 ]]; then

--- a/agent/bench-scripts/test-bin/user-benchmark-script
+++ b/agent/bench-scripts/test-bin/user-benchmark-script
@@ -22,7 +22,7 @@ case $arg in
     with-duration)
         printf "{%s,\n        \"duration\": 10,\n        \"duration-units\": \"sec\"\n        }\n" "$json" > $file
         ;;
-     bad-format)
+    bad-format)
         printf "{%s\n" "$json" > $file
         ;;
 esac

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -203,6 +203,8 @@ declare -A cmds=(
     [test-21]="pbench-trafficgen --help"
     [test-22]="pbench-trafficgen --config=test-22 --traffic-generator=trex-txrx-profile --max-loss-pct=0.0 --samples=1 --validation-runtime=30 --rate=5000000 --num-flows=1000 --frame-size=74 --traffic-direction=bidirectional,unidirectional,revunidirectional --flow-mods=src-ip,dst-ip,src-port,dst-port,protocol --one-shot --postprocess-only=y --run-dir=$_testdir"
     [test-23]="pbench-user-benchmark --config=test-23 --use-tool-triggers -- tool-trigger-example"
+    [test-24]="pbench-user-benchmark --config=test-24                     -- user-benchmark-script no-file"
+    [test-25]="pbench-user-benchmark --config=test-25 --no-stderr-capture -- user-benchmark-script no-file"
 )
 
 declare -A expected_status=(
@@ -241,7 +243,9 @@ declare -A post=(
     [test-11]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
     [test-12]="cat $_testdir/pbench-user-benchmark__1900.01.01T00.00.00/user-benchmark-summary.json >> $_testout"
     [test-22]="cat $_testdir/result.json >> $_testout"
-    [test-23]="rm $_testdir/tool-triggers"
+    [test-23]="cat $_testdir/pbench-user-benchmark_test-23_1900.01.01T00.00.00/user-benchmark.cmd >> $_testout; rm $_testdir/tool-triggers"
+    [test-24]="cat $_testdir/pbench-user-benchmark_test-24_1900.01.01T00.00.00/user-benchmark.cmd >> $_testout"
+    [test-25]="cat $_testdir/pbench-user-benchmark_test-25_1900.01.01T00.00.00/user-benchmark.cmd >> $_testout"
 )
 
 tests="$*"


### PR DESCRIPTION
Sometimes users will have to run a program that can't tolerate capturing
stderr to a file for whatever reason.  The new flag, `--no-stderr-capture`,
gives the users control over that behavior.