### PR TITLE
Refactor to add TS envi var from python

### DIFF
--- a/server/bin/gold/test-2.txt
+++ b/server/bin/gold/test-2.txt
@@ -194,7 +194,7 @@ drwxrwxr-x          - logs/pbench-dispatch
 -rw-rw-r--          0 logs/pbench-dispatch/pbench-dispatch.error
 -rw-rw-r--        147 logs/pbench-dispatch/pbench-dispatch.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--        215 logs/pbench-index/pbench-index.log
+-rw-rw-r--        223 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--       2232 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-001
@@ -285,7 +285,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 result tar balls, 0 successfully (0 partial), with 0 errors, and 0 duplicates
 ----- pbench-dispatch/pbench-dispatch.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-3.txt
+++ b/server/bin/gold/test-3.txt
@@ -211,7 +211,7 @@ drwxrwxr-x          - logs/pbench-dispatch
 -rw-rw-r--          0 logs/pbench-dispatch/pbench-dispatch.error
 -rw-rw-r--        147 logs/pbench-dispatch/pbench-dispatch.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--        215 logs/pbench-index/pbench-index.log
+-rw-rw-r--        223 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--       2604 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-001
@@ -304,7 +304,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 result tar balls, 0 successfully (0 partial), with 0 errors, and 0 duplicates
 ----- pbench-dispatch/pbench-dispatch.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-4.txt
+++ b/server/bin/gold/test-4.txt
@@ -214,7 +214,7 @@ drwxrwxr-x          - logs/pbench-edit-prefixes
 -rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
 -rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--        215 logs/pbench-index/pbench-index.log
+-rw-rw-r--        223 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--       2604 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-001
@@ -322,7 +322,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 edit-prefix requests
 ----- pbench-edit-prefixes/pbench-edit-prefixes.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -249,7 +249,7 @@ drwxrwxr-x          - logs/pbench-edit-prefixes
 -rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
 -rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--        215 logs/pbench-index/pbench-index.log
+-rw-rw-r--        223 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-move-unpacked
 -rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
 -rw-rw-r--         78 logs/pbench-move-unpacked/pbench-move-unpacked.log
@@ -367,7 +367,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 edit-prefix requests
 ----- pbench-edit-prefixes/pbench-edit-prefixes.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
 +++++ pbench-move-unpacked/pbench-move-unpacked.error

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -129,14 +129,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "ca19820804c18e2defe9dcedf8cac234",
+        "_id": "e0a1c4b9160e2121e7bea73993469ead",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 7 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/TO-INDEX/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/TO-INDEX/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/TO-INDEX/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/TO-INDEX/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 7 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/TO-INDEX/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/TO-INDEX/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/TO-INDEX/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS.tar.xz\n\n/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/TO-INDEX/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -566,7 +566,7 @@ drwxrwxr-x          - logs/pbench-edit-prefixes
 -rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
 -rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       6015 logs/pbench-index/pbench-index.log
+-rw-rw-r--       6031 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-move-unpacked
 -rw-rw-r--          0 logs/pbench-move-unpacked/pbench-move-unpacked.error
 -rw-rw-r--       1894 logs/pbench-move-unpacked/pbench-move-unpacked.log
@@ -826,7 +826,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 edit-prefix requests
 ----- pbench-edit-prefixes/pbench-edit-prefixes.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 7 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/TO-INDEX/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz (size 212)
@@ -850,7 +850,7 @@ run-1900-01-01T00:00:00-UTC: Processed 0 edit-prefix requests
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/TO-INDEX/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz (size 228)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- Unsupported Tarball Format: /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz - tarball is missing "tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss/metadata.log".
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/TO-INDEX/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz (size 228)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 7) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 7) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-move-unpacked/pbench-move-unpacked.error

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -249,7 +249,7 @@ drwxrwxr-x          - logs/pbench-edit-prefixes
 -rw-rw-r--          0 logs/pbench-edit-prefixes/pbench-edit-prefixes.error
 -rw-rw-r--         90 logs/pbench-edit-prefixes/pbench-edit-prefixes.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--        215 logs/pbench-index/pbench-index.log
