### PR TITLE
Enhance ansible dashboard README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ run-unittests.log
 dist
 *~
 ????-*.patch
+.npmrc
+.yarnrc

--- a/contrib/ansible/dashboard/README.md
+++ b/contrib/ansible/dashboard/README.md
@@ -4,7 +4,7 @@ This will ease installation, and deployment of the pbench dashboard.
 ## Required
 - Ansible needs to be installed on the host where you want to run this playbook
 - An inventory file containing the following key values defined:
-  - "`elasticsearch`", "`production`", "`run_index`", "`prefix`", "`graphql`"
+  - "`elasticsearch_url`", "`results_url`", "`graphql_url`", "`run_index`", "`prefix`"
     See the `/web-server/v0.4/README.md` for more details. 
 
 ## Run

--- a/contrib/ansible/dashboard/inventory
+++ b/contrib/ansible/dashboard/inventory
@@ -5,13 +5,13 @@ user-server
 [servers:vars]
 results_url="http://{{ inventory_hostname }}"
 run_index="run.example"
+graphql_url="http://{{ inventory_hostname }}"
 
 [ui-server]
 ui-server.example.com
 
 [ui-server:vars]
 elasticsearch_url="http://elasticsearch.example.com"
-results_url="http://{{ inventory_hostname }}"
 prefix="ui-server.example."
 
 [user-server]


### PR DESCRIPTION
We are updating the `README.md` for the dashboard to fix up a few incorrect references to variable names expected by the `config.json.j2` template.  We also adjust the sample `inventory` file.

Lastly, we ignore the `.yarnrc` and `.npmrc` files to avoid folks inadvertently checking them into the code base.