### PR TITLE
Fix perf pp tool

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -48,12 +48,12 @@ TS_FORMAT="%FT%H:%M:%S"
 
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     function timestamp {
-        # use ns in the timestamp
-        echo "$(date --utc +"${TS_FORMAT}.%N")"
+	# use ns in the timestamp
+	echo "$(date --utc +"${TS_FORMAT}.%N")"
     }
 else
     function timestamp {
-        echo "1900-01-01T00:00:00.000000"
+	echo "1900-01-01T00:00:00.000000"
     }
 fi
 # contains the base functions needed to use pbench
@@ -77,7 +77,7 @@ function error_log {
 function debug_log {
     debug_date=$(timestamp)
     if [ "$PBENCH_debug_mode" != "0" ]; then
-        echo "[debug][$debug_date] $*"
+	echo "[debug][$debug_date] $*"
     fi
     echo "[debug][$debug_date] $*" >> $pbench_log
 }
@@ -89,9 +89,9 @@ if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     # date may be set "accidentally" so add a var with an unlikely name
     # to check whether we need to set it.
     if [ -z "$date" -o -z "$_PBENCH_DATE_SET" ] ;then
-        # don't use ns in the date
-        export date=$(date --utc +"${TS_FORMAT}")
-        export _PBENCH_DATE_SET=1
+	# don't use ns in the date
+	export date=$(date --utc +"${TS_FORMAT}")
+	export _PBENCH_DATE_SET=1
     fi
     # don't use colons and dashes in the date suffix
     export date_suffix=$(date --date ${date} --utc +"%Y.%m.%dT%H.%M.%S")
@@ -128,75 +128,73 @@ function get_redhat_version() {
     cat /etc/redhat-release | awk '{ print $7 }'
 }
 
-
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     function check_enable_copr {
-      local copr_user=$1
-      local copr_name=$2
+        local copr_user=$1
+        local copr_name=$2
 
-      if is_fedora ; then
-          dnf copr enable ${copr_user}/${copr_name}
-      else
-          if is_redhat ; then
-              rhel_version=$(get_redhat_version)
-              rhel_major=${rhel_version%.*}
-              cd /etc/yum.repos.d/
-              local copr_url=https://copr.fedorainfracloud.org
-              local repo_file=${copr_user}-${copr_name}-epel-${rhel_major}.repo
+        if is_fedora ; then
+  	    dnf copr enable ${copr_user}/${copr_name}
+        else
+  	    if is_redhat ; then
+    	      	rhel_version=$(get_redhat_version)
+    	      	rhel_major=${rhel_version%.*}
+    	      	cd /etc/yum.repos.d/
+    	      	local copr_url=https://copr.fedorainfracloud.org
+    	      	local repo_file=${copr_user}-${copr_name}-epel-${rhel_major}.repo
 
-              [[ ! -f ${repo_file} ]] && wget -c ${copr_url}/coprs/${copr_user}/${copr_name}/repo/epel-${rhel_major}/${repo_file}
-          else
-              echo "Unsupported distribution"
-          fi
-      fi
+    	      	[[ ! -f ${repo_file} ]] && wget -c ${copr_url}/coprs/${copr_user}/${copr_name}/repo/epel-${rhel_major}/${repo_file}
+  	    else
+  	        echo "Unsupported distribution"
+  	    fi
+        fi
     }
 else
     function check_enable_copr {
-        echo $1
-        #$2 is the version which will vary
-        return 0
+	echo $1
+	#$2 is the version which will vary
+	return 0
     }
 fi
 
 # don't install packages when unit-testing
 if [[ -z "$_PBENCH_BENCH_TESTS" ]]; then
     function check_install_rpm {
-        local this_rpm=$1
-        if [ ! -z "$2" ]; then
+	local this_rpm=$1
+	if [ ! -z "$2" ]; then
     	    local this_version="-$2"
-        else
+	else
 	    local this_version=""
-        fi
+	fi
 
-        local rpm_status=`rpm --query ${this_rpm}$this_version`
-        local rc=0
-        if echo $rpm_status | grep -q "is not installed"; then
+	local rpm_status=`rpm --query ${this_rpm}$this_version`
+	local rc=0
+	if echo $rpm_status | grep -q "is not installed"; then
 	    debug_log "[check_install_rpm] attempting to install ${this_rpm}$this_version"
 	    yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1
 	    rc=$?
-        else
-           local installed_rpm_version=`rpm -q --qf "-%{VERSION}" ${this_rpm}`
+	else
+	    local installed_rpm_version=`rpm -q --qf "-%{VERSION}" ${this_rpm}`
 	    if [ ! -z "$this_version" -a "$this_version" != "$installed_rpm_version" ]; then
-	        yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1
-	        rc=$?
+		yum --debuglevel=0 install -y ${this_rpm}$this_version >> $pbench_log 2>&1
+		rc=$?
 	    else
-	        debug_log "[check_install_rpm] $this_rpm has already been installed"
-	        rc=0
+		debug_log "[check_install_rpm] $this_rpm has already been installed"
+		rc=0
 	    fi
-        fi
-        if [ $rc -ne 0 ]; then
+	fi
+	if [ $rc -ne 0 ]; then
 	    error_log "[check_install_rpm] the installation of $this_rpm$this_version failed"
 	    return 1
-        else
+	else
 	    return 0
-        fi
+	fi
     }
-
 else
     function check_install_rpm {
-        echo $1
-        #$2 is the version which will vary
-        return 0
+	echo $1
+	#$2 is the version which will vary
+	return 0
     }
 fi
 
@@ -219,10 +217,10 @@ function verify_tool_group {
 export INVENTORY=/tmp/inventory.$$
 trap "rm -f $INVENTORY" QUIT INT EXIT
 function generate_inventory {
-	echo "[controller]"
-	echo $HOSTNAME
-	echo "[remote]"
-	ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
+    echo "[controller]"
+    echo $HOSTNAME
+    echo "[remote]"
+    ls $tools_group_dir | awk -F@ '/^remote/ {print $2};'
 }
 
 if [[ "${_PBENCH_BENCH_TESTS}" == 1 ]] ;then

--- a/agent/tool-scripts/perf
+++ b/agent/tool-scripts/perf
@@ -1,12 +1,12 @@
 #!/bin/bash
 # -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
-script_path=`dirname $0`
-script_name=`basename $0`
-pbench_bin="`cd ${script_path}/..; /bin/pwd`"
+script_name="$(basename $0)"
+script_path="$(dirname $(realpath $0))"
+pbench_bin="$(dirname ${script_path})"
 
 # source the base script
-. "$pbench_bin"/base
+. "${pbench_bin}"/base
 
 # Perftool scripts must provide the following functions
 # 1) Install the tool
@@ -15,97 +15,114 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # 4) post-process the data
 
 # Defaults
-tool=perf
-tool_bin=/usr/bin/$tool
+tool=${script_name}
+tool_bin=/usr/bin/${tool}
+tool_package_name=${tool}
 group=default
-dir="/tmp"
+dir=""
 mode=""
 iteration="1"
 options="none"
 record_opts="record -a --freq=100"
 report_opts="report --show-nr-samples -I"
 
+function usage {
+	printf "The following options are available for the ${script_name} tool: \n\n"
+	printf -- "\t-h     --help,			this usage message\n"
+	printf -- "\t       --install,			install this perf tool\n"
+	printf -- "\t       --start|stop|postprocess	start/stop/post-process the data collection\n"
+	printf -- "\t-i int --iteration=int 		the iteration (required)\n"
+	printf -- "\t-g str --group=str			the perftool group (required)\n"
+	printf -- "\t-d str --dir=str			directory to store data collection (required)\n"
+	printf -- "\t       --callgraph			generate a call graph (--record-opts and --report-opts should not be used with this option)\n"
+	printf -- "\t-r str --record-opts=str		options one would use to record perf data, for example: 'record -a'\n"
+	printf -- "\t-p str --report-opts=str		options one would use to report perf data, for example: 'report'\n"
+}
+
 # Process options and arguments
-opts=$(getopt -o d --longoptions "dir:,group:,iteration:,callgraph,record-opts:,report-opts:,start,stop,install,postprocess" -n "getopt.sh" -- "$@");
+opts=$(getopt -o d:hg:i:r:p: --longoptions "dir:,group:,iteration:,callgraph,record-opts:,report-opts:,start,stop,install,postprocess,help" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
-	printf "The following options are available: \n\n"
-	printf -- "\t--install,			install this perf tool\n"
-	printf "\n"
-	printf -- "\t--start|stop|postprocess	start/stop/post-process the data collection\n"
-	printf -- "\t--iteration=int 		the iteration (required)\n"
-	printf -- "\t--group=str		the perftool group (required)\n"
-	printf -- "\t--dir=str			directory to store data collection (required)\n"
-	printf -- "\t--callgraph		generate a call graph (--record-opts and --report-opts should not be used with this option)\n"
-	printf -- "\t--record-opts=str		options one would use to record perf data, for example: 'record -a'\n"
-	printf -- "\t--report-opts=str		options one would use to report perf data, for example: 'report'\n"
+	usage
 	exit 1
 fi
 eval set -- "$opts";
 while true; do
 	case "$1" in
-		--install)
+	--install)
 		mode="install"
 		shift;
 		;;
-		--start)
+	--start)
 		mode="start"
 		shift;
 		;;
