### PR TITLE
Ensure indexing properly cleans up extracted tar balls

### DIFF
--- a/server/bin/index-pbench
+++ b/server/bin/index-pbench
@@ -8,7 +8,7 @@
 from __future__ import print_function
 
 import sys, os, time, re, stat, copy
-import hashlib, json, glob, csv, tarfile, logging
+import hashlib, json, glob, csv, tarfile, shutil
 
 from urllib3 import Timeout
 from datetime import datetime, timedelta
@@ -2097,11 +2097,11 @@ class PbenchTarBall(object):
             raise UnsupportedTarballFormat(
                 "{} - tarball is missing \"{}\".".format(self.tbname, member_name))
 
-        # The caller of index-pbench is expected to clean up the temporary
-        # directory.
+        # We are expected to clean up the extracted tar ball before we exit.
         self.tb.extractall(path=tmpdir)
         self.extracted_root = tmpdir
         if not os.path.isdir(os.path.join(self.extracted_root, self.dirname)):
+            self.delete_extracted()
             raise UnsupportedTarballFormat(
                 "{} - extracted tarball but can't get to the directory \"{}\".".format(
                     self.tbname,
@@ -2110,12 +2110,14 @@ class PbenchTarBall(object):
             self.mdconf = PbenchTarBall.get_mdconfig(
                     os.path.join(self.extracted_root, member_name))
         except Exception:
+            self.delete_extracted()
             raise BadMDLogFormat(self.tbname)
         # We get the start date out of the metadata log.
         try:
             # N.B. the start_run timestamp is in UTC.
             self.start_run, self.start_run_ts, self.end_run, self.end_run_ts, self.date, self.date_ts = self.gen_run_timestamp_info()
         except Exception:
+            self.delete_extracted()
             raise BadDate(self.tbname)
         # Open the MD5 file of the tarball and read the MD5 sum from it.
         self.md5sum = open("%s.md5" % (self.tbname)).read().split()[0]
@@ -2181,6 +2183,16 @@ class PbenchTarBall(object):
         date_ts -= timedelta(0, int(res*60*60), 0)
         date = date_ts.isoformat()
         return start_run, start_run_ts, end_run, end_run_ts, date, date_ts
+
+    def delete_extracted(self):
+        directory = os.path.join(self.extracted_root, self.dirname)
+        if not os.path.exists(directory):
+            return
+        def remove_readonly(func, path, _):
+            "Clear the readonly bit and reattempt the removal"
+            os.chmod(path, stat.S_IWRITE)
+            func(path)
+        shutil.rmtree(directory, onerror=remove_readonly)
 
     @staticmethod
     def get_mdconfig(mdf):
@@ -2262,6 +2274,7 @@ def main(options, args):
     # python 3.2
     filenotfounderror = getattr(__builtins__, 'FileNotFoundError', IOError)
     opctx = []
+    ptb = None
 
     try:
         config=ConfigParser()
@@ -2384,6 +2397,8 @@ def main(options, args):
             print("** Errors encountered while indexing:\n{}\n".format(
                     json.dumps(opctx, indent=4, sort_keys=True)), file=sys.stderr)
         if options.debug_time_operations: _ts("Done", newline=True)
+        if ptb:
+            ptb.delete_extracted()
 
     # status codes: these are used by pbench-index to segregate tarballs into
     #               classes: should we retry (perhaps after fixing bugs in the

--- a/server/bin/pbench-index
+++ b/server/bin/pbench-index
@@ -70,33 +70,32 @@ linksrc=TO-INDEX
 linkdest=INDEXED
 linkerrdest=WONT-INDEX
 
-# get the list of files we'll be operating on
-#list=$(ls $ARCHIVE/*/$linksrc/*.tar.xz 2>/dev/null)
-# Better: avoids long command line problems and sorts by size
-TMPDIR=$TMP/pbench-index.$$
-# index-pbench need to get at it
+WRKDIR=$TMP/pbench-index.$$
+# index-pbench uses TMPDIR as the location to extract tar balls; give it a
+# dedicated sub-directory to work with as its temporary directory.
+TMPDIR=$WRKDIR/extractions
 export TMPDIR
 
 echo "$TS: starting at $(timestamp)"
 
 typeset -i nidx=0
-indexed=$TMPDIR/$PROG.$TS.indexed
+indexed=$WRKDIR/$PROG.$TS.indexed
 typeset -i nerrs=0
-erred=$TMPDIR/$PROG.$TS.erred
+erred=$WRKDIR/$PROG.$TS.erred
 typeset -i nskip=0
-skipped=$TMPDIR/$PROG.$TS.skipped
-report_body=$TMPDIR/$PROG.$TS.report
-errors_json=$TMPDIR/$PROJ.$TS.indexing-errors.json
+skipped=$WRKDIR/$PROG.$TS.skipped
+report_body=$WRKDIR/$PROG.$TS.report
+errors_json=$WRKDIR/$PROJ.$TS.indexing-errors.json
 
-mkdir -p $TMPDIR
-trap "rm -rf $TMPDIR" EXIT QUIT INT
+mkdir -p $WRKDIR
+trap "rm -rf $WRKDIR" EXIT QUIT INT
 
 > $indexed
 > $erred
 > $skipped
 > $errors_json
 
-list=$TMPDIR/list
+list=$WRKDIR/list
 find -L $ARCHIVE/*/$linksrc -name '*.tar.xz' -printf "%s\t%p\n" 2>/dev/null | sort -n > $list
 
 while read size result ;do
@@ -117,12 +116,16 @@ while read size result ;do
     # make sure that all the relevant state directories exist
     mk_dirs $hostname
 
-    # index-pbench depends on a whole hierarchy - this script and
-    # index-pbench are in /opt/pbench-server/bin when deployed, but it
-    # depends on /opt/pbench-server/lib/config/pbench-server.cfg,
-    # /opt/pbench-server/lib/vos etc.  Also, index-pbench requires
-    # python3: that's available on Fedora but, for RHEL, we need
-    # software collections.
+    # Ensure we can create the TMPDIR used for extracted tar balls each time
+    # we call index-pbench to help ensure everything operates cleanly and we
+    # only have one tar ball extracted at a time.
+    mkdir $TMPDIR || doexit "Bad $TMPDIR"
+
+    # index-pbench depends on a whole hierarchy - this script and index-pbench
+    # are in /opt/pbench-server/bin when deployed, but it depends on
+    # /opt/pbench-server/lib/config/pbench-server.cfg,
+    # /opt/pbench-server/lib/vos etc.  Also, index-pbench requires python3:
+    # that's available on Fedora but, for RHEL, we need software collections.
     PROGLOC=$(getconf.py install-dir pbench-server)
     if which python3 > /dev/null 2>&1 ;then
         # we have a python3 here
@@ -147,6 +150,9 @@ while read size result ;do
         rm -f $errors_json.report
         > $errors_json
     fi
+
+    # Exit if index-pbench fails to clean up properly.
+    rmdir $TMPDIR || doexit "Non-empty $TMPDIR"
 
     if [ $status -ne 0 ] ;then
         # Distinguish failure cases, so we can retry the indexing easily if possible.

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -152,6 +152,11 @@ function _save_tree {
         _local_find ${_testdir_sat_local} | _normalize_output >> $_testout
         echo "--- pbench-satellite-local tree state" >> $_testout
     fi
+    if [ -d ${_testtmp} ]; then
+        echo "+++ ${_testtmp}" >> $_testout
+        find ${_testtmp} -ls >> $_testout 2>&1
+        echo "--- ${_testtmp}" >> $_testout
+    fi
 }
 
 function _audit_server {
@@ -243,16 +248,16 @@ function _setup_state {
 
     mkdir $_testdir $_testdir_sat $_testtmp
     if [[ $? -gt 0 ]]; then
-	echo "ERROR: failed to create test pbench, pbench-satellite, and tmp directories, \"$_testdir\", \"$_testdir_sat\", and/or \"$_testtmp\"" >&2
-	exit 1
+        echo "ERROR: failed to create test pbench, pbench-satellite, and tmp directories, \"$_testdir\", \"$_testdir_sat\", and/or \"$_testtmp\"" >&2
+        exit 1
     fi
     if [[ ! -d $_testdir ]]; then
         echo "ERROR: test pbench directory does not exist, \"$_testdir\"" >&2
         exit 1
     fi
     if [[ ! -d $_testdir_sat ]]; then
-	echo "ERROR: test pbench-satellite directory does not exist, \"$_testdir_sat\"" >&2
-	exit 1
+        echo "ERROR: test pbench-satellite directory does not exist, \"$_testdir_sat\"" >&2
+        exit 1
     fi
     if [[ ! -d $_testtmp ]]; then
         echo "ERROR: test tmp directory does not exist, \"$_testtmp\"" >&2
@@ -288,6 +293,7 @@ function _setup_state {
     echo "$_testopt/bin/pbench-server-config-activate ${_testtmp}/pbench-server.cfg" >> $_testactout
     $_testopt/bin/pbench-server-config-activate ${_testtmp}/pbench-server.cfg >> $_testactout
     rc=$?
+    rm ${_testtmp}/pbench-server.cfg
     if [ $rc == 0 ] ;then
         # This script uses the copied config file to do the rest.
         echo "$_testopt/bin/pbench-server-activate ${CONFIG}" >> $_testactout
@@ -313,6 +319,7 @@ function _setup_state {
     echo "$_testopt_sat/bin/pbench-server-config-activate ${_testtmp}/pbench-server.cfg" >> $_testactout
     $_testopt_sat/bin/pbench-server-config-activate ${_testtmp}/pbench-server.cfg >> $_testactout
     rc=$?
+    rm ${_testtmp}/pbench-server.cfg
     if [ $rc == 0 ] ;then
         # This script uses the copied config file to do the rest.
         echo "$_testopt_sat/bin/pbench-server-activate ${SATCONFIG}" >> $_testactout
@@ -398,7 +405,10 @@ function _run_test {
     _setup_state ${testname}
     # echo ${testname}: ${cmd}
     ${cmd} $*
-    _audit_server; _save_tree; _dump_logs
+    _audit_server
+    rmdir ${_testtmp} > /dev/null 2>&1
+    _save_tree
+    _dump_logs
     _verify_output $res ${testname}
     res=$?
     _reset_state ${testname}


### PR DESCRIPTION
Prior to this change, if the indexing job has more than one tar ball to
index, index-pbench will extract each tar ball it works on, leaving the
extracted contents to be cleaned up by pbench-index. This works well for
one or two tar balls, but if we have a large set of tar balls to work
through this can be problematic.

This change makes it so that index-pbench properly cleans up the
extracted tar ball before exiting.  We modify pbench-index to give a
dedicated sub-directory to index-pbench so that we can detect problems.
We also modify the unit test harness to detect when any server script
leaves data around in its given TMPDIR.