+-rw-rw-r--        223 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--       3348 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-001
@@ -364,7 +364,7 @@ run-1900-01-01T00:00:00-UTC
 run-1900-01-01T00:00:00-UTC: Processed 0 edit-prefix requests
 ----- pbench-edit-prefixes/pbench-edit-prefixes.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.1.txt
+++ b/server/bin/gold/test-7.1.txt
@@ -13,14 +13,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b91437755bd2fcda79e705ad856ce58b",
+        "_id": "21ce980d59fd8e9cf364c15ca7789a72",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.1.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.1.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -121,7 +121,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1356 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1372 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -183,13 +183,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.1.tar.xz (size 1232)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- The metadata.log file is curdled in tarball: /var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/test-7.1.tar.xz - error fetching required metadata.log fields, "No section: 'run'"
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.1.tar.xz (size 1232)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.10.txt
+++ b/server/bin/gold/test-7.10.txt
@@ -9449,14 +9449,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "d2350d443025b84ddb23142aedaad572",
+        "_id": "5acaf0ff29a3703870de010a90920769",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.10/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/uperf_uperftest_2018.02.02T20.58.00.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.10/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/uperf_uperftest_2018.02.02T20.58.00.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -9557,7 +9557,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1480 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1504 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -9619,14 +9619,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.10/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/uperf_uperftest_2018.02.02T20.58.00.tar.xz (size 2360408)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 2374, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: dhcp31-44/uperf_uperftest_2018.02.02T20.58.00.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: dhcp31-44/uperf_uperftest_2018.02.02T20.58.00.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.10/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/uperf_uperftest_2018.02.02T20.58.00.tar.xz (size 2360408)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.11.txt
+++ b/server/bin/gold/test-7.11.txt
@@ -5009,14 +5009,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "02005cbcb7223d6f86446d67def70f2d",
+        "_id": "532d612a5ae7cd63c93c3506791ace9a",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.11/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/fio_rw_2018.02.01T22.40.57.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.11/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/fio_rw_2018.02.01T22.40.57.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -5117,7 +5117,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1452 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1476 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -5179,14 +5179,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.11/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/fio_rw_2018.02.01T22.40.57.tar.xz (size 2166868)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 419, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: dhcp31-44/fio_rw_2018.02.01T22.40.57.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: dhcp31-44/fio_rw_2018.02.01T22.40.57.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.11/pbench/archive/fs-version-001/dhcp31-44/TO-INDEX/fio_rw_2018.02.01T22.40.57.tar.xz (size 2166868)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.12.txt
+++ b/server/bin/gold/test-7.12.txt
@@ -3954,14 +3954,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c37527bb70a32f2797359b1b2aecfc00",
+        "_id": "3413e13a7cf1347d0e3a8d9e3551e06d",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.12/pbench/archive/fs-version-001/EC2::ip-172-31-52-154/TO-INDEX/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.12/pbench/archive/fs-version-001/EC2::ip-172-31-52-154/TO-INDEX/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -4062,7 +4062,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1538 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1562 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -4124,14 +4124,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.12/pbench/archive/fs-version-001/EC2::ip-172-31-52-154/TO-INDEX/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz (size 5258824)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 44653, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: EC2::ip-172-31-52-154/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: EC2::ip-172-31-52-154/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.12/pbench/archive/fs-version-001/EC2::ip-172-31-52-154/TO-INDEX/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz (size 5258824)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.13.txt
+++ b/server/bin/gold/test-7.13.txt
@@ -10463,14 +10463,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "6e67466c4dd523000954aac3ca22c2c3",
+        "_id": "ab32d1a6a7a9195b09c9e982eb106eed",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.13/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.13/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -10571,7 +10571,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1558 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1582 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -10633,14 +10633,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.13/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz (size 3318192)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1026970, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.13/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz (size 3318192)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.14.txt
+++ b/server/bin/gold/test-7.14.txt
@@ -7438,14 +7438,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "9bd2adf0742f0309533e678f9c352cd0",
+        "_id": "069106b2f08665f70b732d4747ffcfe1",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.14/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.14/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -7546,7 +7546,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1558 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1582 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -7608,14 +7608,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.14/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz (size 3321424)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1029657, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.14/pbench/archive/fs-version-001/b03-h01-1029p/TO-INDEX/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz (size 3321424)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.15.txt
+++ b/server/bin/gold/test-7.15.txt
@@ -8078,14 +8078,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "9722fe1b2e0ad7031938b0977ea99b65",
+        "_id": "cc2186f9170c36752c3f3e3fb51f0155",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.15/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.15/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -8186,7 +8186,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1460 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1484 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -8248,14 +8248,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.15/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5807176)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 19845, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: master_40gb/uperf__2016-10-06_16:34:03.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: master_40gb/uperf__2016-10-06_16:34:03.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.15/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5807176)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.16.txt
+++ b/server/bin/gold/test-7.16.txt
@@ -9673,14 +9673,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "07ffd6af771f5674821e47ef8ec72a31",
+        "_id": "edce3963b781c3bcbcc2e49fdc7f244e",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.16/pbench/archive/fs-version-001/rhel8-4/TO-INDEX/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.16/pbench/archive/fs-version-001/rhel8-4/TO-INDEX/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -9781,7 +9781,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1535 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1559 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -9843,14 +9843,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.16/pbench/archive/fs-version-001/rhel8-4/TO-INDEX/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz (size 1585016)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 75293, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: rhel8-4/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: rhel8-4/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.16/pbench/archive/fs-version-001/rhel8-4/TO-INDEX/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz (size 1585016)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.17.txt
+++ b/server/bin/gold/test-7.17.txt
@@ -3167,14 +3167,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b5b804fb81b56f57065757f63a45f04e",
+        "_id": "87276c7bc386dd4a491161e5a8c5f52b",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.17/pbench/archive/fs-version-001/ansible-host/TO-INDEX/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.17/pbench/archive/fs-version-001/ansible-host/TO-INDEX/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -3275,7 +3275,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1548 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1572 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -3337,14 +3337,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.17/pbench/archive/fs-version-001/ansible-host/TO-INDEX/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz (size 31384)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 2006, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: ansible-host/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: ansible-host/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.17/pbench/archive/fs-version-001/ansible-host/TO-INDEX/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz (size 31384)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.18.txt
+++ b/server/bin/gold/test-7.18.txt
@@ -13,14 +13,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "590f65a8a33b48160ae7773e72f518f2",
+        "_id": "5b74265f9bd856d79a1609d36576e7f4",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/TO-INDEX/test-7.18.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/TO-INDEX/test-7.18.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -121,7 +121,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1687 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1703 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -184,14 +184,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 WARNING pbench-index.pbench-index main -- Missing .md5 file for /var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/TO-INDEX/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/TO-INDEX/test-7.18.tar.xz (size 1496)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- The metadata.log file is curdled in tarball: /var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/test-7.18.tar.xz - error fetching required metadata.log fields, "run.controller ("alphaville.usersys.redhat.com") does not match controller_dir ("bad-controller")"
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/TO-INDEX/test-7.18.tar.xz (size 1496)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.2.0.txt
+++ b/server/bin/gold/test-7.2.0.txt
@@ -13,14 +13,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f9b21509b58d4f7a96b8b7a386021121",
+        "_id": "52009c3535bf738ca2cf76a3e5c1c5b5",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.2.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.2.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -121,7 +121,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1324 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1340 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -183,13 +183,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.2.tar.xz (size 1204)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- Unsupported Tarball Format: /var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/test-7.2.tar.xz - tarball is missing "test-7.2/metadata.log".
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/TO-INDEX/test-7.2.tar.xz (size 1204)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.2.1.txt
+++ b/server/bin/gold/test-7.2.1.txt
@@ -13,14 +13,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c903d2189dcecf32d055ca39dcc83c54",
+        "_id": "6963963c9712fb637b51aadbc0bed5d4",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -121,7 +121,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1467 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1483 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -183,13 +183,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5809020)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- Unsupported Tarball Format: /var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/uperf__2016-10-06_16:34:03.tar.xz - directory prefix should be "uperf__2016-10-06_16:34:03", but is "." instead, for tarball member "./uperf__2016-10-06_16:34:03"
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5809020)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.3.txt
+++ b/server/bin/gold/test-7.3.txt
@@ -13,14 +13,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "bf57cfa19f705f21f8df2fcfb40251ad",
+        "_id": "d4f8d72a9a660bec18c2b2703ed29b25",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.3.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.3.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -121,7 +121,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1358 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1374 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -183,13 +183,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.3.tar.xz (size 1476)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- The metadata.log file is curdled in tarball: /var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/test-7.3.tar.xz - error fetching required metadata.log fields, "empty pbench.script"
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.3.tar.xz (size 1476)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.4.txt
+++ b/server/bin/gold/test-7.4.txt
@@ -23,14 +23,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "812b517339decded40ed310be2e7f6f7",
+        "_id": "b6a05d4268fe11e38de441937213afe4",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.4/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.4.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.4/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.4.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -131,7 +131,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1241 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1257 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -193,13 +193,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.4/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.4.tar.xz (size 1484)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- Bad hostname in sosreport: The sosreport did not collect a hostname other than 'localhost'
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.4/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.4.tar.xz (size 1484)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.5.txt
+++ b/server/bin/gold/test-7.5.txt
@@ -23,14 +23,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "6dc87b761e0abedf59f68e63671f1787",
+        "_id": "60ea84d9d6bdef509941f95d214bd1a3",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.5/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.5.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 0 results, skipped 1 results\n\nSkipped Results\n===============\n/var/tmp/pbench-test-server/test-7.5/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.5.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -131,7 +131,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1241 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1257 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -193,13 +193,13 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.5/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.5.tar.xz (size 1496)
 1970-01-01T00:00:00.000000 ERROR pbench-index.pbench-index main -- Bad hostname in sosreport: The sosreport did not collect a hostname other than 'localhost'
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.5/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.5.tar.xz (size 1496)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 0 (skipped 1) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 0 (skipped 1) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.6.txt
+++ b/server/bin/gold/test-7.6.txt
@@ -157,14 +157,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "64e89a2097812a47a3f6d77c69a02e4a",
+        "_id": "43fa7622de82e8dc8a80fa18398f8345",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.6/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.6.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.6/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.6.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -265,7 +265,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1391 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1415 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -327,14 +327,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.6/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.6.tar.xz (size 1492)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 5, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: alphaville/test-7.6.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: alphaville/test-7.6.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.6/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.6.tar.xz (size 1492)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.7.txt
+++ b/server/bin/gold/test-7.7.txt
@@ -157,14 +157,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "6e1aeb802b3883e79856864c8798397a",
+        "_id": "c8d902645aeef3fba2748bf37e13b836",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.7/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.7.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.7/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.7.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -265,7 +265,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1391 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1415 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -327,14 +327,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.7/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.7.tar.xz (size 1500)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 5, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: alphaville/test-7.7.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: alphaville/test-7.7.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.7/pbench/archive/fs-version-001/alphaville/TO-INDEX/test-7.7.tar.xz (size 1500)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.8.txt
+++ b/server/bin/gold/test-7.8.txt
@@ -8078,14 +8078,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f71d21a1f66c1f2e8ed995f2dfc29638",
+        "_id": "4ae929d27e9dae0c88858b05aeb9fa3b",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.8/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.8/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -8186,7 +8186,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1458 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1482 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -8248,14 +8248,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.8/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5822724)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 19845, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: master_40gb/uperf__2016-10-06_16:34:03.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: master_40gb/uperf__2016-10-06_16:34:03.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.8/pbench/archive/fs-version-001/master_40gb/TO-INDEX/uperf__2016-10-06_16:34:03.tar.xz (size 5822724)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/gold/test-7.9.txt
+++ b/server/bin/gold/test-7.9.txt
@@ -8623,14 +8623,14 @@ Index:  pbench-unittests-server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "7c5f5f32f4a1fca545f166f7af07a1e2",
+        "_id": "2b890514c0f018ff4c44645dfed113fb",
         "_index": "pbench-unittests-server-reports.1970-01",
         "_op_type": "create",
         "_source": {
             "@timestamp": "1970-01-01T00:00:00",
             "doctype": "status",
             "name": "pbench-index",
-            "text": "pbench-index.1970-01-01T00:00:00 - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.9/pbench/archive/fs-version-001/dhcp31-144/TO-INDEX/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz\n\n"
+            "text": "pbench-index.run-1900-01-01T00:00:00-UTC - Indexed 1 results\n\nIndexed Results\n===============\n/var/tmp/pbench-test-server/test-7.9/pbench/archive/fs-version-001/dhcp31-144/TO-INDEX/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz\n\n"
         },
         "_type": "pbench-server-reports"
     }
