### PR TITLE
Reference @metadata.controller_dir when querying result.json files

### DIFF
--- a/web-server/v0.4/mock/api.js
+++ b/web-server/v0.4/mock/api.js
@@ -74,6 +74,11 @@ export const mockMappings = {
               user: { type: 'string', index: 'not_analyzed' },
             },
           },
+          '@metadata': {
+            properties: {
+              controller_dir: { type: 'string', index: 'not_analyzed' },
+            },
+          },
         },
       },
     },
@@ -91,6 +96,9 @@ export const mockSearch = {
             name: 'test_run',
             script: 'test',
             user: 'test_user',
+          },
+          '@metadata': {
+            controller_dir: 'test_controller',
           },
         },
       },

--- a/web-server/v0.4/src/e2e/search.e2e.js
+++ b/web-server/v0.4/src/e2e/search.e2e.js
@@ -45,38 +45,27 @@ afterAll(() => {
 });
 
 describe('search page component', () => {
-  test(
-    'should load run mapping',
-    async done => {
-      await page.waitForSelector('.ant-table-tbody', { visible: true });
-      done();
-    },
-    30000
-  );
-
-  test('should select search filter tag', async () => {
-    await page.waitForSelector('.ant-tag', { visible: true });
-    await page.click('.ant-tag');
+  test('should load month indices', async () => {
+    await page.waitForSelector(
+      '.ant-form-item-control > .ant-form-item-children > .ant-select > .ant-select-selection > .ant-select-selection__rendered'
+    );
+    const testMonth = await page.$eval(
+      '.ant-select-selection > .ant-select-selection__rendered > ul > li.ant-select-selection__choice',
+      elem => elem.getAttribute('title')
+    );
+    expect(testMonth).toBe(mockIndices[0].index.split('.').pop());
   });
 
-  test('should reset search filter tags', async () => {
-    await page.waitForSelector('button[name="Reset"]', { visible: true });
-    await page.click('button[name="Reset"]');
+  test('should load mappings', async () => {
+    await page.waitForSelector(
+      'div.ant-col.ant-col-md-24.ant-col-lg-7 > div > div.ant-card-body > div:nth-child(2) > p:nth-child(2) > span:nth-child(1)'
+    );
+    const testField = await page.$eval(
+      'div.ant-col.ant-col-md-24.ant-col-lg-7 > div > div.ant-card-body > div:nth-child(2) > p:nth-child(2) > span:nth-child(1)',
+      elem => elem.innerHTML
+    );
+    expect(testField).toBe('config');
   });
-
-  test('should input search query', async () => {
-    await page.type('.ant-input', 'test', { delay: 50 });
-  });
-
-  test(
-    'should execute search query',
-    async () => {
-      await page.waitForSelector('.ant-input-search-button', { visible: true });
-      await page.click('.ant-input-search-button');
-      await page.waitForResponse(response => response.status() === 200);
-    },
-    30000
-  );
 
   test('should select month index', async () => {
     await page.waitForSelector('.ant-select-selection', { visible: true });
@@ -85,15 +74,40 @@ describe('search page component', () => {
     await page.click('.ant-select-dropdown-menu-item[aria-selected="false"]');
   });
 
-  test(
-    'should update search results for selected month index',
-    async done => {
-      await page.waitForSelector('button[name="Apply"]', { visible: true });
-      await page.click('button[name="Apply"]');
-      await page.waitForResponse(response => response.status() === 200);
-      await page.waitForSelector('.ant-table-tbody', { visible: true });
-      done();
-    },
-    30000
-  );
+  test('should select field tag', async () => {
+    await page.waitForSelector('.ant-tag', { visible: true });
+    await page.click('.ant-tag');
+  });
+
+  test('should apply filter changes', async () => {
+    await page.waitForSelector(
+      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn-primary'
+    );
+    await page.click(
+      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn-primary'
+    );
+  });
+
+  test('should reset filter changes', async () => {
+    await page.waitForSelector(
+      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn:nth-child(1)'
+    );
+    await page.click(
+      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn:nth-child(1)'
+    );
+  });
+
+  test('should input search query', async () => {
+    await page.type('.ant-input', 'test', { delay: 50 });
+  });
+
+  test('should execute search query', async () => {
+    await page.waitForSelector('.ant-input-search-button', { visible: true });
+    await page.click('.ant-input-search-button');
+    const testResult = await page.$eval(
+      '.ant-table-tbody > tr > td:nth-child(2)',
+      elem => elem.innerHTML
+    );
+    expect(testResult).toBe('test_run');
+  });
 });

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -37,7 +37,7 @@ export default {
       });
       yield put({
         type: 'global/modifySelectedFields',
-        payload: ['run.name', 'run.config', 'run.controller'],
+        payload: ['run.name', 'run.config', 'run.controller', '@metadata.controller_dir'],
       });
     },
     *fetchSearchResults({ payload }, { call, put }) {

--- a/web-server/v0.4/src/pages/Results/index.js
+++ b/web-server/v0.4/src/pages/Results/index.js
@@ -50,7 +50,8 @@ class Results extends Component {
     const { dispatch, results } = this.props;
     const selectedRows = [];
     selectedRowKeys.forEach(key => {
-      selectedRows.push(results[key]);
+      const selectedKey = results.find(result => result.key === key);
+      selectedRows.push(selectedKey);
     });
     this.setState({ selectedRowKeys });
 

--- a/web-server/v0.4/src/pages/Search/index.js
+++ b/web-server/v0.4/src/pages/Search/index.js
@@ -105,7 +105,7 @@ class SearchList extends Component {
 
     dispatch({
       type: 'global/updateSelectedFields',
-      payload: ['run.name', 'run.config', 'run.controller'],
+      payload: ['run.name', 'run.config', 'run.controller', '@metadata.controller_dir'],
     });
   };
 


### PR DESCRIPTION
**Summary**

Enforces the use of the `@metadata.controller_dir` field across run comparison initiation points (Result and Search views). Selecting a result row from the Result page now finds the result `key` property for building the `selectedResults` data structure within the `dashboard` Redux model. 