### PR TITLE
PbenchBase.pm: add required metadata log for benchmark run name

### DIFF
--- a/agent/lib/PbenchBase.pm
+++ b/agent/lib/PbenchBase.pm
@@ -182,6 +182,11 @@ sub metadata_log_end_run {
         $iteration_names = $iteration_names . ",iteration" . $i;
     }
     $iteration_names =~ s/^,//;
+
+    my $benchmark_run_name = $benchmark_run_dir;
+    $benchmark_run_name =~ s/.*\///g;
+
+    system("echo " . $benchmark_run_name . " | pbench-add-metalog-option " . $mdlog . " pbench name");
     system("echo " . $iteration_names  . " | pbench-add-metalog-option " . $mdlog . " pbench iterations");
     system("echo " . $config  . " | pbench-add-metalog-option " . $mdlog . " pbench config");
     system("echo " . $benchmark_name  . " | pbench-add-metalog-option " . $mdlog . " pbench script");


### PR DESCRIPTION
- Without this metadata log entry you cannot use pbench-move-results
  to upload the data.