### PR TITLE
Remove 'selectorIndices' logic for simple month selection

### DIFF
--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -8,7 +8,6 @@ export default {
     datastoreConfig: {},
     indices: [],
     selectedIndices: [],
-    selectorIndices: ['0'],
   },
 
   effects: {
@@ -52,12 +51,6 @@ export default {
         payload: payload,
       });
     },
-    *updateSelectorIndices({ payload }, { put }) {
-      yield put({
-        type: 'modifySelectorIndices',
-        payload: payload,
-      });
-    },
   },
 
   reducers: {
@@ -76,6 +69,7 @@ export default {
     getMonthIndices(state, { payload }) {
       return {
         ...state,
+        selectedIndices: [payload[0]],
         indices: payload,
       };
     },
@@ -83,12 +77,6 @@ export default {
       return {
         ...state,
         selectedIndices: payload,
-      };
-    },
-    modifySelectorIndices(state, { payload }) {
-      return {
-        ...state,
-        selectorIndices: payload,
       };
     },
   },

--- a/web-server/v0.4/src/pages/Dashboard/Controllers.js
+++ b/web-server/v0.4/src/pages/Dashboard/Controllers.js
@@ -10,7 +10,6 @@ import { compareByAlph } from '../../utils/utils';
   controllers: dashboard.controllers,
   indices: global.indices,
   selectedIndices: global.selectedIndices,
-  selectorIndices: global.selectorIndices,
   datastoreConfig: global.datastoreConfig,
   loadingControllers: loading.effects['dashboard/fetchControllers'],
   loadingIndices: loading.effects['global/fetchMonthIndices'],
@@ -61,9 +60,7 @@ export default class Controllers extends Component {
       type: 'global/fetchMonthIndices',
       payload: { datastoreConfig: datastoreConfig },
     }).then(() => {
-      Promise.resolve(this.updateSelectedIndices(['0'])).then(() => {
-        this.fetchControllers();
-      });
+      this.fetchControllers();
     });
   };
 
@@ -84,21 +81,11 @@ export default class Controllers extends Component {
   };
 
   updateSelectedIndices = value => {
-    const { dispatch, indices } = this.props;
-    let selectedIndices = [];
-
-    value.map(item => {
-      selectedIndices.push(indices[item]);
-    });
+    const { dispatch } = this.props;
 
     dispatch({
       type: 'global/updateSelectedIndices',
-      payload: selectedIndices,
-    }).then(() => {
-      dispatch({
-        type: 'global/updateSelectorIndices',
-        payload: value,
-      });
+      payload: value,
     });
   };
 
@@ -170,7 +157,7 @@ export default class Controllers extends Component {
       loadingControllers,
       loadingConfig,
       loadingIndices,
-      selectorIndices,
+      selectedIndices,
       indices,
     } = this.props;
     const suffix = searchText ? <Icon type="close-circle" onClick={this.emitEmpty} /> : null;
@@ -225,15 +212,15 @@ export default class Controllers extends Component {
                 mode="multiple"
                 style={{ width: '100%' }}
                 placeholder="Select index"
-                value={selectorIndices}
+                value={selectedIndices}
                 onChange={value => {
                   this.updateSelectedIndices(value);
                   this.setState({ selectedIndicesUpdated: true });
                 }}
                 tokenSeparators={[',']}
               >
-                {indices.map((index, i) => {
-                  return <Select.Option key={i}>{index}</Select.Option>;
+                {indices.map((month) => {
+                  return <Select.Option key={month}>{month}</Select.Option>;
                 })}
               </Select>
             </FormItem>

--- a/web-server/v0.4/src/pages/Search/SearchList.js
+++ b/web-server/v0.4/src/pages/Search/SearchList.js
@@ -12,7 +12,6 @@ const Option = Select.Option;
   fields: search.fields,
   selectedFields: search.selectedFields,
   selectedIndices: global.selectedIndices,
-  selectorIndices: global.selectorIndices,
   indices: global.indices,
   datastoreConfig: global.datastoreConfig,
   loadingMapping: loading.effects['search/fetchIndexMapping'],
@@ -83,19 +82,10 @@ export default class SearchList extends Component {
   };
 
   updateSelectedIndices = value => {
-    const { dispatch, indices } = this.props;
-    let selectedIndices = [];
-
-    value.map(item => {
-      selectedIndices.push(indices[item]);
-    });
+    const { dispatch } = this.props;
 
     dispatch({
-      type: 'search/updateSelectedIndices',
-      payload: selectedIndices,
-    });
-    dispatch({
-      type: 'global/updateSelectorIndices',
+      type: 'global/updateSelectedIndices',
       payload: value,
     });
   };
@@ -157,7 +147,7 @@ export default class SearchList extends Component {
 
   render() {
     const {
-      selectorIndices,
+      selectedIndices,
       indices,
       mapping,
       selectedFields,
@@ -210,12 +200,12 @@ export default class SearchList extends Component {
                     mode="multiple"
                     style={{ width: '100%' }}
                     placeholder="Select index"
-                    value={selectorIndices}
+                    value={selectedIndices}
                     onChange={this.updateSelectedIndices}
                     tokenSeparators={[',']}
                   >
-                    {indices.map((index, i) => {
-                      return <Select.Option key={i}>{index}</Select.Option>;
+                    {indices.map((month) => {
+                      return <Select.Option key={month}>{month}</Select.Option>;
                     })}
                   </Select>
                   <Divider />


### PR DESCRIPTION
Two arrays were being used to track the value and position
of a selected month. This is now referencing only the month
value and references the month string as a key within the
`<Select.Option>` child component.