### PR TITLE
Query dashboard datastoreConfig on page entrypoints

### DIFF
--- a/web-server/v0.4/src/pages/Controllers/index.js
+++ b/web-server/v0.4/src/pages/Controllers/index.js
@@ -29,13 +29,13 @@ class Controllers extends Component {
   }
 
   componentDidMount() {
-    const { controllers, selectedIndices, indices } = this.props;
+    const { controllers } = this.props;
 
-    if (selectedIndices.length === 0 || indices.length === 0) {
-      this.queryDatastoreConfig();
-    } else if (controllers.length === 0) {
-      this.fetchControllers();
-    }
+    this.queryDatastoreConfig().then(() => {
+      if (controllers.length === 0) {
+        this.fetchControllers();
+      }
+    });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/web-server/v0.4/src/pages/Search/index.js
+++ b/web-server/v0.4/src/pages/Search/index.js
@@ -32,13 +32,13 @@ class SearchList extends Component {
   }
 
   componentDidMount() {
-    const { selectedIndices, indices, mapping } = this.props;
+    const { mapping } = this.props;
 
-    if (selectedIndices.length === 0 || indices.length === 0) {
-      this.queryDatastoreConfig();
-    } else if (Object.keys(mapping).length === 0) {
-      this.fetchIndexMapping();
-    }
+    this.queryDatastoreConfig().then(() => {
+      if (Object.keys(mapping).length === 0) {
+        this.fetchIndexMapping();
+      }
+    });
   }
 
   componentWillReceiveProps(nextProps, prevProps) {


### PR DESCRIPTION
Avoids completely blacklisting the `global` namespace while
querying up to date config data for deployed dashboard instance