### PR TITLE
Update README for using dashboard playbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ doc/*.html
 __pycache__
 *.swp
 unittests.log
+run-unittests.log
+dist
 *~
+????-*.patch

--- a/contrib/ansible/dashboard/README.md
+++ b/contrib/ansible/dashboard/README.md
@@ -1,15 +1,24 @@
-## Ansible playbook for pbench dashboard
-This will ease installation, using pbench dashboard.
+## Ansible playbooks for installing and deploying the pbench dashboard
+This will ease installation, and deployment of the pbench dashboard.
 
 ## Required
 - Ansible needs to be installed on the host where you want to run this playbook
-- Python
-- JSON file containing the following key values: "elasticsearch", "production", "run_index", "prefix"
+- An inventory file containing the following key values defined:
+  - "`elasticsearch`", "`production`", "`run_index`", "`prefix`", "`graphql`"
+    See the `/web-server/v0.4/README.md` for more details. 
 
 ## Run
-Running the below command from the root directory of the dashboard will install pbench dashboard, on the hosts mentioned under [servers:children] in the inventory file. 
-There's also an option to define the dashboard configuration  in the inventory file. 
+Running the below commands from this checked-out directory to install the
+pbench dashboard components locally, and then deploy hosts mentioned under
+the "`[servers:children]`" section of the given `inventory` file.
+ 
+There's also an option to define the dashboard configuration in the provided
+inventory file.
+
+See the `inventory` file in this directory for an example.
 ```
+$ # First add a link to the "dist" folder where the dashboard will be built.
+$ ln -sf ../../../web-server/v0.4/dist dist
 $ ansible-playbook -i inventory dashboard-install.yml
 $ ansible-playbook -i inventory dashboard-deploy.yml
 ```

--- a/contrib/ansible/dashboard/config.json.j2
+++ b/contrib/ansible/dashboard/config.json.j2
@@ -1,0 +1,1 @@
+../../../web-server/v0.4/config.json.j2

--- a/web-server/v0.4/config.json.j2
+++ b/web-server/v0.4/config.json.j2
@@ -1,6 +1,7 @@
 {
     "elasticsearch": "{{ elasticsearch_url }}",
     "results": "{{ results_url }}",
+    "graphql": "{{ graphql_url }}",
     "run_index": "{{ run_index }}",
     "prefix": "{{ prefix }}"
 }


### PR DESCRIPTION
We also add a convenience link to the `config.json.j2` to make it easier to use the scripts, and add an ignore the generated `dist` directories.

Further, we now ignore patch files from git format-patch, and ignore `run-unittests.log` files.