### PR TITLE
Centrally log pbench-server

### DIFF
--- a/server/bin/gold/test-26.1.txt
+++ b/server/bin/gold/test-26.1.txt
@@ -1,0 +1,155 @@
++++ Running test_logger_type.py
+--- Finished test_logger_type.py (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-26.1/var-www-html)
+lrwxrwxrwx         65 incoming -> /var/tmp/pbench-test-server/test-26.1/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        120 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         64 results -> /var/tmp/pbench-test-server/test-26.1/pbench/public_html/results
+lrwxrwxrwx         63 static -> /var/tmp/pbench-test-server/test-26.1/pbench/public_html/static
+lrwxrwxrwx         62 users -> /var/tmp/pbench-test-server/test-26.1/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.1/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.1/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-26.1/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.1/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-26.1/var-www-html-satellite)
+lrwxrwxrwx         75 incoming -> /var/tmp/pbench-test-server/test-26.1/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        140 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         74 results -> /var/tmp/pbench-test-server/test-26.1/pbench-satellite/public_html/results
+lrwxrwxrwx         73 static -> /var/tmp/pbench-test-server/test-26.1/pbench-satellite/public_html/static
+lrwxrwxrwx         72 users -> /var/tmp/pbench-test-server/test-26.1/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.1/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.1/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-26.1/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.1/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-26.1/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-26.1/pbench-local)
+drwxrwxr-x          - logs
+-rw-rw-r--         34 logs/file.log
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--        365 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - logs/pbench-logger-test
+-rw-rw-r--          0 logs/pbench-logger-test/pbench-logger-test.log
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-26.1/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-26.1/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ file.log
+logger_type=file in file file.log
+----- file.log
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-audit-server/pbench-audit-server.log
++++++ pbench-logger-test/pbench-logger-test.log
+----- pbench-logger-test/pbench-logger-test.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/gold/test-26.2.txt
+++ b/server/bin/gold/test-26.2.txt
@@ -1,0 +1,150 @@
++++ Running test_logger_type.py
+--- Finished test_logger_type.py (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-26.2/var-www-html)
+lrwxrwxrwx         65 incoming -> /var/tmp/pbench-test-server/test-26.2/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        120 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         64 results -> /var/tmp/pbench-test-server/test-26.2/pbench/public_html/results
+lrwxrwxrwx         63 static -> /var/tmp/pbench-test-server/test-26.2/pbench/public_html/static
+lrwxrwxrwx         62 users -> /var/tmp/pbench-test-server/test-26.2/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.2/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.2/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-26.2/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.2/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-26.2/var-www-html-satellite)
+lrwxrwxrwx         75 incoming -> /var/tmp/pbench-test-server/test-26.2/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        140 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         74 results -> /var/tmp/pbench-test-server/test-26.2/pbench-satellite/public_html/results
+lrwxrwxrwx         73 static -> /var/tmp/pbench-test-server/test-26.2/pbench-satellite/public_html/static
+lrwxrwxrwx         72 users -> /var/tmp/pbench-test-server/test-26.2/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.2/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.2/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-26.2/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.2/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-26.2/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-26.2/pbench-local)
+drwxrwxr-x          - logs
+-rw-rw-r--         38 logs/devlog.log
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - logs/pbench-logger-test
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-26.2/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-26.2/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ devlog.log
+logger_type=devlog in file devlog.log
+----- devlog.log
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+----- pbench-audit-server/pbench-audit-server.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/gold/test-26.3.txt
+++ b/server/bin/gold/test-26.3.txt
@@ -1,0 +1,112 @@
++++ Running test_logger_type.py
+BadConfig exception was raised
+--- Finished test_logger_type.py (status=1)
++++ Running unit test audit
+pbench-audit-server: No option 'logger_host' in section: 'logging' (config file /var/tmp/pbench-test-server/test-26.3/opt/pbench-server/lib/config/pbench-server.cfg)
+--- Finished unit test audit (status=1)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-26.3/var-www-html)
+lrwxrwxrwx         65 incoming -> /var/tmp/pbench-test-server/test-26.3/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        120 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         64 results -> /var/tmp/pbench-test-server/test-26.3/pbench/public_html/results
+lrwxrwxrwx         63 static -> /var/tmp/pbench-test-server/test-26.3/pbench/public_html/static
+lrwxrwxrwx         62 users -> /var/tmp/pbench-test-server/test-26.3/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.3/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.3/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-26.3/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.3/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-26.3/var-www-html-satellite)
+lrwxrwxrwx         75 incoming -> /var/tmp/pbench-test-server/test-26.3/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        140 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         74 results -> /var/tmp/pbench-test-server/test-26.3/pbench-satellite/public_html/results
+lrwxrwxrwx         73 static -> /var/tmp/pbench-test-server/test-26.3/pbench-satellite/public_html/static
+lrwxrwxrwx         72 users -> /var/tmp/pbench-test-server/test-26.3/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.3/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.3/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-26.3/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.3/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-26.3/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-26.3/pbench-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-26.3/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-26.3/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/gold/test-26.4.txt
+++ b/server/bin/gold/test-26.4.txt
@@ -1,0 +1,150 @@
++++ Running test_logger_type.py
+--- Finished test_logger_type.py (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-26.4/var-www-html)
+lrwxrwxrwx         65 incoming -> /var/tmp/pbench-test-server/test-26.4/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        120 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         64 results -> /var/tmp/pbench-test-server/test-26.4/pbench/public_html/results
+lrwxrwxrwx         63 static -> /var/tmp/pbench-test-server/test-26.4/pbench/public_html/static
+lrwxrwxrwx         62 users -> /var/tmp/pbench-test-server/test-26.4/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.4/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.4/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-26.4/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.4/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-26.4/var-www-html-satellite)
+lrwxrwxrwx         75 incoming -> /var/tmp/pbench-test-server/test-26.4/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        140 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         74 results -> /var/tmp/pbench-test-server/test-26.4/pbench-satellite/public_html/results
+lrwxrwxrwx         73 static -> /var/tmp/pbench-test-server/test-26.4/pbench-satellite/public_html/static
+lrwxrwxrwx         72 users -> /var/tmp/pbench-test-server/test-26.4/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-26.4/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-26.4/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-26.4/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-26.4/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-26.4/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-26.4/pbench-local)
+drwxrwxr-x          - logs
+-rw-rw-r--         42 logs/hostport.log
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - logs/pbench-logger-test
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-26.4/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-26.4/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ hostport.log
+logger_type=hostport in file hostport.log
+----- hostport.log
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+----- pbench-audit-server/pbench-audit-server.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/state/config-satellite/pbench-server.cfg
+++ b/server/bin/state/config-satellite/pbench-server.cfg
@@ -22,6 +22,9 @@ debug_unittest = True
 [apache]
 documentroot = %(unittest-dir)s/var-www-html-satellite
 
