### PR TITLE
Some minor behavior changes for field names and use of incoming URL

### DIFF
--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -1,5 +1,6 @@
 ## Foreword
 
+
 Pbench Dashboard is a web-based platform for consuming indexed performance benchmark data. The platform provides a consolidated view of benchmark data within tables, charts, and other powerful visualizations. Users are able to quickly navigate through benchmark data and tune analytics through comparison tools for in-depth analysis.
 
 ## Scaffolding
@@ -28,14 +29,14 @@ Pbench Dashboard is a web-based platform for consuming indexed performance bench
 │   ├── index.less                  # global stylesheet
 │   └── router.js                   # router entry file
 ├── .eslintrc.js                    # js linting configuration
-├── .gitignore               
+├── .gitignore
 ├── .prettierignore                 # code formatting ignore file
 ├── .prettierrc                     # code formatting configuration
 ├── .stylelintrc                    # style linting configuration
 ├── jsconfig.json                   # js compiler configuration
 ├── config.json.j2                  # template JSON configuration
 ├── package.json                    # project dependencies
-├── README.md               
+├── README.md
 └── LICENSE.ant-design-pro          # template license file
 ```
 
@@ -59,7 +60,7 @@ $ yarn install
 Start Development Server
 
 ```bash
-$ yarn start 
+$ yarn start
 ```
 
 This will automatically open the application on [http://localhost:8000](http://localhost:8000).
@@ -92,8 +93,8 @@ $ yarn build
 This will generate the `dist` folder in the root directory, which contains packaged files such as `***.js`, `***.css`, and `index.html`.
 
 
-## Template 
+## Template
 
 This application is based on v1 of Ant Design Pro which is a production-ready UI solution for admin interfaces. For more information regarding the foundation and template of the application, please visit [https://v1.pro.ant.design/docs/getting-started](https://v1.pro.ant.design/docs/getting-started).
 
-For information regarding the library license, please reference the `LICENSE.ant-design-pro` file. 
+For information regarding the library license, please reference the `LICENSE.ant-design-pro` file.

--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -15,6 +15,11 @@ export default {
     *fetchDatastoreConfig({ payload }, { call, put }) {
       let response = yield call(queryDatastoreConfig, payload);
 
+      // Remove the trailing slashes if present, we'll take care of adding
+      // them back in the proper context.
+      response.elasticsearch = response.elasticsearch.replace(/\/+$/, '');
+      response.results = response.results.replace(/\/+$/, '');
+
       yield put({
         type: 'getDatastoreConfig',
         payload: response,

--- a/web-server/v0.4/src/pages/Dashboard/Results.js
+++ b/web-server/v0.4/src/pages/Dashboard/Results.js
@@ -180,14 +180,14 @@ export default class Results extends Component {
       },
       {
         title: 'Start Time',
-        dataIndex: 'run.startRun',
-        key: 'run.startRun',
-        sorter: (a, b) => a['run.startRunUnixTimestamp'] - b['run.startRunUnixTimestamp'],
+        dataIndex: 'run.start',
+        key: 'run.start',
+        sorter: (a, b) => a['run.startUnixTimestamp'] - b['run.startUnixTimestamp'],
       },
       {
         title: 'End Time',
-        dataIndex: 'run.endRun',
-        key: 'run.endRun',
+        dataIndex: 'run.end',
+        key: 'run.end',
       },
     ];
 

--- a/web-server/v0.4/src/pages/Dashboard/Results.js
+++ b/web-server/v0.4/src/pages/Dashboard/Results.js
@@ -182,7 +182,7 @@ export default class Results extends Component {
         title: 'Start Time',
         dataIndex: 'run.start',
         key: 'run.start',
-        sorter: (a, b) => a['run.startUnixTimestamp'] - b['run.startUnixTimestamp'],
+        sorter: (a, b) => a['startUnixTimestamp'] - b['startUnixTimestamp'],
       },
       {
         title: 'End Time',
@@ -256,11 +256,15 @@ export default class Results extends Component {
 }
 
 function compareByAlph(a, b) {
+  let ret;
   if (a > b) {
-    return -1;
+    ret = 1;
   }
-  if (a < b) {
-    return 1;
+  else if (a < b) {
+    ret = -1;
   }
-  return 0;
+  else {
+    ret = 0;
+  }
+  return ret;
 }

--- a/web-server/v0.4/src/pages/Dashboard/RunComparison.js
+++ b/web-server/v0.4/src/pages/Dashboard/RunComparison.js
@@ -221,7 +221,7 @@ export default class RunComparison extends ReactJS.Component {
           iterationRequests.push(
             axios.get(
               datastoreConfig.results +
-              '/results/' +
+              '/incoming/' +
               encodeURIComponent(
                 clusteredIterations[primaryMetric][cluster][iteration].controller_name
               ) +

--- a/web-server/v0.4/src/pages/Dashboard/Summary.js
+++ b/web-server/v0.4/src/pages/Dashboard/Summary.js
@@ -110,18 +110,16 @@ class Summary extends ReactJS.Component {
     if (selectedController != null && selectedController.includes('.')) {
       iterationEndpoint =
         datastoreConfig.results +
-        '/results/' +
+        '/incoming/' +
         encodeURI(selectedController.slice(0, selectedController.indexOf('.'))) +
-        (selectedResults['run.prefix'] != null ? '/' + selectedResults['run.prefix'] : '') +
         '/' +
         encodeURI(selectedResults['run.name']) +
         '/result.json';
     } else {
       iterationEndpoint =
         datastoreConfig.results +
-        '/results/' +
+        '/incoming/' +
         encodeURI(selectedController) +
-        (selectedResults['run.prefix'] != null ? '/' + selectedResults['run.prefix'] : '') +
         '/' +
         encodeURI(selectedResults['run.name']) +
         '/result.json';

--- a/web-server/v0.4/src/services/dashboard.js
+++ b/web-server/v0.4/src/services/dashboard.js
@@ -28,14 +28,20 @@ export async function queryControllers(params) {
           terms: {
             field: 'controller',
             size: 0,
-            order: {
-              runs: 'desc',
-            },
+            order: [
+              { runs: 'desc' },
+              { runs_preV1: 'desc' }
+            ]
           },
           aggs: {
-            runs: {
-              min: {
+            runs_preV1: {
+              max: {
                 field: 'run.start_run',
+              },
+            },
+            runs: {
+              max: {
+                field: 'run.start',
               },
             },
           },
@@ -59,15 +65,17 @@ export async function queryResults(params) {
     body: {
       fields: [
         'run.controller',
-        'run.start_run',
-        'run.end_run',
+        'run.start',
+        'run.start_run', // For pre-v1 run mapping version
+        'run.end',
+        'run.end_run', // For pre-v1 run mapping version
         'run.name',
         'run.config',
         'run.prefix',
         'run.id',
       ],
       sort: {
-        'run.end_run': {
+        'run.end': {
           order: 'desc',
           ignore_unmapped: true,
         },

--- a/web-server/v0.4/src/services/dashboard.js
+++ b/web-server/v0.4/src/services/dashboard.js
@@ -134,9 +134,8 @@ export async function queryIterations(params) {
       iterationRequests.push(
         axios.get(
           datastoreConfig.results +
-          '/results/' +
+          '/incoming/' +
           (result.controller.includes('.') ? encodeURI(result.controller.slice(0, result.controller.indexOf('.'))) : encodeURI(result.controller)) +
-          (result['run.prefix'] != null ? '/' + result['run.prefix'] : '') +
           '/' +
           encodeURI(result['run.name']) +
           '/result.json'


### PR DESCRIPTION
 * Handle both new and old field names (requires PR #1073 for new field names)
   * Adding some error handling when we don't get our expected data
 * Strip trailing slashes in the configured URLs in case somebody makes a mistake
 * Instead of using the configured prefix, use the `incoming` URL which does not need the `run.prefix` value

