### PR TITLE
Add crontab entry for running pbench-audit-server.

### DIFF
--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -133,7 +133,7 @@ tasks = pbench-dispatch, pbench-unpack-tarballs, pbench-copy-sosreports, pbench-
 host = %(default-host)s
 user = %(default-user)s
 mailfrom = %(user)s@%(host)s
-tasks = pbench-backup-tarballs, pbench-verify-backup-tarballs
+tasks = pbench-backup-tarballs, pbench-verify-backup-tarballs, pbench-audit-server
 
 ###########################################################################
 # crontab tasks
@@ -149,6 +149,9 @@ crontab = 41 4 * * *  flock -n %(lock-dir)s/pbench-backup-tarballs.lock %(script
 
 [pbench-verify-backup-tarballs]
 crontab = 59 4 * * *  flock -n %(lock-dir)s/pbench-verify-backup-tarballs.lock %(script-dir)s/pbench-verify-backup-tarballs
+
+[pbench-audit-server]
+crontab = 0 0 * * *  flock -n %(lock-dir)s/pbench-audit-server %(script-dir)s/pbench-audit-server
 
 [pbench-unpack-tarballs]
 crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs.lock %(script-dir)s/pbench-unpack-tarballs


### PR DESCRIPTION
Fixes #1281.

We add a crontab line to run pbench-audit-server at 00:00 UTC (8pm
EDT, 7pm EST). The crontab task is added to the pbench-backup crontab
role, so that any environment that enables the pbench-backup role will
run the audit.