+[logging]
+logger_type = file
+
 ###########################################################################
 # crontab roles
 #

--- a/server/bin/state/config/pbench-server.cfg
+++ b/server/bin/state/config/pbench-server.cfg
@@ -22,6 +22,9 @@ bulk_action_count = 2000
 [apache]
 documentroot = %(unittest-dir)s/var-www-html
 
+[logging]
+logger_type = file
+
 ###########################################################################
 # crontab roles
 [pbench-server-backup]

--- a/server/bin/state/test-23.config/pbench-server.cfg
+++ b/server/bin/state/test-23.config/pbench-server.cfg
@@ -21,6 +21,9 @@ server = elasticsearch.example.com:9280
 [apache]
 documentroot = %(unittest-dir)s/var-www-html
 
+[logging]
+logger_type = file
+
 ###########################################################################
 # crontab roles
 # The definition of the crontab role for sync'ing satellite pbench servers.

--- a/server/bin/state/test-24.config/pbench-server.cfg
+++ b/server/bin/state/test-24.config/pbench-server.cfg
@@ -4,15 +4,6 @@ install-dir = %(unittest-dir)s/opt/pbench-server
 ## Deployment section
 ###########################################################################
 [pbench-server]
-commit_id = unit-test
-environment = unit-test
-admin-email = unit-test-user@example.com
-pbench-top-dir = %(unittest-dir)s/pbench
-pbench-local-dir = %(unittest-dir)s/pbench-local
-pbench-backup-dir = %(pbench-local-dir)s/archive.backup
-# Add role for sync'ing with satellites
-roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
-debug_unittest = True
 # override the versions in pbench-config-default.cfg
 pbench-move-results-receive-versions = 002 003
 # add the shim versions