-		--stop)
+	--stop)
 		mode="stop"
 		shift;
 		;;
-		--postprocess)
+	--postprocess)
 		mode="postprocess"
 		shift;
 		;;
-		-d|--dir)
+	-d|--dir)
 		shift;
 		if [ -n "$1" ]; then
 			dir="$1"
 			shift
 		fi
 		;;
-		-g|--group)
+	-g|--group)
 		shift;
 		if [ -n "$1" ]; then
 			group="$1"
 			shift
 		fi
 		;;
-		-i|--iteration)
+	-i|--iteration)
 		shift;
 		if [ -n "$1" ]; then
 			iteration="$1"
 			shift
 		fi
 		;;
-		--callgraph)
+	--callgraph)
 		shift;
 		if [ -n "$1" ]; then
 			record_opts="record -a --freq=100 -g"
 			report_opts="report -I -g"
 		fi
 		;;
-		-r|--record-opts)
+	-r|--record-opts)
 		shift;
 		if [ -n "$1" ]; then
 			record_opts="$1"
 			shift
 		fi
 		;;
-		-p|--report-opts)
+	-p|--report-opts)
 		shift;
 		if [ -n "$1" ]; then
 			report_opts="$1"
 			shift
 		fi
 		;;
-		--)
+	-h|--help)
+		shift;
+		usage
+		exit 0
+		;;
+	--)
 		shift;
 		break;
