### PR TITLE
Integrate Explore page for discovering and launching shared dashboard sessions

### DIFF
--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -76,6 +76,7 @@ export default {
   '/dev/datastoreConfig': {
       "elasticsearch": "http://elasticsearch.example.com",
       "results": "http://results.example.com",
+      "graphql": "http://graphql.example.com",
       "prefix": "example.prefix",
       "run_index": "example.index"
   },

--- a/web-server/v0.4/config/router.config.js
+++ b/web-server/v0.4/config/router.config.js
@@ -35,6 +35,11 @@ module.exports = [
         component: './Search',
       },
       {
+        path: '/explore',
+        name: 'explore',
+        component: './Explore',
+      },
+      {
         path: '/exception/403',
         name: 'exception-403',
         component: './Exception/403',

--- a/web-server/v0.4/mock/datastoreConfig.js.example
+++ b/web-server/v0.4/mock/datastoreConfig.js.example
@@ -2,6 +2,7 @@ export default {
   '/dev/datastoreConfig': {
       "elasticsearch": "",
       "results": "",
+      "graphql": "",
       "prefix": "",
       "run_index": "",
   },

--- a/web-server/v0.4/src/common/menu.js
+++ b/web-server/v0.4/src/common/menu.js
@@ -11,6 +11,11 @@ const menuData = [
     icon: 'search',
     path: '/search',
   },
+  {
+    name: 'Explore',
+    icon: 'global',
+    path: '/explore',
+  },
 ];
 
 function formatter(data, parentPath = '/', parentAuthority) {

--- a/web-server/v0.4/src/models/explore.js
+++ b/web-server/v0.4/src/models/explore.js
@@ -1,0 +1,30 @@
+import querySharedSessions from '../services/explore';
+
+export default {
+  namespace: 'explore',
+
+  state: {
+    sharedSessions: [],
+    loading: false,
+  },
+
+  effects: {
+    *fetchSharedSessions({ payload }, { call, put }) {
+      const response = yield call(querySharedSessions, payload);
+
+      yield put({
+        type: 'getSharedSessions',
+        payload: response.data.urls,
+      });
+    },
+  },
+
+  reducers: {
+    getSharedSessions(state, { payload }) {
+      return {
+        ...state,
+        sharedSessions: payload,
+      };
+    },
+  },
+};

--- a/web-server/v0.4/src/pages/Explore/index.js
+++ b/web-server/v0.4/src/pages/Explore/index.js
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+import { connect } from 'dva';
+import { routerRedux } from 'dva/router';
+import { Card, Button, Popconfirm } from 'antd';
+
+import PageHeaderLayout from '../../layouts/PageHeaderLayout';
+import Table from '@/components/Table';
+
+@connect(({ global, explore, loading }) => ({
+  sharedSessions: explore.sharedSessions,
+  datastoreConfig: global.datastoreConfig,
+  loadingSharedSessions: loading.effects['explore/fetchSharedSessions'],
+}))
+class Explore extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sharedSessions: props.sharedSessions,
+    };
+  }
+
+  componentDidMount() {
+    this.fetchDatastoreConfig();
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { sharedSessions } = this.props;
+
+    if (nextProps.sharedSessions !== sharedSessions) {
+      this.setState({ sharedSessions: nextProps.sharedSessions });
+    }
+  }
+
+  fetchDatastoreConfig = () => {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'global/fetchDatastoreConfig',
+    }).then(() => {
+      this.fetchSharedSessions();
+    });
+  };
+
+  fetchSharedSessions = () => {
+    const { dispatch, datastoreConfig } = this.props;
+
+    dispatch({
+      type: 'explore/fetchSharedSessions',
+      payload: { datastoreConfig },
+    });
+  };
+
+  startSharedSession = record => {
+    const { dispatch } = this.props;
+
+    const parsedConfig = JSON.parse(record.config);
+    window.localStorage.setItem('persist:root', parsedConfig);
+
+    dispatch(routerRedux.push(parsedConfig.routing.location.pathname));
+  };
+
+  render() {
+    const { sharedSessions } = this.state;
+    const { loadingSharedSessions } = this.props;
+    const sharedSessionColumns = [
+      {
+        title: 'Session ID',
+        dataIndex: 'id',
+        key: 'id',
+      },
+      {
+        title: 'Date Created',
+        dataIndex: 'createdAt',
+        key: 'createdAt',
+        defaultSortOrder: 'descend',
+        sorter: (a, b) => Date.parse(a.createdAt) - Date.parse(b.createdAt),
+      },
+      {
+        title: 'Description',
+        dataIndex: 'description',
+        key: 'description',
+      },
+      {
+        title: 'Action',
+        dataIndex: '',
+        key: 'action',
+        render: (text, record) => (
+          <Popconfirm
+            title="Start a new dashboard session?"
+            cancelText="No"
+            okText="Yes"
+            onConfirm={() => this.startSharedSession(record)}
+          >
+            <Button type="link">Start Session</Button>
+          </Popconfirm>
+        ),
+      },
+    ];
+
+    return (
+      <PageHeaderLayout title="Explore">
+        <Card title="Shared Sessions" bordered={false}>
+          <Table
+            columns={sharedSessionColumns}
+            dataSource={sharedSessions}
+            loading={loadingSharedSessions}
+          />
+        </Card>
+      </PageHeaderLayout>
+    );
+  }
+}
+
+export default Explore;

--- a/web-server/v0.4/src/services/explore.js
+++ b/web-server/v0.4/src/services/explore.js
@@ -1,0 +1,21 @@
+import request from '../utils/request';
+
+export default async function querySharedSessions(params) {
+  const { datastoreConfig } = params;
+
+  const endpoint = `${datastoreConfig.graphql}`;
+
+  return request.post(endpoint, {
+    data: {
+      query: `
+        query {
+          urls {
+              id
+              config
+              description
+              createdAt
+          }   
+        }`,
+    },
+  });
+}


### PR DESCRIPTION
Users may launch collected dashboard sessions from the shared
session table which includes details regarding session IDs, created
times, and description.

This page adds a new datastoreConfig field for the GraphQL server.