### PR TITLE
Problems while testing v0.63 release candidate

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-14.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-14.txt
@@ -87,8 +87,6 @@ The following options are available:
 --- Finished test-14 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-14_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-14_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
@@ -102,6 +100,3 @@ The following options are available:
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
 --- test-execution.log file contents
-+++ fio_test-14_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-14_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-17.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-17.txt
@@ -87,8 +87,6 @@ The following options are available:
 --- Finished test-17 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-17_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-17_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
@@ -102,6 +100,3 @@ The following options are available:
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
 --- test-execution.log file contents
-+++ fio_test-17_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-17_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-18.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-18.txt
@@ -90,8 +90,6 @@ The following options are available:
 --- Finished test-18 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-18_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-18_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -103,6 +101,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 --- test-execution.log file contents
-+++ fio_test-18_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-18_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-19.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-19.txt
@@ -3,8 +3,6 @@ ERROR: foo must be executable
 --- Finished test-19 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-19_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-19_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -15,6 +13,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 --- pbench.log file contents
 +++ test-execution.log file contents
 --- test-execution.log file contents
-+++ fio_test-19_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-19_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-21.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-21.txt
@@ -90,8 +90,6 @@ The following options are available:
 --- Finished test-21 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-21_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-21_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -103,6 +101,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 --- test-execution.log file contents
-+++ fio_test-21_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-21_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-26.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-26.txt
@@ -90,8 +90,6 @@ The following options are available:
 --- Finished test-26 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-26_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-26_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -103,6 +101,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 --- test-execution.log file contents
-+++ fio_test-26_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-26_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-27.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-27.txt
@@ -90,8 +90,6 @@ The following options are available:
 --- Finished test-27 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-27_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-27_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -103,6 +101,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 --- test-execution.log file contents
