### PR TITLE
Modify PbenchConfig.timestamp() to return string in proper format

### DIFF
--- a/server/lib/pbench/__init__.py
+++ b/server/lib/pbench/__init__.py
@@ -244,10 +244,14 @@ class PbenchConfig(object):
         return self.conf.get(*args, **kwargs)
 
     def timestamp(self):
+        """
+        "Return timestamp formatted as a string of the following form:
+                  <YYYY>-<MM>-<DD>T<hh>:<mm>:<ss>-<TZ>
+        """
         if self._unittests:
             ts = "1900-01-01T00:00:00-UTC"
         else:
-            ts = datetime.utcnow().isoformat()
+            ts = tstos()
         return ts
 
 


### PR DESCRIPTION
Fixes #1250.

The timestamp() method should return a string of the form

    YYYY-MM-DDThh:mm:ss-TZ

It does that for unit tests with a hardcoded string, but for the "real"
case, it was returning a timestamp with microseconds added and no TZ.
Modify it to use the tstos() function in the latter case.

TBD: Change it in the unit test case to return `tstos(0)', i.e. the Unix
Epoch date: 1970-01-01T00:00:00-GMT. That will require wholesale changes
to the unit test gold files however, so postpone that change for the next
release.