### PR TITLE
Destructure page components for reducing component rerenders.

### DIFF
--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -25,7 +25,7 @@
     "@babel/runtime": "^7.3.1",
     "@nivo/bar": "^0.36.0",
     "ant-design-pro": "^2.1.1",
-    "antd": "^3.13.5",
+    "antd": "^3.15.0",
     "axios": "^0.18.0",
     "classnames": "^2.2.5",
     "dva": "^2.4.1",

--- a/web-server/v0.4/src/components/Button/index.js
+++ b/web-server/v0.4/src/components/Button/index.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button as AntdButton } from 'antd';
+
+export default class Button extends Component {
+  static propTypes = {
+    name: PropTypes.string.isRequired,
+    type: PropTypes.string,
+    disabled: PropTypes.bool,
+    onClick: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    type: 'primary',
+    disabled: false,
+  };
+
+  render() {
+    const { name, type, disabled, onClick, ...props } = this.props;
+
+    return (
+      <AntdButton type={type} disabled={disabled} onClick={onClick} {...props}>
+        {name}
+      </AntdButton>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/GlobalHeader/index.js
+++ b/web-server/v0.4/src/components/GlobalHeader/index.js
@@ -1,14 +1,10 @@
 import { PureComponent } from 'react';
-import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
 import { Icon, Divider, Tooltip } from 'antd';
 import Debounce from 'lodash-decorators/debounce';
 import { Link } from 'dva/router';
 import styles from './index.less';
 
-@connect(({ routing }) => ({
-  location: routing.location.pathname,
-}))
 class GlobalHeader extends PureComponent {
   componentWillUnmount() {
     this.triggerResizeEvent.cancel();
@@ -29,7 +25,7 @@ class GlobalHeader extends PureComponent {
   }
 
   render() {
-    const { collapsed, isMobile, logo, location, dispatch } = this.props;
+    const { collapsed, isMobile, logo, dispatch } = this.props;
 
     return (
       <div className={styles.header}>
@@ -77,4 +73,4 @@ class GlobalHeader extends PureComponent {
   }
 }
 
-export default connect(() => ({}))(GlobalHeader);
+export default GlobalHeader;

--- a/web-server/v0.4/src/components/MonthSelect/index.js
+++ b/web-server/v0.4/src/components/MonthSelect/index.js
@@ -1,0 +1,75 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Select, Form } from 'antd';
+
+import Button from '../Button';
+
+const FormItem = Form.Item;
+
+export default class MonthSelect extends PureComponent {
+  static propTypes = {
+    indices: PropTypes.array,
+    value: PropTypes.array,
+    onChange: PropTypes.func,
+    reFetch: PropTypes.func,
+    updateButtonVisible: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    indices: [],
+    value: ['0'],
+    onChange: () => {},
+    reFetch: () => {},
+    updateButtonVisible: true,
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      updateDisabled: true,
+    };
+  }
+
+  reFetch = () => {
+    const { reFetch } = this.props;
+    reFetch();
+    this.setState({ updateDisabled: true });
+  };
+
+  render() {
+    const { indices, value, onChange, updateButtonVisible } = this.props;
+    const { updateDisabled } = this.state;
+
+    return (
+      <div>
+        <FormItem label="Selected Months" colon={false} style={{ fontWeight: '500' }}>
+          <Select
+            mode="multiple"
+            style={{ width: '100%' }}
+            placeholder="Select index"
+            value={value}
+            onChange={selectedValue => {
+              onChange(selectedValue);
+              this.setState({ updateDisabled: false });
+            }}
+            tokenSeparators={[',']}
+          >
+            {indices.map(item => {
+              return <Select.Option key={item}>{item}</Select.Option>;
+            })}
+          </Select>
+        </FormItem>
+        {updateButtonVisible ? (
+          <FormItem>
+            <Button name="Update" type="primary" disabled={updateDisabled} onClick={this.reFetch}>
+              {'Update'}
+            </Button>
+          </FormItem>
+        ) : (
+          <div />
+        )}
+      </div>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/RowSelection/index.js
+++ b/web-server/v0.4/src/components/RowSelection/index.js
@@ -1,0 +1,36 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import Button from '../Button';
+
+export default class RowSelection extends PureComponent {
+  static propTypes = {
+    selectedItems: PropTypes.array.isRequired,
+    compareActionName: PropTypes.string.isRequired,
+    onCompare: PropTypes.func.isRequired,
+    styles: PropTypes.object,
+  };
+
+  static defaultProps = {
+    styles: {},
+  } 
+
+  render () {
+    const { selectedItems, compareActionName, onCompare, styles } = this.props;
+    const selectedItemsLength = selectedItems.length;
+
+    return (
+      <div styles={styles}>
+        <Button
+          type="primary"
+          onClick={onCompare}
+          name={compareActionName}
+          disabled={!(selectedItemsLength > 0)}
+        />
+        <span style={{ marginLeft: 8 }}>
+          {selectedItemsLength > 0 ? `Selected ${selectedItemsLength} items` : ''}
+        </span>
+      </div>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/SearchBar/index.js
+++ b/web-server/v0.4/src/components/SearchBar/index.js
@@ -1,0 +1,60 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import { Input, Icon } from 'antd';
+
+const { Search } = Input;
+
+export default class SearchBar extends PureComponent {
+  static propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    style: PropTypes.object,
+  };
+
+  static defaultProps = {
+    style: {},
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      searchValue: '',
+    };
+  }
+
+  onChange = e => {
+    this.setState({ searchValue: e.target.value });
+  };
+
+  emitEmpty = () => {
+    const { onSearch } = this.props;
+
+    this.searchBar.focus();
+    onSearch('');
+    this.setState({ searchValue: '' });
+  };
+
+  render() {
+    const { onSearch, placeholder, style } = this.props;
+    const { searchValue } = this.state;
+    const suffix = searchValue ? <Icon type="close-circle" onClick={this.emitEmpty} /> : <span />;
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'row', alignContent: 'center', maxWidth: 300, ...style }}>
+        <Search
+          ref={node => {
+            this.searchBar = node;
+            return this.searchBar;
+          }}
+          prefix={<Icon type="search" style={{ color: 'rgba(0,0,0,.25)' }} />}
+          suffix={suffix}
+          placeholder={placeholder}
+          value={searchValue}
+          onChange={this.onChange}
+          onSearch={value => onSearch(value)}
+          enterButton="Search"
+        />
+      </div>
+    );
+  }
+}

--- a/web-server/v0.4/src/components/Table/index.js
+++ b/web-server/v0.4/src/components/Table/index.js
@@ -1,0 +1,38 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Table as AntdTable } from 'antd';
+
+export default class Table extends Component {
+  static propTypes = {
+    columns: PropTypes.array,
+    dataSource: PropTypes.array,
+    loading: PropTypes.bool,
+    onRow: PropTypes.func,
+  };
+
+  static defaultProps = {
+    columns: [],
+    dataSource: [],
+    loading: false,
+    onRow: () => {},
+  };
+
+  render() {
+    const { dataSource, columns, loading, onRow, ...childProps } = this.props;
+
+    return (
+      <AntdTable
+        bordered
+        bodyStyle={{ borderRadius: 4 }}
+        columns={columns}
+        dataSource={dataSource}
+        loading={loading}
+        onRow={onRow}
+        scroll={{
+          x: true,
+        }}
+        {...childProps}
+      />
+    );
+  }
+}

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -64,7 +64,7 @@ export default {
         console.log('Unsuccessful run data query, no hits on matching documents: ' + error);
         hits = [];
       }
-      hits.map(result => {
+      hits.map((result, index) => {
         let name, controller, id, start, end;
         try {
           name = result.fields['run.name'][0];
@@ -86,7 +86,7 @@ export default {
           return;
         }
         let record = {
-          key: name,
+          key: index,
           startUnixTimestamp: Date.parse(start),
           ['run.name']: name,
           ['run.controller']: controller,

--- a/web-server/v0.4/src/pages/Search/SearchList.js
+++ b/web-server/v0.4/src/pages/Search/SearchList.js
@@ -1,10 +1,11 @@
-import ReactJS, { Component } from 'react';
-import { Input, Card, Row, Col, Divider, Tag, Table, Select, Spin } from 'antd';
+import React, { Component } from 'react';
+import { Input, Card, Row, Col, Divider, Tag, Spin } from 'antd';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 
-const Option = Select.Option;
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import MonthSelect from '../../components/MonthSelect';
+import Table from '../../components/Table';
 
 @connect(({ search, global, loading }) => ({
   mapping: search.mapping,
@@ -15,7 +16,7 @@ const Option = Select.Option;
   indices: global.indices,
   datastoreConfig: global.datastoreConfig,
   loadingMapping: loading.effects['search/fetchIndexMapping'],
-  loadingResults: loading.effects['search/fetchSearchResults'],
+  loadingSearchResults: loading.effects['search/fetchSearchResults'],
 }))
 export default class SearchList extends Component {
   constructor(props) {
@@ -152,7 +153,7 @@ export default class SearchList extends Component {
       mapping,
       selectedFields,
       searchResults,
-      loadingResults,
+      loadingSearchResults,
       loadingMapping,
     } = this.props;
     let columns = [];
@@ -195,19 +196,12 @@ export default class SearchList extends Component {
                 style={{ marginBottom: 24 }}
               >
                 <Spin spinning={loadingMapping}>
-                  <p style={{ fontWeight: 'bold' }}>{'Indices'}</p>
-                  <Select
-                    mode="multiple"
-                    style={{ width: '100%' }}
-                    placeholder="Select index"
-                    value={selectedIndices}
+                  <MonthSelect
+                    indices={indices}
+                    updateButtonVisible={false}
                     onChange={this.updateSelectedIndices}
-                    tokenSeparators={[',']}
-                  >
-                    {indices.map((month) => {
-                      return <Select.Option key={month}>{month}</Select.Option>;
-                    })}
-                  </Select>
+                    value={selectedIndices}
+                  />
                   <Divider />
                 </Spin>
                 {Object.keys(mapping).map(field => {
@@ -245,17 +239,12 @@ export default class SearchList extends Component {
                   style={{ marginTop: 20 }}
                   columns={columns}
                   dataSource={searchResults.results}
-                  onRow={(record) => ({
-                    onClick: () => { 
-                      this.retrieveResults([record]); 
-                    }
+                  onRow={record => ({
+                    onClick: () => {
+                      this.retrieveResults([record]);
+                    },
                   })}
-                  defaultPageSize={20}
-                  loading={loadingMapping || loadingResults}
-                  showSizeChanger={true}
-                  showTotal={true}
-                  pagination={{ pageSize: 20 }}
-                  bordered
+                  loading={loadingSearchResults}
                 />
               </Card>
             </Col>


### PR DESCRIPTION
This first pass in an effort to reduce page component rerenders represents one of three steps to enhance component performance:

1. Destructure page components by reorganizing logic into subcomponents (SearchBar, MonthSelect, RowSelection, Table, etc).
2. Group Redux actions and reducers to reorganize information needed for dashboard entry points that require page initializing (Controllers and Search)
3. Compare previous props and state values to prevent page rerenders using shouldComponentUpdate() or converting components to PureComponent