### PR TITLE
Matrix visualization for increase/decrease in percentage for comparison cluster

### DIFF
--- a/web-server/v0.4/src/pages/RunComparison/index.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.js
@@ -15,6 +15,8 @@ import {
   Input,
   Switch,
   message,
+  Collapse,
+  Icon,
 } from 'antd';
 import { ResponsiveBar } from '@nivo/bar';
 import DescriptionList from 'ant-design-pro/lib/DescriptionList';
@@ -22,12 +24,13 @@ import jsPDF from 'jspdf';
 import html2canvas from 'html2canvas';
 import moment from 'moment';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
-import { generateIterationClusters } from '../../utils/parse';
+import { generateIterationClusters, getComparisonColumn } from '../../utils/parse';
 import TimeseriesGraph from '@/components/TimeseriesGraph';
 
 const { Description } = DescriptionList;
 const { TabPane } = Tabs;
 const FormItem = Form.Item;
+const { Panel } = Collapse;
 
 const columns = [
   {
@@ -102,6 +105,7 @@ class RunComparison extends React.Component {
       selectedComponents: [],
       pdfHeader: '',
       pdfName: '',
+      column: [],
     };
   }
 
@@ -131,6 +135,10 @@ class RunComparison extends React.Component {
         this.setState({ loadingClusters: false });
         this.setState({
           ...timeseriesData,
+        });
+        const column = getComparisonColumn(iterationClusters.maxIterationLength);
+        this.setState({
+          column,
         });
       });
     });
@@ -266,6 +274,7 @@ class RunComparison extends React.Component {
       loadingPdf,
       exportModalVisible,
       loadingClusters,
+      column,
     } = this.state;
     const { selectedControllers, selectedResults, iterationParams } = this.props;
 
