### PR TITLE
Fix the creation of the reception area(s)

### DIFF
--- a/server/ansible/roles/pbench-server-activate-create-results-dir-structure/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-create-results-dir-structure/tasks/main.yml
@@ -44,11 +44,10 @@
 
 - name: ensure reception areas and quarantine areas are present
   file:
-    path: "{{ pbench_reception_dir }}/{{ item }}"
+    path: "{{ pbench_reception_dir_prefix }}-{{ item }}"
     owner: "{{ pbench_user }}"
     group: "{{ pbench_group }}"
     mode:  0775
     state: directory
   with_items:
-    - fs-version-001
-    - fs-version-002
+    - 002

--- a/server/ansible/roles/pbench-server-vars/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-vars/tasks/main.yml
@@ -97,10 +97,10 @@
     CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
 
 - set_fact:
-    pbench_reception_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
+    pbench_reception_dir_prefix: "{{ cmd_output.stdout_lines[0].strip() }}"
 
 - debug:
-    msg: "{{ pbench_reception_dir }}"
+    msg: "{{ pbench_reception_dir_prefix }}"
     verbosity: 1
 
 # httpd document root


### PR DESCRIPTION
Get rid of the fs-version-001 item when creating the reception areas.

The config file now provides the prefix
".../pbench-local/pbench-move-results-receive/fs-version", so we only
need to append the version number "002" with a dash in between.