### PR TITLE
Use only query iterations

### DIFF
--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -35,8 +35,7 @@ export default {
           // Look for v1 data
           last_mod_val = controller.runs.value;
           last_mod_str = controller.runs.value_as_string;
-        }
-        else {
+        } else {
           // Fall back to pre-v1 data
           last_mod_val = controller.runs_preV1.value;
           last_mod_str = controller.runs_preV1.value_as_string;
@@ -81,7 +80,8 @@ export default {
               : result.fields['run.end_run'][0];
         } catch (error) {
           console.log(
-            "Problem handling 'run' documents (most likely missing required 'run' field name): " + error
+            "Problem handling 'run' documents (most likely missing required 'run' field name): " +
+              error
           );
           return;
         }
@@ -96,6 +96,7 @@ export default {
         results.push({
           key: name,
           startUnixTimestamp: Date.parse(start),
+          controller: controller,
           ['run.name']: name,
           ['run.config']: config,
           ['run.prefix']: prefix,

--- a/web-server/v0.4/src/pages/Dashboard/ComparisonSelect.js
+++ b/web-server/v0.4/src/pages/Dashboard/ComparisonSelect.js
@@ -43,12 +43,14 @@ class ComparisonSelect extends ReactJS.Component {
     queryIterations({ selectedResults: selectedResults, datastoreConfig: datastoreConfig })
       .then(res => {
         let parsedIterationData = parseIterationData(res);
-        this.setState({ responseData: parsedIterationData.responseData });
-        this.setState({ selectedRowKeys: parsedIterationData.selectedRowKeys });
-        this.setState({ responseDataAll: parsedIterationData.responseDataAll });
-        this.setState({ configData: parsedIterationData.configData });
-        this.setState({ ports: parsedIterationData.ports });
-        this.setState({ loading: false });
+        this.setState({
+          responseData: parsedIterationData.responseData,
+          selectedRowKeys: parsedIterationData.selectedRowKeys,
+          responseDataAll: parsedIterationData.responseDataAll,
+          configData: parsedIterationData.configData,
+          ports: parsedIterationData.ports,
+          loading: false,
+        });
       })
       .catch(err => {
         this.openNetworkErrorNotification('error');
@@ -174,8 +176,10 @@ class ComparisonSelect extends ReactJS.Component {
   };
 
   clearFilters = () => {
-    this.setState({ selectedConfig: [] });
-    this.setState({ selectedPort: 'all' });
+    this.setState({
+      selectedConfig: [],
+      selectedPort: 'all',
+    });
   };
 
   portChange = value => {

--- a/web-server/v0.4/src/pages/Dashboard/Controllers.js
+++ b/web-server/v0.4/src/pages/Dashboard/Controllers.js
@@ -2,8 +2,9 @@ import { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
 import { Card, Table, Input, Button, Icon, Form, Select, notification } from 'antd';
-import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 const FormItem = Form.Item;
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import { compareByAlph } from '../../utils/utils';
 
 @connect(({ global, dashboard, loading }) => ({
   controllers: dashboard.controllers,
@@ -263,14 +264,4 @@ export default class Controllers extends Component {
       </PageHeaderLayout>
     );
   }
-}
-
-function compareByAlph(a, b) {
-  if (a > b) {
-    return -1;
-  }
-  if (a < b) {
-    return 1;
-  }
-  return 0;
 }

--- a/web-server/v0.4/src/pages/Dashboard/Controllers.js
+++ b/web-server/v0.4/src/pages/Dashboard/Controllers.js
@@ -23,7 +23,7 @@ export default class Controllers extends Component {
     this.state = {
       controllers: [],
       selectedIndicesUpdated: false,
-      searchText: ''
+      searchText: '',
     };
   }
 
@@ -45,11 +45,13 @@ export default class Controllers extends Component {
 
     dispatch({
       type: 'global/fetchDatastoreConfig',
-    }).then(() => {
-      this.fetchMonthIndices();
-    }).catch((err) => {
-      console.log(err)
-    });
+    })
+      .then(() => {
+        this.fetchMonthIndices();
+      })
+      .catch(err => {
+        console.log(err);
+      });
   };
 
   fetchMonthIndices = async () => {
@@ -156,8 +158,10 @@ export default class Controllers extends Component {
 
   emitEmpty = () => {
     this.searchInput.focus();
-    this.setState({ controllers: this.props.controllers });
-    this.setState({ searchText: '' });
+    this.setState({
+      controllers: this.props.controllers,
+      searchText: '',
+    });
   };
 
   render() {
@@ -251,8 +255,10 @@ export default class Controllers extends Component {
             columns={columns}
             dataSource={controllers}
             defaultPageSize={20}
-            onRow={(record) => ({
-              onClick: () => { this.retrieveResults(record); }
+            onRow={record => ({
+              onClick: () => {
+                this.retrieveResults(record);
+              },
             })}
             loading={loadingControllers || loadingConfig || loadingIndices}
             showSizeChanger={true}

--- a/web-server/v0.4/src/pages/Dashboard/Results.js
+++ b/web-server/v0.4/src/pages/Dashboard/Results.js
@@ -249,7 +249,7 @@ export default class Results extends Component {
             dataSource={results}
             onRow={record => ({
               onClick: () => {
-                this.retrieveResults(record);
+                this.retrieveResults([record]);
               },
             })}
             loading={loading}

--- a/web-server/v0.4/src/pages/Dashboard/Results.js
+++ b/web-server/v0.4/src/pages/Dashboard/Results.js
@@ -23,7 +23,7 @@ export default class Results extends Component {
       selectedRowNames: [],
       loading: false,
       loadingButton: false,
-      searchText: ''
+      searchText: '',
     };
   }
 
@@ -148,8 +148,10 @@ export default class Results extends Component {
 
   emitEmpty = () => {
     this.searchInput.focus();
-    this.setState({ results: this.props.results });
-    this.setState({ searchText: '' });
+    this.setState({
+      results: this.props.results,
+      searchText: '',
+    });
   };
 
   render() {
@@ -198,7 +200,7 @@ export default class Results extends Component {
           <Form layout={'inline'} style={{ display: 'flex', flex: 1, alignItems: 'center' }}>
             <FormItem>
               <Input
-                style={{ width: 300, }}
+                style={{ width: 300 }}
                 ref={ele => (this.searchInput = ele)}
                 prefix={<Icon type="search" style={{ color: 'rgba(0,0,0,.25)' }} />}
                 suffix={suffix}
@@ -245,8 +247,10 @@ export default class Results extends Component {
             rowSelection={rowSelection}
             columns={columns}
             dataSource={results}
-            onRow={(record) => ({
-              onClick: () => { this.retrieveResults(record); }
+            onRow={record => ({
+              onClick: () => {
+                this.retrieveResults(record);
+              },
             })}
             loading={loading}
             pagination={{ pageSize: 20 }}

--- a/web-server/v0.4/src/pages/Dashboard/Results.js
+++ b/web-server/v0.4/src/pages/Dashboard/Results.js
@@ -2,8 +2,9 @@ import { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
 import { Tag, Card, Table, Input, Button, Icon, Form } from 'antd';
-import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 const FormItem = Form.Item;
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import { compareByAlph } from '../../utils/utils';
 
 @connect(({ global, dashboard, loading }) => ({
   selectedIndices: global.selectedIndices,
@@ -255,18 +256,4 @@ export default class Results extends Component {
       </PageHeaderLayout>
     );
   }
-}
-
-function compareByAlph(a, b) {
-  let ret;
-  if (a > b) {
-    ret = 1;
-  }
-  else if (a < b) {
-    ret = -1;
-  }
-  else {
-    ret = 0;
-  }
-  return ret;
 }

--- a/web-server/v0.4/src/pages/Dashboard/RunComparison.js
+++ b/web-server/v0.4/src/pages/Dashboard/RunComparison.js
@@ -120,9 +120,9 @@ export default class RunComparison extends ReactJS.Component {
         for (var iteration in clusteredIterations[primaryMetric][cluster]) {
           clusterObject[iteration] =
             clusteredIterations[primaryMetric][cluster][iteration][
-            Object.keys(clusteredIterations[primaryMetric][cluster][iteration]).find(
-              this.findAggregation
-            )
+              Object.keys(clusteredIterations[primaryMetric][cluster][iteration]).find(
+                this.findAggregation
+              )
             ];
         }
         clusteredGraphData[primaryMetric].push(clusterObject);
@@ -142,15 +142,17 @@ export default class RunComparison extends ReactJS.Component {
         graphKeys[primaryMetric].push(i);
       }
     }
-    this.setState({ tableData: tableData });
-    this.setState({ graphKeys: graphKeys });
-    this.setState({ clusteredGraphData: clusteredGraphData });
-    this.setState({ loading: false });
+    this.setState({
+      tableData: tableData,
+      graphKeys: graphKeys,
+      clusteredGraphData: clusteredGraphData,
+      loading: false,
+    });
   };
 
   groupClusters = (array, cluster, f) => {
     var groups = {};
-    array.forEach(function (o) {
+    array.forEach(function(o) {
       var group = f(o).join('-');
       groups[group] = groups[group] || [];
       groups[group].push(o);
@@ -158,14 +160,16 @@ export default class RunComparison extends ReactJS.Component {
     var { clusterLabels } = this.state;
     clusterLabels[cluster] = Object.keys(groups);
     this.setState({ clusterLabels: clusterLabels });
-    return Object.keys(groups).map(function (group) {
+    return Object.keys(groups).map(function(group) {
       return groups[group];
     });
   };
 
   generateIterationClusters = config => {
-    this.setState({ loading: true });
-    this.setState({ selectedConfig: config });
+    this.setState({
+      loading: true,
+      selectedConfig: config,
+    });
     const { iterations } = this.props.location.state;
     var primaryMetricIterations = [];
     primaryMetricIterations = _.mapValues(_.groupBy(iterations, 'primary_metric'), clist =>
@@ -178,7 +182,7 @@ export default class RunComparison extends ReactJS.Component {
         clusteredIterations = this.groupClusters(
           primaryMetricIterations[cluster],
           cluster,
-          function (item) {
+          function(item) {
             var configData = [];
             for (var filter in config) {
               configData.push(item[config[filter]]);
@@ -221,29 +225,29 @@ export default class RunComparison extends ReactJS.Component {
           iterationRequests.push(
             axios.get(
               datastoreConfig.results +
-              '/incoming/' +
-              encodeURIComponent(
-                clusteredIterations[primaryMetric][cluster][iteration].controller_name
-              ) +
-              '/' +
-              encodeURIComponent(
-                clusteredIterations[primaryMetric][cluster][iteration].result_name
-              ) +
-              '/' +
-              encodeURIComponent(
-                clusteredIterations[primaryMetric][cluster][iteration].iteration_number
-              ) +
-              '-' +
-              encodeURIComponent(
-                clusteredIterations[primaryMetric][cluster][iteration].iteration_name
-              ) +
-              '/' +
-              'sample' +
-              encodeURIComponent(
-                clusteredIterations[primaryMetric][cluster][iteration].closest_sample
-              ) +
-              '/' +
-              'result.json'
+                '/incoming/' +
+                encodeURIComponent(
+                  clusteredIterations[primaryMetric][cluster][iteration].controller_name
+                ) +
+                '/' +
+                encodeURIComponent(
+                  clusteredIterations[primaryMetric][cluster][iteration].result_name
+                ) +
+                '/' +
+                encodeURIComponent(
+                  clusteredIterations[primaryMetric][cluster][iteration].iteration_number
+                ) +
+                '-' +
+                encodeURIComponent(
+                  clusteredIterations[primaryMetric][cluster][iteration].iteration_name
+                ) +
+                '/' +
+                'sample' +
+                encodeURIComponent(
+                  clusteredIterations[primaryMetric][cluster][iteration].closest_sample
+                ) +
+                '/' +
+                'result.json'
             )
           );
         }
@@ -285,8 +289,8 @@ export default class RunComparison extends ReactJS.Component {
                     }
                     timeseriesLabels.push(
                       clusteredIterations[primaryMetric][cluster][iteration].result_name +
-                      '-' +
-                      clusteredIterations[primaryMetric][cluster][iteration].iteration_name
+                        '-' +
+                        clusteredIterations[primaryMetric][cluster][iteration].iteration_name
                     );
                     iterationTimeseriesData = _.merge(
                       iterationTimeseriesData,
@@ -313,9 +317,11 @@ export default class RunComparison extends ReactJS.Component {
           timeseriesData[Object.keys(timeseriesData)[primaryMetric]]
         );
       }
-      this.setState({ timeseriesData: timeseriesData });
-      this.setState({ timeseriesDropdownSelected: timeseriesDropdownSelected });
-      this.setState({ timeseriesDropdown: timeseriesDropdown });
+      this.setState({
+        timeseriesData: timeseriesData,
+        timeseriesDropdownSelected: timeseriesDropdownSelected,
+        timeseriesDropdown: timeseriesDropdown,
+      });
     });
   }
 
@@ -384,32 +390,37 @@ export default class RunComparison extends ReactJS.Component {
   };
 
   handleOk = e => {
-    this.setState({
-      pdfName: document.getElementById("pdfName").value,
-      pdfHeader: document.getElementById("pdfHeader").value,
-    }, () => {
-      if (this.state.pdfName == '') {
-        console.log(document.getElementById("pdfName").value, moment().format())
-        this.setState({
-          pdfName: moment().format(),
-        });
+    this.setState(
+      {
+        pdfName: document.getElementById('pdfName').value,
+        pdfHeader: document.getElementById('pdfHeader').value,
+      },
+      () => {
+        if (this.state.pdfName == '') {
+          console.log(document.getElementById('pdfName').value, moment().format());
+          this.setState({
+            pdfName: moment().format(),
+          });
+        }
+        if (this.state.pdfHeader == ' ') {
+          message.error('Add PDF description');
+        } else {
+          this.setState(
+            {
+              generatingPdf: true,
+              selectedComponents:
+                this.state.defaultComponents.length == 4
+                  ? ['all']
+                  : [...this.state.defaultComponents],
+            },
+            () => {
+              console.log(this.state.selectedComponents);
+              this.savePDF();
+            }
+          );
+        }
       }
-      if (this.state.pdfHeader == ' ') {
-        message.error('Add PDF description');
-      } else {
-        this.setState(
-          {
-            generatingPdf: true,
-            selectedComponents:
-              this.state.defaultComponents.length == 4 ? ['all'] : [...this.state.defaultComponents],
-          },
-          () => {
-            console.log(this.state.selectedComponents);
-            this.savePDF();
-          }
-        );
-      }
-    });
+    );
   };
 
   handleCancel = e => {
@@ -729,43 +740,43 @@ export default class RunComparison extends ReactJS.Component {
             </TabPane>
             <TabPane forceRender={true} tab="All" key="all" style={{ padding: 16 }}>
               {(Object.keys(timeseriesData).length > 0) &
-                (Object.keys(timeseriesDropdown).length > 0) ? (
-                  <div id="timeseries">
-                    {Object.keys(tableData).map(table => (
-                      <Card
-                        type="inner"
-                        title={table}
-                        style={{ marginBottom: 16 }}
-                        extra={
-                          <Form layout={'inline'}>
-                            <FormItem
-                              label="Selected Cluster"
-                              colon={false}
-                              style={{ marginLeft: 16, fontWeight: '500' }}
+              (Object.keys(timeseriesDropdown).length > 0) ? (
+                <div id="timeseries">
+                  {Object.keys(tableData).map(table => (
+                    <Card
+                      type="inner"
+                      title={table}
+                      style={{ marginBottom: 16 }}
+                      extra={
+                        <Form layout={'inline'}>
+                          <FormItem
+                            label="Selected Cluster"
+                            colon={false}
+                            style={{ marginLeft: 16, fontWeight: '500' }}
+                          >
+                            <Select
+                              defaultValue={'Cluster ' + 0}
+                              style={{ width: 120, marginLeft: 16 }}
+                              value={timeseriesDropdownSelected[table]}
+                              onChange={value => this.clusterDropdownChange(value, table)}
                             >
-                              <Select
-                                defaultValue={'Cluster ' + 0}
-                                style={{ width: 120, marginLeft: 16 }}
-                                value={timeseriesDropdownSelected[table]}
-                                onChange={value => this.clusterDropdownChange(value, table)}
-                              >
-                                {timeseriesDropdown[table].map(cluster => (
-                                  <Select.Option value={cluster}>
-                                    {'Cluster ' + cluster}
-                                  </Select.Option>
-                                ))}
-                              </Select>
-                            </FormItem>
-                          </Form>
-                        }
-                      >
-                        <div id={table} />
-                      </Card>
-                    ))}
-                  </div>
-                ) : (
-                  <div />
-                )}
+                              {timeseriesDropdown[table].map(cluster => (
+                                <Select.Option value={cluster}>
+                                  {'Cluster ' + cluster}
+                                </Select.Option>
+                              ))}
+                            </Select>
+                          </FormItem>
+                        </Form>
+                      }
+                    >
+                      <div id={table} />
+                    </Card>
+                  ))}
+                </div>
+              ) : (
+                <div />
+              )}
             </TabPane>
           </Tabs>
         </Card>

--- a/web-server/v0.4/src/pages/Dashboard/Summary.js
+++ b/web-server/v0.4/src/pages/Dashboard/Summary.js
@@ -134,8 +134,10 @@ class Summary extends ReactJS.Component {
           selectedResults['run.name'],
           selectedController
         );
-        this.setState({ responseData: responseData });
-        this.setState({ loading: false });
+        this.setState({
+          responseData: responseData,
+          loading: false,
+        });
       })
       .catch(error => {
         this.openNetworkErrorNotification('error');
@@ -478,8 +480,10 @@ class Summary extends ReactJS.Component {
     responseData['resultName'] = resultName;
     responseData['columns'] = columns;
     responseData['iterations'] = iterations;
-    this.setState({ ports: ports });
-    this.setState({ configData: configCategories });
+    this.setState({
+      ports: ports,
+      configData: configCategories,
+    });
     return responseData;
   }
 
@@ -581,16 +585,17 @@ class Summary extends ReactJS.Component {
   };
 
   clearFilters = () => {
-    this.setState({ selectedConfig: [] });
-    this.setState({ selectedPort: 'all' });
+    this.setState({
+      selectedConfig: [],
+      selectedPort: 'all',
+    });
   };
 
   portChange = value => {
+    this.setState({ selectedPort: value });
     if (value == 'all') {
-      this.setState({ selectedPort: value });
       this.forceUpdate();
     }
-    this.setState({ selectedPort: value });
   };
 
   insertTreeData = (items = [], [head, ...tail]) => {
@@ -624,13 +629,14 @@ class Summary extends ReactJS.Component {
 
   onTabChange = key => {
     const { tocResult } = this.props;
-    this.setState({ activeTab: key });
+    let newstate = { activeTab: key };
     if (key == 'toc') {
       let tocTree = Object.keys(tocResult)
         .map(path => path.split('/').slice(1))
         .reduce((items, path) => this.insertTreeData(items, path), []);
-      this.setState({ tocTree: tocTree });
+      newstate['tocTree'] = tocTree;
     }
+    this.setState(newstate);
   };
 
   list(data) {

--- a/web-server/v0.4/src/utils/utils.js
+++ b/web-server/v0.4/src/utils/utils.js
@@ -152,3 +152,15 @@ const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(?::\d+)?|(
 export function isUrl(path) {
   return reg.test(path);
 }
+
+export function compareByAlph(a, b) {
+  let ret;
+  if (a > b) {
+    ret = 1;
+  } else if (a < b) {
+    ret = -1;
+  } else {
+    ret = 0;
+  }
+  return ret;
+}


### PR DESCRIPTION
Use one common code for fetching and parsing iteration data (`queryIterations` and `parseIterationData`).

We also fix the sorting to behave correctly on all the pages by sharing the same sort method.

We reduce the number of calls to `setState()` to avoid repeated renderings of the page unnecessarily.

Depends on PR #1112.