### PR TITLE
Restructure selected dashboard components in redux store

### DIFF
--- a/web-server/v0.4/src/app.js
+++ b/web-server/v0.4/src/app.js
@@ -2,10 +2,17 @@ import { createStore } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+/*
+* redux persist configuration for saving state object to persisted storage.
+*
+* `dashboard` and `search` are blacklisted from the saved state as the namespaces 
+* persist data that is constantly updated on the server side. 
+*/
 const persistConfig = {
   timeout: 1000,
   key: 'root',
   storage,
+  blacklist: ['dashboard', 'search'],
 };
 
 const persistEnhancer = () => createStore => (reducer, initialState, enhancer) => {

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -16,9 +16,7 @@ export default {
     configData: [],
     iterations: [],
     controllers: [],
-    selectedResults: [],
     tocResult: [],
-    selectedControllers: [],
     loading: false,
   },
 
@@ -158,18 +156,6 @@ export default {
       yield put({
         type: 'getIterations',
         payload: iterations,
-      });
-    },
-    *updateSelectedControllers({ payload }, { select, put }) {
-      yield put({
-        type: 'modifySelectedControllers',
-        payload: payload,
-      });
-    },
-    *updateSelectedResults({ payload }, { select, put }) {
-      yield put({
-        type: 'modifySelectedResults',
-        payload: payload,
       });
     },
     *updateConfigCategories({ payload }, { select, put }) {

--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -8,6 +8,9 @@ export default {
     datastoreConfig: {},
     indices: [],
     selectedIndices: [],
+    selectedResults: [],
+    selectedControllers: [],
+    selectedFields: [],
   },
 
   effects: {
@@ -51,6 +54,24 @@ export default {
         payload: payload,
       });
     },
+    *updateSelectedControllers({ payload }, { select, put }) {
+      yield put({
+        type: 'modifySelectedControllers',
+        payload: payload,
+      });
+    },
+    *updateSelectedResults({ payload }, { select, put }) {
+      yield put({
+        type: 'modifySelectedResults',
+        payload: payload,
+      });
+    },
+    *updateSelectedFields({ payload }, { select, put }) {
+      yield put({
+        type: 'modifySelectedFields',
+        payload: payload,
+      });
+    },
   },
 
   reducers: {
@@ -77,6 +98,24 @@ export default {
       return {
         ...state,
         selectedIndices: payload,
+      };
+    },
+    modifySelectedControllers(state, { payload }) {
+      return {
+        ...state,
+        selectedControllers: payload,
+      };
+    },
+    modifySelectedResults(state, { payload }) {
+      return {
+        ...state,
+        selectedResults: payload,
+      };
+    },
+    modifySelectedFields(state, { payload }) {
+      return {
+        ...state,
+        selectedFields: payload,
       };
     },
   },

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -7,8 +7,6 @@ export default {
     mapping: {},
     searchResults: [],
     fields: [],
-    selectedFields: [],
-    loading: false,
   },
 
   effects: {
@@ -37,12 +35,8 @@ export default {
         payload: fields,
       });
       yield put({
-        type: 'modifySelectedFields',
+        type: 'global/modifySelectedFields',
         payload: ['run.name', 'run.config', 'run.controller'],
-      });
-      yield put({
-        type: 'modifySelectedIndices',
-        payload: [indices[0]],
       });
     },
     *fetchSearchResults({ payload }, { call, put }) {
@@ -76,12 +70,6 @@ export default {
         console.log(e.message);
       }
     },
-    *updateSelectedFields({ payload }, { select, put }) {
-      yield put({
-        type: 'modifySelectedFields',
-        payload: payload,
-      });
-    },
   },
 
   reducers: {
@@ -101,12 +89,6 @@ export default {
       return {
         ...state,
         searchResults: payload,
-      };
-    },
-    modifySelectedFields(state, { payload }) {
-      return {
-        ...state,
-        selectedFields: payload,
       };
     },
   },

