### PR TITLE
Fixes dashboard comparison of fio runs rendering incorrect metric

### DIFF
--- a/web-server/v0.4/src/pages/RunComparison/index.test.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.test.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme';
 import 'jest-canvas-mock';
 
 import RunComparison from './index';
+import { parseClusteredIterations } from '../../utils/parse';
 
 const mockProps = {
   selectedControllers: ['controller1', 'controller2'],
@@ -15,6 +16,19 @@ const mockLocation = {
     clusteredGraphData: [],
   },
 };
+
+const clusteredIterations = {};
+clusteredIterations.sample_metric = [
+  {
+    benchmark_name: 'fio',
+    'throughput-sample_metric-client_hostname:all-closestsample': 0,
+    'throughput-sample_metric-client_hostname:all-mean': 0,
+    'throughput-sample_metric-client_hostname:all-stddevpct': 0,
+  },
+];
+const clusterLabels = [];
+clusterLabels.sample_metric = ['sample-1'];
+const selectedConfig = ['benchmark-sample-1'];
 
 const mockDispatch = jest.fn();
 const wrapper = shallow(
@@ -29,5 +43,10 @@ describe('test RunComparison page component', () => {
 
   it('render multiple user selected controllers', () => {
     expect(wrapper.instance().props.selectedControllers).toEqual(['controller1', 'controller2']);
+  });
+
+  it('displays correct metric data', () => {
+    const result = parseClusteredIterations(clusteredIterations, clusterLabels, selectedConfig);
+    expect(result.tableData.sample_metric[0].primaryMetric).toEqual('sample_metric');
   });
 });

--- a/web-server/v0.4/src/utils/parse.js
+++ b/web-server/v0.4/src/utils/parse.js
@@ -303,7 +303,7 @@ export const parseClusteredIterations = (clusteredIterations, clusterLabels, sel
         clusterObject[iteration] =
           clusteredIterations[primaryMetric][cluster][iteration][
             Object.keys(clusteredIterations[primaryMetric][cluster][iteration]).find(key => {
-              if (key.includes('all') && key.includes('mean')) {
+              if (key.includes('all') && key.includes('mean') && key.includes(primaryMetric)) {
                 return key;
               }
               return false;


### PR DESCRIPTION
Fixes #1208 
Currently when a comparison of pbench-fio produced data is made using the dashboard it is labeled as using the iops_sec metric but the data that is displayed is actually from the clat metric. This fixes the data display to primary metric instead of clat metric.
