### PR TITLE
Add env var for server unit test parallelism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,28 @@
 dist: xenial
 language: perl
 perl:
- - "5.28"
- - "5.26"
- - "5.24"
- - "5.22"
- - "5.20"
- - "5.18"
- - "5.16"
- - "5.10"
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
+  - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.10"
 before_install:
- - sudo apt-get update
+  - sudo apt-get update
 install:
- - sudo apt-get install python python-pip bc libjson-perl libswitch-perl realpath
- - sudo pip install configtools elasticsearch
- - sudo apt-get install python-software-properties
- - sudo add-apt-repository ppa:fkrull/deadsnakes -y
- - sudo apt-get update
- - sudo apt-get install python3.6 --force-yes -y
- - sudo wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
- - sudo python3.6 /tmp/get-pip.py
- - sudo pip install 'configtools<0.4.0' elasticsearch
- - sudo ln -sf python3.6 /usr/bin/python3
+  - sudo apt-get install python python-pip bc libjson-perl libswitch-perl realpath
+  - sudo pip install configtools elasticsearch
+  - sudo apt-get install python-software-properties
+  - sudo add-apt-repository ppa:fkrull/deadsnakes -y
+  - sudo apt-get update
+  - sudo apt-get install python3.6 --force-yes -y
+  - sudo wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+  - sudo python3.6 /tmp/get-pip.py
+  - sudo pip install 'configtools<0.4.0' elasticsearch
+  - sudo ln -sf python3.6 /usr/bin/python3
+env:
+  - PBENCH_UNITTEST_SERVER_MODE=serial
 script:
- - ./run-unittests
+  - ./run-unittests

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -644,6 +644,9 @@ declare -A cmds=(
 all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\)-\([0-9]\)/\1.\2/')
 
 mode="serial"
+if [[ -n "$PBENCH_UNITTEST_SERVER_MODE" ]]; then
+    mode="$PBENCH_UNITTEST_SERVER_MODE"
+fi
 case $1 in
     --serial)
         shift
@@ -658,6 +661,10 @@ case $1 in
         exit 1
         ;;
 esac
+if [[ "$mode" != "serial" && "$mode" != "parallel" ]]; then
+    printf "Bad server unit test mode \"$mode\", choose either 'serial' or 'parallel'\n" >&2
+    exit 1
+fi
 
 test_args=$*
 if [ -z "$test_args" ] ;then


### PR DESCRIPTION
We also ensure that for now TravisCI runs server tests serially to avoid
not emitting output for more than ten minutes triggering the TravisCI auto
kill feature.