### PR TITLE
Resolve 404 error for loading dashboard favicon assets

### DIFF
--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -20,12 +20,12 @@ Pbench Dashboard is a web-based platform for consuming indexed performance bench
 │   ├── layouts                     # common layouts
 │   ├── models                      # redux models
 │   ├── pages                       # app page components and templates
+│   │   └── document.ejs            # HTML entry
 │   ├── services                    # redux services
 │   ├── utils                       # utility scripts
 │   ├── app.js                      # app theme configuration
 │   ├── global.js                   # global imports
 │   ├── global.less                 # global styling
-│   ├── index.ejs                   # HTML entry
 │   └── polyfill.js                 # polyfill configuration
 ├── .eslintrc.js                    # js linting configuration
 ├── .gitignore

--- a/web-server/v0.4/src/pages/document.ejs
+++ b/web-server/v0.4/src/pages/document.ejs
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pbench Dashboard</title>
-  <link rel="icon" href="/dashboard/favicon.png" type="image/x-icon">
+  <link rel="icon" href="/favicon.png" type="image/x-icon">
 </head>
 
 <body>


### PR DESCRIPTION
`index.ejs` has been moved to `/pages/document.ejs` according to UmiJS conventions