### PR TITLE
Create local storage key via window pathname

### DIFF
--- a/web-server/v0.4/src/app.js
+++ b/web-server/v0.4/src/app.js
@@ -7,9 +7,11 @@ import storage from 'redux-persist/lib/storage';
  * `dashboard` and `search` are blacklisted from the saved state as the namespaces
  * persist data that is constantly updated on the server side.
  */
+const appPath = window.location.pathname.split('/').pop();
+
 const persistConfig = {
   timeout: 1000,
-  key: 'root',
+  key: appPath !== '' ? appPath : 'root',
   storage,
   blacklist: ['dashboard', 'search'],
 };


### PR DESCRIPTION
In order to maintain unique dashboard deployments across one host, a unique local storage key is required for the dashboard to read separate Redux data stores. This PR resolves issue #1270.