### PR TITLE
Enhance puppeteer e2e tests to use request API for intercepting requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,64 @@
-dist: xenial
-language: perl
-perl:
-  - "5.28"
-  - "5.26"
-  - "5.24"
-  - "5.22"
-  - "5.20"
-  - "5.18"
-  - "5.16"
-  - "5.10"
-before_install:
-  - sudo apt-get update
-install:
-  - sudo apt-get install python python-pip bc libjson-perl libswitch-perl realpath
-  - sudo pip install configtools elasticsearch
-  - sudo apt-get install python-software-properties
-  - sudo add-apt-repository ppa:fkrull/deadsnakes -y
-  - sudo apt-get update
-  - sudo apt-get install python3.6 --force-yes -y
-  - sudo wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
-  - sudo python3.6 /tmp/get-pip.py
-  - sudo pip install 'configtools<0.4.0' elasticsearch sh boto3
-  - sudo ln -sf python3.6 /usr/bin/python3
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - sudo echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-env:
-  - PBENCH_UNITTEST_SERVER_MODE=serial
-script:
-  - ./run-unittests
+jobs:
+  include:
+    - stage: "Unit Tests"
+      name: "Unit Tests"
+      dist: xenial
+      language: perl
+      perl:
+        - "5.28"
+        - "5.26"
+        - "5.24"
+        - "5.22"
+        - "5.20"
+        - "5.18"
+        - "5.16"
+        - "5.10"
+      before_install:
+        - sudo apt-get update
+      install:
+        - sudo apt-get install python python-pip bc libjson-perl libswitch-perl realpath
+        - sudo pip install configtools elasticsearch
+        - sudo apt-get install python-software-properties
+        - sudo add-apt-repository ppa:fkrull/deadsnakes -y
+        - sudo apt-get update
+        - sudo apt-get install python3.6 --force-yes -y
+        - sudo wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py
+        - sudo python3.6 /tmp/get-pip.py
+        - sudo pip install 'configtools<0.4.0' elasticsearch sh boto3
+        - sudo ln -sf python3.6 /usr/bin/python3
+        - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+        - sudo echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+        - sudo apt-get update -qq
+        - sudo apt-get install -y -qq yarn
+      env:
+        - PBENCH_UNITTEST_SERVER_MODE=serial
+      script: ./run-unittests
+    - stage: "E2E Tests"
+      name: "E2E Tests"
+      language: node_js
+      node_js:
+        - "12"
+      dist: trusty
+      sudo: required
+      addons:
+        chrome: stable
+        hostname: localhost
+        apt:
+          packages:
+            # This is required to run new chrome on old trusty
+            - libnss3
+      # allow headful tests
+      before_install:
+        # Enable user namespace cloning
+        - "sysctl kernel.unprivileged_userns_clone=1"
+        # Launch XVFB
+        - "export DISPLAY=:99.0"
+        - "sh -e /etc/init.d/xvfb start"
+        - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+      install:
+        - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+        - sudo echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+        - sudo apt-get update -qq
+        - sudo apt-get install -y -qq yarn
+      script: ./run-e2etests
+      

--- a/run-e2etests
+++ b/run-e2etests
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+dir=$(dirname $0)
+let sts=0
+
+function tail_and_wait {
+    pid=$1
+    name=$2
+    file=$3
+    printf -- "+++ ${name} E2E Tests +++\n\n"
+
+    tail -n 9999999 -f ${file} --pid ${pid}
+    if [[ $? -ne 0 ]]; then
+        printf -- "tail -f ${file} --pid ${pid} failed\n" >&2
+        return 1
+    fi
+    wait ${pid}
+    let tw_sts=$?
+    if [[ $tw_sts -ne 0 ]]; then
+	  status="FAILED"
+    else
+	  status="SUCCEEDED"
+    fi
+    rm -f ${file}
+
+    printf -- "\n--- ${name} E2E Tests ($status) ---\n"
+    return $tw_sts
+}
+
+trap "kill -KILL -$$ > /dev/null 2>&1" INT TERM QUIT
+
+> /var/tmp/dashboard.out
+$dir/web-server/v0.4/e2etests > /var/tmp/dashboard.out 2>&1 < /dev/null &
+dpid=$!
+
+tail_and_wait $dpid 'Dashboard' /var/tmp/dashboard.out
+let sts=sts+$?
+
+if [ $sts -gt 0 ]; then
+    echo "E2E tests FAILED"
+fi
+exit $sts