+		;;
+	*)
+		shift;
+		printf "\n"
+		printf "$script_name: you specified an invalid option or parameter, $1\n\n"
+		usage
+		exit 1
 		;;
 	esac
 done
@@ -118,63 +135,81 @@ tool_pid_file=$pbench_tmp/$group.$iteration.$tool.pid
 tool_output_file=$tool_output_dir/$tool.txt
 case "$mode" in
 	install)
-        ;;
+		check_install_rpm $tool_package_name
+        	;;
 	start)
-	if ! cat /proc/mounts | grep -q debugfs; then
-		mount -t debugfs none /sys/kernel/debug
-	fi
-	mkdir $tool_output_dir
-	pushd $tool_output_dir >/dev/null
-        echo "$tool_cmd" >$tool_cmd_file
-	# call the tool and background it...
-	$tool_cmd > "$tool_output_dir/perf-stdout.txt" 2> "$tool_output_dir/perf-stderr.txt" & echo $! >"$tool_pid_file"
-	wait
-	popd >/dev/null
-	;;
-	stop)
-	if [[ -s "$tool_pid_file" ]]; then
-		pushd $tool_output_dir >/dev/null
-		pid=`cat "$tool_pid_file"`
-		if [ ! -z "$pid" ]; then
-			kill -SIGINT $pid
-			# wait for perf to finish recording.
-			# if you do not wait, 'perf report' will not be correct.
-			# perf is not a child process, so we cannot use "wait".
-			# this is an alternative.
-			pidcmd=`ps -p $pid | tail -1 | awk '{print $4}'`
-			while [ -d /proc/$pid ]; do
-				debug_log "waiting for PID $pid ($pidcmd) to finish"
-				sleep 0.5
-			done
+		if ! cat /proc/mounts | grep -q debugfs; then
+			mount -t debugfs none /sys/kernel/debug
 		fi
-		/bin/rm "$tool_pid_file"
-		popd >/dev/null
-	else
-		warn_log "[$script_name]: tool is not running, nothing to kill"
-	fi
-	;;
+		mkdir $tool_output_dir
+		if [ $? -ne 0 ]; then
+			error_log "$script_name: start -- unable to create directory $tool_output_dir"
+			exit 1
+		fi
+	        echo "$tool_cmd" > $tool_cmd_file
+		# call the tool and background it...
+		$tool_cmd --output=$tool_output_dir/perf.data > "$tool_output_dir/perf-stdout.txt" 2> "$tool_output_dir/perf-stderr.txt" & echo $! > "$tool_pid_file"
+		wait
+		exit_status=0
+		;;
+	stop)
+		if [[ -s "$tool_pid_file" ]]; then
+			pid=`cat "$tool_pid_file"`
+			if [ ! -z "$pid" ]; then
+				kill -SIGINT $pid
+				# wait for perf to finish recording.
+				# if you do not wait, 'perf report' will not be correct.
+				# perf is not a child process, so we cannot use "wait".
+				# this is an alternative.
+				pidcmd=`ps -p $pid | tail -1 | awk '{print $4}'`
+				while [ -d /proc/$pid ]; do
+					debug_log "waiting for PID $pid ($pidcmd) to finish"
+					sleep 0.5
+				done
+			fi
+			/bin/rm "$tool_pid_file"
+			if [ -f $tool_output_dir/perf.data ]; then
+				exit_status=0
+			else
+				warn_log "$script_name: stop - missing ${tool_output_dir}/perf.data file!"
+				exit_status=1
+			fi
+		else
+			warn_log "[$script_name]: tool is not running, nothing to stop"
+			exit_status=1
+		fi
+		;;
 	postprocess)
