### PR TITLE
Process "base" file in pbench-run-benchmark & co. scripts

### DIFF
--- a/agent/bench-scripts/pbench-gen-iterations
+++ b/agent/bench-scripts/pbench-gen-iterations
@@ -80,13 +80,20 @@
 
 use strict;
 use warnings;
-use lib $ENV{'pbench_lib_dir'};
+use File::Basename;
+my %pbench_env;
+BEGIN {
+    chomp(my $script_path = dirname($0));
+    chomp(my $dir = `cd ${script_path}/..; /bin/pwd`);
+    foreach (grep(/^pbench\S+=/, `. $dir/base; env`)) {
+    $pbench_env{$1} = $2 if (/^pbench_(\S+)=(.+)/);
+    }
+}
+use lib $pbench_env{'lib_dir'};
 use Text::ParseWords;
 use JSON;
 use Data::Dumper;
-use PbenchBase qw(get_json_file get_benchmark_names
-                  get_pbench_bench_config_dir load_benchmark_config);
-my $pbench_bench_config_dir = get_pbench_bench_config_dir;
+use PbenchBase qw(get_json_file get_benchmark_names load_benchmark_config);
 
 # Return an array of all the valid arguments for a specific benchmark
 sub get_benchmark_args {
@@ -336,13 +343,13 @@ sub handle_iparams {
 # Check for required options for pbench-gen-iterations
 if (scalar @ARGV == 0) {
     print "You must supply at least a benchmark name:\n";
-    my @benchmarks = get_benchmark_names($pbench_bench_config_dir);
+    my @benchmarks = get_benchmark_names($pbench_env{'install_dir'} . "/config/benchmark");
     printf "%s\n",  join(" ", @benchmarks);
     exit;
 }
 my $benchmark = shift(@ARGV);
 if ($benchmark eq "list") {
-    my @benchmarks = get_benchmark_names($pbench_bench_config_dir);
+    my @benchmarks = get_benchmark_names($pbench_env{'install_dir'} . "/config/benchmark");
     printf "%s\n",  join(" ", @benchmarks);
     exit;
 }
@@ -362,8 +369,8 @@ if ($ARGV[0] eq "--defaults-only") {
 #     get transformed
 
 # This is what we need to validate against
-my %pbench_config = load_benchmark_config($pbench_bench_config_dir, "pbench");
-my %bench_config = load_benchmark_config($pbench_bench_config_dir, $benchmark);
+my %pbench_config = load_benchmark_config($pbench_env{'install_dir'} . "/config/benchmark", "pbench");
+my %bench_config = load_benchmark_config($pbench_env{'install_dir'} . "/config/benchmark", $benchmark);
 # Ensure we have some basic info from the benchmark configuration
 if (! exists $bench_config{"controller"} ) {
     print "There is no 'contoller' section in the benchmark config\n";

--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -15,14 +15,20 @@
 use strict;
 use warnings;
 use File::Basename;
-my $pbench_install_dir = $ENV{'pbench_install_dir'};
-use lib $ENV{'pbench_lib_dir'};
+my %pbench_env;
+BEGIN {
+    chomp(my $script_path = dirname($0));
+    chomp(my $dir = `cd ${script_path}/..; /bin/pwd`);
+    foreach (grep(/^pbench\S+=/, `. $dir/base; env`)) {
+    $pbench_env{$1} = $2 if (/^pbench_(\S+)=(.+)/);
+    }
+}
+use lib $pbench_env{'lib_dir'};
 use File::Path qw(remove_tree);
 use PbenchCDM        qw(create_run_doc create_config_osrelease_doc create_config_cpuinfo_doc
                         create_config_netdevs_doc create_config_ethtool_doc create_config_base_doc
                         get_uuid create_bench_iter_doc create_config_doc);
-use PbenchBase       qw(get_json_file put_json_file get_benchmark_names get_pbench_run_dir
-                        get_pbench_install_dir get_pbench_config_dir get_pbench_bench_config_dir
+use PbenchBase       qw(get_json_file put_json_file get_benchmark_names 
                         get_benchmark_results_dir get_params remove_params get_hostname
                         metadata_log_begin_run metadata_log_end_run metadata_log_record_iteration);
 use PbenchAnsible    qw(ssh_hosts ping_hosts copy_files_to_hosts copy_files_from_hosts
@@ -39,13 +45,13 @@ my $base_bench_dir = "";
 # The only required [positional] argument is the benchmark name; verify it now
 if (scalar @ARGV == 0) {
     print "You must supply at least a benchmark name:\n";
-    my @benchmarks = get_benchmark_names(get_pbench_bench_config_dir);
+    my @benchmarks = get_benchmark_names($pbench_env{'install_dir'} . "/config/benchmark");
     printf "%s\n",  join(" ", @benchmarks);
     exit;
 }
 my $benchmark = shift(@ARGV);
 if ($benchmark eq "list") {
-    my @benchmarks = get_benchmark_names(get_pbench_bench_config_dir);
+    my @benchmarks = get_benchmark_names($pbench_env{'install_dir'} . "/config/benchmark");
     printf "%s\n",  join(" ", @benchmarks);
     exit;
 }
@@ -197,7 +203,7 @@ my @iteration_names;
 my %param_sets_common_params = find_common_parameters(@param_sets);
 mkdir($base_bench_dir);
 open(my $fh, ">" . $base_bench_dir . "/iteration-list.txt");
-metadata_log_begin_run($base_bench_dir, $params{"tool-group"});
+metadata_log_begin_run($base_bench_dir, $benchmark, $params{"tool-group"});
 # There can be multiple parts of a run if the user generated multiple parameter-sets
 # (used a "--" in their cmdline).  Each part of the run has it's own run document,
 # but all of the run documents share the same run ID.
@@ -366,7 +372,7 @@ metadata_log_end_run($base_bench_dir, $benchmark, $params{'user-tags'}, $params{
 close $fh;
 if ($params{'postprocess-mode'} eq 'html') {
     # Generate the result.html (to go away once CDM/Elastic UI is available)
-    system(". " . $pbench_install_dir . "/base; " . $pbench_install_dir .
+    system(". " . $pbench_env{'install_dir'} . "/base; " . $pbench_env{'install_dir'} .
         "/bench-scripts/postprocess/generate-benchmark-summary " . $benchmark .
         " " . $benchmark . " " . $base_bench_dir);
 }

--- a/agent/bench-scripts/pbench-run-benchmark-sample
+++ b/agent/bench-scripts/pbench-run-benchmark-sample
@@ -11,18 +11,26 @@
 
 use strict;
 use warnings;
-use lib $ENV{'pbench_lib_dir'};
+use File::Basename;
+my %pbench_env;
+BEGIN {
+    chomp(my $script_path = dirname($0));
+    chomp(my $dir = `cd ${script_path}/..; /bin/pwd`);
+    foreach (grep(/^pbench\S+=/, `. $dir/base; env`)) {
+    $pbench_env{$1} = $2 if (/^pbench_(\S+)=(.+)/);
+    }
+}
+use lib $pbench_env{'lib_dir'};
 use File::Temp;
 use Data::Dumper;
 use PbenchBase       qw(get_json_file put_json_file get_benchmark_names get_clients
-                        get_params get_pbench_bench_config_dir load_benchmark_config
-                        get_pbench_install_dir );
+                        get_params load_benchmark_config );
 use PbenchAnsible    qw(ssh_hosts ping_hosts copy_files_to_hosts copy_files_from_hosts
                         remove_files_from_hosts remove_dir_from_hosts create_dir_hosts
                         sync_dir_from_hosts verify_success yum_install_hosts);
 use PbenchCDM        qw(create_bench_iter_sample_doc);
 
-my $pbench_bench_config_dir = get_pbench_bench_config_dir;
+my $pbench_bench_config_dir = $pbench_env{'install_dir'} . "/config/benchmark";
 
 # main program starts here
 
@@ -50,7 +58,7 @@ my %sample = create_bench_iter_sample_doc(\%iteration);
 my %specs = load_benchmark_config($pbench_bench_config_dir, $iteration{'run'}{'bench'}{'name'});
 
 my $output_wrapper_name = "pbench-output-monitor";
-my $local_output_wrapper_path = get_pbench_install_dir . "/util-scripts";
+my $local_output_wrapper_path = $pbench_env{'install_dir'} . "/util-scripts";
 my $remote_output_wrapper_path = "/tmp";
 
 my $sample_num = 0;


### PR DESCRIPTION
-Use a BEGIN code block to get pbench environment variables
 before loading pbench-provided perl modules
-Calls to other pbench scripts are prepended with sourcing "base"