### PR TITLE
Don't assign "all" to timeseries array when creating aggregate

### DIFF
--- a/agent/bench-scripts/postprocess/BenchPostprocess.pm
+++ b/agent/bench-scripts/postprocess/BenchPostprocess.pm
@@ -488,6 +488,7 @@ sub calc_aggregate_metrics {
 				foreach my $label ( grep { $_ ne get_label('description_label') and
 							   $_ ne get_label('value_label') and
 							   $_ ne get_label('uid_label') and
+							   $_ ne get_label('timeseries_label') and
 							   $_ ne get_label('role_label') } (keys %{ $$workload_ref{$metric_class}{$metric_type}[0] } ) ) {
 					$agg_dataset{$label} = "all";
 				}


### PR DESCRIPTION
Fixes https://github.com/distributed-system-analysis/pbench/issues/1336

-Aggregate metrics start with a dataset with many keys being
 assigned to "all", but this should not be the case for 'timeseries',
 which is used to reference an array.