### PR TITLE
Specify the application history type to use hash history

### DIFF
--- a/web-server/v0.4/config/config.js
+++ b/web-server/v0.4/config/config.js
@@ -5,7 +5,8 @@ export default {
     'process.env': process.env.NODE_ENV,
   },
   dynamicImport: undefined,
-  base: '/dashboard',
+  base: '/dashboard/',
+  history: 'hash',
   publicPath: process.env.NODE_ENV === 'development' ? '/' : '/dashboard/',
   ignoreMomentLocale: true,
   lessLoaderOptions: {


### PR DESCRIPTION
Currently the default application history configuration against dashboard deployments produces page not found errors. Hash history will enable the storing of all path information within the hash of the URL.  