-+++ fio_test-27_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-27_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-29.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-29.txt
@@ -90,8 +90,6 @@ The following options are available:
 --- Finished test-29 pbench-fio (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-bench/pbench-agent
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-29_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-29_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/tmp
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
@@ -103,6 +101,3 @@ grep: /var/tmp/pbench-test-bench/pbench-agent/pbench.log: No such file or direct
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --options
 --- test-execution.log file contents
-+++ fio_test-29_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- fio_test-29_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-trafficgen/test-22.txt
+++ b/agent/bench-scripts/gold/pbench-trafficgen/test-22.txt
@@ -32145,8 +32145,6 @@ Iteration 3-revunidirectional-74B-1000flows-0.0pct_drop complete (3 of 3), with 
 /var/tmp/pbench-test-bench/pbench-agent/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/mpstat
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
-/var/tmp/pbench-test-bench/pbench-agent/trafficgen_test-22_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/pbench-agent/trafficgen_test-22_1900.01.01T00.00.00/metadata.log
 /var/tmp/pbench-test-bench/pbench-agent/trex_cfg.yaml
 --- pbench tree state
 +++ pbench.log file contents
@@ -32175,6 +32173,3 @@ Iteration 3-revunidirectional-74B-1000flows-0.0pct_drop complete (3 of 3), with 
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent end
 --- test-execution.log file contents
-+++ trafficgen_test-22_1900.01.01T00.00.00/metadata.log file contents
-[pbench]
---- trafficgen_test-22_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -131,6 +131,10 @@ if [ ! -z "$cpu" ]; then
 fi
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 printf "# these results generated with:\n# %s\n\n" "$script_name $orig_cmd" >$benchmark_summary_txt_file
 printf "%20s%20s%20s%20s\n" "iteration" "min" "avg" "max" >>$benchmark_summary_txt_file
 printf "\n" >>$benchmark_summary_txt_file

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -295,6 +295,10 @@ if [ "$postprocess_only" != "y" ]; then
 fi
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 benchmark_summary_txt_file="$benchmark_run_dir/summary-result.txt"
 rm -f $benchmark_summary_txt_file
 benchmark_summary_csv_file="$benchmark_run_dir/summary-result.csv"

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -178,6 +178,10 @@ benchmark_iterations="${benchmark_run_dir}/.iterations"
 benchmark_summary_file="$benchmark_run_dir/$benchmark-summary.txt"
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 export benchmark config
 pbench-collect-sysinfo --group=$tool_group --dir=$benchmark_run_dir --sysinfo=$sysinfo beg
 pbench-metadata-log --group=$tool_group --dir=$benchmark_run_dir beg

--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -121,11 +121,14 @@ benchmark_fullname="${benchmark}_${config}_${date_suffix}"
 export benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
+benchmark_iterations="${benchmark_run_dir}/.iterations"
 
 mkdir -p ${benchmark_run_dir}/.running
 
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 iteration=1-$threads-threads
-benchmark_iterations="${benchmark_run_dir}/.iterations"
 echo $iteration >> $benchmark_iterations
 benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 result_file=$benchmark_results_dir/result.txt

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -339,6 +339,9 @@ benchmark_summary_html_file="$benchmark_run_dir/$benchmark-summary.html"
 
 mkdir -p ${benchmark_run_dir}/.running
 
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 loops=$round_trips
 if [ $loops -eq 0 ]; then
 	loops=1

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -407,6 +407,10 @@ if [ "$postprocess_only" != "y" ]; then
 fi
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 benchmark_summary_txt_file="$benchmark_run_dir/$benchmark-summary.txt"
 rm -f $benchmark_summary_txt_file
 benchmark_summary_csv_file="$benchmark_run_dir/$benchmark-summary.csv"

--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -270,6 +270,10 @@ if [ $? -ne 0 ]; then
 	exit 1
 fi
 
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
+
 pbench-register-tool-trigger --group=$tool_group --start-trigger="Timing Measurement began" --stop-trigger="Timing Measurement ended"
 
 # Collect system information before we begin, and record the beginning.

--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -42,7 +42,7 @@ trafficgen_dir="/opt/lua-trafficgen"
 traffic_generator="trex-txrx" # can be either trex-txrx or moongen-txrx
 trex_use_ht="n"
 trex_use_l2="n"
-benchmark_run_dir=""
+export benchmark_run_dir=""
 traffic_directions="bidirectional"
 max_loss_pcts="0.002"
 num_flows="1024"
@@ -884,6 +884,7 @@ else
 	fi
 	benchmark_fullname=$(basename $benchmark_run_dir)
 fi
+
 # we'll record the iterations in this file
 benchmark_iterations="${benchmark_run_dir}/.iterations"
 > ${benchmark_iterations}

--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -887,7 +887,6 @@ fi
 
 # we'll record the iterations in this file
 benchmark_iterations="${benchmark_run_dir}/.iterations"
-> ${benchmark_iterations}
 mdlog=${benchmark_run_dir}/metadata.log
 
 function record_default_iteration {
@@ -921,6 +920,10 @@ function record_profile_iteration {
 }
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 # save a copy of the command, in case the test needs to be reproduced or post-processed again
 echo "$script_name $pbench_cmd" >$benchmark_run_dir/$script_name.cmd
 chmod +x $benchmark_run_dir/$script_name.cmd

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -445,7 +445,6 @@ else
 fi
 # we'll record the iterations in this file
 benchmark_iterations="${benchmark_run_dir}/.iterations"
-> ${benchmark_iterations}
 mdlog=${benchmark_run_dir}/metadata.log
 
 function record_iteration {
@@ -466,6 +465,10 @@ function record_iteration {
 }
 
 mkdir -p $benchmark_run_dir/.running
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
+
 # save a copy of the command, in case the test needs to be reproduced or post-processed again
 echo "$script_name $pbench_cmd" >$benchmark_run_dir/$script_name.cmd
 chmod +x $benchmark_run_dir/$script_name.cmd

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -128,7 +128,7 @@ benchmark_run_dir="$pbench_run/${benchmark_fullname}"
 
 # we'll record the iterations in this file
 benchmark_iterations="${benchmark_run_dir}/.iterations"
-> ${benchmark_iterations}
+
 mdlog=${benchmark_run_dir}/metadata.log
 
 # make the run dir available to the user script
@@ -136,6 +136,9 @@ export benchmark_run_dir
 benchmark_results_dir="$benchmark_run_dir/$iteration/sample1"
 mkdir -p $benchmark_results_dir/.running
 export benchmark_results_dir=$benchmark_results_dir
+
+# now that the benchmark_run_dir directory exists, we can initialize the iterations file
+> ${benchmark_iterations}
 
 # For now, since we usually only ever run one iteration here, don't bother
 # collecting sysinfo data before and after, just do it after.

--- a/agent/bench-scripts/test-bin/mock-cmd
+++ b/agent/bench-scripts/test-bin/mock-cmd
@@ -1,3 +1,16 @@
 #!/bin/bash
 
 echo "$0 $*" >> $_testlog
+
+prog=$(basename "$0")
+args=( "$@" )
+lastidx=$((${#args[@]} - 1))
+# avoid "bad array subscript" error
+if [[ "$lastidx" -lt 0 ]] ;then
+   exit 0
+fi
+
+last=${args[$lastidx]}
+if [[ "$prog" == "pbench-metadata-log" ]] && [[ "$last" == "beg" ]];then
+    echo [pbench] > ${benchmark_run_dir}/metadata.log
+fi

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -130,10 +130,11 @@ function _dump_logs {
     _dump_file ${1} user-benchmark-summary.json
     _dump_file ${1} user-benchmark.cmd
     (
-    cd ${_testdir}/${1}
-    for f in $(find . -name results.html 2> /dev/null | sort); do
-        _dump_file ${1} ${f}
-    done
+    if cd ${_testdir}/${1} > /dev/null 2>&1 ;then
+        for f in $(find . -name results.html 2> /dev/null | sort); do
+            _dump_file ${1} ${f}
+        done
+    fi
     )
 }
 
@@ -196,14 +197,6 @@ function _setup_state {
         exit 1
     fi
     cp -a $_tdir/sample-tools/tools-default $_testdir/
-    if [[ ! -z "$1" ]] ;then
-        mkdir -p $_testdir/$1
-	if [[ $? -gt 0 ]]; then
-	    echo "ERROR: failed to create pbench result directory, \"$_testdir/$1\"" >&2
-	    exit 1
-	fi
-        echo [pbench] > $_testdir/$1/metadata.log
-    fi
     mkdir ${_testtmp}
     if [[ $? -gt 0 ]]; then
         echo "ERROR: failed to create tmp directory, \"$_testtmp\"" >&2


### PR DESCRIPTION
This PR addresses a problem in bench-scripts/unittests and associated problems. There are three commits:

 - the first commit fixes the script and modifies some gold files to accommodate those fixes. That uncovers the failures that should have been there, but were not, when PR#1261 was tested.
- the second commit fixes  pbench-uperf and pbench-user-benchmark so that the unit tests all pass.
- the third commit applies the same fix to all the other bench scripts (which have no unit test coverage).