### PR TITLE
fixup iteration naming for pbench-run-benchmark

### DIFF
--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -54,6 +54,46 @@ if ($benchmark eq "list") {
 # The rest of the parameters are --arg=val, most of which we just pass to other scripts,
 my %params = get_params(@ARGV);
 
+# determine the common parameters from a group of iterations
+sub find_common_parameters {
+    my @iterations = @_;
+
+    my %common_parameters;
+    my $counter = 1;
+    for my $iteration_params (@iterations) {
+	$iteration_params =~ s/^\s+(.+)\s+$/$1/;
+
+	my @split_params = split(/\s+/, $iteration_params);
+
+	# count the number of occurences of each parameter key=value
+	# pair
+	for my $param_piece (@split_params) {
+	    if (! exists($common_parameters{$param_piece})) {
+		$common_parameters{$param_piece} = 1;
+	    } else {
+		$common_parameters{$param_piece}++;
+	    }
+	}
+
+	$counter++;
+    }
+
+    # decrement by one since we are post decrementing in the loop
+    $counter--;
+
+    for my $key (keys %common_parameters) {
+	# if the number of iterations is the same as the count for the
+	# key=value pair then the key=value pair is common across all
+	# iterations -- so remove key=value pairs where the count is
+	# not the same
+	if ($common_parameters{$key} != $counter) {
+	    delete $common_parameters{$key};
+	}
+    }
+
+    return(%common_parameters);
+}
+
 # Prepare for a post-process only mode if detected
 if (exists $params{"postprocess-only"} and $params{"postprocess-only"} eq "y") {
     $pp_only = 1;
@@ -159,6 +199,8 @@ if ($? != 0) {
     printf "%s\nCalling pbench-gen-iterations failed, exiting\n", join(" ", @param_sets);
     exit 1;
 }
+my @iteration_names;
+my %param_sets_common_params = find_common_parameters(@param_sets);
 mkdir($base_bench_dir);
 open(my $fh, ">" . $base_bench_dir . "/iteration-list.txt");
 metadata_log_begin_run($base_bench_dir, $params{"tool-group"});
@@ -204,7 +246,44 @@ while (scalar @param_sets > 0) {
         open(BULK_FH, ">bulk-sample.sh");
         print BULK_FH "#!/bin/bash\n";
     }
+
+    my %iterations_common_params = find_common_parameters(@iterations);
+
+    my @iterations_labels;
+
     for my $iteration_params (@iterations) {
+	$iteration_params =~ s/^\s+(.+)\s+$/$1/;
+
+	my @split_params = split(/\s+/, $iteration_params);
+
+	# create a label for the iteration, which becomes part of the
+	# iteration name.  the label should be comprised of the
+	# parameters that are not common across all iterations
+	my $iteration_label = "";
+	for my $param_piece (@split_params) {
+	    # if the param_piece does not exist in either of the
+	    # common parameters hashes then it should become part of
+	    # the iteration's label
+	    if (! exists($iterations_common_params{$param_piece}) ||
+		! exists($param_sets_common_params{$param_piece})) {
+		$iteration_label .= $param_piece . " ";
+	    }
+	}
+
+	# strip off the -- from each parameter, remove beginning and
+	# ending spaces, and convert spaces to underscores
+	$iteration_label =~ s/\s*--/ /g;
+	$iteration_label =~ s/\s+$//;
+	$iteration_label =~ s/^\s+//;
+	$iteration_label =~ s/\s/_/g;
+
+	push(@iterations_labels, $iteration_label);
+    }
+
+    for (my $index=0; $index<@iterations; $index++) {
+	my $iteration_params = $iterations[$index];
+	my $iteration_label = $iterations_labels[$index];
+
         chomp $iteration_params;
         if ($iteration_params =~ /^#/) {
             printf "%s\n", $param_set;
@@ -212,10 +291,11 @@ while (scalar @param_sets > 0) {
         }
         my %iter_doc = create_bench_iter_doc(\%run_doc, $iteration_params,);
         put_json_file(\%iter_doc, $es_dir . "/bench/iteration-" . $iter_doc{'iteration'}{'id'} . ".json");
-        metadata_log_record_iteration($base_bench_dir, $iteration_id, $iteration_params);
+	my $iteration_name = metadata_log_record_iteration($base_bench_dir, $iteration_id, $iteration_params, $iteration_label);
+        push(@iteration_names, $iteration_name);
         printf $fh "%d %s\n", $iteration_id, $iteration_params;
         printf "\n\n\niteration_ID: %d\niteration_params: %s\n", $iteration_id, $iteration_params;
-        my $iteration_dir = $base_bench_dir . "/iteration" . $iteration_id;
+        my $iteration_dir = $base_bench_dir . "/" . $iteration_name;
         my @sample_dirs;
         if ($pp_only) {
             opendir(my $iter_dh, $iteration_dir) || die "Can't opendir $iteration_dir: $!";
@@ -276,7 +356,7 @@ while (scalar @param_sets > 0) {
     %last_run_doc = %run_doc; # We need to keep at least 1 run doc to create the config docs later
     $run_part++;
 }
-metadata_log_end_run($base_bench_dir, $iteration_id, $benchmark, $params{'user-tags'}, $params{'tool-group'});
+metadata_log_end_run($base_bench_dir, $benchmark, $params{'user-tags'}, $params{'tool-group'}, @iteration_names);
 close $fh;
 # Generate the result.html (to go away once CDM/Elastic UI is available)
 system(". " . $pbench_install_dir . "/base; " . $pbench_install_dir .

--- a/agent/bench-scripts/postprocess/generate-benchmark-summary
+++ b/agent/bench-scripts/postprocess/generate-benchmark-summary
@@ -34,16 +34,29 @@ my %iterations_by_num;
 my %all_metric_names_by_type;
 my $iter_num = $1;
 my $iter_name = $2;
+my $iter_name_format;
 my @iterations;
 my $iteration_data_field = 'iteration_data';
 my $iteration_name_field = 'iteration_name';
 my $iteration_number_field = 'iteration_number';
+my $iteration_name_format_field = 'iteration_name_format';
 # build an array from all of the iterations 
 foreach $dir (sort @dirs) {
 	$iteration_dir = $benchmark_run_dir . "/" . $dir;
-	if ((-d $iteration_dir) && (($dir =~ /(\d+)-(.+)/) or ($dir =~ /^iteration(\d+)(.*)/))) {
+	if ((-d $iteration_dir) && (($dir =~ /(\d+)-(.+)/) or
+				    ($dir =~ /(\d+)__(.+)/) or
+				    ($dir =~ /^iteration(\d+)(.*)/))) {
 		$iter_num = $1;
 		$iter_name = $2;
+
+		if ($dir =~ /(\d+)-(.+)/) {
+		    $iter_name_format = "%d-%s";
+		} elsif ($dir =~ /(\d+)__(.+)/) {
+		    $iter_name_format = "%d__%s";
+		} elsif ($dir =~ /^iteration(\d+)(.*)/) {
+		    $iter_name_format = "iteration%d%s";
+		}
+
 		my $length;
 		# collect spacing info for output later
 		$length = get_length($iter_num);
@@ -63,7 +76,7 @@ foreach $dir (sort @dirs) {
 				}
 			close ITERATION_JSON;
 			my $perl_scalar = from_json( $json_text );
-			my %iteration = ( $iteration_number_field => int $iter_num, $iteration_name_field => $iter_name, $iteration_data_field => $perl_scalar );
+			my %iteration = ( $iteration_number_field => int $iter_num, $iteration_name_field => $iter_name, $iteration_data_field => $perl_scalar, $iteration_name_format_field => $iter_name_format );
 			push @iterations, \%iteration;
 		 } else {
 			print "could not find file $result_json_file\n";
@@ -78,6 +91,7 @@ print JSON $json_text;
 close(JSON);
 
 my $iteration_name;
+my $iteration_name_format;
 my $iteration_num;
 my $metric_name;
 my $metric_type;
@@ -397,12 +411,13 @@ printf HTML "</tr>\n";
 foreach my $iteration (sort { $a->{$iteration_number_field} <=> $b->{$iteration_number_field} } @iterations) {
 	#print Dumper \%{ $iteration };
 	$iteration_name = $iteration->{$iteration_name_field};
+	$iteration_name_format = $iteration->{$iteration_name_format_field};
 	my $cell_bgcolor;
 	$iteration_num = $iteration->{$iteration_number_field};
 	printf TXT "%$spacing{iter_num}s%$spacing{iter_name}s", $iteration_num, $iteration_name;
 	printf CSV "%s,%s,", $iteration_num, $iteration_name;
 	my $href_spacing = $spacing{iter_name} - (scalar split("", $iteration_name));
-	printf HTML "<tr><td>%s</td><td nowrap><tt>%s</tt></td>", $iteration_num, "<a href=./$iteration_num-$iteration_name>$iteration_name</a>";
+	printf HTML "<tr><td>%s</td><td nowrap><tt>%s</tt></td>", $iteration_num, sprintf("<a href=./$iteration_name_format>%s</a>", $iteration_num, $iteration_name, $iteration_name);
 	foreach $metric_type (reverse sort keys %spacing) {
 		if ( grep(/^$metric_type$/, @all_metric_types) ) {
 			my $metric_section = "";

--- a/agent/lib/PbenchBase.pm
+++ b/agent/lib/PbenchBase.pm
@@ -172,14 +172,16 @@ sub metadata_log_begin_run {
 
 sub metadata_log_end_run {
     my $benchmark_run_dir = shift;
-    my $last_iteration_num = shift;
     my $benchmark_name = shift;
     my $config = shift;
     my $group = shift;
+    my @iteration_names = @_;
+
     my $iteration_names = "";
     my $mdlog = $benchmark_run_dir . "/metadata.log";
-    for (my $i=0; $i<=$last_iteration_num; $i++) {
-        $iteration_names = $iteration_names . ",iteration" . $i;
+
+    for (my $i=0; $i<@iteration_names; $i++) {
+        $iteration_names = $iteration_names . "," . $iteration_names[$i];
     }
     $iteration_names =~ s/^,//;
     system("echo " . $iteration_names  . " | pbench-add-metalog-option " . $mdlog . " pbench iterations");
@@ -192,7 +194,10 @@ sub metadata_log_record_iteration {
     my $benchmark_run_dir = shift;
     my $num = shift;
     my $iteration_params = shift;
-    my $iteration_name = "iteration" . $num;
+    my $iteration_label = shift;
+
+    my $iteration_name = $num . "__" . $iteration_label;
+
     my $mdlog = $benchmark_run_dir . "/metadata.log";
     system("echo " . $num .      " | pbench-add-metalog-option " . $mdlog . " iterations/" . $iteration_name . " iteration_number");
     system("echo " . $iteration_name  . " | pbench-add-metalog-option " . $mdlog . " iterations/" . $iteration_name . " iteration_name");
@@ -203,5 +208,7 @@ sub metadata_log_record_iteration {
             system("echo " . $2 . " | pbench-add-metalog-option " . $mdlog . " iterations/" . $iteration_name . " " . $1);
         }
     }
+
+    return($iteration_name);
 }
 1;

--- a/agent/tool-scripts/postprocess/gold/generate-benchmark-summary-0/result.json
+++ b/agent/tool-scripts/postprocess/gold/generate-benchmark-summary-0/result.json
@@ -7442,6 +7442,7 @@
          }
       },
       "iteration_name" : "tcp_rr-64B-1i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 1
    },
    {
@@ -14891,6 +14892,7 @@
          }
       },
       "iteration_name" : "tcp_rr-64B-8i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 2
    },
    {
@@ -22520,6 +22522,7 @@
          }
       },
       "iteration_name" : "tcp_rr-16384B-1i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 3
    },
    {
@@ -30025,6 +30028,7 @@
          }
       },
       "iteration_name" : "tcp_rr-16384B-8i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 4
    },
    {
@@ -35283,6 +35287,7 @@
          }
       },
       "iteration_name" : "tcp_stream-64B-1i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 5
    },
    {
@@ -40613,6 +40618,7 @@
          }
       },
       "iteration_name" : "tcp_stream-64B-8i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 6
    },
    {
@@ -45979,6 +45985,7 @@
          }
       },
       "iteration_name" : "tcp_stream-16384B-1i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 7
    },
    {
@@ -51349,6 +51356,7 @@
          }
       },
       "iteration_name" : "tcp_stream-16384B-8i",
+      "iteration_name_format" : "%d-%s",
       "iteration_number" : 8
    }
 ]


### PR DESCRIPTION
- Give each iteration a unique name based on it's unique benchmark
  parameters.

- The unique names are picked up by generate-benchmark-summary and
  allow the iterations to be identified in the resulting summary
  reports.