@@ -21,41 +12,8 @@ shim-version = 002
 [prep-shim-003]
 shim-version = 003
 
-[Indexing]
-server = elasticsearch.example.com:9280
-index_prefix = pbench-unittests
-bulk_action_count = 2000
-
-[apache]
-documentroot = %(unittest-dir)s/var-www-html
-
 ###########################################################################
-# crontab roles
-[pbench-server-backup]
-endpoint_url = %(unittest-dir)s/pbench-local/s3-backup
-bucket_name = testbucket
-access_key_id = ACCESS_KEY_ID
-secret_access_key = SECRET_ACCESS_KEY
-
-# The definition of the crontab role for sync'ing satellite pbench servers.
-[pbench-sync-satellites]
-host = %(default-host)s
-satellites = satellite-one
-tasks = pbench-sync
-
-# Template values for this satellite
-[satellite-one]
-# NOTE WELL: this satellite host name, pbench-satellite.example.com, is the
-# host name expected by the mock ssh command which triggers the behavior of
-# running the actual commands instead of just echoing them.
-satellite-host = pbench-satellite.example.com
-satellite-prefix = ONE
-satellite-lock = pbench-sync-satellite-%(satellite-prefix)s.lock
-satellite-archive = %(unittest-dir)s/pbench-satellite/archive/fs-version-001
-satellite-opt = %(unittest-dir)s/opt/pbench-server-satellite
-
-###########################################################################
-# The rest will come from the default config file.
+# The rest will come from the global state config file and the default config file.
 [config]
-path = %(install-dir)s/lib/config
-files = pbench-server-default.cfg
+path = %(unittest-dir)s/tmp, %(install-dir)s/lib/config
+files = state-pbench-server.cfg

--- a/server/bin/state/test-26.1.config/pbench-server.cfg
+++ b/server/bin/state/test-26.1.config/pbench-server.cfg
@@ -1,9 +1,7 @@
 install-dir = %(unittest-dir)s/opt/pbench-server
 
-###########################################################################
-# crontab roles
-[pbench-server-backup]
-bucket_name = SPECIAL_BUCKET
+[logging]
+logger_type = file
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-26.2.config/pbench-server.cfg
+++ b/server/bin/state/test-26.2.config/pbench-server.cfg
@@ -1,9 +1,7 @@
 install-dir = %(unittest-dir)s/opt/pbench-server
 
-###########################################################################
-# crontab roles
-[pbench-server-backup]
-bucket_name = SPECIAL_BUCKET
+[logging]
+logger_type = devlog
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-26.3.config/pbench-server.cfg
+++ b/server/bin/state/test-26.3.config/pbench-server.cfg
@@ -1,9 +1,7 @@
 install-dir = %(unittest-dir)s/opt/pbench-server
 
-###########################################################################
-# crontab roles
-[pbench-server-backup]
-bucket_name = SPECIAL_BUCKET
+[logging]
+logger_type = hostport
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-26.4.config/pbench-server.cfg
+++ b/server/bin/state/test-26.4.config/pbench-server.cfg
@@ -1,9 +1,9 @@
 install-dir = %(unittest-dir)s/opt/pbench-server
 
-###########################################################################
-# crontab roles
-[pbench-server-backup]
-bucket_name = SPECIAL_BUCKET
+[logging]
+logger_type = hostport
+logger_host = localhost
+logger_port = 514
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-5.1.config/pbench-server.cfg
+++ b/server/bin/state/test-5.1.config/pbench-server.cfg
@@ -9,51 +9,7 @@ host = pbench-sosreports.example.com
 dir = /path/to/sosreport/dir
 
 ###########################################################################
