### PR TITLE
Enhances TOC entries with new features

### DIFF
--- a/web-server/v0.4/.eslintrc.js
+++ b/web-server/v0.4/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
         devDependencies: ['**/tests/**.js', '/mock/**/**.js', '**/**.test.js'],
       },
     ],
+    'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
     'import/no-cycle': 0,
     'import/extensions': 0,
     'jsx-a11y/no-noninteractive-element-interactions': 0,

--- a/web-server/v0.4/src/components/GraphModal/index.js
+++ b/web-server/v0.4/src/components/GraphModal/index.js
@@ -1,0 +1,52 @@
+import React, { PureComponent } from 'react';
+import { Modal } from 'antd';
+import TimeseriesGraph from '../TimeseriesGraph';
+
+export default class GraphModal extends PureComponent {
+  constructor(props) {
+    super(props);
+    this.timeseriesGraph = React.createRef();
+
+    this.state = {
+      visible: false,
+    };
+  }
+
+  handleShow = () => {
+    this.setState({
+      visible: true,
+    });
+  };
+
+  handleHide = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  render() {
+    const { sampleNumber, graphId, timeseriesData, dataSeries, modalTitle } = this.props;
+    const { visible } = this.state;
+    return (
+      <div>
+        <a onClick={this.handleShow}>{sampleNumber}</a>
+        <Modal
+          centered
+          visible={visible}
+          onOk={this.handleHide}
+          onCancel={this.handleHide}
+          width={this.timeseriesGraph}
+        >
+          <TimeseriesGraph
+            ref={this.timeseriesGraph}
+            graphId={graphId}
+            graphName={modalTitle}
+            data={timeseriesData}
+            dataSeriesNames={dataSeries}
+            xAxisSeries="time"
+          />
+        </Modal>
+      </div>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/TableTree/index.js
+++ b/web-server/v0.4/src/components/TableTree/index.js
@@ -1,0 +1,111 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Table } from 'antd';
+
+export default class TableTree extends PureComponent {
+  static propTypes = {
+    id: PropTypes.string,
+    dataSource: PropTypes.array,
+    extension: PropTypes.array,
+    onload: PropTypes.func,
+    config: PropTypes.object,
+  };
+
+  static defaultProps = {
+    id: '',
+    dataSource: [],
+    extension: [],
+    onload: () => {},
+    config: {},
+  };
+
+  constructor(props) {
+    super(props);
+    this.fileData = [];
+    this.state = {
+      expandedKeys: [],
+    };
+  }
+
+  componentDidMount() {
+    const { dataSource, onload } = this.props;
+    onload(dataSource);
+  }
+
+  onExpand = (expanded, record) => {
+    let { expandedKeys } = this.state;
+    const keys = expandedKeys;
+    expandedKeys = expanded ? keys.concat(record.key) : keys.slice(0, keys.indexOf(record.key));
+    this.setState({ expandedKeys });
+  };
+
+  filterNames = (record, value) =>
+    record.some(childRecord => {
+      if (childRecord.name.toLowerCase().includes(value)) {
+        return true;
+      }
+      if (childRecord.children) {
+        return this.filterNames(childRecord.children, value);
+      }
+      return false;
+    });
+
+  render() {
+    const { id, dataSource, extension, config } = this.props;
+    const extensions = extension.map(x => ({ text: x, value: x }));
+    const { expandedKeys } = this.state;
+    const configLink = `${config.config + config.controller_name}/${config.run_name}/`;
+
+    const columns = [
+      {
+        title: 'Names',
+        dataIndex: 'name',
+        key: 'name',
+        width: '60%',
+        filters: extensions,
+        render: (text, record) => {
+          if (record.url === '') {
+            return text;
+          }
+          return (
+            <a
+              style={{ color: 'inherit' }}
+              href={configLink + record.url}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {text}
+            </a>
+          );
+        },
+        onFilter: (value, record) =>
+          (record.children && this.filterNames(record.children, value)) ||
+          record.name.toLowerCase().includes(value),
+      },
+      {
+        title: 'Size',
+        dataIndex: 'size',
+        key: 'size',
+        width: '20%',
+      },
+      {
+        title: 'Mode',
+        dataIndex: 'mode',
+        key: 'mode',
+      },
+    ];
+
+    return (
+      <div>
+        <Table
+          id={id}
+          columns={columns}
+          dataSource={dataSource}
+          rowKey={tocTree => tocTree.key}
+          onExpand={this.onExpand}
+          expandedRowKeys={expandedKeys}
+        />
+      </div>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/TimeseriesGraph/index.js
+++ b/web-server/v0.4/src/components/TimeseriesGraph/index.js
@@ -46,7 +46,6 @@ export default class TimeseriesGraph extends PureComponent {
 
   componentDidUpdate = prevProps => {
     const { data, dataSeriesNames, xAxisSeries, graphId } = this.props;
-
     if (
       JSON.stringify(prevProps.data) !== JSON.stringify(data) ||
       JSON.stringify(prevProps.dataSeriesNames) !== JSON.stringify(dataSeriesNames) ||

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -156,7 +156,7 @@ export default {
             if (!extension.includes(ext[ext.length - 1])) {
               extension.push(ext[ext.length - 1]);
             }
-            const url = source.directory + path.name;
+            const url = `${source.directory}/${path.name}`;
             tocResult[url] = [path.size, path.mode, url];
             return tocResult;
           });

--- a/web-server/v0.4/src/pages/Summary/index.js
+++ b/web-server/v0.4/src/pages/Summary/index.js
@@ -27,25 +27,25 @@ const tabList = [
   },
 ];
 
-const tocColumns = [
-  {
-    title: 'Name',
-    dataIndex: 'name',
-    key: 'name',
-    width: '60%',
-  },
-  {
-    title: 'Size',
-    dataIndex: 'size',
-    key: 'size',
-    width: '20%',
-  },
-  {
-    title: 'Mode',
-    dataIndex: 'mode',
-    key: 'mode',
-  },
-];
+// const tocColumns = [
+//   {
+//     title: 'Name',
+//     dataIndex: 'name',
+//     key: 'name',
+//     width: '60%',
+//   },
+//   {
+//     title: 'Size',
+//     dataIndex: 'size',
+//     key: 'size',
+//     width: '20%',
+//   },
+//   {
+//     title: 'Mode',
+//     dataIndex: 'mode',
+//     key: 'mode',
+//   },
+// ];
 
 @connect(({ global, datastore, dashboard, loading }) => ({
   iterations: dashboard.iterations,
@@ -53,7 +53,7 @@ const tocColumns = [
   iterationPorts: dashboard.iterationPorts,
   result: dashboard.result,
   summaryTocResult: dashboard.summaryTocResult,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedIndices: global.selectedIndices,

--- a/web-server/v0.4/src/pages/Summary/index.test.js
+++ b/web-server/v0.4/src/pages/Summary/index.test.js
@@ -13,6 +13,7 @@ const mockProps = {
   selectedControllers: ['test_controller'],
   iterations: [{}],
   iterationParams: {},
+  summaryTocResult: [],
 };
 
 const mockDispatch = jest.fn();

--- a/web-server/v0.4/src/services/dashboard.js
+++ b/web-server/v0.4/src/services/dashboard.js
@@ -249,3 +249,33 @@ export async function queryTimeseriesData(params) {
     };
   });
 }
+
+export async function queryClosestSampleData(param, record, datastoreConfig) {
+  const timeData = [];
+  const dataSeries = ['time'];
+  return request(
+    `${datastoreConfig.results}/results/${record.controller_name}/${record.result_name}/${
+      record.iteration_number
+    }-${record.iteration_name}/sample${record.closest_sample}/result.json`
+  ).then(args => {
+    args.throughput[param].map(y => {
+      const clientHostname = `/${`client_hostname:${y.client_hostname}-server_hostname:${
+        y.server_hostname
+      }-server_port:${y.server_port}`}`;
+      dataSeries.push(clientHostname);
+      return y.timeseries.map(z => {
+        const extData = timeData.filter(arr => arr[0] === z.date);
+        if (extData.length === 0) {
+          return timeData.push([z.date, z.value]);
+        }
+        return timeData.map(k => {
+          if (k[0] === z.date) {
+            k.push(z.value);
+          }
+          return k;
+        });
+      });
+    });
+    return { timeData, dataSeries };
+  });
+}

--- a/web-server/v0.4/src/services/dashboard.js
+++ b/web-server/v0.4/src/services/dashboard.js
@@ -114,7 +114,19 @@ export async function queryTocResult(params) {
     selectedIndices
   )}/_search?q=_parent:"${id}"`;
 
-  return request.post(endpoint);
+  return request.post(endpoint, {
+    data: {
+      aggs: {
+        directories: {
+          terms: {
+            field: 'directory',
+            exclude: '.*pid.*',
+            size: 0,
+          },
+        },
+      },
+    },
+  });
 }
 
 export async function queryIterations(params) {

--- a/web-server/v0.4/src/utils/parse.js
+++ b/web-server/v0.4/src/utils/parse.js
@@ -36,7 +36,7 @@ export const parseIterationData = results => {
     selectedIterationKeys.push([]);
 
     result.iterationData.forEach(iteration => {
-      let iterationMetadata = {
+      const iterationMetadata = {
         iteration_name: iteration.iteration_name,
         iteration_number: iteration.iteration_number,
         result_name: result.resultName,

--- a/web-server/v0.4/src/utils/utils.js
+++ b/web-server/v0.4/src/utils/utils.js
@@ -10,6 +10,7 @@ export function getAppPath() {
 export function fixedZero(val) {
   return val * 1 < 10 ? `0${val}` : val;
 }
+const fileData = [];
 
 export function getTimeDistance(type) {
   const now = new Date();
@@ -160,10 +161,13 @@ export const renameProp = (oldProp, newProp, { [oldProp]: old, ...others }) => (
 
 export const insertTocTreeData = (tocResult, items = [], [head, ...tail]) => {
   const tocResultCopy = Object.assign({}, tocResult);
-  const fileData = [];
 
   if (tocResultCopy[`/${[head, ...tail].join('/')}`] !== undefined) {
-    fileData[tail[tail.length - 1]] = tocResultCopy[`/${[head, ...tail].join('/')}`];
+    if (tail[tail.length - 1] !== undefined) {
+      fileData[tail[tail.length - 1]] = tocResult[`/${[head, ...tail].join('/')}`];
+    } else {
+      fileData[head] = tocResult[`/${[head, ...tail].join('/')}`];
+    }
   }
   let child = items.find(childNode => childNode.name === head);
   if (!child) {
@@ -174,11 +178,12 @@ export const insertTocTreeData = (tocResult, items = [], [head, ...tail]) => {
           key: Math.random(),
           size: fileData[head][0],
           mode: fileData[head][1],
+          url: fileData[head][2],
           children: [],
         })
       );
     } else {
-      items.push((child = { name: head, key: Math.random(), children: [] }));
+      items.push((child = { name: head, key: Math.random(), children: [], url: '' }));
     }
   }
   if (tail.length > 0) {


### PR DESCRIPTION
Will fix #1110 

- [x] Searching the TOC tab with keywords entered by the user.

- [x] Filtering the TOC data with file extension from dropdown.

- [x] Link the closest sample entries in the iteration table to sample graphs on the results server

- [x] Link items in the TOC tab to their file on the results server

- [x] Any collapsed item should also collapse all of its children nodes in the tree view

**Preview**
1.Filtering of TOC files
![main5](https://user-images.githubusercontent.com/16955978/55012139-f6165880-500c-11e9-8965-6563308cd77e.gif)

2.Searching name of a file
![main6](https://user-images.githubusercontent.com/16955978/55012172-01698400-500d-11e9-9c8e-f327030c083e.gif)

3.Sample graphs integration
![main4](https://user-images.githubusercontent.com/16955978/55012807-fe22c800-500d-11e9-8b50-cbb0265adb80.gif)
