### PR TITLE
Fix two bugs in server ansible playbooks.

### DIFF
--- a/server/ansible/roles/pbench-server-activate-create-results-dir-structure/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-create-results-dir-structure/tasks/main.yml
@@ -50,4 +50,4 @@
     mode:  0775
     state: directory
   with_items:
-    - 002
+    - "002"

--- a/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: "set up active files"
   copy:
     dest:  "{{ httpd_document_root_dir }}/{{ pbench_host_info_prefix }}{{ item }}.active"
-    content: "{{ pbench_user}}@{{ pbench_host }}:{{ pbench_reception_dir }}-{{ item }}\n"
+    content: "{{ pbench_user}}@{{ pbench_host }}:{{ pbench_reception_dir_prefix }}-{{ item }}\n"
     owner: "{{ pbench_user }}"
     group: "{{ pbench_group }}"
     mode:  0444


### PR DESCRIPTION
Missed renaming of pbench_reception_dir_prefix in one place.
Make the version string "002" a string, otherwise it is an int
and loses the leading zeros.