--- a/web-server/v0.4/src/pages/ComparisonSelect/index.js
+++ b/web-server/v0.4/src/pages/ComparisonSelect/index.js
@@ -9,8 +9,8 @@ import { parseIterationData } from '../../utils/parse';
 import { queryIterations } from '../../services/dashboard';
 
 @connect(({ global, dashboard, loading }) => ({
-  selectedControllers: dashboard.selectedControllers,
-  selectedResults: dashboard.selectedResults,
+  selectedControllers: global.selectedControllers,
+  selectedResults: global.selectedResults,
   iterations: dashboard.iterations,
   results: dashboard.results,
   controllers: dashboard.controllers,

--- a/web-server/v0.4/src/pages/Controllers/index.js
+++ b/web-server/v0.4/src/pages/Controllers/index.js
@@ -31,8 +31,10 @@ export default class Controllers extends Component {
   componentDidMount() {
     const { controllers, selectedIndices, indices } = this.props;
 
-    if (controllers.length === 0 || selectedIndices.length === 0 || indices.length === 0) {
+    if (selectedIndices.length === 0 || indices.length === 0) {
       this.queryDatastoreConfig();
+    } else if (controllers.length === 0) {
+      this.fetchControllers();
     }
   }
 
@@ -121,7 +123,7 @@ export default class Controllers extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'dashboard/updateSelectedControllers',
+      type: 'global/updateSelectedControllers',
       payload: [controller.key],
     }).then(() => {
       dispatch(

--- a/web-server/v0.4/src/pages/Results/index.js
+++ b/web-server/v0.4/src/pages/Results/index.js
@@ -12,7 +12,7 @@ import { compareByAlph } from '../../utils/utils';
 @connect(({ global, dashboard, loading }) => ({
   selectedIndices: global.selectedIndices,
   results: dashboard.results,
-  selectedControllers: dashboard.selectedControllers,
+  selectedControllers: global.selectedControllers,
   datastoreConfig: global.datastoreConfig,
   loading: loading.effects['dashboard/fetchResults'],
 }))
@@ -55,7 +55,7 @@ export default class Results extends Component {
     this.setState({ selectedRowKeys });
 
     dispatch({
-      type: 'dashboard/updateSelectedResults',
+      type: 'global/updateSelectedResults',
       payload: selectedRows,
     });
   };
@@ -108,7 +108,7 @@ export default class Results extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'dashboard/updateSelectedResults',
+      type: 'global/updateSelectedResults',
       payload: params,
     });
 

--- a/web-server/v0.4/src/pages/RunComparison/index.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.js
@@ -32,7 +32,7 @@ const TabPane = Tabs.TabPane;
 const FormItem = Form.Item;
 
 @connect(({ global, dashboard }) => ({
-  selectedControllers: dashboard.selectedControllers,
+  selectedControllers: global.selectedControllers,
   datastoreConfig: global.datastoreConfig,
 }))
 export default class RunComparison extends ReactJS.Component {

--- a/web-server/v0.4/src/pages/Search/index.js
+++ b/web-server/v0.4/src/pages/Search/index.js
@@ -13,7 +13,7 @@ import Table from '../../components/Table';
   mapping: search.mapping,
   searchResults: search.searchResults,
   fields: search.fields,
-  selectedFields: search.selectedFields,
+  selectedFields: global.selectedFields,
   selectedIndices: global.selectedIndices,
   indices: global.indices,
   datastoreConfig: global.datastoreConfig,
@@ -32,16 +32,18 @@ export default class SearchList extends Component {
   }
 
   componentDidMount() {
-    const { selectedIndices, indices, mapping} = this.props;
+    const { selectedIndices, indices, mapping } = this.props;
 
-    if (selectedIndices.length === 0 || indices.length === 0 || Object.keys(mapping).length === 0) {
-      this.queryDatastoreConfig();      
+    if (selectedIndices.length === 0 || indices.length === 0) {
+      this.queryDatastoreConfig();
+    } else if (Object.keys(mapping).length === 0) {
+      this.fetchIndexMapping();
     }
   }
 
   componentDidUpdate(prevProps) {
     const { selectedIndices, selectedFields } = this.props;
-    
+
     if (selectedIndices !== prevProps.selectedIndices || selectedFields !== prevProps.selectedFields) {
       this.setState({ updateFiltersDisabled: false });
     }
@@ -92,11 +94,11 @@ export default class SearchList extends Component {
     this.setState({ selectedRowKeys });
 
     dispatch({
-      type: 'dashboard/updateSelectedResults',
+      type: 'global/updateSelectedResults',
       payload: selectedRows,
     });
     dispatch({
-      type: 'dashboard/updateSelectedControllers',
+      type: 'global/updateSelectedControllers',
       payload: selectedControllers,
     })
   }
@@ -105,7 +107,7 @@ export default class SearchList extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'search/modifySelectedFields',
+      type: 'global/updateSelectedFields',
       payload: ['run.name', 'run.config', 'run.controller'],
     });
   };
@@ -130,7 +132,7 @@ export default class SearchList extends Component {
     }
 
     dispatch({
-      type: 'search/updateSelectedFields',
+      type: 'global/updateSelectedFields',
       payload: newSelectedFields,
     });
     this.setState({ updateFiltersDisabled: false });
@@ -154,7 +156,7 @@ export default class SearchList extends Component {
       },
     });
     dispatch({
-      type: 'dashboard/updateSelectedResults',
+      type: 'global/updateSelectedResults',
       payload: [],
     });
     this.setState({ selectedRowKeys: [] });
@@ -165,11 +167,11 @@ export default class SearchList extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'dashboard/updateSelectedControllers',
+      type: 'global/updateSelectedControllers',
       payload: [selectedResults[0]['run.controller']],
     }).then(() => {
       dispatch({
-        type: 'dashboard/updateSelectedResults',
+        type: 'global/updateSelectedResults',
         payload: selectedResults,
       }).then(() => {
         dispatch(

--- a/web-server/v0.4/src/pages/Summary/index.js
+++ b/web-server/v0.4/src/pages/Summary/index.js
@@ -46,8 +46,8 @@ const columns = [
 ];
 
 @connect(({ global, dashboard, loading }) => ({
-  selectedControllers: dashboard.selectedControllers,
-  selectedResults: dashboard.selectedResults,
+  selectedControllers: global.selectedControllers,
+  selectedResults: global.selectedResults,
   iterations: dashboard.iterations,
   summaryResult: dashboard.result,
   results: dashboard.results,


### PR DESCRIPTION
For handling persistence of the redux store, selected configuration
data needs to be stored in the global reducer while the dashboard
namespace is blacklisted to avoid local caching.

Previously, caching of the dashboard namespace was causing conflicts
with an edge case where server side data was being updated but was not
reflected in persisted user sessions.