### PR TITLE
Upgrade Prisma service to v1.34 to enable storage of large string values

### DIFF
--- a/web-server/prisma/datamodel.prisma
+++ b/web-server/prisma/datamodel.prisma
@@ -1,6 +1,7 @@
 type Url {
-  id: ID! @unique
-  createdAt: DateTime!
+  id: ID! @id
+  createdAt: DateTime! @createdAt
+  updatedAt: DateTime! @updatedAt
   config: String!
   description: String
 }

--- a/web-server/prisma/package.json
+++ b/web-server/prisma/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "prisma-client-lib": "^1.26.6"
+    "prisma-client-lib": "^1.34.8"
   }
 }


### PR DESCRIPTION
Prisma was reporting the following issue during url generation for run comparison pages: `Error: Value for field config is too long.` This error was preventing pbench dashboard from saving config data to our postgres db.

Upgrading and redeploying the Prisma service with the latest version and migrating the datamodel schema to support syntax changes as part of the version bump has resolved this error.  