@@ -8731,7 +8731,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-index
--rw-rw-r--       1502 logs/pbench-index/pbench-index.log
+-rw-rw-r--       1526 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-report-status
 -rw-rw-r--        372 logs/pbench-report-status/pbench-report-status.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -8793,14 +8793,14 @@ drwxrwxr-x          - tmp
 +++++ pbench-audit-server/pbench-audit-server.log
 ----- pbench-audit-server/pbench-audit-server.log
 +++++ pbench-index/pbench-index.log
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: starting
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: starting
 1970-01-01T00:00:00.000000 DEBUG pbench-index.pbench-index main -- Preparing to index 1 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ update_templates -- done templates (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 10, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Starting /var/tmp/pbench-test-server/test-7.9/pbench/archive/fs-version-001/dhcp31-144/TO-INDEX/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz (size 1137024)
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- done indexing (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 3835, duplicates: 0, failures: 0, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- 1970-01-01T00:00:00: dhcp31-144/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz: success
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- run-1900-01-01T00:00:00-UTC: dhcp31-144/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz: success
 1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- Finished /var/tmp/pbench-test-server/test-7.9/pbench/archive/fs-version-001/dhcp31-144/TO-INDEX/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz (size 1137024)
-1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.1970-01-01T00:00:00: indexed 1 (skipped 0) results, 0 errors
+1970-01-01T00:00:00.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1900-01-01T00:00:00-UTC: indexed 1 (skipped 0) results, 0 errors
 1970-01-01T00:00:00.000000 INFO pbench-index.__init__ report_status -- posted status (end ts: 1970-01-01T00:00:00-GMT, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
 +++++ pbench-report-status/pbench-report-status.log

--- a/server/bin/pbench-base.py
+++ b/server/bin/pbench-base.py
@@ -51,7 +51,7 @@ except BadConfig as e:
 
 # Exclude the "files" and "conf" attributes from being exported
 vars = sorted([ key for key in config.__dict__.keys() \
-        if key not in ('files', 'conf') ])
+        if key not in ('files', 'conf', 'timestamp', '_unittests', 'get') ])
 for att in vars:
     try:
         os.environ[att] = getattr(config, att)
@@ -59,6 +59,9 @@ for att in vars:
         print("{}: Missing internal pbench attribute, \"{}\", in"
                 " configuration".format(_prog, att), file=sys.stderr)
         sys.exit(1)
+
+if config._unittests:
+    os.environ['_PBENCH_SERVER_TEST'] = "1"
 
 cmd = "{}.sh".format(sys.argv[1])
 args = [ cmd ] + sys.argv[2:]

--- a/server/bin/pbench-base.sh
+++ b/server/bin/pbench-base.sh
@@ -63,11 +63,6 @@ else
     }
 fi
 
