### PR TITLE
Eliminates shims option from the [pbench-prep] section of pbench-server-default.cfg

### DIFF
--- a/server/bin/gold/test-24.txt
+++ b/server/bin/gold/test-24.txt
@@ -1,0 +1,229 @@
++++ Verifying server activation
+/var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-config-activate /var/tmp/pbench-test-server/test-24/tmp/pbench-server.cfg
+/var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-activate /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/config/pbench-server.cfg
+/var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-server-config-activate /var/tmp/pbench-test-server/test-24/tmp/pbench-server.cfg
+/var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-server-activate /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/config/pbench-server.cfg
+++++ /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/crontab/crontab
+CONFIG=/var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/config/pbench-server.cfg
+MAILTO=unit-test-user@example.com
+MAILFROM=pbench@pbench.example.com
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-prep-002.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-prep-shim-002
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-prep-003.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-prep-shim-003
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-dispatch.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-dispatch
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs
+41 * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-copy-sosreports.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-copy-sosreports
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-edit-prefixes.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-edit-prefixes
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-index.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-index
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-index-tool-data.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-index --tool-data
+41 4 * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-backup-tarballs.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-backup-tarballs
+59 4 * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-verify-backup-tarballs.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-verify-backup-tarballs
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-sync-satellite-ONE.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-sync-satellite satellite-one
+---- /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/crontab/crontab
+++++ /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/crontab/crontab
+CONFIG=/var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/config/pbench-server.cfg
+MAILTO=unit-test-user@example.com
+MAILFROM=pbench@pbench-satellite.example.com
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks/pbench-prep-002.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-server-prep-shim-002
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks/pbench-dispatch.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-dispatch
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks/pbench-unpack-tarballs.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-unpack-tarballs
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks/pbench-edit-prefixes.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-edit-prefixes
+37 * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks/pbench-satellite-cleanup.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/bin/pbench-satellite-cleanup
+---- /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/crontab/crontab
+++++ test-activation-execution.log file contents
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/config
+hostname -f
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/crontab/crontab
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/pbench /var/tmp/pbench-test-server/test-24/pbench/archive/fs-version-001 /var/tmp/pbench-test-server/test-24/pbench/public_html /var/tmp/pbench-test-server/test-24/pbench/public_html/incoming /var/tmp/pbench-test-server/test-24/pbench/public_html/results /var/tmp/pbench-test-server/test-24/pbench/public_html/users /var/tmp/pbench-test-server/test-24/pbench/public_html/static
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/pbench/archive/fs-version-001/* /var/tmp/pbench-test-server/test-24/pbench/public_html/incoming/* /var/tmp/pbench-test-server/test-24/pbench/public_html/results/* /var/tmp/pbench-test-server/test-24/pbench/public_html/users/* /var/tmp/pbench-test-server/test-24/pbench/public_html/static/*
+selinuxenabled 
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench/public_html/incoming
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench/public_html/results
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench/public_html/users
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench/public_html/static
+restorecon -v /var/tmp/pbench-test-server/test-24/pbench/public_html /var/tmp/pbench-test-server/test-24/pbench/public_html/incoming /var/tmp/pbench-test-server/test-24/pbench/public_html/results /var/tmp/pbench-test-server/test-24/pbench/public_html/users /var/tmp/pbench-test-server/test-24/pbench/public_html/static
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-local/logs
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-local/tmp
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-local/pbench-move-results-receive/fs-version-002
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-local/pbench-move-results-receive/fs-version-003
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-local/quarantine
+systemctl enable httpd.service
+systemctl start httpd.service
+firewall-cmd --add-service=http
+firewall-cmd --permanent --add-service=http
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/config
+hostname -f
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/crontab/crontab
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/opt/pbench-server-satellite/lib/locks
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite /var/tmp/pbench-test-server/test-24/pbench-satellite/archive/fs-version-001 /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/incoming /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/results /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/users /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/static
+chown pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite/archive/fs-version-001/* /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/incoming/* /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/results/* /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/users/* /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/static/*
+selinuxenabled 
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/incoming
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/results
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/users
+semanage fcontext -a -t httpd_sys_content_t /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/static
+restorecon -v /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/incoming /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/results /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/users /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/static
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite-local/logs
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite-local/tmp
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+chown -R pbench.pbench /var/tmp/pbench-test-server/test-24/pbench-satellite-local/quarantine
+systemctl enable httpd.service
+systemctl start httpd.service
+firewall-cmd --add-service=http
+firewall-cmd --permanent --add-service=http
+---- test-activation-execution.log file contents
+--- Finished verifying server activation (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-24/var-www-html)
+lrwxrwxrwx         63 incoming -> /var/tmp/pbench-test-server/test-24/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        118 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL003 -> pbench-results-host-info.URL003.active
+-rw-rw-r--        118 pbench-results-host-info.versioned/pbench-results-host-info.URL003.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL003.maint
+lrwxrwxrwx         62 results -> /var/tmp/pbench-test-server/test-24/pbench/public_html/results
+lrwxrwxrwx         61 static -> /var/tmp/pbench-test-server/test-24/pbench/public_html/static
+lrwxrwxrwx         60 users -> /var/tmp/pbench-test-server/test-24/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-24/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-24/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-24/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-24/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+/var/tmp/pbench-test-server/test-24/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL003.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-24/pbench-local/pbench-move-results-receive/fs-version-003
+/var/tmp/pbench-test-server/test-24/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL003.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-24/var-www-html-satellite)
+lrwxrwxrwx         73 incoming -> /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        138 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         72 results -> /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/results
+lrwxrwxrwx         71 static -> /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/static
+lrwxrwxrwx         70 users -> /var/tmp/pbench-test-server/test-24/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-24/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-24/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-24/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-24/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-24/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-24/pbench-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--        365 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - pbench-move-results-receive/fs-version-003
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/duplicates-003
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/errors-003
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - quarantine/md5-003
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-24/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-24/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-audit-server/pbench-audit-server.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/pbench-server-activate-create-crontab
+++ b/server/bin/pbench-server-activate-create-crontab
@@ -143,11 +143,11 @@ for role in $roles ;do
             done
             ;;
         pbench-prep)
-            shims=$(getconf.py -l shims $role)
+            versions=$(getconf.py -l pbench-move-results-receive-versions pbench-server)
             tasks=$(getconf.py -l tasks $role)
-            for shim in $shims ;do
+            for version in $versions ;do
                 for task in $tasks; do
-                    crontab_with_substitutions $shim $task
+                    crontab_with_substitutions prep-shim-$version $task
                 done
             done
             ;;

--- a/server/bin/state/test-24.config/pbench-server.cfg
+++ b/server/bin/state/test-24.config/pbench-server.cfg
@@ -1,0 +1,61 @@
+install-dir = %(unittest-dir)s/opt/pbench-server
+
+###########################################################################
+## Deployment section
+###########################################################################
+[pbench-server]
+commit_id = unit-test
+environment = unit-test
+admin-email = unit-test-user@example.com
+pbench-top-dir = %(unittest-dir)s/pbench
+pbench-local-dir = %(unittest-dir)s/pbench-local
+pbench-backup-dir = %(pbench-local-dir)s/archive.backup
+# Add role for sync'ing with satellites
+roles = pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
+debug_unittest = True
+# override the versions in pbench-config-default.cfg
+pbench-move-results-receive-versions = 002 003
+# add the shim versions
+[prep-shim-002]
+shim-version = 002
+[prep-shim-003]
+shim-version = 003
+
+[Indexing]
+server = elasticsearch.example.com:9280
+index_prefix = pbench-unittests
+bulk_action_count = 2000
+
+[apache]
+documentroot = %(unittest-dir)s/var-www-html
+
+###########################################################################
+# crontab roles
+[pbench-server-backup]
+endpoint_url = %(unittest-dir)s/pbench-local/s3-backup
+bucket_name = testbucket
+access_key_id = ACCESS_KEY_ID
+secret_access_key = SECRET_ACCESS_KEY
+
+# The definition of the crontab role for sync'ing satellite pbench servers.
+[pbench-sync-satellites]
+host = %(default-host)s
+satellites = satellite-one
+tasks = pbench-sync
+
+# Template values for this satellite
+[satellite-one]
+# NOTE WELL: this satellite host name, pbench-satellite.example.com, is the
+# host name expected by the mock ssh command which triggers the behavior of
+# running the actual commands instead of just echoing them.
+satellite-host = pbench-satellite.example.com
+satellite-prefix = ONE
+satellite-lock = pbench-sync-satellite-%(satellite-prefix)s.lock
+satellite-archive = %(unittest-dir)s/pbench-satellite/archive/fs-version-001
+satellite-opt = %(unittest-dir)s/opt/pbench-server-satellite
+
+###########################################################################
+# The rest will come from the default config file.
+[config]
+path = %(install-dir)s/lib/config
+files = pbench-server-default.cfg

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -671,8 +671,11 @@ declare -A cmds=(
 
     # Uses pbench-dispatch to test report status via syslog
     [test-23]="_run pbench-dispatch"
+
+    # Tests config file that specifies two shims versions
+    [test-24]="_run_activate"
 )
-all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\)-\([0-9]\)/\1.\2/')
+all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\+\)-\([0-9]\+\)/\1.\2/')
 
 mode="serial"
 if [[ -n "$PBENCH_UNITTEST_SERVER_MODE" ]]; then

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -116,7 +116,6 @@ host_info_url = http://%(webserver)s/%(host-info-path-prefix)s
 host = %(default-host)s
 user = %(default-user)s
 mailfrom = %(user)s@%(host)s
-shims = prep-shim-002
 tasks = pbench-prep-task
 
 [prep-shim-002]


### PR DESCRIPTION
Fixes #1307 
The fix eliminates `shims` option in the `[pbench-prep]` section of `pbench-server-default.cfg` and adress the use of it in `pbench-server-activate-create-crontab` with the help of
`pbench-move-results-receive-versions` from the `[pbench-server]' section.