### PR TITLE
Fix use of sosreport for version 3.5.1 and later

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -85,37 +85,45 @@ function collect_block {
 }
 
 function collect_sos {
-	name=$(hostname -f)-pbench
+	_name="$(hostname -f)-pbench"
 	debug_log "[$script_name]collecting sosreport"
-	read sos_ver sos_ver_minor <<< `rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $1" "$2}'`
+	read sos_ver sos_ver_minor sos_ver_subminor <<< `rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $1" "$2" "$3}'`
 	if [[ "$sos_ver" -ge 3 ]]; then
-		quiet="--quiet"
-		block="-o block"
-		processor="-o processor"
-		# ref for plugin collectd: https://github.com/sosreport/sos/pull/866
+		_quiet="--quiet"
+		_block="-o block"
+		_processor="-o processor"
 		if [[ "$sos_ver_minor" -ge 4 ]]; then
-		    collectd="-o collectd"
+			# ref for plugin collectd: https://github.com/sosreport/sos/pull/866
+			_collectd="-o collectd"
 		else
-		    collectd=""
+			_collectd=""
 		fi
-		sos_ver=`rpm -q sos | awk -F- '{print $2}' | awk -F. '{print $2}'`
-		if [[ "$sos_ver" == "0" ]]; then
-		    # No tuned plug-in in sosreport v3.0
-		    tuned=""
+		if [[ "$sos_ver_minor" -eq 0 ]]; then
+			# No tuned plug-in in sosreport v3.0
+			_tuned=""
 		else
-		    # tuned plug-in in sosreport v3.1+
-		    tuned="-o tuned"
+			# tuned plug-in in sosreport v3.1+
+			_tuned="-o tuned"
+		fi
+		if [[ "$sos_ver_minor" -ge 6 || ( "$sos_ver_minor" -eq 5 && ! -z "$sos_ver_subminor" ) ]]; then
+			_general="-o date -o host"
+			_release="-o release"
+		else
+			_general="-o general"
+			_release="-o lsbrelease"
 		fi
 	else
-		quiet=""
-		block=""
-		processor=""
-		tuned=""
-		collectd=""
+		_quiet=""
+		_block=""
+		_processor=""
+		_tuned=""
+		_collectd=""
+		_general="-o general"
+		_release="-o lsbrelease"
 	fi
-	sosreport -o general -o kernel -o filesys -o devicemapper -o system -o memory \
-	      -o hardware -o networking -o lsbrelease ${block} ${processor} ${tuned} \
-	      ${collectd} --batch ${quiet} --tmp-dir=$dir --name "$name" > /dev/null 2>&1
+	sosreport ${_general} -o kernel -o filesys -o devicemapper -o system -o memory \
+	      -o hardware -o networking ${_release} ${_block} ${_processor} ${_tuned} \
+	      ${_collectd} --batch ${_quiet} --tmp-dir=$dir --name "$_name" > /dev/null 2>&1
 	if [[ -f "sosreport-$name-*.tar.xz" ]]; then
 		debug_log "[$script_name]done collecting sosreport"
 	else


### PR DESCRIPTION
Starting with version 3.5.1, the `general` plugin was removed, having
it functionality moved into other existing plugins, and two new plugins
added, `date` and `host`.  The collection of `/proc/stat` was in the
`general` plugin, but was moved to the `process` plugin.  We don't add
the `process` plugin at this point because it was not on our original
list.  A separate commit should propose the addition of such a plugin.
In the mean time, we add the collection of the `date` and `host`
plugins now.

The `lsbrelease` plugin was renamed to `release`.

See also the sosreport commit: [971b958](https://github.com/sosreport/sos/commit/971b9581779da20384f0a4d8de5177c0b87d6892)

Fixes #1161.