--- a/web-server/v0.4/e2etests
+++ b/web-server/v0.4/e2etests
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+cd $(dirname $0)
+cat > mock/datastoreConfig.js <<EOF
+export default {
+  '/dev/datastoreConfig': {
+    elasticsearch: 'http://test_domain.com',
+    results: 'http://test_domain.com',
+    graphql: 'http://test_domain.com',
+    prefix: 'test_prefix.',
+    run_index: 'test_index.',
+  },
+};
+EOF
+yarn --network-timeout 1000000
+if [[ $? -ne 0 ]]; then
+  echo "yarn failed!" >&2
+  exit 1
+fi
+yarn start &
+if [[ $? -ne 0 ]]; then
+  echo "yarn failed!" >&2
+  exit 1
+fi
+sleep 60
+if [[ $? -ne 0 ]]; then
+  echo "sleep failed!" >&2
+  exit 1
+fi
+yarn test:e2e
+if [[ $? -ne 0 ]]; then
+  echo "yarn e2e tests failed!" >&2
+  exit 1
+fi
+exit 0

--- a/web-server/v0.4/mock/api.js
+++ b/web-server/v0.4/mock/api.js
@@ -1,0 +1,99 @@
+import config from './datastoreConfig';
+
+export const mockControllerAggregation = {
+  aggregations: {
+    controllers: {
+      buckets: [
+        {
+          key: 'a_test_controller',
+          doc_count: 1,
+          runs_preV1: { value: null },
+          runs: { value: 1, value_as_string: '1111-11-11' },
+        },
+        {
+          key: 'b_test_controller',
+          doc_count: 2,
+          runs_preV1: { value: null },
+          runs: { value: 2, value_as_string: '2222-22-22' },
+        },
+      ],
+    },
+  },
+};
+
+const datastoreConfig = config['/dev/datastoreConfig'];
+const prefix = datastoreConfig.prefix + datastoreConfig.run_index.slice(0, -1);
+export const mockIndices = [
+  {
+    index: `${prefix}.0000-00-00`,
+  },
+  {
+    index: `${prefix}.0000-00-01`,
+  },
+];
+
+export const mockResults = {
+  hits: {
+    hits: [
+      {
+        fields: {
+          'run.name': ['a_test_run'],
+          '@metadata.controller_dir': ['test_run.test_domain.com'],
+          'run.start': ['1111-11-11T11:11:11+00:00'],
+          'run.id': ['1111'],
+          'run.end': ['1111-11-11T11:11:12+00:00'],
+          'run.controller': ['test_run.test_domain.com'],
+          'run.config': ['test_size_1'],
+        },
+      },
+      {
+        fields: {
+          'run.name': ['b_test_run'],
+          '@metadata.controller_dir': ['b_test_run.test_domain.com'],
+          'run.start': ['1111-11-11T11:11:13+00:00'],
+          'run.id': ['2222'],
+          'run.end': ['1111-11-11T11:11:14+00:00'],
+          'run.controller': ['b_test_run.test_domain.com'],
+          'run.config': ['test_size_2'],
+        },
+      },
+    ],
+  },
+};
+
+export const mockMappings = {
+  [`${prefix}.0000-00-00`]: {
+    mappings: {
+      'pbench-run': {
+        properties: {
+          run: {
+            properties: {
+              config: { type: 'string', index: 'not_analyzed' },
+              name: { type: 'string', index: 'not_analyzed' },
+              script: { type: 'string', index: 'not_analyzed' },
+              user: { type: 'string', index: 'not_analyzed' },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const mockSearch = {
+  hits: {
+    total: 1,
+    hits: [
+      {
+        _source: {
+          run: {
+            config: 'test-size-1',
+            name: 'test_run',
+            script: 'test',
+            user: 'test_user',
+          },
+        },
+      },
+    ],
+  },
+};

--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -98,8 +98,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run lint-staged",
-      "pre-push": "npm run test:e2e"
+      "pre-commit": "npm run lint-staged"
     }
   },
   "lint-staged": {

--- a/web-server/v0.4/src/e2e/results.e2e.js
+++ b/web-server/v0.4/src/e2e/results.e2e.js
@@ -1,4 +1,5 @@
 import puppeteer from 'puppeteer';
+import { mockControllerAggregation, mockIndices, mockResults } from '../../mock/api';
 
 let browser;
 let page;
@@ -9,7 +10,34 @@ beforeAll(async () => {
     args: ['--no-sandbox'],
   });
   page = await browser.newPage();
-  await page.goto('http://localhost:8000/dashboard', { waitUntil: 'networkidle2' });
+  await page.goto('http://localhost:8000/dashboard/#/');
+  await page.setRequestInterception(true);
+  page.on('request', request => {
+    if (request.method() === 'POST' && request.postData().includes('controllers')) {
+      request.respond({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify(mockControllerAggregation),
+      });
+    } else if (request.method() === 'GET' && request.url().includes('indices')) {
+      request.respond({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify(mockIndices),
+      });
+    } else if (request.method() === 'POST' && request.postData().includes('run.controller')) {
+      request.respond({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify(mockResults),
+      });
+    } else {
+      request.continue();
+    }
+  });
 });
 
 afterAll(() => {
@@ -18,41 +46,84 @@ afterAll(() => {
 
 describe('results page component', () => {
   test(
-    'should navigate to result',
+    'should load controllers',
     async done => {
-      await page.waitForResponse(response => response.status() === 200);
-      await page.waitForSelector('.ant-table-tbody', { visible: true });
       await page.waitForSelector('.ant-table-row[data-row-key]', { visible: true });
-      await page.click('.ant-table-row[data-row-key]');
+      const testController = await page.$eval('.ant-table-row', elem =>
+        elem.getAttribute('data-row-key')
+      );
+      expect(testController).toBe('a_test_controller');
       done();
     },
     30000
   );
 
+  test('should navigate to result', async () => {
+    await page.waitForSelector('.ant-table-row[data-row-key]', { visible: true });
+    await page.click('.ant-table-row[data-row-key]');
+  });
+
   test('should search for result name', async () => {
     await page.waitForSelector('.ant-table-row[data-row-key]', { visible: true });
-    const result = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
-    await page.type('.ant-input', result, { delay: 50 });
+    let testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    await page.type('.ant-input', testRun);
     await page.click('.ant-input-search-button');
-    await page.waitForSelector(`.ant-table-row[data-row-key="${result}"]`, { visible: true });
+    testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('a_test_run');
   });
 
   test('should reset search results', async () => {
-    await page.click('.ant-input-suffix');
+    await page.waitForSelector(
+      '.ant-input-wrapper > .ant-input-search > .ant-input-suffix > .anticon > svg'
+    );
+    await page.click('.ant-input-wrapper > .ant-input-search > .ant-input-suffix > .anticon > svg');
     await page.waitForSelector('.ant-table-row[data-row-key]', { visible: true });
+
+    const testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('a_test_run');
   });
 
-  test('should sort result column alphabetically', async () => {
-    await page.$eval('.ant-table-column-title', elem => elem.click());
+  test('should sort result column alphabetically ascending', async () => {
+    await page.waitForSelector(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(2) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    await page.click(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(2) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    const testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('a_test_run');
   });
 
-  test('should sort start time column chronologically', async done => {
-    await page.$$eval('.ant-table-column-title', elem => {
-      if (elem.innerText === 'Start Time') {
-        return elem.click();
-      }
-      return elem;
-    });
-    done();
+  test('should sort result column alphabetically descending', async () => {
+    await page.waitForSelector(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(2) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    await page.click(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(2) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    const testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('b_test_run');
+  });
+
+  test('should sort start time column chronologically ascending', async () => {
+    await page.waitForSelector(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(4) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    await page.click(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(4) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    const testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('a_test_run');
+  });
+
+  test('should sort start time column chronologically descending', async () => {
+    await page.waitForSelector(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(4) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    await page.click(
+      '.ant-table-thead > tr > .ant-table-column-has-actions:nth-child(4) > .ant-table-header-column > .ant-table-column-sorters'
+    );
+    const testRun = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
+    expect(testRun).toBe('b_test_run');
   });
 });

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -59,7 +59,7 @@ export default {
       const response = yield call(queryResults, payload);
       const results = [];
 
-      response.hits.hits.forEach((result, index) => {
+      response.hits.hits.forEach(result => {
         const { fields } = result;
         const name = fields['run.name'].shift();
         const controller = fields['run.controller'].shift();
@@ -74,7 +74,7 @@ export default {
             : fields['run.end_run'][0];
 
         const record = {
-          key: index,
+          key: name,
           startUnixTimestamp: Date.parse(start),
           'run.name': name,
           'run.controller': controller,

--- a/web-server/v0.4/src/pages/Controllers/index.js
+++ b/web-server/v0.4/src/pages/Controllers/index.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
 import { Card, Form } from 'antd';
-import { compareByAlph } from '../../utils/utils';
 
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import SearchBar from '@/components/SearchBar';
@@ -137,7 +136,7 @@ class Controllers extends Component {
         title: 'Controller',
         dataIndex: 'controller',
         key: 'controller',
-        sorter: (a, b) => compareByAlph(a['run.controller'], b['run.controller']),
+        sorter: (a, b) => a.key.localeCompare(b.key),
       },
       {
         title: 'Last Modified',

--- a/web-server/v0.4/src/pages/Results/index.js
+++ b/web-server/v0.4/src/pages/Results/index.js
@@ -7,7 +7,6 @@ import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import SearchBar from '@/components/SearchBar';
 import RowSelection from '@/components/RowSelection';
 import Table from '@/components/Table';
-import { compareByAlph } from '../../utils/utils';
 
 @connect(({ datastore, global, dashboard, loading }) => ({
   selectedIndices: global.selectedIndices,
@@ -134,7 +133,7 @@ class Results extends Component {
         title: 'Result',
         dataIndex: 'run.name',
         key: 'run.name',
-        sorter: (a, b) => compareByAlph(a['run.name'], b['run.name']),
+        sorter: (a, b) => a.key.localeCompare(b.key),
       },
       {
         title: 'Config',

--- a/web-server/v0.4/src/utils/utils.js
+++ b/web-server/v0.4/src/utils/utils.js
@@ -153,18 +153,6 @@ export function isUrl(path) {
   return reg.test(path);
 }
 
-export function compareByAlph(a, b) {
-  let ret;
-  if (a > b) {
-    ret = 1;
-  } else if (a < b) {
-    ret = -1;
-  } else {
-    ret = 0;
-  }
-  return ret;
-}
-
 export const renameProp = (oldProp, newProp, { [oldProp]: old, ...others }) => ({
   [newProp]: old,
   ...others,


### PR DESCRIPTION
**Summary**

In order to facilitate the automation of unit tests and e2e tests within a single environment (Travis CI), the `.travis.yml` config will execute jobs within a build matrix for both tests. The `Unit Tests` job will be executed for the pbench agent, server, and dashboard unit tests under `./unittests`. The `E2E Tests` job will be executed for the pbench dashboard e2e tests under `./e2etests`. 

Each build matrix initializes the required environment for running the type of test defined within the outer bash scripts. Each bash script invokes the respective test being executed for a specific component of the platform e.g. pbench dashboard unit tests invokes `yarn test`. 

Migration of E2E tests to Travis CI is now made possible by utilizing request intercepting made available via jest & puppeteer. `mock/api.js` provides access to fake data used for replicating views throughout pbench dashboard and allows tests to be conducted without reaching into the internal network. The pre-commit hook for executing E2E tests has been removed as part of this PR. 

Fixes #1276 

**Other Information**

- Added test cases for ascending/descending matching for table columns
- Sorter for controller and results names now references row `key` by default
- Removed `compareByAlph()` function in favor for built-in `.localeCompare()` utility function