### PR TITLE
fixed stockpile cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "agent/stockpile"]
 	path = agent/stockpile
-	url = https://github.com/redhat-performance/stockpile
+	url = https://github.com/cloud-bulldozer/stockpile


### PR DESCRIPTION
Stockpile moved to cloud-bulldozer organization.
Following https://github.com/cloud-bulldozer/stockpile/issues/59