### PR TITLE
Launch run comparison across multiple controllers using search view

### DIFF
--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -10,7 +10,6 @@ export default {
   namespace: 'dashboard',
 
   state: {
-    controller: '',
     result: [],
     results: [],
     configCategories: [],
@@ -19,7 +18,7 @@ export default {
     controllers: [],
     selectedResults: [],
     tocResult: [],
-    selectedController: '',
+    selectedControllers: [],
     loading: false,
   },
 
@@ -161,9 +160,9 @@ export default {
         payload: iterations,
       });
     },
-    *updateSelectedController({ payload }, { select, put }) {
+    *updateSelectedControllers({ payload }, { select, put }) {
       yield put({
-        type: 'modifySelectedController',
+        type: 'modifySelectedControllers',
         payload: payload,
       });
     },
@@ -218,10 +217,10 @@ export default {
         iterations: payload,
       };
     },
-    modifySelectedController(state, { payload }) {
+    modifySelectedControllers(state, { payload }) {
       return {
         ...state,
-        selectedController: payload,
+        selectedControllers: payload,
       };
     },
     modifySelectedResults(state, { payload }) {

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -53,13 +53,16 @@ export default {
         let searchResults = {};
         searchResults['resultCount'] = response.hits.total;
         let parsedResults = [];
-        response.hits.hits.map(result => {
+        response.hits.hits.map((result) => {
           let parsedResult = {};
           selectedFields.map(field => {
             parsedResult[field] = result._source[field.split('.')[0]][field.split('.')[1]];
           });
           if (typeof result._source['run']['prefix'] != 'undefined') {
             parsedResult['run.prefix'] = result._source['run']['prefix'];
+          }
+          if (typeof result._source['run']['id'] !== 'undefined') {
+            parsedResult['key'] = result._source['run']['id'];
           }
           parsedResults.push(parsedResult);
         });

--- a/web-server/v0.4/src/pages/ComparisonSelect/index.js
+++ b/web-server/v0.4/src/pages/ComparisonSelect/index.js
@@ -9,7 +9,7 @@ import { parseIterationData } from '../../utils/parse';
 import { queryIterations } from '../../services/dashboard';
 
 @connect(({ global, dashboard, loading }) => ({
-  selectedController: dashboard.selectedController,
+  selectedControllers: dashboard.selectedControllers,
   selectedResults: dashboard.selectedResults,
   iterations: dashboard.iterations,
   results: dashboard.results,
@@ -100,7 +100,7 @@ class ComparisonSelect extends ReactJS.Component {
 
   compareIterations = params => {
     const { configData } = this.state;
-    const { results, selectedController, selectedResults } = this.props;
+    const { results, selectedControllers, selectedResults } = this.props;
     const { dispatch } = this.props;
     const configCategories = Object.keys(configData);
 
@@ -125,7 +125,6 @@ class ComparisonSelect extends ReactJS.Component {
           configCategories: configCategories,
           configData: configData,
           results: results,
-          controller: selectedController,
           selectedResults: selectedResults,
         },
       })
@@ -134,7 +133,7 @@ class ComparisonSelect extends ReactJS.Component {
 
   compareAllIterations = () => {
     const { responseDataAll, configData } = this.state;
-    const { results, selectedController, selectedResults } = this.props;
+    const { results, selectedControllers, selectedResults } = this.props;
     const { dispatch } = this.props;
     const configCategories = Object.keys(configData);
 
@@ -159,7 +158,6 @@ class ComparisonSelect extends ReactJS.Component {
           configCategories: configCategories,
           configData: configData,
           results: results,
-          controller: selectedController,
           selectedResults: selectedResults,
         },
       })
@@ -198,7 +196,7 @@ class ComparisonSelect extends ReactJS.Component {
       configData,
       selectedConfig,
     } = this.state;
-    const { selectedController } = this.props;
+    const { selectedControllers } = this.props;
 
     var selectedRowNames = [];
     for (var item in selectedRowKeys) {
@@ -266,7 +264,7 @@ class ComparisonSelect extends ReactJS.Component {
     }
 
     return (
-      <PageHeaderLayout title={selectedController}>
+      <PageHeaderLayout title={selectedControllers.join(', ')}>
         <Spin style={{ marginTop: 200, alignSelf: 'center' }} spinning={loading}>
           <Card style={{ marginBottom: 16 }}>
             <Card

--- a/web-server/v0.4/src/pages/ComparisonSelect/index.test.js
+++ b/web-server/v0.4/src/pages/ComparisonSelect/index.test.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import ComparisonSelect from './index';
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 
 const mockProps = {
   selectedResults: [],
+  selectedControllers: ['controller1', 'controller2'],
 }
 
 const mockDispatch = jest.fn();
@@ -14,4 +16,8 @@ describe('test ComparisonSelect page component', () => {
   it('render with empty props', () => {
     expect(wrapper).toMatchSnapshot();
   });
+
+  it('render multiple user selected controllers', () => {
+    expect(wrapper.find(PageHeaderLayout).prop('title')).toBe('controller1, controller2');
+  })
 });

--- a/web-server/v0.4/src/pages/Controllers/index.js
+++ b/web-server/v0.4/src/pages/Controllers/index.js
@@ -121,8 +121,8 @@ export default class Controllers extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'dashboard/updateSelectedController',
-      payload: controller.key,
+      type: 'dashboard/updateSelectedControllers',
+      payload: [controller.key],
     }).then(() => {
       dispatch(
         routerRedux.push({

--- a/web-server/v0.4/src/pages/Results/index.js
+++ b/web-server/v0.4/src/pages/Results/index.js
@@ -12,7 +12,7 @@ import { compareByAlph } from '../../utils/utils';
 @connect(({ global, dashboard, loading }) => ({
   selectedIndices: global.selectedIndices,
   results: dashboard.results,
-  selectedController: dashboard.selectedController,
+  selectedControllers: dashboard.selectedControllers,
   datastoreConfig: global.datastoreConfig,
   loading: loading.effects['dashboard/fetchResults'],
 }))
@@ -28,14 +28,14 @@ export default class Results extends Component {
   }
 
   componentDidMount() {
-    const { dispatch, datastoreConfig, selectedIndices, selectedController } = this.props;
+    const { dispatch, datastoreConfig, selectedIndices, selectedControllers } = this.props;
 
     dispatch({
       type: 'dashboard/fetchResults',
       payload: {
         datastoreConfig: datastoreConfig,
         selectedIndices: selectedIndices,
-        controller: selectedController,
+        controller: selectedControllers,
       },
     });
   }
@@ -121,7 +121,7 @@ export default class Results extends Component {
 
   render() {
     const { results, selectedRowKeys } = this.state;
-    const { selectedController, loading } = this.props;
+    const { selectedControllers, loading } = this.props;
     const rowSelection = {
       selectedRowKeys,
       onChange: this.onSelectChange
@@ -153,7 +153,7 @@ export default class Results extends Component {
     ];
 
     return (
-      <PageHeaderLayout title={selectedController}>
+      <PageHeaderLayout title={selectedControllers.join(', ')}>
         <Card bordered={false}>
           <Form layout={'vertical'}>
             <SearchBar

--- a/web-server/v0.4/src/pages/Results/index.test.js
+++ b/web-server/v0.4/src/pages/Results/index.test.js
@@ -4,9 +4,14 @@ import Results from './index';
 
 import Table from '@/components/Table';
 import RowSelection from '@/components/RowSelection';
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+
+const mockProps = {
+  selectedControllers: ['controller1'],
+}
 
 const mockDispatch = jest.fn();
-const wrapper = shallow(<Results.WrappedComponent dispatch={mockDispatch} />, { disableLifecycleMethods: true });
+const wrapper = shallow(<Results.WrappedComponent dispatch={mockDispatch} {...mockProps} />, { disableLifecycleMethods: true });
 
 describe('test Results page component', () => {
   it('render with empty props', () => {
@@ -20,4 +25,8 @@ describe('test Results page component', () => {
   it('render RowSelection component', () => {
     expect(wrapper.find(RowSelection).length).toBe(1);
   });
+
+  it('render user selected controllers', () => {
+    expect(wrapper.find(PageHeaderLayout).prop('title')).toBe('controller1');
+  })
 });

--- a/web-server/v0.4/src/pages/RunComparison/index.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.js
@@ -31,7 +31,8 @@ const { Description } = DescriptionList;
 const TabPane = Tabs.TabPane;
 const FormItem = Form.Item;
 
-@connect(({ global }) => ({
+@connect(({ global, dashboard }) => ({
+  selectedControllers: dashboard.selectedControllers,
   datastoreConfig: global.datastoreConfig,
 }))
 export default class RunComparison extends ReactJS.Component {
@@ -40,7 +41,6 @@ export default class RunComparison extends ReactJS.Component {
     configCategories: PropTypes.array,
     configData: PropTypes.array,
     results: PropTypes.array,
-    controller: PropTypes.string,
   };
 
   constructor(props) {
@@ -448,7 +448,7 @@ export default class RunComparison extends ReactJS.Component {
   };
 
   render() {
-    const { configCategories, controller, selectedResults } = this.props.location.state;
+    const { configCategories, selectedResults } = this.props.location.state;
     const {
       graphKeys,
       tableData,
@@ -460,6 +460,7 @@ export default class RunComparison extends ReactJS.Component {
       timeseriesDropdownSelected,
       generatingPdf,
     } = this.state;
+    const { selectedControllers } = this.props;
 
     const expandedRowRender = cluster => {
       var columns = [
@@ -499,39 +500,41 @@ export default class RunComparison extends ReactJS.Component {
     };
 
     const description = (
-      <div>
-        <DescriptionList size="small" col="1" gutter={16}>
-          <Description term="Controller">{<Tag>{controller}</Tag>}</Description>
-          <Description term="Results">
-            {selectedResults.map(result => (
-              <Tag>{result['run.name']}</Tag>
-            ))}
-          </Description>
-          <Description term="Clustering Config">
-            <div>
-              <Select
-                addonBefore="Cluster Parameters"
-                mode="tags"
-                placeholder="Select cluster config"
-                value={selectedConfig}
-                defaultValue={configCategories}
-                onChange={this.generateIterationClusters}
-              >
-                {configCategories.map((category, i) => (
-                  <Select.Option value={category}>{category}</Select.Option>
-                ))}
-              </Select>
-              <Button
-                type="primary"
-                onClick={this.resetIterationClusters}
-                style={{ marginLeft: 8 }}
-              >
-                {'Reset'}
-              </Button>
-            </div>
-          </Description>
-        </DescriptionList>
-      </div>
+      <DescriptionList size="small" col="1" gutter={16}>
+        <Description term="Controllers">
+          {selectedControllers.map((controller) => (
+            <Tag key={controller}>{controller}</Tag>
+          ))}
+        </Description>
+        <Description term="Results">
+          {selectedResults.map(result => (
+            <Tag>{result['run.name']}</Tag>
+          ))}
+        </Description>
+        <Description term="Clustering Config">
+          <div>
+            <Select
+              addonBefore="Cluster Parameters"
+              mode="tags"
+              placeholder="Select cluster config"
+              value={selectedConfig}
+              defaultValue={configCategories}
+              onChange={this.generateIterationClusters}
+            >
+              {configCategories.map((category, i) => (
+                <Select.Option value={category}>{category}</Select.Option>
+              ))}
+            </Select>
+            <Button
+              type="primary"
+              onClick={this.resetIterationClusters}
+              style={{ marginLeft: 8 }}
+            >
+              {'Reset'}
+            </Button>
+          </div>
+        </Description>
+      </DescriptionList>
     );
 
     const action = (

--- a/web-server/v0.4/src/pages/RunComparison/index.test.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.test.js
@@ -1,20 +1,34 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import 'jest-canvas-mock';
 
 import RunComparison from './index';
 
+const mockProps = {
+  selectedControllers: ['controller1', 'controller2'],
+};
 const mockLocation = {
   state: {
-    configCategories: [], controller: "", selectedResults: [], iterations: [],
+    configCategories: [],
+    controller: '',
+    selectedResults: [],
+    iterations: [],
   },
-}
+};
 
 const mockDispatch = jest.fn();
-const wrapper = shallow(<RunComparison.WrappedComponent dispatch={mockDispatch} location={mockLocation} />);
+const wrapper = mount(
+  <RunComparison.WrappedComponent dispatch={mockDispatch} location={mockLocation} {...mockProps} />,
+  { disableLifecycleMethods: true }
+);
 
 describe('test RunComparison page component', () => {
   it('render with empty props', () => {
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('render multiple user selected controllers', () => {
+    expect(wrapper.findWhere(node => node.key() === 'controller1').length).toEqual(1);
+    expect(wrapper.findWhere(node => node.key() === 'controller2').length).toEqual(1);
   });
 });

--- a/web-server/v0.4/src/pages/Summary/index.js
+++ b/web-server/v0.4/src/pages/Summary/index.js
@@ -46,7 +46,7 @@ const columns = [
 ];
 
 @connect(({ global, dashboard, loading }) => ({
-  selectedController: dashboard.selectedController,
+  selectedControllers: dashboard.selectedControllers,
   selectedResults: dashboard.selectedResults,
   iterations: dashboard.iterations,
   summaryResult: dashboard.result,
@@ -87,7 +87,7 @@ class Summary extends ReactJS.Component {
       datastoreConfig,
       selectedIndices,
       selectedResults,
-      selectedController,
+      selectedControllers,
     } = this.props;
 
     if (!Array.isArray(selectedResults)) {
@@ -117,12 +117,12 @@ class Summary extends ReactJS.Component {
       },
     });
 
-    if (selectedResults[0]['run.controller'] != selectedController) {
+    if (selectedResults[0]['run.controller'] != selectedControllers[0]) {
       throw new Error(
         "Logic bomb! selected results controller, "
           + selectedResults[0]['run.controller']
           + " != selected controller "
-          + selectedController);
+          + selectedControllers[0]);
     }
     queryIterations({ selectedResults: selectedResults, datastoreConfig: datastoreConfig })
       .then(res => {
@@ -332,7 +332,7 @@ class Summary extends ReactJS.Component {
       activeTab,
       tocTree,
     } = this.state;
-    const { selectedResults, summaryResult, selectedController, tocResult } = this.props;
+    const { selectedResults, summaryResult, selectedControllers, tocResult } = this.props;
 
     if (Array.isArray(summaryResult)) {
       // console.log("summaryResult is not supposed to be an array!");
@@ -573,8 +573,8 @@ class Summary extends ReactJS.Component {
           <PageHeaderLayout
             title={selectedResults[0]['run.name']}
             content={
-              <Tag color="blue" key={selectedController}>
-                {'controller: ' + selectedController}
+              <Tag color="blue" key={selectedControllers[0]}>
+                {'controller: ' + selectedControllers[0]}
               </Tag>
             }
             tabList={tabList}

--- a/web-server/v0.4/src/services/dashboard.js
+++ b/web-server/v0.4/src/services/dashboard.js
@@ -81,7 +81,7 @@ export async function queryResults(params) {
       },
       query: {
         term: {
-          'run.controller': controller,
+          'run.controller': controller[0],
         },
       },
       size: 5000,

--- a/web-server/v0.4/src/services/search.js
+++ b/web-server/v0.4/src/services/search.js
@@ -35,9 +35,10 @@ export async function searchQuery(params) {
       query: {
           query_string: {
               analyze_wildcard: true,
-              query: searchQuery
-          }
-      }
-    }
+              query: searchQuery,
+          },
+      },
+      size: 1000,
+    },
   });
 }


### PR DESCRIPTION
This PR modifies redux store logic for tracking a single selected controller or multiple selected controllers for visualization throughout the pbench dashboard. In addition, this PR improves the search view UX to apply or reset filters once the user has made their selection on the filters pane.

Users are now able to select multiple results from their search query and launch a run to run comparison that may have originated from more than one controller.