@@ -509,9 +518,26 @@ class RunComparison extends React.Component {
                         />
                       </Col>
                     </Row>
+                    <Collapse
+                      bordered
+                      defaultActiveKey={['1']}
+                      expandIcon={({ isActive }) => (
+                        <Icon type="caret-right" rotate={isActive ? 90 : 0} />
+                      )}
+                    >
+                      <Panel header="Percent Differences Table" key="1">
+                        <Table
+                          columns={column}
+                          dataSource={clusteredGraphData[cluster]}
+                          pagination={{ pageSize: 50 }}
+                          scroll={{ x: 1500, y: 240 }}
+                          bordered
+                        />
+                      </Panel>
+                    </Collapse>
                     <br
                       style={{
-                        borderTopWidth: 1,
+                        borderTopWidth: 3,
                         borderStyle: 'solid',
                         borderColor: '#8c8b8b',
                       }}

--- a/web-server/v0.4/src/pages/RunComparison/index.test.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.test.js
@@ -12,6 +12,7 @@ const mockProps = {
 const mockLocation = {
   state: {
     iterations: [],
+    clusteredGraphData: [],
   },
 };
 

--- a/web-server/v0.4/src/utils/parse.js
+++ b/web-server/v0.4/src/utils/parse.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import { Icon } from 'antd';
+import React from 'react';
 
 export const parseIterationData = results => {
   const iterations = [];
@@ -258,6 +260,7 @@ export const parseClusteredIterations = (clusteredIterations, clusterLabels, sel
   const clusteredGraphData = [];
   const graphKeys = [];
   const tableData = [];
+  let maxIterationLength = 0;
 
   Object.keys(clusteredIterations).forEach(primaryMetric => {
     clusteredGraphData[primaryMetric] = [];
@@ -266,6 +269,7 @@ export const parseClusteredIterations = (clusteredIterations, clusterLabels, sel
     let maxClusterLength = 0;
     Object.keys(clusteredIterations[primaryMetric]).forEach(cluster => {
       const clusterObject = { cluster };
+      const meanValues = [];
       Object.keys(clusteredIterations[primaryMetric][cluster]).forEach(iteration => {
         clusterObject[iteration] =
           clusteredIterations[primaryMetric][cluster][iteration][
@@ -276,6 +280,20 @@ export const parseClusteredIterations = (clusteredIterations, clusterLabels, sel
               return false;
             })
           ];
+        meanValues.push(clusterObject[iteration]);
+        let percentage = 0;
+        if (iteration !== 0) {
+          percentage =
+            ((clusterObject[iteration] - clusterObject[0]) /
+              ((clusterObject[iteration] + clusterObject[0]) / 2)) *
+            100;
+        }
+        clusterObject[`percent${iteration}`] = percentage.toFixed(1);
+        if (meanValues.length > maxIterationLength) {
+          maxIterationLength = meanValues.length;
+        }
+        clusterObject[`name${iteration}`] =
+          clusteredIterations[primaryMetric][cluster][iteration].iteration_name;
       });
       clusteredGraphData[primaryMetric].push(clusterObject);
       const clusterItems = Object.keys(clusterObject).length - 1;
@@ -294,11 +312,11 @@ export const parseClusteredIterations = (clusteredIterations, clusterLabels, sel
       graphKeys[primaryMetric].push(i);
     }
   });
-
   return {
     tableData,
     graphKeys,
     clusteredGraphData,
+    maxIterationLength,
     clusteredIterations,
     selectedConfig,
   };
@@ -350,4 +368,108 @@ export const generateIterationClusters = (config, iterations) => {
   });
 
   return parseClusteredIterations(primaryMetricIterations, clusterLabels, selectedConfig);
+};
+
+export const getComparisonColumn = maxIterationLength => {
+  const children = [];
+  for (let i = 0; i < maxIterationLength; i += 1) {
+    children.push({
+      title: `Iteration - ${i}`,
+      dataIndex: `Iteration-${i}`,
+      key: `Iteration${i}`,
+      children: [
+        {
+          title: 'Name',
+          dataIndex: `name${i}`,
+          key: `name${i}`,
+          width: 250,
+          render: text => {
+            if (text === undefined) {
+              return {
+                props: {
+                  style: { background: '#e8e8e8' },
+                },
+              };
+            }
+            return <div>{text}</div>;
+          },
+        },
+        {
+          title: 'Mean',
+          dataIndex: i,
+          key: `mean${i}`,
+          width: 250,
+          render: text => {
+            if (text === undefined) {
+              return {
+                props: {
+                  style: { background: '#e8e8e8' },
+                },
+              };
+            }
+            return <div>{text}</div>;
+          },
+        },
+        {
+          title: 'Percent',
+          dataIndex: `percent${i}`,
+          key: `percent${i}`,
+          width: 0,
+          render: text => {
+            if (text > 0) {
+              return (
+                <div style={{ textAlign: 'right' }}>
+                  {`${text}%`}
+                  <Icon
+                    type="caret-up"
+                    theme="filled"
+                    style={{ marginLeft: '3%', color: 'green' }}
+                  />
+                </div>
+              );
+            }
+            if (text < 0) {
+              return (
+                <div style={{ textAlign: 'right' }}>
+                  {`${Math.abs(text)}%`}
+                  <Icon
+                    type="caret-down"
+                    theme="filled"
+                    style={{ marginLeft: '3%', color: 'red' }}
+                  />
+                </div>
+              );
+            }
+            if (text === undefined) {
+              return {
+                props: {
+                  style: { background: '#e8e8e8' },
+                },
+              };
+            }
+            return (
+              <div>
+                <Icon type="dash" style={{ color: 'red' }} />
+              </div>
+            );
+          },
+        },
+      ],
+    });
+  }
+  const column = [
+    {
+      title: 'Cluster',
+      dataIndex: 'cluster',
+      key: 'cluster',
+      width: 150,
+      fixed: 'left',
+      render: text => `cluster - ${text}`,
+    },
+    {
+      title: 'Iteration',
+      children,
+    },
+  ];
+  return column;
 };


### PR DESCRIPTION
- This PR includes visualization for describing the percent differences across generated clusters for a run comparison. 
- This will enhance the summary bar graph displayed showing mean values for each cluster.

![main7](https://user-images.githubusercontent.com/16955978/56444593-00c7c300-6317-11e9-823f-72b9a3649e46.gif)

