### PR TITLE
Don't use reference-result directly, use sample1

### DIFF
--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-09.txt
@@ -12,8 +12,9 @@ Collecting system information
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo/end
@@ -37,7 +38,7 @@ Collecting system information
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-10.txt
@@ -14,8 +14,9 @@ Collecting system information
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo/end
@@ -39,7 +40,7 @@ Collecting system information
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-11.txt
@@ -14,8 +14,9 @@ Collecting system information
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo/end
@@ -39,7 +40,7 @@ Collecting system information
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-12.txt
@@ -25,8 +25,9 @@ Collecting system information
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/sysinfo/end
@@ -50,7 +51,7 @@ Collecting system information
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark__1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-23.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-23.txt
@@ -5,22 +5,22 @@ Running tool-trigger-example
 [pbench-tool-trigger]found trigger: tool-group:default start-trigger:"START DEFAULT" stop-trigger:"STOP DEFAULT"
 fud
 START DEFAULT
-[pbench-tool-trigger]pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
+[pbench-tool-trigger]pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
 bud
 STOP DEFAULT
-[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
+[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
 lud
 START DEFAULT
-[pbench-tool-trigger]pbench-start-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
+[pbench-tool-trigger]pbench-start-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
 zud
 STOP DEFAULT
-[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
+[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
 mud
 START DEFAULT
-[pbench-tool-trigger]pbench-start-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
+[pbench-tool-trigger]pbench-start-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
 yud
 STOP DEFAULT
-[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
+[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
 sud
 Collecting system information
 [warn][1900-01-01T00:00:00.000000] [pbench-collect-sysinfo]mpstat does not exist in /var/tmp/pbench-test-bench/opt/pbench-agent/tool-scripts; spurious file perhaps? Please consider deleting it.
@@ -32,13 +32,16 @@ tool-trigger-example 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-be
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/result.txt
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/sysinfo
@@ -63,13 +66,13 @@ tool-trigger-example 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-be
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/2/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=3 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-23_1900.01.01T00.00.00/3/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-24.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-24.txt
@@ -4,14 +4,15 @@ Collecting system information
 [warn][1900-01-01T00:00:00.000000] [pbench-collect-sysinfo]mpstat does not exist in /var/tmp/pbench-test-bench/opt/pbench-agent/tool-scripts; spurious file perhaps? Please consider deleting it.
 [warn][1900-01-01T00:00:00.000000] [pbench-collect-sysinfo]sar does not exist in /var/tmp/pbench-test-bench/opt/pbench-agent/tool-scripts; spurious file perhaps? Please consider deleting it.
 --- Finished test-24 pbench-user-benchmark (status=0)
-user-benchmark-script no-file 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/result.txt
+user-benchmark-script no-file 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1/result.txt
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/sysinfo/end
@@ -35,7 +36,7 @@ user-benchmark-script no-file 2>&1 | tee /var/tmp/pbench-test-bench/pbench/pbenc
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/gold/pbench-user-benchmark/test-25.txt
+++ b/agent/bench-scripts/gold/pbench-user-benchmark/test-25.txt
@@ -4,14 +4,15 @@ Collecting system information
 [warn][1900-01-01T00:00:00.000000] [pbench-collect-sysinfo]mpstat does not exist in /var/tmp/pbench-test-bench/opt/pbench-agent/tool-scripts; spurious file perhaps? Please consider deleting it.
 [warn][1900-01-01T00:00:00.000000] [pbench-collect-sysinfo]sar does not exist in /var/tmp/pbench-test-bench/opt/pbench-agent/tool-scripts; spurious file perhaps? Please consider deleting it.
 --- Finished test-25 pbench-user-benchmark (status=0)
-user-benchmark-script no-file | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/result.txt
+user-benchmark-script no-file | tee /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1/result.txt
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/result.txt
-/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result/tools-default
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1/result.txt
+/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/sysinfo
 /var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/sysinfo/end
@@ -35,7 +36,7 @@ user-benchmark-script no-file | tee /var/tmp/pbench-test-bench/pbench/pbench-use
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/reference-result
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-bench/pbench/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1/sample1
 --- test-execution.log file contents

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -133,7 +133,7 @@ mdlog=${benchmark_run_dir}/metadata.log
 
 # make the run dir available to the user script
 export benchmark_run_dir
-benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
+benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 mkdir -p $benchmark_results_dir/.running
 export benchmark_results_dir=$benchmark_results_dir
 
@@ -174,7 +174,7 @@ fi
 benchmark_run_cmd="${benchmark_run_dir}/user-benchmark.cmd"
 if [ $use_tool_triggers -eq 0 ]; then
 	# We are not using tool triggers, so we'll only have one iteration,
-	# "1/reference-result/", so for compatibility we'll place the results
+	# "1/sample1/", so for compatibility we'll place the results
 	# output file there.
 	_final_results_dir="${benchmark_results_dir}"
 else
@@ -208,11 +208,13 @@ fi
 if [ $use_tool_triggers -eq 0 ]; then
 	pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 	pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
+	ln -s $(basename ${benchmark_results_dir}) $(dirname ${benchmark_results_dir})/reference-result
 else
-	result_dirs=$(ls -1d ${benchmark_run_dir}/*/reference-result)
+	result_dirs=$(ls -1d ${benchmark_run_dir}/*/sample1)
 	for rdir in $result_dirs; do
 		iteration_dir=$(basename $(dirname ${rdir}))
 		pbench-postprocess-tools --group=${tool_group} --iteration=${iteration_dir} --dir=${rdir}
+		ln -s $(basename ${rdir}) $(dirname ${rdir})/reference-result
 	done
 fi
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end

--- a/agent/util-scripts/gold/test-tool-trigger/test-19.txt
+++ b/agent/util-scripts/gold/test-tool-trigger/test-19.txt
@@ -4,28 +4,28 @@
 [pbench-tool-trigger]found trigger: tool-group:default start-trigger:"START DEFAULT" stop-trigger:"STOP DEFAULT"
 foo
 START DEFAULT
-[pbench-tool-trigger]pbench-start-tools --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result
+[pbench-tool-trigger]pbench-start-tools --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/sample1
 bar
 STOP DEFAULT
-[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result
+[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/sample1
 [warn][1900-01-01T00:00:00.000000] [sar]: tool is not running, nothing to kill
 rab
 START DEFAULT
-[pbench-tool-trigger]pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result
+[pbench-tool-trigger]pbench-start-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/sample1
 bir
 STOP DEFAULT
-[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result
+[pbench-tool-trigger]pbench-stop-tools --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/sample1
 [warn][1900-01-01T00:00:00.000000] [sar]: tool is not running, nothing to kill
 baz
 --- Finished test-19 test-tool-trigger (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/0
-/var/tmp/pbench-test-utils/pbench/0/reference-result
-/var/tmp/pbench-test-utils/pbench/0/reference-result/tools-default
+/var/tmp/pbench-test-utils/pbench/0/sample1
+/var/tmp/pbench-test-utils/pbench/0/sample1/tools-default
 /var/tmp/pbench-test-utils/pbench/1
-/var/tmp/pbench-test-utils/pbench/1/reference-result
-/var/tmp/pbench-test-utils/pbench/1/reference-result/tools-default
+/var/tmp/pbench-test-utils/pbench/1/sample1
+/var/tmp/pbench-test-utils/pbench/1/sample1/tools-default
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tmp/.empty
@@ -37,32 +37,32 @@ baz
 /var/tmp/pbench-test-utils/pbench/tmp/.empty:
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]started: --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]started: --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/sample1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]started: --group default
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --iteration=1 --group=default --dir=/tmp --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result --interval=3
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/sample1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[warn][1900-01-01T00:00:00.000000] [sar]: tool is not running, nothing to kill
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]completed: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]started: --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]started: --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/sample1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]started: --group default
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --iteration=1 --group=default --dir=/tmp --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result --interval=3
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/sample1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[warn][1900-01-01T00:00:00.000000] [sar]: tool is not running, nothing to kill
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]completed: 
 --- pbench.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/reference-result --interval=3
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/reference-result --interval=3
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-tool-trigger
+++ b/agent/util-scripts/pbench-tool-trigger
@@ -35,8 +35,8 @@ my $stop_t = "";
 my $pbrun = $ENV{'pbench_run'};
 print "$pbrun\n";
 if (!$pbrun) {
-        $pbrun = `getconf.py pbench_run pbench-agent`;
-        chop $pbrun;
+	$pbrun = `getconf.py pbench_run pbench-agent`;
+	chop $pbrun;
 }
 
 my $t_file =  $pbrun . "/tool-triggers";
@@ -62,7 +62,7 @@ while (<TRIG>) {
 close(TRIG);
 
 # Initial reference result directory for tools
-my $benchmark_results_dir = $benchmark_run_dir . '/' . $iteration . '/reference-result';
+my $benchmark_results_dir = $benchmark_run_dir . '/' . $iteration . '/sample1';
 
 while (<STDIN>) {
 	# Echo the line we read
@@ -77,7 +77,7 @@ while (<STDIN>) {
 		# Increment the iteration and adjust the benchmark results
 		# directory now that this iteration is done.
 		$iteration++;
-		$benchmark_results_dir = $benchmark_run_dir . '/' . $iteration . '/reference-result';
+		$benchmark_results_dir = $benchmark_run_dir . '/' . $iteration . '/sample1';
 	}
 	if ((/$start_t/) && !$started) {
 		$cmd="pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir\n";


### PR DESCRIPTION
For pbench-user-benchmark and pbench-tool-trigger, don't use reference-result, use
sample1 instead for the result directory name.  Then create the symlink to sample1
using reference-result.

Fixes #1093.