-## Deployment section
-###########################################################################
-[pbench-server]
-commit_id = unit-test
-environment = unit-test
-admin-email = unit-test-user@example.com
-pbench-top-dir = %(unittest-dir)s/pbench
-pbench-local-dir = %(unittest-dir)s/pbench-local
-pbench-backup-dir = %(pbench-local-dir)s/archive.backup
-# Add role for sync'ing with satellites
-roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
-debug_unittest = True
-
-[Indexing]
-server = elasticsearch.example.com:9280
-index_prefix = pbench-unittests
-bulk_action_count = 2000
-
-[pbench-server-backup]
-endpoint_url = %(unittest-dir)s/pbench-local/s3-backup
-bucket_name = testbucket
-access_key_id = ACCESS_KEY_ID
-secret_access_key = SECRET_ACCESS_KEY
-
-[apache]
-documentroot = %(unittest-dir)s/var-www-html
-
-###########################################################################
-# crontab roles
-# The definition of the crontab role for sync'ing satellite pbench servers.
-[pbench-sync-satellites]
-host = %(default-host)s
-satellites = satellite-one
-tasks = pbench-sync
-
-# Template values for this satellite
-[satellite-one]
-satellite-host = pbench-satellite.example.com
-satellite-prefix = ONE
-satellite-lock = pbench-sync-satellite-%(satellite-prefix)s.lock
-satellite-archive = %(unittest-dir)s/pbench-satellite/archive/fs-version-001
-satellite-opt = %(unittest-dir)s/opt/pbench-server-satellite
-
-###########################################################################
-# The rest will come from the default config file.
+# The rest will come from the global state config file and the default config file.
 [config]
-path = %(install-dir)s/lib/config
-files = pbench-server-default.cfg
+path = %(unittest-dir)s/tmp, %(install-dir)s/lib/config
+files = state-pbench-server.cfg

--- a/server/bin/state/test-6.13.config/pbench-server.cfg
+++ b/server/bin/state/test-6.13.config/pbench-server.cfg
@@ -28,6 +28,9 @@ bucket_name = testbucket
 access_key_id = ACCESS_KEY_ID
 secret_access_key = SECRET_ACCESS_KEY
 
+[logging]
+logger_type = file
+
 ###########################################################################
 # crontab roles
 # The definition of the crontab role for sync'ing satellite pbench servers.

--- a/server/bin/state/test-6.14.config/pbench-server.cfg
+++ b/server/bin/state/test-6.14.config/pbench-server.cfg
@@ -28,6 +28,9 @@ documentroot = %(unittest-dir)s/var-www-html
 # access_key_id = ACCESS_KEY_ID
 # secret_access_key = SECRET_ACCESS_KEY
 
+[logging]
+logger_type = file
+
 ###########################################################################
 # crontab roles
 # The definition of the crontab role for sync'ing satellite pbench servers.

--- a/server/bin/test-bin/test_logger_type.py
+++ b/server/bin/test-bin/test_logger_type.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- mode: python -*-
+
+import os, sys
+import logging
+
+from pbench import PbenchConfig, BadConfig, get_pbench_logger
+
+_NAME_ = "pbench-logger-test"
+cfg_name = os.environ["CONFIG"]
+logdir = os.environ["LOGSDIR"]
+
+log_files = {
+    "file": "file.log",
+    "devlog": "devlog.log",
+    "hostport": "hostport.log"
+    }
+
+log_msgs = {
+    "file": "logger_type=file in file file.log",
+    "devlog": "logger_type=devlog in file devlog.log",
+    "hostport": "logger_type=hostport in file hostport.log"
+}
+
+def mock_the_handler(logger, logger_type, fname):
+    
+    # Assumption: only one Handler is present.
+    hdlr = logger.logger.handlers[0]
+    logger.logger.removeHandler(hdlr)
+
+    # logger.logger is used: the first logger is used to format 
+    # the logs with the help of _styleAdapter and the second is 
+    # used to log the messages
+    fh = logging.FileHandler(os.path.join(logdir,fname))
+    fh.setLevel(logging.DEBUG)
+    logger.logger.addHandler(fh)
+    
+    return logger
+
+def test_pbench_logger():
+
+    config = PbenchConfig(cfg_name)
+    logger = get_pbench_logger(_NAME_, config)
+
+    logger_type = config.get("logging", "logger_type")
+
+    logger = mock_the_handler(logger, logger_type, log_files[logger_type])
+    logger.debug(log_msgs[logger_type])
+    
+    if os.path.isfile(os.path.join(logdir,log_files[logger_type])):
+        with open(os.path.join(logdir,log_files[logger_type]), 'r') as f:
+            assert f.read()[:-1] == log_msgs[logger_type], "Mismatch: the file did not contain the expected message."
+
+if __name__ == "__main__":
+    try:
+        test_pbench_logger()
+    except BadConfig as bd:
+        print("BadConfig exception was raised")
+        sys.exit(1)

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -49,6 +49,7 @@ function _run {
     else
         echo "+++ Running ${tname} ${@}" >> ${_testout}
     fi
+    export PYTHONPATH=${_testopt}/lib:$PYTHONPATH
     ${tname} ${@} >> ${_testout} 2>&1
     echo "--- Finished ${tname} (status=${?})" >> ${_testout}
 }