-# Convenient task run identifier.
-if [ "$TS" = "" ]; then
-    TS="run-$(timestamp)"
-fi
-
 function mk_dirs {
     hostname=$1
 

--- a/server/bin/pbench-index.py
+++ b/server/bin/pbench-index.py
@@ -2880,23 +2880,16 @@ class IdxContext(object):
                 raise ConfigFileError("Index prefix, '{}', not allowed to"
                         " contain a period ('.')".format(self.idx_prefix))
 
-        try:
-            debug_unittest = self.config.get('Indexing', 'debug_unittest')
-        except Exception as e:
-            debug_unittest = False
-        else:
-            debug_unittest = bool(debug_unittest)
-        if debug_unittest:
+        if self.config._unittests:
             import collections
             global _dict_const
             _dict_const = collections.OrderedDict
-            self.TS = datetime.utcfromtimestamp(0).isoformat()
             def _do_time():
                 return 0
             self.time = _do_time
         else:
-            self.TS = datetime.utcnow().isoformat()
             self.time = time.time
+        self.TS = self.config.TS
 
         self.logger = get_pbench_logger(_NAME_, self.config)
         self.es = get_es(self.config, self.logger)

--- a/server/bin/state/config-satellite/pbench-server.cfg
+++ b/server/bin/state/config-satellite/pbench-server.cfg
@@ -16,6 +16,7 @@ roles = pbench-prep, pbench-results
 # This has to be set to the same value as what the mock'd "hostname"
 # command returns.
 realhost = pbench.example.com
+debug_unittest = True
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html-satellite

--- a/server/bin/state/config/pbench-server.cfg
+++ b/server/bin/state/config/pbench-server.cfg
@@ -13,12 +13,12 @@ pbench-backup-dir = %(pbench-local-dir)s/archive.backup
 roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
 # Ensure all dispatch states are used
 dispatch-states = TO-UNPACK, TO-INDEX, TO-COPY-SOS, TO-BACKUP
+debug_unittest = True
 
 [Indexing]
 server = elasticsearch.example.com:9280
 index_prefix = pbench-unittests
 bulk_action_count = 2000
-debug_unittest = True
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/state/test-23.config/pbench-server.cfg
+++ b/server/bin/state/test-23.config/pbench-server.cfg
@@ -13,11 +13,11 @@ pbench-backup-dir = %(pbench-local-dir)s/archive.backup
 roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
 # Ensure all dispatch states are used
 dispatch-states = TO-UNPACK, TO-INDEX, TO-COPY-SOS, TO-BACKUP
+debug_unittest = True
 
 [Indexing]
 server = elasticsearch.example.com:9280
 # No index_prefix so logger should be used in pbench-report-status
-debug_unittest = True
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/state/test-5.1.config/pbench-server.cfg
+++ b/server/bin/state/test-5.1.config/pbench-server.cfg
@@ -22,12 +22,12 @@ pbench-backup-dir = %(pbench-local-dir)s/archive.backup
 roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
 # Ensure all dispatch states are used
 dispatch-states = TO-UNPACK, TO-INDEX, TO-COPY-SOS, TO-BACKUP
+debug_unittest = True
 
 [Indexing]
 server = elasticsearch.example.com:9280
 index_prefix = pbench-unittests
 bulk_action_count = 2000
-debug_unittest = True
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -41,10 +41,6 @@ PATH=$(remove_path /opt/pbench-server/bin $PATH)
 PATH=$(remove_path /opt/pbench-agent/bench-scripts $PATH)
 export PATH=$(remove_path /opt/pbench-agent/util-scripts $PATH)
 
-# Fixed timestamp output
-export _PBENCH_SERVER_TEST=1
-export TZ="UTC"
-
 function _run {
     tname=$1
     shift


### PR DESCRIPTION
This moves the `TS` environment variable definition to the python `pbench-base.py`, and then consolidates the use of `debug_unittest` check further, moving it to only be in the `pbench-server` section of the server config file.

This helps to remove some foundational work out of #976.