### PR TITLE
pbench-*-tools: fixup some iteration related issues

### DIFF
--- a/agent/util-scripts/gold/test-tool-trigger/test-19.txt
+++ b/agent/util-scripts/gold/test-tool-trigger/test-19.txt
@@ -42,7 +42,7 @@ baz
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --iteration=1 --group=default --dir=/tmp --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=0 --dir=/var/tmp/pbench-test-utils/pbench/0/sample1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
@@ -53,7 +53,7 @@ baz
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --iteration=1 --group=default --dir=/tmp --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] screen -dmS pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --iteration=1 --dir=/var/tmp/pbench-test-utils/pbench/1/sample1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
@@ -62,7 +62,7 @@ baz
 --- pbench.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-0 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=0 --group=default --dir=/var/tmp/pbench-test-utils/pbench/0/sample1 --interval=3
 /var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default-1 /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dmS pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --iteration=1 --group=default --dir=/var/tmp/pbench-test-utils/pbench/1/sample1 --interval=3
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-postprocess-tools
+++ b/agent/util-scripts/pbench-postprocess-tools
@@ -28,7 +28,7 @@ debug_log "[$script_name]started: $@"
 
 # Process options and arguments
 
-opts=$(getopt -q -o d:g: --longoptions "dir:,group:,iteration:" -n "getopt.sh" -- "$@");
+opts=$(getopt -q -o d:g:i: --longoptions "dir:,group:,iteration:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
 	printf "\n"
 	printf "$script_name: you specified an invalid option\n\n"
@@ -159,7 +159,7 @@ for this_tool_file in `/bin/ls $tool_group_dir`; do
 			((i++))
 		done < "$tool_group_dir/$this_tool_file"
 		name="$this_tool_file"
-		screen_name="pbench-tool-$name-$group-$iteration_num"
+		screen_name="pbench-tool-$name-$group"
 		debug_log "[$script_name] $pbench_bin/tool-scripts/$name --$action --iteration=$iteration --group=$group --dir=$dir ${tool_opts[@]}"
 		if [ "$action" == "start" ]; then 
 			# using screen to avoid tty issues and guarantee tool is backgrounded


### PR DESCRIPTION
- First, the -i option is documented but was not actually processed
  (--iteration was).

- Second, when killing the tools for a tool group the iteration number
  is not relevant so remove it from the equation.  We always want the
  tools from the specified tool group to be killed no matter what the
  current iteration is.  This also makes iteration numbering schemes
  irrelevant when killing tools.