-	pushd $tool_output_dir >/dev/null
-	$tool_bin $report_opts -i ./perf.data --stdio >perf-report.txt 2>&1
-	# report per-cpu
-	mkdir -p perf-percpu
-	for cpu_id in `cat /proc/cpuinfo  | grep processor | awk -F: '{print $2}'`; do
-		$tool_bin $report_opts -i ./perf.data --stdio --cpu $cpu_id >./perf-percpu/perf-report-cpu_$cpu_id.txt 2>/dev/null
-		xz --threads=0 perf-percpu/perf-report-cpu_$cpu_id.txt
-		chmod go+r perf-percpu/perf-report-cpu_$cpu_id.txt.xz
-	done
-	if [ -f perf.data ]; then
-		xz --threads=0 perf.data
-		chmod go+r perf.data.xz
-	fi
-	# only postprocess the perf report if the default options are used
-	if echo $record_opts | grep -E -q -- -g\|--callgraph; then
-		debug_log "Not going to run perf postprocess script since this report contains a callgraph"
-	else
-		$script_path/postprocess/$script_name-postprocess .
-	fi
-	xz --threads=0 perf-report.txt
-	chmod go+r perf-report.txt.xz
-	popd >/dev/null
-	;;
+		if [ -f ${tool_output_dir}/perf.data ]; then
+			# Collect the archive of perf information so the perf data can be
+			# processed off host.  We explicitly ignore any errors since we
+			# have already stopped the tool.  Note we have to use push/popd
+			# since the "perf archive" command always creates the tar ball in
+			# the local directory.
+			pushd ${tool_output_dir} > /dev/null 2>&1
+			$tool_bin archive ./perf.data > ./perf-archive.log 2>&1
+			popd > /dev/null 2>&1
+			# Generate the initial report.
+			$tool_bin $report_opts -i ${tool_output_dir}/perf.data --stdio > ${tool_output_dir}/perf-report.txt 2> ${tool_output_dir}/perf-report.err
+			xz --threads=0 ${tool_output_dir}/perf.data
+			# only postprocess the perf report if the default options are used
+			if echo $record_opts | grep -E -q -- -g\|--callgraph; then
+				debug_log "$script_name: not going to run perf postprocess script since this report contains a callgraph"
+			else
+				$script_path/postprocess/$script_name-postprocess ${tool_output_dir}
+			fi
+			xz --threads=0 ${tool_output_dir}/perf-report.txt
+			# Provide a README file to help users work with perf data locally.
+			copy ${script_path}/${script_name}.README ${tool_output_dir}/README
+			exit_status=0
+		else
+			warn_log "$script_name: postprocess - missing ${tool_output_dir}/perf.data file!"
+			exit_status=1
+		fi
+		;;
+	*)
+		error_log "$script_name: unexpected mode: $mode, no action taken"
+		exit_status=1
+		;;
 esac
+exit $exit_status

--- a/agent/tool-scripts/perf.README
+++ b/agent/tool-scripts/perf.README
@@ -1,0 +1,26 @@
+# How to use perf tools locally
+#
+# The pbench "perf" tool ends up creating a perf.data.xz and perf.data.tar.bz2 file.
+# The system on which this file was created may no longer be accessible to you when
+# viewing perf data in a pbench tar ball.  However, you can still process the perf
+# data on your local system.
+#
+# Copy both files to your local system:
+#
+# $ curl -X GET -o ./perf.data.xz      <URL>/perf.data.xz
+# $ curl -X GET -o ./perf.data.tar.bz2 <URL>/perf.data.tar.bz2
+#
+# Then unpack the perf.data.tar.bz2 file in a .debug directory as a sub-directory
+# of the user's home directory:
+#
+# $ mkdir -p $HOME/.debug
+# $ tar xf ./perf.data.tar.bz2 -C $HOME/.debug
+#
+# Then run perf report on the data file as normal:
+#
+# $ unxz ./perf.data.xz
+# $ perf report -i ./perf.data
+#
+# The presence of that $HOME/.debug directory will be picked up by perf report and
+# the symbols in the perf.data file will be resolved with the stored data in the
+# $HOME/.debug directory.

