### PR TITLE
Add path analyzer for indexing ToC data

### DIFF
--- a/server/bin/gold/test-7.0.1.txt
+++ b/server/bin/gold/test-7.0.1.txt
@@ -581,13 +581,13 @@ Template: pbench-unittests.v1.run
                     "type": "date"
                 },
                 "directory": {
-                    "index": "not_analyzed",
+                    "analyzer": "path_analyzer",
                     "type": "string"
                 },
                 "files": {
                     "properties": {
                         "linkpath": {
-                            "index": "not_analyzed",
+                            "analyzer": "path_analyzer",
                             "type": "string"
                         },
                         "mode": {
@@ -626,12 +626,18 @@ Template: pbench-unittests.v1.run
             "analyzer": {
                 "comma_analyzer": {
                     "tokenizer": "comma_tokenizer"
+                },
+                "path_analyzer": {
+                    "tokenizer": "path_tokenizer"
                 }
             },
             "tokenizer": {
                 "comma_tokenizer": {
                     "pattern": ",",
                     "type": "pattern"
+                },
+                "path-tokenizer": {
+                    "type": "path_hierarchy"
                 }
             }
         },

--- a/server/lib/mappings/run-toc-entry.json
+++ b/server/lib/mappings/run-toc-entry.json
@@ -14,14 +14,14 @@
             },
             "directory": {
                 "type": "string",
-                "index": "not_analyzed"
+                "analyzer": "path_analyzer"
             },
             "files": {
                 "type": "nested",
                 "properties": {
                     "linkpath" : {
                         "type": "string",
-                        "index": "not_analyzed"
+                        "analyzer": "path_analyzer"
                     },
                     "mode" : {
                         "type": "string",

--- a/server/lib/settings/run.json
+++ b/server/lib/settings/run.json
@@ -3,12 +3,18 @@
         "analyzer": {
             "comma_analyzer": {
                 "tokenizer": "comma_tokenizer"
+            },
+            "path_analyzer": {
+                "tokenizer": "path_tokenizer"
             }
         },
         "tokenizer": {
             "comma_tokenizer": {
                 "type": "pattern",
                 "pattern": ","
+            },
+            "path-tokenizer": {
+                "type": "path_hierarchy"
             }
         }
     },


### PR DESCRIPTION
Uses the "`path_hierarchy`" tokenizer for the directory and link fields of the table-of-contents JSON documents. The tokenizer creates multiple tokens out of paths, e.g. the path "`/home/foo/bar/file.txt`" would end up with four tokens when indexed into Elasticsearch [1]:

 * `/home`
 * `/home/foo`
 * `/home/foo/bar`
 * `/home/foo/bar/file.txt`

[1] https://www.elastic.co/guide/en/elasticsearch/reference/1.7/analysis-pathhierarchy-tokenizer.html