### PR TITLE
Further fixes to stop using reference-result directly

### DIFF
--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -158,7 +158,7 @@ for runtime in `echo $runtimes | sed -e s/,/" "/g`; do
 		iteration="$iteration-cpu_$cpu"
 	fi
 	echo $iteration >> $benchmark_iterations
-	benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result/"
+	benchmark_results_dir="$benchmark_run_dir/$iteration/sample1/"
 	result_file=$benchmark_results_dir/result.txt
 	benchmark_cmd_file=$benchmark_results_dir/cyclictest.cmd
 	mkdir -p $benchmark_results_dir
@@ -169,6 +169,7 @@ for runtime in `echo $runtimes | sed -e s/,/" "/g`; do
 	$benchmark_cmd_file | tee $result_file
 	pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 	pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
+	ln -s sample1 $benchmark_run_dir/$iteration/reference-result
 	min=`grep "Min Latencies:" $result_file | awk '{print $4}'`
 	avg=`grep "Avg Latencies:" $result_file | awk '{print $4}'`
 	max=`grep "Max Latencies:" $result_file | awk '{print $4}'`

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -182,7 +182,7 @@ export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo beg
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir beg
 
-benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
+benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 echo $iteration >> $benchmark_iterations
 benchmark_tools_dir="$benchmark_results_dir/tools-$tool_group"
 mkdir -p $benchmark_results_dir $benchmark_tools_dir
@@ -201,6 +201,7 @@ done
 
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
+ln -s sample1 $benchmark_run_dir/$iteration/reference-result
 
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo end

--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -127,7 +127,7 @@ mkdir -p ${benchmark_run_dir}/.running
 iteration=1-$threads-threads
 benchmark_iterations="$pbench_tmp/${benchmark_fullname}.iterations"
 echo $iteration >> $benchmark_iterations
-benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
+benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 result_file=$benchmark_results_dir/result.txt
 mkdir -p $benchmark_results_dir
 export benchmark config
@@ -142,6 +142,8 @@ OMP_NUM_THREADS=$threads ${linpack_dir}/${linpack_cmd} < ${linpack_dir}/${linpac
 
 pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 pbench-postprocess-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
+
+ln -s sample1 $benchmark_run_dir/$iteration/reference-result
 
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo end

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -343,14 +343,16 @@ loops=$round_trips
 if [ $loops -eq 0 ]; then
 	loops=1
 fi
-count=1
+
 export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo beg
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir beg
+
+count=1
 for i in `seq 1 $loops`; do
 	iteration="$count-from-$src_host-to-$dest_host"
 	echo $iteration >> $benchmark_iterations
-	benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
+	benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 	if [ "$postprocess" != "only" ]; then
 		mkdir -p $benchmark_results_dir
 		do_migrate $src_host $dest_host $dest_ipaddr
@@ -366,7 +368,7 @@ for i in `seq 1 $loops`; do
 		# this will complete the round-trip migration
 		# this time the src and dest hosts are swapped for the do_migrate command
 		iteration="$count-from-$dest_host-to-$src_host"
-		benchmark_results_dir="$benchmark_run_dir/$iteration/reference-result"
+		benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 		if [ "$postprocess" != "only" ]; then
 			mkdir -p $benchmark_results_dir
 			do_migrate $dest_host $src_host $src_ipaddr
@@ -384,10 +386,13 @@ done
 # after all the migrations are done, postprocess the data
 echo sleeping for $seconds_before_postprocess seconds before postprocessing tools
 sleep $seconds_before_postprocess
+
 for postprocess_dir in $postprocess_dirs; do
 	pbench-postprocess-tools --group=$tool_group --dir=$postprocess_dir &
+	ln -s sample1 $(dirname $postprocess_dir)/reference-result
 done
 wait
+
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir end
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo end
 

--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -359,13 +359,13 @@ function record_iteration {
 > ${benchmark_iterations}
 iteration=1
 for i in `seq $start_warehouses $inc_warehouses $stop_warehouses`; do
-	if [ ! -d ${iteration}/reference-result ]; then
-		error_log "missing iteration directory ${benchmark_run_dir}/${iteration}/reference-result"
+	if [ ! -d ${iteration}/sample1 ]; then
+		error_log "missing iteration directory ${benchmark_run_dir}/${iteration}/sample1"
 		let iteration=$iteration+1
 		continue
 	fi
 	# for each of the test iterations (each test with a specific number of warehouses), copy the raw result data for that iteration in the iteration directory
-	grep "test${i}" ${specjbb_results}/SPECjbb.001.raw > ${iteration}/reference-result/SPECjbb.raw
+	grep "test${i}" ${specjbb_results}/SPECjbb.001.raw > ${iteration}/sample1/SPECjbb.raw
 	if [ $? -ne 0 ]; then
 		error_log "missing test${i} raw results in ${specjbb_results}/SPECjbb.raw"
 	fi
@@ -375,7 +375,8 @@ for i in `seq $start_warehouses $inc_warehouses $stop_warehouses`; do
 		error_log "unable to move ${iteration} directory hierarchy to ${new_iteration_name}, skipping post-processing"
 	else
 		record_iteration ${iteration} ${new_iteration_name} ${benchmark}
-		pbench-postprocess-tools --group=${tool_group} --iteration=${new_iteration_name} --dir=${benchmark_run_dir}/${new_iteration_name}/reference-result
+		pbench-postprocess-tools --group=${tool_group} --iteration=${new_iteration_name} --dir=${benchmark_run_dir}/${new_iteration_name}/sample1
+		ln -s sample1 ${benchmark_run_dir}/${new_iteration_name}/reference-result
 	fi
 	let iteration=$iteration+1
 done

--- a/agent/util-scripts/pbench-tool-trigger
+++ b/agent/util-scripts/pbench-tool-trigger
@@ -17,7 +17,7 @@
 # trigger are easily managed.
 #
 # The tools are given a unique results directory for each iteration by using
-# the pattern "$benchmark_run_dir/$iteration/reference-result".
+# the pattern "$benchmark_run_dir/$iteration/sample1".
 
 my $script="pbench-tool-trigger";
 


### PR DESCRIPTION
We fix references in the less-used benchmark scripts, cyclictest, iozone,
linpack, migrate, and specjbb2005.

We also fix a wayward comment in pbench-tool-trigger.

Further fixes for #1093.