### PR TITLE
Integrate Husky for pre-commit git hook management via package.json

### DIFF
--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "pbench_dashbaord",
+  "name": "pbench_dashboard",
   "version": "2.0.0",
   "description": "UI solution for scalable visualization of benchmark data.",
   "private": true,
@@ -69,7 +69,7 @@
     "eslint-plugin-markdown": "^1.0.0-beta.6",
     "eslint-plugin-react": "^7.0.1",
     "gh-pages": "^1.0.0",
-    "husky": "^0.14.3",
+    "husky": "^1.3.1",
     "jest-canvas-mock": "^2.0.0-beta.1",
     "lint-staged": "^7.2.0",
     "mockjs": "^1.0.1-beta3",
@@ -92,6 +92,11 @@
   "peerDependencies": {
     "react": ">=15.0.0",
     "react-dom": ">=15.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint-staged"
+    }
   },
   "lint-staged": {
     "**/*.{js,jsx,less}": [


### PR DESCRIPTION
Husky automatically creates git hook scripts as part of `.git/hooks`
when the developer runs `yarn` to install package dependencies. Husky
will trigger `npm run lint-staged` which runs both prettier and linting
commands configured by their respective `.prettierrc` and `.eslintrc`
files.