### PR TITLE
Adds snapshot test for Table and Button component

### DIFF
--- a/web-server/v0.4/src/components/Button/index.test.js
+++ b/web-server/v0.4/src/components/Button/index.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Button from './index';
+
+const mockProps = {
+  name: 'mockButton',
+  type: 'primary',
+  disabled: false,
+  onClick: jest.fn(),
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(<Button dispatch={mockDispatch} {...mockProps} />);
+
+describe('test rendering of Button component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/web-server/v0.4/src/components/Table/index.test.js
+++ b/web-server/v0.4/src/components/Table/index.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Table from './index';
+
+const mockProps = {
+  dataSource: [],
+  columns: [{ title: 'Controller', dataIndex: 'controller', key: 'ctrl' }],
+  loading: true,
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(<Table dispatch={mockDispatch} {...mockProps} />);
+
+describe('test rendering of Table component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
Code Coverage Report:

```
 File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line 
 components/Table  |      100 |      100 |      100 |      100 |                   |
 index.js          |      100 |      100 |      100 |      100 |                   |

```

```
 File               |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line 
 components/Button  |      100 |      100 |      100 |      100 |                   |
 index.js           |      100 |      100 |      100 |      100 |                   |

```
Coverage reports are currently retrieved in Jest by running the following command: umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand "--coverage"