### PR TITLE
Several fix-ups for CDM and pbench-run-benchmark

### DIFF
--- a/agent/bench-scripts/pbench-gen-iterations
+++ b/agent/bench-scripts/pbench-gen-iterations
@@ -156,11 +156,16 @@ sub process_param {
                         }
                     }
                     # Because these will get processed again by build_iteration_cmds,
-                    # quotes are wrapped on all values, since quotes may have been stripped earlier.
+                    # single-values which have commas need to be wrapped in quotes,
+                    # so they are not mis-iterpreted as mulitple values.  The quotes
+                    # will be removed in build_iteration_cmds()
+                    if ($value =~ /,/) {
+                        $value = '"' . $value . '"';
+                    }
                     if ($processed_values eq "") {
-                        $processed_values = '"' . $value . '"';
+                        $processed_values = $value;
                     } else {
-                        $processed_values .= ',"' . $value . '"';
+                        $processed_values .= ',' . $value;
                     }
                 } else {
                     printf "the value, \'%s\' for argument, \'--%s\' is not valid\n", $value, $argument;
@@ -190,18 +195,15 @@ sub build_iteration_cmds {
         # As in process_param, quotewords() allows a comma to be within a single value
         # as long as it is wraped in quotes
         for my $value (quotewords(',', 0, $values)) {
-            if (not $value =~ /,/) {
-                $value =~ s/\"//g;
-            }
+            # Since these params are fully rendered (this will not be passed to
+            # pbench-gen-iterations again), we can remove the quotes
+            $value =~ s/\"//g;
             push(@cmds, build_iteration_cmds($cmdline . " --" . $arg . "=" . $value . " ",
                  \%multiplex_params, \%simplex_params));
         }
         return @cmds;
     } else {
         for my $arg (keys %simplex_params) {
-            if (not $arg =~ /,/) {
-                $arg =~ s/\"//g;
-            }
             $cmdline .= " --" . $arg . "=" . $simplex_params{$arg};
         }
         return ($cmdline);
@@ -312,17 +314,12 @@ while ( scalar @params > 0 ) {
             # Only output the processed params without expanding into multiple iterations
             my $cmd = "";
             for my $arg (keys %processed_pbench_params) {
-                if (not $processed_pbench_params{$arg} =~ /,/) {
-                    $processed_pbench_params{$arg} =~ s/\"//g;
-                }
                 $cmd .= sprintf "--%s=%s ", $arg, $processed_pbench_params{$arg};
             }
             for my $arg (keys %processed_bench_params) {
-                if (not $processed_bench_params{$arg} =~ /,/) {
-                    $processed_bench_params {$arg}=~ s/\"//g;
-                }
                 $cmd .= sprintf "--%s=%s ", $arg, $processed_bench_params{$arg};
             }
+            $cmd =~ s/\s$//;
             push(@cmds, $cmd);
         } else {
             # Output the processed params with expanding into multiple iterations

--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -116,7 +116,7 @@ my $get_defs_cmd = "pbench-gen-iterations " . $benchmark . " --defaults-only " .
 $get_defs_cmd =~ s/\"/\\\"/g;
 my @param_sets = `$get_defs_cmd`;
 if ($? != 0) {
-    printf "%s\nCalling pbench-gen-iterations failed, exiting\n", $get_defs_cmd;
+    printf "%s\nCalling pbench-gen-iterations failed, exiting\n", join(" ", @param_sets);
     exit 1;
 }
 mkdir($base_bench_dir);

--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -62,7 +62,7 @@ if (! $params{'clients'}) {
 }
 
 # Warn if a few optional but highly recommended params are missing (can also be defined with env vars)
-for my $param (qw(user-name user-email user-desc)) {
+for my $param (qw(user-name user-email user-desc user-tags)) {
     my $env_var = uc $param;
     $env_var =~ s/-/_/g;
     if (!$params{$param}) { # if --arg_name was used, $ARG_NAME will not be used
@@ -85,8 +85,10 @@ for my $def (keys %defaults) {
 }
 
 # Prepare all the dirs for the run
-my $base_bench_dir = get_benchmark_results_dir($benchmark, $params{"user-desc"});
-mkdir($base_bench_dir);
+my $base_bench_dir = get_benchmark_results_dir($benchmark, $params{"user-tags"});
+# Spaces in directories, just don't do it
+$base_bench_dir =~ s/\s+/_/g;
+mkdir("$base_bench_dir");
 my $es_dir = $base_bench_dir . "/es";
 mkdir($es_dir);
 for my $es_subdir (qw(run bench config metrics)) {
@@ -106,13 +108,13 @@ my $run_id = get_uuid;
 my %last_run_doc;
 print "Generating all benchmark iterations\n";
 # We don't want these params passed to gen-iterations because they are not bechmark-native options
-remove_params(\@ARGV, qw(user-desc user-name user-email)); 
+remove_params(\@ARGV, qw(user-desc user-tags user-name user-email)); 
 # First call pbench-gen-iterations and only resolve any --defaults=, so that the run
 # doc has the full set of params
 my $get_defs_cmd = "pbench-gen-iterations " . $benchmark . " --defaults-only " . join(" ", @ARGV);
 # Escape any quotes so they don't get lost before calling pbench-gen-iterations
 $get_defs_cmd =~ s/\"/\\\"/g;
-my @output = `$get_defs_cmd`;
+my @param_sets = `$get_defs_cmd`;
 if ($? != 0) {
     printf "%s\nCalling pbench-gen-iterations failed, exiting\n", $get_defs_cmd;
     exit 1;
@@ -123,35 +125,41 @@ open(my $fh, ">" . $base_bench_dir . "/iteration-list.txt");
 # (used a "--" in their cmdline).  Each part of the run has it's own run document, 
 # but all of the run documents share the same run ID.
 my $run_part = 0;
-while (scalar @output > 0) {
+while (scalar @param_sets > 0) {
     my $num_samples;
-    my $line = shift(@output);
-    if ($line =~ /^#/) {
-        printf "%s\n", $line;
+    my $param_set = shift(@param_sets);
+    chomp $param_set;
+    if ($param_set =~ /^#/) {
+        printf "%s\n", $param_set;
         next;
     }
+    printf "param_set[%s]\n", $param_set;
     # Process --samples= here, since it can be different for each parameter-set,
     # and we need this below for running pbench-run-benchmark-sample N times
-    if ($line =~ s/--samples=(\S+)\s*//) {
+    if ($param_set =~ s/--samples=(\S+)\s*//) {
         $num_samples = $1;
     } else {
         $num_samples = $defaults{'num_samples'};
     }
-    my $get_iters_cmd = "pbench-gen-iterations " . $benchmark . " " . $line;
+    my $get_iters_cmd = "pbench-gen-iterations " . $benchmark . " " . $param_set;
+    # Escape quotes again as this will get passed to pbench-gen-iterations again.
+    # We don't escape the quotes when writing to the run document (with $param_set)
+    # because the conversion to JSON will do it for us.
+    $get_iters_cmd =~ s/\"/\\\"/g;
     my @iterations = `$get_iters_cmd`;
     if ($? != 0) {
         printf "%s\nCalling pbench-gen-iterations failed, exiting\n", $get_iters_cmd;
         exit 1;
     }
-    my %run_doc = create_run_doc($benchmark, $line, $params{"clients"}, $params{"servers"},
-                    $params{"user-desc"}, $params{"user-name"}, $params{"user-email"},
+    my %run_doc = create_run_doc($benchmark, $param_set, $params{"clients"}, $params{"servers"},
+                    $params{"user-desc"}, $params{"user-tags"}, $params{"user-name"}, $params{"user-email"},
                     "pbench", ""); #todo: include tool names
     $run_doc{'run'}{'id'} = $run_id; # use the same run ID for all run docs
     # Now run the iterations for this parameter-set
     for my $iteration_params (@iterations) {
         chomp $iteration_params;
         if ($iteration_params =~ /^#/) {
-            printf "%s\n", $line;
+            printf "%s\n", $param_set;
             next;
         }
         my %iter_doc = create_bench_iter_doc(\%run_doc, $iteration_params,); 
@@ -188,7 +196,7 @@ while (scalar @output > 0) {
 }
 close $fh;
 # Generate the result.html (to go away once CDM/Elastic UI is available)
-system($pbench_install_path . "/bench-scripts/postprocess/generate-benchmark-summary " . $benchmark . " " . $benchmark . " " . $base_bench_dir);
+system(". " . $pbench_install_path . "/base; " . $pbench_install_path . "/bench-scripts/postprocess/generate-benchmark-summary " . $benchmark . " " . $benchmark . " " . $base_bench_dir);
 
 # Convert the stockpile data with scribe, then create CDM docs in ./es/config
 if (-e $base_bench_dir . "/stockpile.json") {

--- a/agent/bench-scripts/pbench-run-benchmark-sample
+++ b/agent/bench-scripts/pbench-run-benchmark-sample
@@ -44,7 +44,7 @@ my $base_dir = shift(@ARGV); # dir for all of the pbench run
 my $tool_group = shift(@ARGV);
 my $last_sample = shift(@ARGV);
 if (! -d $base_dir) {
-    die "The base bench directory $base_dir must already exist";
+    die "The base bench directory, $base_dir must already exist";
 }
 mkdir($sample_dir);
 my $json_ref = get_json_file($iter_doc_filename);

--- a/agent/bench-scripts/pbench-run-benchmark-sample
+++ b/agent/bench-scripts/pbench-run-benchmark-sample
@@ -26,7 +26,7 @@ use PbenchBase       qw(get_json_file put_json_file get_benchmark_names get_clie
                         get_params get_pbench_bench_config_dir load_benchmark_config);
 use PbenchAnsible    qw(ssh_hosts ping_hosts copy_files_to_hosts copy_files_from_hosts
                         remove_files_from_hosts remove_dir_from_hosts create_dir_hosts
-                        sync_dir_from_hosts verify_success);
+                        sync_dir_from_hosts verify_success yum_install_hosts);
 use PbenchCDM        qw(create_bench_iter_sample_doc);
 
 my $pbench_bench_config_dir = get_pbench_bench_config_dir; 
@@ -74,8 +74,32 @@ if (! $hosts{"client"}) {
 }
 
 # pre-benchmark-execution:
-# - verify access to clients and servers (todo)
+# - verify access to clients and servers by attempting to create the directories
+for my $type (keys %hosts) {
+    if (scalar @{ $hosts{$type} }) {
+        if ($specs{$type} and ${specs}{$type}{"copy-to"}) {
+            my $result;
+            my $rc;
+            my @files = @{ ${specs}{$type}{"copy-to"} };
+            # the end of the dir name gets "-client" or "-server" just in case this host is
+            # also a controller or both client and server
+            $result = create_dir_hosts(\@{ $hosts{$type} }, $sample_dir . "-" .  $type,
+                                       $base_dir);
+        }
+    }
+}
 # - verify required software on clients and server (todo)
+for my $type (keys %hosts) {
+    if (scalar @{ $hosts{$type} }) {
+        if ($specs{$type} and ${specs}{$type}{"packages"}) {
+            my $result;
+            my $rc;
+            my @packages = @{ ${specs}{$type}{"packages"} };
+            $result = yum_install_hosts(\@{ $hosts{$type} }, \@packages,
+                                       $base_dir);
+        }
+    }
+}
 # - run pre-script in controller
 if ($specs{"controller"}{"pre-script"} and $specs{"controller"}{"pre-script"} ne "") {
     # pre-script gets same params as benchmark.
@@ -88,7 +112,6 @@ if ($specs{"controller"}{"pre-script"} and $specs{"controller"}{"pre-script"} ne
         exit 1;
     }
 }
-# - create sample_dir on clients and servers
 # - copy files to clients and servers
 for my $type (keys %hosts) {
     if (scalar @{ $hosts{$type} }) {
@@ -98,8 +121,6 @@ for my $type (keys %hosts) {
             my @files = @{ ${specs}{$type}{"copy-to"} };
             # the end of the dir name gets "-client" or "-server" just in case this host is
             # also a controller or both client and server
-            $result = create_dir_hosts(\@{ $hosts{$type} }, $sample_dir . "-" .  $type,
-                                       $base_dir);
             $result = copy_files_to_hosts(\@{ $hosts{$type} }, \@files, $sample_dir . "-" .
                                           $type, $base_dir);
         }
@@ -172,9 +193,12 @@ if ($specs{"controller"}{"post-script"} and $specs{"controller"}{"post-script"} 
     my $postprocess_cmd = ". /opt/pbench-agent/base; cd " . $sample_dir . "; " .
                           $specs{"controller"}{"post-script"} . " " . $sample_dir . " " .
                           $base_dir . " " . $tool_group . " " .$last_sample;
+    open(my $fh_cmd, ">" . $sample_dir . "/postprocess.cmd");
+    printf { $fh_cmd } "%s\n", $postprocess_cmd;
     my $postprocess_output = `$postprocess_cmd`;
     my $rc = $?;
-    open(my $fh, ">" . $sample_dir . "/postprocess-output.txt");
+    open(my $fh_output, ">" . $sample_dir . "/postprocess-output.txt");
+    printf { $fh_output } "%s\n", $postprocess_output;
     if ($rc != 0) {
         printf "Controller post-script failed, exiting\n";
         exit 1;

--- a/agent/bench-scripts/postprocess/fio-postprocess-cdm
+++ b/agent/bench-scripts/postprocess/fio-postprocess-cdm
@@ -87,8 +87,8 @@ for my $client (@client_dirs) {
                 remove_element(\@log_metric_types, $metric_type);
                 open(my $log_fh, "clients/$client/$log_file")
                     || die "$script_name: could not open file clients/$client/$log_file $!\n";
+                my $last_timestamp_ms;
                 while (<$log_fh>) {
-                    my $last_timestamp_ms;
                     my $line = "$_";
                     chomp($line);
                     if ( $line =~  /(\d+),\s+(\d+),\s+(\d+),\s+(\d+)/ ) {
@@ -106,14 +106,15 @@ for my $client (@client_dirs) {
                                 $value,     # The value of the metric
                                 $timestamp_ms   # The timestamp
                                 );
-
-                            $metric_sample{'metric'}{'begin'} = $last_timestamp_ms;
+			    # Our 'begin' is the smallest amount of time just after the previous
+			    # sample, and since we have a millisecond granularity, it is 1ms.
+                            $metric_sample{'metric'}{'begin'} = $last_timestamp_ms + 1;
                             put_json_file(\%metric_sample, "../../es/metrics/" .
                                 $client .
                                 "/metric-" .
                                 $metric_sample{'metric'}{'id'} .
                                 ".json");
-                        }
+			}
                         if (! $earliest_timestamp or $earliest_timestamp > $timestamp_ms) {
                             $earliest_timestamp = $timestamp_ms;
                         }

--- a/agent/config/benchmark/fio.json
+++ b/agent/config/benchmark/fio.json
@@ -5,7 +5,7 @@
     "parameters" : { 
       "defaults": {
         "basic" : [ "--rw=read,randread", "--filename=/tmp/fio-tst", "--filesize=256M",
-          "--runtime=30s", "--bs=16k"
+          "--runtime=30s", "--bs=16k", "--time_based=1"
           ],
         "ceph-osp" : [ "--rw=read,randread,write,randwrite", "--bs=1m", "--ioengine=sync",
           "--numjobs=1", "--runtime=30s", "--filesize=512M" 
@@ -111,7 +111,7 @@
       }
     },
   "client" : { 
-    "packages" : [ "pbench-fio-3.3-1" ],
+    "packages" : [ "pbench-fio-3.12-2" ],
     "pre-script" : " ",
     "post-script" : " ",
     "copy-to" : [ "/var/lib/pbench-agent/tmp/fio.job" ],

--- a/agent/lib/PbenchCDM.pm
+++ b/agent/lib/PbenchCDM.pm
@@ -50,7 +50,7 @@ sub get_user_email { # Looks for USER_NAME in %ENV
 # Create the fields every doc must have
 sub populate_base_fields {
     my $doc_ref = shift;
-    $$doc_ref{'cdm'}{'ver'} = 2;
+    $$doc_ref{'cdm'}{'ver'} = get_cdm_ver;
 }
 
 sub copy_doc_fields {
@@ -69,6 +69,7 @@ sub create_run_doc {
     $doc{'run'}{'bench'}{'clients'} = shift; # Client hosts involved in the benchmark
     $doc{'run'}{'bench'}{'servers'} = shift; # Server hosts involved in the benchmark
     $doc{'run'}{'user'}{'desc'} = shift; # User provided test description
+    $doc{'run'}{'user'}{'tags'} = shift; # User provided tags like, "beta,project-X"
     $doc{'run'}{'user'}{'name'} = shift; # User's real name
     $doc{'run'}{'user'}{'email'} = shift; # User's email address
     $doc{'run'}{'harness_name'} = shift; # Harness name like pbench, browbeat, cbt

--- a/agent/tool-scripts/postprocess/iostat-postprocess-cdm
+++ b/agent/tool-scripts/postprocess/iostat-postprocess-cdm
@@ -83,7 +83,7 @@ while (my $line = <IOSTAT_TXT>) {
 					$timestamp_ms	# the timestamp
 					);
 				$metric_sample{"metric"}{"device"} = $dev;
-				$metric_sample{"metric"}{"begin"} = $last_timestamp_ms - 1;
+				$metric_sample{"metric"}{"begin"} = $last_timestamp_ms + 1;
 				put_json_file(\%metric_sample, $es_dir . "/metrics/" .
 						$hostname .
 						"/metric-" .

--- a/agent/util-scripts/pbench-import-cdm
+++ b/agent/util-scripts/pbench-import-cdm
@@ -30,12 +30,13 @@ sub process_dir {
 			process_dir($dir . "/" . $entry, $index, $host);
 		} else {
 			# separate the UUID (like -23316532-b21a-448c-8634-fa91c2a3410c) from the index name)
-			if ($entry =~ /(.+)-([a-x0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\.json$/) {
+			if ($entry =~ /(\D+)\d*-([a-x0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\.json$/) {
 				my $doc_type = $1;
 				my $curl_cmd = sprintf "curl -X POST \"%s/%s\" -H \'Content-Type: application/json\' -d@%s\n", $host, "cdm" . get_cdm_ver . "-" . $doc_type . "/" . $doc_type, $dir . "/" . $entry;
+				printf "curl_cmd: %s\n", $curl_cmd;
 				my $output = `$curl_cmd`;
 				if ($? > 0) {
-					printf "curl failed, so aboting now\n";
+					printf "curl failed, so aborting now\n";
 					die;
 				}
 				my $json_ref = from_json($output);


### PR DESCRIPTION
- Fix metric generation for fio
- Tweak the 'begin' value for fio metrics such that it does not overlap
  with previous metric's 'end' value
- Add --user-tags/USER_TAGS to pbench-run-benchmark and user.tags in run doc
- Eliminate excessive use of quotes in pbench-run-benchmark and pbench-gen-iterations
- Ensure the benchmark directory does not have spaces
- Use the correct CDM version in all documents