### PR TITLE
Cephfs fio

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -567,22 +567,34 @@ function fio_run_job() {
 	pbench-start-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
 	local client_opts=""
 
-	if [ ! -z "$client_file" ] ;then
-		typeset -i nclients=$(wc -l $client_file | cut -d ' ' -f 1)
-		client_opts="--client=$client_file --max-jobs=$nclients"
-	elif [ ! -z "$clients" ]; then
+	# if a client-file parameter was passed, then clients is already 
+	# initialized to its contents
+
+	if [ ! -z "$clients" ]; then
 		local max_jobs=0
+		local nclients=0
+
+		if [ ! -z $numjobs ]; then
+			# so that a separate filename will be generated
+			# for each (host, job-number) pair
+			let max_jobs=$numjobs
+		else
+		       for t in `echo $targets | sed -e s/,/" "/g` ; do
+			       let max_jobs=$max_jobs+1
+		       done
+		fi
+
+		# make the fio command shorter by always using a client file
+		# regardless of how clients were specified
+		# we always save the client list in the benchmark results directory
+
+		client_file=$benchmark_results_dir/pbench-clients.list
 		for client in `echo $clients | sed -e s/,/" "/g`; do
-			client_opts="$client_opts --client=$client"
-			if [ ! -z $numjobs ]; then
-				let max_jobs=$numjobs
-			else
-			       for t in `echo $targets | sed -e s/,/" "/g` ; do
-				       let max_jobs=$max_jobs+1
-			       done
-			fi
-		done
-		client_opts="$client_opts --max-jobs=$max_jobs"
+			echo $client
+		done > $client_file
+		let nclients=`wc -l < $client_file`
+		let max_jobs=$max_jobs*$nclients
+		client_opts="$client_opts --client=$client_file --max-jobs=$max_jobs"
 	fi
 
 	# create a command file and keep it with the results for debugging later, or user can run outside of pbench
@@ -593,7 +605,7 @@ function fio_run_job() {
 	$benchmark_results_dir/fio.cmd >$benchmark_results_dir/fio-result.txt
 	popd >/dev/null
 	pbench-stop-tools --group=$tool_group --iteration=$iteration --dir=$benchmark_results_dir
-
+ 
 	histogram_cmd="fio-histo-log-pctiles.py --time-quantum $histogram_interval_sec --percentiles 0 50 90 95 99 100 -- "
 	if [ ! -z "$clients" ]; then
 		for client in `echo $clients | sed -e s/,/" "/g`; do

--- a/agent/bench-scripts/templates/fio-shared-fs.job
+++ b/agent/bench-scripts/templates/fio-shared-fs.job
@@ -1,0 +1,33 @@
+# Syntax:
+#   $target : expands to the fio target file directory
+#   $@ : expands to the value of the option as passed to
+#        pbench-fio
+#
+# For python2 without the latest configparser installed, lines
+# cannot be indented.
+
+[global]
+bs = $@
+ioengine = libaio
+iodepth = 32
+direct = 1
+sync = 0
+time_based = 1
+clocksource = gettimeofday
+ramp_time = 5
+write_bw_log = fio
+write_iops_log = fio
+write_lat_log = fio
+log_avg_msec = 1000
+write_hist_log = fio
+log_hist_msec = 10000
+# log_hist_coarseness = 4 # 76 bins
+
+[TheJob]
+runtime = $runtime
+directory = $target
+rw = $@
+size = $size
+# if you want to specify more than 1 process per fio client host/pod,
+# uncomment this next line and add --numjobs=K to your pbench-fio command
+#numjobs = $numjobs


### PR DESCRIPTION
This PR should make pbench-fio work with shared filesystems (where multiple hosts/pods access the same files).  In this situation, fio needs to generate filenames unique to the host and job number.

There is a new templates/fio-shared-fs.job file.  I hesitate for now to change filename=$target to directory=$target in the templates/fio.job file because this could break some other use case.  Specifically filename=$target is probably more appropriate for block devices/partitions being fed to pbench-fio (where fio can't make up the pathname as it sees fit).   So I created a separate templates/fio-shared-fs.job that just changes "filename=$target" to "directory=$target" , and you can specify this alternate job file template using the --job-file= option.

See the documentation change and commit comments for more explanation.

This PR has had limited testing.   I would like to see it tested a bit more before merging, but wanted people to have a look at it and see what they thought.