### PR TITLE
Reference application data via static `appName` field in `app.js`

### DIFF
--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -83,6 +83,21 @@ export default {
 }
 ```
 
+## Storage Config
+
+Pbench Dashboard stores application data using local browser storage given an application key defined in `app.js`. To deploy multiple instances of the dashboard on the same domain, change the `appName` field to a unique value for each deployment. 
+
+```JavaScript
+const appName = 'dashboard';
+
+const persistConfig = {
+  timeout: 1000,
+  key: appName,
+  storage,
+  blacklist: ['dashboard', 'search'],
+};
+```
+
 ## Build
 
 Build Application

--- a/web-server/v0.4/src/app.js
+++ b/web-server/v0.4/src/app.js
@@ -7,13 +7,13 @@ import storage from 'redux-persist/lib/storage';
  * `dashboard` and `search` are blacklisted from the saved state as the namespaces
  * persist data that is constantly updated on the server side.
  */
-const appPath = window.location.pathname.split('/').pop();
+const appName = 'dashboard';
 
 const persistConfig = {
   timeout: 1000,
-  key: appPath !== '' ? appPath : 'root',
+  key: appName,
   storage,
-  blacklist: ['dashboard', 'search'],
+  blacklist: ['dashboard', 'search', 'datastore'],
 };
 
 const persistEnhancer = () => createStore => (reducer, initialState, enhancer) => {

--- a/web-server/v0.4/src/app.js
+++ b/web-server/v0.4/src/app.js
@@ -1,18 +1,18 @@
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
 
+import { getAppPath } from './utils/utils';
+
 /*
  * redux persist configuration for saving state object to persisted storage.
  *
  * `dashboard` and `search` are blacklisted from the saved state as the namespaces
  * persist data that is constantly updated on the server side.
  */
-const pathKey = window.location.pathname.split('/')[1];
-const appPath = pathKey || 'dashboard';
 
 const persistConfig = {
   timeout: 1000,
-  key: appPath,
+  key: getAppPath(),
   storage,
   blacklist: ['dashboard', 'search', 'datastore'],
 };

--- a/web-server/v0.4/src/app.js
+++ b/web-server/v0.4/src/app.js
@@ -7,11 +7,12 @@ import storage from 'redux-persist/lib/storage';
  * `dashboard` and `search` are blacklisted from the saved state as the namespaces
  * persist data that is constantly updated on the server side.
  */
-const appName = 'dashboard';
+const pathKey = window.location.pathname.split('/')[1];
+const appPath = pathKey || 'dashboard';
 
 const persistConfig = {
   timeout: 1000,
-  key: appName,
+  key: appPath,
   storage,
   blacklist: ['dashboard', 'search', 'datastore'],
 };

--- a/web-server/v0.4/src/models/datastore.js
+++ b/web-server/v0.4/src/models/datastore.js
@@ -40,6 +40,10 @@ export default {
         type: 'getMonthIndices',
         payload: indices,
       });
+      yield put({
+        type: 'global/updateSelectedIndices',
+        payload: [indices[0]],
+      });
     },
   },
 
@@ -53,7 +57,6 @@ export default {
     getMonthIndices(state, { payload }) {
       return {
         ...state,
-        selectedIndices: [payload[0]],
         indices: payload,
       };
     },

--- a/web-server/v0.4/src/models/datastore.js
+++ b/web-server/v0.4/src/models/datastore.js
@@ -1,0 +1,61 @@
+import { queryDatastoreConfig, queryMonthIndices } from '../services/global';
+
+export default {
+  namespace: 'datastore',
+
+  state: {
+    datastoreConfig: {},
+    indices: [],
+  },
+
+  effects: {
+    *fetchDatastoreConfig({ payload }, { call, put }) {
+      const response = yield call(queryDatastoreConfig, payload);
+
+      // Remove the trailing slashes if present, we'll take care of adding
+      // them back in the proper context.
+      response.elasticsearch = response.elasticsearch.replace(/\/+$/, '');
+      response.results = response.results.replace(/\/+$/, '');
+
+      yield put({
+        type: 'getDatastoreConfig',
+        payload: response,
+      });
+    },
+    *fetchMonthIndices({ payload }, { call, put }) {
+      const response = yield call(queryMonthIndices, payload);
+      const { datastoreConfig } = payload;
+      const indices = [];
+
+      const prefix = datastoreConfig.prefix + datastoreConfig.run_index.slice(0, -1);
+      response.forEach(index => {
+        if (index.index.includes(prefix)) {
+          indices.push(index.index.split('.').pop());
+        }
+      });
+
+      indices.sort((a, b) => parseInt(b.replace('-', ''), 10) - parseInt(a.replace('-', ''), 10));
+
+      yield put({
+        type: 'getMonthIndices',
+        payload: indices,
+      });
+    },
+  },
+
+  reducers: {
+    getDatastoreConfig(state, { payload }) {
+      return {
+        ...state,
+        datastoreConfig: payload,
+      };
+    },
+    getMonthIndices(state, { payload }) {
+      return {
+        ...state,
+        selectedIndices: [payload[0]],
+        indices: payload,
+      };
+    },
+  },
+};

--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -1,12 +1,8 @@
-import { queryDatastoreConfig, queryMonthIndices } from '../services/global';
-
 export default {
   namespace: 'global',
 
   state: {
     collapsed: false,
-    datastoreConfig: {},
-    indices: [],
     selectedIndices: [],
     selectedResults: [],
     selectedControllers: [],
@@ -16,38 +12,6 @@ export default {
   },
 
   effects: {
-    *fetchDatastoreConfig({ payload }, { call, put }) {
-      const response = yield call(queryDatastoreConfig, payload);
-
-      // Remove the trailing slashes if present, we'll take care of adding
-      // them back in the proper context.
-      response.elasticsearch = response.elasticsearch.replace(/\/+$/, '');
-      response.results = response.results.replace(/\/+$/, '');
-
-      yield put({
-        type: 'getDatastoreConfig',
-        payload: response,
-      });
-    },
-    *fetchMonthIndices({ payload }, { call, put }) {
-      const response = yield call(queryMonthIndices, payload);
-      const { datastoreConfig } = payload;
-      const indices = [];
-
-      const prefix = datastoreConfig.prefix + datastoreConfig.run_index.slice(0, -1);
-      response.forEach(index => {
-        if (index.index.includes(prefix)) {
-          indices.push(index.index.split('.').pop());
-        }
-      });
-
-      indices.sort((a, b) => parseInt(b.replace('-', ''), 10) - parseInt(a.replace('-', ''), 10));
-
-      yield put({
-        type: 'getMonthIndices',
-        payload: indices,
-      });
-    },
     *updateSelectedIndices({ payload }, { put }) {
       yield put({
         type: 'modifySelectedIndices',
@@ -85,19 +49,6 @@ export default {
       return {
         ...state,
         collapsed: payload,
-      };
-    },
-    getDatastoreConfig(state, { payload }) {
-      return {
-        ...state,
-        datastoreConfig: payload,
-      };
-    },
-    getMonthIndices(state, { payload }) {
-      return {
-        ...state,
-        selectedIndices: [payload[0]],
-        indices: payload,
       };
     },
     modifySelectedIndices(state, { payload }) {

--- a/web-server/v0.4/src/pages/ComparisonSelect/index.js
+++ b/web-server/v0.4/src/pages/ComparisonSelect/index.js
@@ -9,13 +9,13 @@ import TableFilterSelection from '@/components/TableFilterSelection';
 import Button from '@/components/Button';
 import Table from '@/components/Table';
 
-@connect(({ global, dashboard, loading }) => ({
+@connect(({ datastore, global, dashboard, loading }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
   iterationPorts: dashboard.iterationPorts,
   results: dashboard.results,
   controllers: dashboard.controllers,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedIterationKeys: global.selectedIterationKeys,

--- a/web-server/v0.4/src/pages/Controllers/index.js
+++ b/web-server/v0.4/src/pages/Controllers/index.js
@@ -9,15 +9,15 @@ import SearchBar from '@/components/SearchBar';
 import MonthSelect from '@/components/MonthSelect';
 import Table from '@/components/Table';
 
-@connect(({ global, dashboard, loading }) => ({
+@connect(({ datastore, global, dashboard, loading }) => ({
   controllers: dashboard.controllers,
-  indices: global.indices,
+  indices: datastore.indices,
   selectedIndices: global.selectedIndices,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   loadingControllers:
     loading.effects['dashboard/fetchControllers'] ||
-    loading.effects['global/fetchMonthIndices'] ||
-    loading.effects['global/fetchDatastoreConfig'],
+    loading.effects['datastore/fetchMonthIndices'] ||
+    loading.effects['datastore/fetchDatastoreConfig'],
 }))
 class Controllers extends Component {
   constructor(props) {
@@ -44,7 +44,7 @@ class Controllers extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'global/fetchDatastoreConfig',
+      type: 'datastore/fetchDatastoreConfig',
     }).then(() => {
       this.fetchMonthIndices();
     });
@@ -54,7 +54,7 @@ class Controllers extends Component {
     const { dispatch, datastoreConfig } = this.props;
 
     dispatch({
-      type: 'global/fetchMonthIndices',
+      type: 'datastore/fetchMonthIndices',
       payload: { datastoreConfig },
     }).then(() => {
       this.fetchControllers();

--- a/web-server/v0.4/src/pages/Explore/index.js
+++ b/web-server/v0.4/src/pages/Explore/index.js
@@ -6,9 +6,9 @@ import { Card, Button, Popconfirm } from 'antd';
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import Table from '@/components/Table';
 
-@connect(({ global, explore, loading }) => ({
+@connect(({ datastore, explore, loading }) => ({
   sharedSessions: explore.sharedSessions,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   loadingSharedSessions: loading.effects['explore/fetchSharedSessions'],
 }))
 class Explore extends Component {
@@ -36,7 +36,7 @@ class Explore extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'global/fetchDatastoreConfig',
+      type: 'datastore/fetchDatastoreConfig',
     }).then(() => {
       this.fetchSharedSessions();
     });

--- a/web-server/v0.4/src/pages/Results/index.js
+++ b/web-server/v0.4/src/pages/Results/index.js
@@ -9,11 +9,11 @@ import RowSelection from '@/components/RowSelection';
 import Table from '@/components/Table';
 import { compareByAlph } from '../../utils/utils';
 
-@connect(({ global, dashboard, loading }) => ({
+@connect(({ datastore, global, dashboard, loading }) => ({
   selectedIndices: global.selectedIndices,
   results: dashboard.results,
   selectedControllers: global.selectedControllers,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   loading: loading.effects['dashboard/fetchResults'],
 }))
 class Results extends Component {

--- a/web-server/v0.4/src/pages/RunComparison/index.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.js
@@ -79,12 +79,12 @@ const legendColumns = [
   },
 ];
 
-@connect(({ dashboard, global }) => ({
+@connect(({ dashboard, global, datastore }) => ({
   iterationParams: dashboard.iterationParams,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedIterations: global.selectedIterations,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
 }))
 class RunComparison extends React.Component {
   constructor(props) {

--- a/web-server/v0.4/src/pages/Search/index.js
+++ b/web-server/v0.4/src/pages/Search/index.js
@@ -9,14 +9,14 @@ import RowSelection from '@/components/RowSelection';
 import MonthSelect from '@/components/MonthSelect';
 import Table from '@/components/Table';
 
-@connect(({ search, global, loading }) => ({
+@connect(({ search, global, datastore, loading }) => ({
   mapping: search.mapping,
   searchResults: search.searchResults,
   fields: search.fields,
   selectedFields: global.selectedFields,
   selectedIndices: global.selectedIndices,
-  indices: global.indices,
-  datastoreConfig: global.datastoreConfig,
+  indices: datastore.indices,
+  datastoreConfig: datastore.datastoreConfig,
   loadingMapping: loading.effects['search/fetchIndexMapping'],
   loadingSearchResults: loading.effects['search/fetchSearchResults'],
 }))
@@ -50,7 +50,7 @@ class SearchList extends Component {
     const { dispatch } = this.props;
 
     dispatch({
-      type: 'global/fetchDatastoreConfig',
+      type: 'datastore/fetchDatastoreConfig',
     }).then(() => {
       this.fetchMonthIndices();
     });
@@ -60,7 +60,7 @@ class SearchList extends Component {
     const { dispatch, datastoreConfig } = this.props;
 
     dispatch({
-      type: 'global/fetchMonthIndices',
+      type: 'datastore/fetchMonthIndices',
       payload: { datastoreConfig },
     }).then(() => {
       this.fetchIndexMapping();

--- a/web-server/v0.4/src/pages/Summary/index.js
+++ b/web-server/v0.4/src/pages/Summary/index.js
@@ -46,13 +46,13 @@ const tocColumns = [
   },
 ];
 
-@connect(({ global, dashboard, loading }) => ({
+@connect(({ global, datastore, dashboard, loading }) => ({
   iterations: dashboard.iterations,
   iterationParams: dashboard.iterationParams,
   iterationPorts: dashboard.iterationPorts,
   result: dashboard.result,
   tocResult: dashboard.tocResult,
-  datastoreConfig: global.datastoreConfig,
+  datastoreConfig: datastore.datastoreConfig,
   selectedControllers: global.selectedControllers,
   selectedResults: global.selectedResults,
   selectedIndices: global.selectedIndices,

--- a/web-server/v0.4/src/utils/utils.js
+++ b/web-server/v0.4/src/utils/utils.js
@@ -1,6 +1,12 @@
 import moment from 'moment';
 import { parse, stringify } from 'qs';
 
+export function getAppPath() {
+  const pathKey = window.location.pathname.split('/')[1];
+  const appPath = pathKey || 'dashboard';
+  return appPath;
+}
+
 export function fixedZero(val) {
   return val * 1 < 10 ? `0${val}` : val;
 }


### PR DESCRIPTION
Separates user selected data and datastore data into separate stores of
`global` and `datastore`. The `datastore` Redux model is now blacklisted
to support constant updates to server side data.