@@ -302,6 +303,7 @@ function _setup_state {
 
     # Expected location of the final configuration files
     export CONFIG=$_testopt/lib/config/pbench-server.cfg
+    export LOGSDIR=$_testdir_local/logs
     export SATCONFIG=$_testopt_sat/lib/config/pbench-server.cfg
 
     # The activate invocations are supposed to work without CONFIG being set,
@@ -314,6 +316,12 @@ function _setup_state {
     _state_config="${_tdir}/state/${1}.config/pbench-server.cfg"
     if [ ! -e ${_state_config} ]; then
         _state_config="${_tdir}/state/config/pbench-server.cfg"
+    else
+        # the testcase-specific config file includes the global state config file
+        # but under the name "state-pbench-server.cfg" to prevent conflicts. It also
+        # gets the default section below, so we have to include the install-dir line in it
+        # and delete it from the global state config file.
+        sed 1d "${_tdir}/state/config/pbench-server.cfg" > ${_testopt}/lib/config/state-pbench-server.cfg
     fi
     > ${_testtmp}/pbench-server.cfg
     printf "[DEFAULT]\n"                   >> ${_testtmp}/pbench-server.cfg
@@ -340,6 +348,12 @@ function _setup_state {
     _state_config="${_tdir}/state/${1}.config-satellite/pbench-server.cfg"
     if [ ! -e ${_state_config} ]; then
         _state_config="${_tdir}/state/config-satellite/pbench-server.cfg"
+    else
+        # the testcase-specific config file includes the global state config file
+        # but under the name "state-pbench-server.cfg" to prevent conflicts. It also
+        # gets the default section below, so we have to include the install-dir line in it
+        # and delete it from the global state config file.
+        sed 1d "${_tdir}/state/config/pbench-server.cfg" > ${_testopt}/lib/config/state-pbench-server.cfg
     fi
     > ${_testtmp}/pbench-server.cfg
     printf "[DEFAULT]\n"                   >> ${_testtmp}/pbench-server.cfg
@@ -462,8 +476,10 @@ function _reset_state {
 
     export PATH=${_orig_PATH}
     unset CONFIG
+    unset LOGSDIR
     unset SATCONFIG
 
+    rm -f ${_testopt}/lib/config/state-pbench-server.cfg
     rm -f $_testactout
     rm -f $_testlog
     rm -f $_testactlog
@@ -678,6 +694,19 @@ declare -A cmds=(
     # Tests that the behavior of the find command works as we expect to
     # ensure that buckets for pbench-unpack-tarballs work properly.
     [test-25]="_run test-find-behavior"
+
+    # Test to Log messages on File
+    [test-26.1]="_run test_logger_type.py"
+
+    # Test to Log messages on devlog
+    [test-26.2]="_run test_logger_type.py" 
+
+    # Test to check error when logger_port and logger_host are not provided with hostport
+    [test-26.3]="_run test_logger_type.py"
+
+    # Test to Log messages on hostport with logger-host and logger_port
+    [test-26.4]="_run test_logger_type.py"  
+
 )
 all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\+\)-\([0-9]\+\)/\1.\2/')
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -122,6 +122,12 @@ webserver = %(default-host)s
 host-info-path-prefix = pbench-results-host-info.versioned/pbench-results-host-info.URL
 host_info_url = http://%(webserver)s/%(host-info-path-prefix)s
 
+[logging]
+logger_type = devlog
+# hostport logger type uses UDP-based logging.
+# logger_host = localhost
+# logger_port = 514
+
 ###########################################################################
 # crontab roles
 [pbench-prep]


### PR DESCRIPTION
Fixes #310

The PR is regarding sending the logs to central server instead of using local log files.
To store the logs on Local log files FileHandler was used. I replaced the File Handler with the sysLogHandler to store logs on server.
To store logs on server rsyslog is required. It forwards log messages in an IP network with the help of configuration file in which we can define the IP network of where we want to send the data.