### PR TITLE
update the closest samples index handling

### DIFF
--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -277,6 +277,14 @@ while (scalar @param_sets > 0) {
 	$iteration_label =~ s/^\s+//;
 	$iteration_label =~ s/\s/_/g;
 
+	# if the logic for determining a label for the iteration has
+	# yielded an empty string just use the benchmark name -- this
+	# is likely because there is a single iteration so all
+	# parameters are common
+	if (length($iteration_label) == 0) {
+	    $iteration_label = $benchmark;
+	}
+
 	push(@iterations_labels, $iteration_label);
     }
 

--- a/agent/bench-scripts/postprocess/generate-benchmark-summary
+++ b/agent/bench-scripts/postprocess/generate-benchmark-summary
@@ -436,7 +436,7 @@ foreach my $iteration (sort { $a->{$iteration_number_field} <=> $b->{$iteration_
 								my $metric_label_string;
 								$metric_label_string = sprintf "%$spacing{$metric_type}{$metric_name}[$j]{$metric_label}s", $iteration->{$iteration_data_field}{$metric_type}{$metric_name}[$j-1]{$metric_label};
 								if ( $metric_label eq get_label('closest_sample_label') ) { # embed a link to the closest sample
-									printf HTML "<td><div align=\"right\"><a href=\"./$iteration_num-$iteration_name/sample$iteration->{$iteration_data_field}{$metric_type}{$metric_name}[$j-1]{$metric_label}\">$metric_label_string</a></dev></td>";
+									printf HTML "<td><div align=\"right\"><a href=\"./$iteration_name_format/sample%d\">%s</a></dev></td>", $iteration_num, $iteration_name, $iteration->{$iteration_data_field}{$metric_type}{$metric_name}[$j-1]{$metric_label}, $metric_label_string;
 								} elsif ($metric_type and
 									 $metric_type eq 'throughput' and
 									 $metric_label eq get_label('stddevpct_label') and

--- a/agent/bench-scripts/postprocess/process-iteration-samples
+++ b/agent/bench-scripts/postprocess/process-iteration-samples
@@ -83,12 +83,13 @@ my @json_samples;
 my $nr_significant_figures = 4;
 
 sub get_avg_stddev {
+	my $samples_start_index = shift;
         my @numbers = @_;
 	my $count = scalar @numbers;
 	my $sum = 0;
 
 	if ($count == 1) {
-		return ($numbers[0]{get_label('value_label')}, 0, 0, 1);
+		return ($numbers[0]{get_label('value_label')}, 0, 0, $samples_start_index);
 	} elsif ($count == 0) {
 		return (0, 0, 0, 0);
 	} else {
@@ -109,7 +110,7 @@ sub get_avg_stddev {
 		}
 		$avg = $sum / $count;
 		
-		$index = 1;
+		$index = $samples_start_index;
 		for ($i=0; $i < scalar @numbers; $i++) {
 			$val = $numbers[$i]{get_label('value_label')};
 			$sqdiff = ($avg - $val)**2;
@@ -140,6 +141,7 @@ sub get_avg_stddev {
 	}
 }
 
+my $samples_start_index;
 my $file;
 my $dh;
 # It's possible some of the sample directories have already been archived
@@ -155,6 +157,9 @@ opendir($dh, $dir) || die "$script: could not open directory $dir: $!\n";
 foreach $file ( sort readdir($dh) ) {
 	if ($file =~ /^sample(\d+)$/) {
 		my $sample_id = $1;
+		if (!defined($samples_start_index) || ($sample_id < $samples_start_index)) {
+		    $samples_start_index = $sample_id;
+		}
 		my $sample_file = "$dir/sample$sample_id/result.json";
 		open( TXT, "<$sample_file" ) or die "Can't open $sample_file: $!";
 		my $json_text = "";
@@ -261,7 +266,7 @@ foreach my $metric_name (sort keys %iteration) {
 					($iteration{$metric_name}{$metric_type}[$i]{get_label('mean_label')},
 					 $iteration{$metric_name}{$metric_type}[$i]{get_label('stddev_label')},
 					 $iteration{$metric_name}{$metric_type}[$i]{get_label('stddevpct_label')},
-					 $iteration{$metric_name}{$metric_type}[$i]{get_label('closest_sample_label')}) = get_avg_stddev(@{$iteration{$metric_name}{$metric_type}[$i]{get_label('samples_label')}});
+					 $iteration{$metric_name}{$metric_type}[$i]{get_label('closest_sample_label')}) = get_avg_stddev($samples_start_index, @{$iteration{$metric_name}{$metric_type}[$i]{get_label('samples_label')}});
 					if ($iteration{$metric_name}{$metric_type}[$i]{get_label('role_label')} and
 						$iteration{$metric_name}{$metric_type}[$i]{get_label('role_label')} eq 'aggregate' and
 						$metric_name eq "throughput" and


### PR DESCRIPTION
- The logic that finds the closest samples index for an iteration
  needs to be updated to properly handle different indexing schemes.
  For example, the old pbench style of indexing starts at 1
  (ie. sample1) while the new pbench-run-benchmark style of indexing
  starts at 0 (ie. sample0).

- Update the hyperlinks that are generated for the HTML output from
  generate-benchmark-summary to use the $iteration_name_format to
  properly recreate the iteration name.