### PR TITLE
pbench-run-benchmark monitor

### DIFF
--- a/agent/bench-scripts/pbench-run-benchmark-sample
+++ b/agent/bench-scripts/pbench-run-benchmark-sample
@@ -17,7 +17,8 @@ use JSON;
 use File::Temp;
 use Data::Dumper;
 use PbenchBase       qw(get_json_file put_json_file get_benchmark_names get_clients
-                        get_params get_pbench_bench_config_dir load_benchmark_config);
+                        get_params get_pbench_bench_config_dir load_benchmark_config
+                        get_pbench_install_dir );
 use PbenchAnsible    qw(ssh_hosts ping_hosts copy_files_to_hosts copy_files_from_hosts
                         remove_files_from_hosts remove_dir_from_hosts create_dir_hosts
                         sync_dir_from_hosts verify_success yum_install_hosts);
@@ -48,6 +49,10 @@ my $json_ref = get_json_file($iter_doc_filename);
 my %iteration = %$json_ref; # this is the CDM doc for this benchmark-iteration
 my %sample = create_bench_iter_sample_doc(\%iteration);
 my %specs = load_benchmark_config($pbench_bench_config_dir, $iteration{'run'}{'bench'}{'name'});
+
+my $output_wrapper_name = "pbench-output-monitor";
+my $local_output_wrapper_path = get_pbench_install_dir . "/util-scripts";
+my $remote_output_wrapper_path = "/tmp";
 
 my $sample_num = 0;
 if ($sample_dir =~ /.+([0-9])+$/) {
@@ -122,6 +127,13 @@ if (! $pp_only) {
                 $result = copy_files_to_hosts(\@{ $hosts{$type} }, \@files, $sample_dir . "-" .
                                               $type, $base_dir);
             }
+	    if ($specs{$type} and ${specs}{$type}{"bin"}) {
+		# since there is an executable that is going to be used lets copy over the output
+		# wrapper in advance
+		my $result;
+		my @files = ( $local_output_wrapper_path ."/" . $output_wrapper_name );
+		$result = copy_files_to_hosts(\@{ $hosts{$type} }, \@files, $remote_output_wrapper_path, $base_dir);
+	    }
         }
     }
     # - execute pre-benchmark scripts on clients and servers (todo)
@@ -134,7 +146,8 @@ if (! $pp_only) {
         if ($hosts{$type} and scalar @{ $hosts{$type} }) {
             my $cmd;
             if ($specs{$type}{"bin"}) {
-                $cmd = $specs{$type}{"bin"} . " " .  $iteration{'iteration'}{'params'};
+                $cmd = $remote_output_wrapper_path . "/" . $output_wrapper_name. " " .
+		       $specs{$type}{"bin"} . " " .  $iteration{'iteration'}{'params'};
             } else {
                 printf "%s->bin does not exist, exiting\n", $type;
                 exit 1;

--- a/agent/lib/PbenchAnsible.pm
+++ b/agent/lib/PbenchAnsible.pm
@@ -211,7 +211,7 @@ sub copy_files_to_hosts { # copies local files to hosts with a new, common desti
 	my $inv_file = build_inventory($hosts_ref, $logdir);
 	my @tasks;
 	for my $src_file (@$src_files_ref) {
-		my %task = ( name => "copy files to hosts", copy => "src=" . $src_file . " dest=" . $dst_path . "/" . basename($src_file) );
+		my %task = ( name => "copy files to hosts", copy => "mode=preserve src=" . $src_file . " dest=" . $dst_path . "/" . basename($src_file) );
 		push(@tasks, \%task);
 	}
 	my %play = ( hosts => "all", tasks => \@tasks );;

--- a/agent/lib/PbenchBase.pm
+++ b/agent/lib/PbenchBase.pm
@@ -33,7 +33,7 @@ sub get_pbench_run_dir {
 }
 
 sub get_pbench_install_dir {
-    my $dir = $ENV{'pbench_install_dir'}; # typically /var/lib/pbench-agent
+    my $dir = $ENV{'pbench_install_dir'}; # typically /opt/pbench-agent
     chomp $dir;
     return $dir;
 }

--- a/agent/util-scripts/pbench-output-monitor
+++ b/agent/util-scripts/pbench-output-monitor
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+SESSION_NAME=$(basename ${0})
+
+CMD="$@"
+
+LOCK_FILE="/tmp/${SESSION_NAME}.lock"
+
+function setup_pipe()
+{
+    local FILE=${1}
+
+    rm ${FILE}
+    mknod ${FILE} p
+}
+
+function run()
+{
+    ${CMD} > >(tee -i ${STDOUT_FILE}) 2> >(tee -i ${STDERR_FILE} >&2)
+
+    rm ${STDOUT_FILE} ${STDERR_FILE}
+}
+
+function primary()
+{
+    TITLE="primary"
+    screen -dmS ${SESSION_NAME} -t ${TITLE} bash -c "cat ${STDOUT_FILE} & cat ${STDERR_FILE} >&2 & wait"
+
+    run
+
+    exit
+}
+
+function secondary()
+{
+    while screen -list ${SESSION_NAME} | grep -q "No sockets found"; do
+	sleep 0.1
+    done
+
+    TITLE="secondary"
+    screen -x ${SESSION_NAME} -X screen -t ${TITLE} bash -c "cat ${STDOUT_FILE} & cat ${STDERR_FILE} >&2 & wait"
+
+    run
+
+    exit
+}
+
+STDOUT_FILE=$(mktemp)
+STDERR_FILE=$(mktemp)
+
+setup_pipe ${STDOUT_FILE}
+setup_pipe ${STDERR_FILE}
+
+(
+    flock --exclusive --nonblock 9 || secondary
+    primary
+) 9>${LOCK_FILE}


### PR DESCRIPTION
When pbench-run-benchmark launches a process via PbenchAnsible.pm the output of that process is buffered within Ansible until the process exits.  In order to be able to monitor a benchmark while it is running these patches introduce a monitor script that is used as a wrapper around the benchmark process.  This wrapper takes special care to preserve the distinctly separate STDERR and STDOUT data streams while allowing the user to attach to a screen session on a/the client (named pbench-output-monitor) to view the output in real time with identical separation of output streams.

In the monitor, each benchmark process has it's STDERR and STDOUT redirected to named pipes via tee.  Using tee ensures that the output is preserved in the Ansible workflow as is currently done.  A bash process is laucned inside of the screen session which simply uses cat to extract the output from the named pipes while preserving the STDERR/STDOUT relationship.

Since it is possible that a given client may be executing multiple copies of a benchmark, special care is taken to ensure that the screen session which handles the output monitor(s) is launched properly.  A flock call is used to ensure that only the first invocation of the monitor creates the screen session; any subsequent call to the output monitor fails to obtain the flock so it attaches to the existing screen session rather than creating a new one.  This allows all invocations that are being monitored to be contained within a single screen session for easier navigation and monitoring.  There is potential for a race between the first invocation and any subsequent invocation of the screen session so a small polling loop is introduced (with 0.1 second granularity to minimize polling overhead) to ensure that the screen session's socket file exists prior to attempting to attach additional sessions.