### PR TITLE
Further fixes for indexing

### DIFF
--- a/server/bin/gold/test-7.0.1.txt
+++ b/server/bin/gold/test-7.0.1.txt
@@ -3049,12 +3049,18 @@ Template: pbench-unittests.v3.result-data
             "analyzer": {
                 "comma_analyzer": {
                     "tokenizer": "comma_tokenizer"
+                },
+                "path_analyzer": {
+                    "tokenizer": "path_tokenizer"
                 }
             },
             "tokenizer": {
                 "comma_tokenizer": {
                     "pattern": ",",
                     "type": "pattern"
+                },
+                "path_tokenizer": {
+                    "type": "path_hierarchy"
                 }
             }
         },
@@ -3435,10 +3441,10 @@ Template: pbench-unittests.v3.server-reports
                     "type": "string"
                 },
                 "total_chunks": {
-                    "type": "integer"
+                    "type": "long"
                 },
                 "total_size": {
-                    "type": "integer"
+                    "type": "long"
                 }
             }
         }

--- a/server/lib/mappings/server-reports.json
+++ b/server/lib/mappings/server-reports.json
@@ -49,10 +49,10 @@
                 "type": "string"
             },
             "total_chunks": {
-                "type": "integer"
+                "type": "long"
             },
             "total_size": {
-                "type": "integer"
+                "type": "long"
             }
         }
     }

--- a/server/lib/pbench/indexer.py
+++ b/server/lib/pbench/indexer.py
@@ -1001,12 +1001,11 @@ class ResultData(PbenchData):
                 self.counters['not_valid_json_file'] += 1
                 continue
 
-            # The outer results object shoul be an array of iterations. Probe
+            # The outer results object should be an array of iterations. Probe
             # to see if that is true.
             if not isinstance(results, list):
                 self.logger.warning("result-data-indexing: encountered unexpected"
                         " JSON file format, %s" % (result_json,))
-                self.counters['unexpected_json_file_format'] += 1
                 continue
 
             for iteration in results:
@@ -2784,13 +2783,17 @@ def mk_tool_data(ptb, idxctx):
         samples = get_samples(ptb, iteration)
         for sample in samples:
             for host_tools in tools_array:
-                if not host_tools['tools']:
+                try:
+                    tools_data = host_tools['tools']
+                except KeyError:
+                    # No actual tools found.
                     continue
-                tool_names = list(host_tools['tools'].keys())
+                hostname = host_tools['hostname']
+                tool_names = list(tools_data.keys())
                 tool_names.sort()
                 for tool in tool_names:
                     yield ToolData(ptb, iteration, sample,
-                            host_tools['hostname'], tool, idxctx)
+                            hostname, tool, idxctx)
     return
 
 def mk_tool_data_actions(ptb, idxctx):

--- a/server/lib/settings/result-data.json
+++ b/server/lib/settings/result-data.json
@@ -3,12 +3,18 @@
         "analyzer": {
             "comma_analyzer": {
                 "tokenizer": "comma_tokenizer"
+            },
+            "path_analyzer": {
+                "tokenizer": "path_tokenizer"
             }
         },
         "tokenizer": {
             "comma_tokenizer": {
                 "type": "pattern",
                 "pattern": ","
+            },
+            "path_tokenizer": {
+                "type": "path_hierarchy"
             }
         }
     },


### PR DESCRIPTION
Don't index result.json files that are not lists. This lets us safely
ignore user-benchmark results that create result.json files which are
not in the expected format without recording them as errors.

There are cases where tools are partially defined in a metadata.log
file, but there are no actual tools listed.  In those cases, we don't
want to issue an error, we just want to skip indexing tools for that
host.