--- a/agent/tool-scripts/postprocess/perf-postprocess
+++ b/agent/tool-scripts/postprocess/perf-postprocess
@@ -2,10 +2,9 @@
 
 # Author: Andrew Theurer
 #
-# usage: proc-sched_debug-postprocess <dir>  dir = directory where proc-sched_debug.txt can be found
+# usage: perf-postprocess <dir>  dir = directory where perf-report.txt can be found
 #
-# The purpose of this script is to look through /proc/sched_debug data to identify potential 
-# Linux CPU scheduler problems
+# The purpose of this script is to generate a consolidated report per-symbol.
 
 use strict;
 use warnings;
@@ -26,9 +25,9 @@ my $line;
 open(TXT, "$dir/$file") || die "could not find $dir/$file\n";
 while (my $line = <TXT>) {
 	chomp $line;
-	#    32.95%        928412         qemu-kvm  [kernel.kallsyms]             [k] _raw_spin_lock                                   
-	#     5.50%        242887         qemu-kvm  [kernel.kallsyms]             [k] kvm_vcpu_on_spin                                 
-	#     3.66%        261976         qemu-kvm  [kernel.kallsyms]             [k] update_cfs_rq_blocked_load   
+	#    32.95%        928412         qemu-kvm  [kernel.kallsyms]             [k] _raw_spin_lock
+	#     5.50%        242887         qemu-kvm  [kernel.kallsyms]             [k] kvm_vcpu_on_spin
+	#     3.66%        261976         qemu-kvm  [kernel.kallsyms]             [k] update_cfs_rq_blocked_load
 
 	if ($line =~ /^\s*(\d+\.\d+)%\s+(\d+)\s+(\S+)\s+\[(\S+)\]\s+\[(\S+)\]\s+(\S+)/) {
 		$pct = $1;

--- a/agent/tool-scripts/postprocess/unittests
+++ b/agent/tool-scripts/postprocess/unittests
@@ -279,10 +279,15 @@ function testpidstat {
 
     _TEST_ALTERNATE_TOOLS_LIBRARY=$(pwd) ./pidstat-postprocess ${_testroot}/${1} > ${_testroot}/${1}/stdout 2> ${_testroot}/${1}/stderr
 
+    remove_sample_data $1
     rm -rf ${_testroot}/${1}/pids
 
     diff -cr gold/${1}/ ${_testroot}/${1}
-    return $?
+    sts=$?
+    if [ $sts -eq 0 ]; then
+        rm -rf ${_testroot}/$1
+    fi
+    return $sts
 }
 
 res=0

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.1.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.1.txt
@@ -4,6 +4,7 @@ mpstat tool is now registered in group default
 vmstat tool is now registered in group default
 pbench-sysstat
 iostat tool is now registered in group default
+perf
 perf tool is now registered in group default
 --- Finished test-11.1 pbench-register-tool-set (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.2.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.2.txt
@@ -4,6 +4,7 @@ mpstat tool is now registered in group default
 vmstat tool is now registered in group default
 pbench-sysstat
 iostat tool is now registered in group default
+perf
 perf tool is now registered in group default
 --- Finished test-11.2 pbench-register-tool-set (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.3.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.3.txt
@@ -7,6 +7,7 @@ pbench-sysstat
 pidstat tool is now registered in group default
 pbench-sysstat
 sar tool is now registered in group default
+perf
 perf tool is now registered in group default
 --- Finished test-11.3 pbench-register-tool-set (status=0)
 +++ pbench tree state


### PR DESCRIPTION
Fixes #1058.

We address the problem of generating per-CPU data taking too long by forking each CPU data generation into its own process to run at whatever level parallelism the host can afford.

We also:

 * Fix up the `tool-scripts/postprocess/gold/index.html` with the missing `.html` files
 * Fix the `jstack`/`jmap` unit tests to include the generated `.html` files
 * Address some minor comment cleanups in `perf-postprocess`
 * Provide a minimal fix to parallelize the perf per-CPU report generation
 * Provide a more complete refactoring of the `perf` tool to address both reduce the use of `pushd`/`popd` pairs