### PR TITLE
Report which config file failed

### DIFF
--- a/server/bin/gold/test-0.1.txt
+++ b/server/bin/gold/test-0.1.txt
@@ -1,17 +1,17 @@
 +++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-server-prep-shim-002: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
-pbench-sync-satellite: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-sync-satellite: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
 +++ Running pbench-dispatch
-pbench-dispatch: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-dispatch: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
 +++ Running pbench-unpack-tarballs
-pbench-unpack-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-unpack-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports
-pbench-copy-sosreports: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-copy-sosreports: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-copy-sosreports (status=1)
 +++ Running pbench-index
 pbench-index: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
@@ -20,10 +20,10 @@ pbench-index: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
 pbench-index-tool-data: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
 --- Finished pbench-index (status=3)
 +++ Running pbench-clean-up-dangling-results-links
-pbench-clean-up-dangling-results-links: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-clean-up-dangling-results-links: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-clean-up-dangling-results-links (status=1)
 +++ Running pbench-edit-prefixes
-pbench-edit-prefixes: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-edit-prefixes: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-edit-prefixes (status=1)
 +++ Running pbench-backup-tarballs
 pbench-backup-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
@@ -32,10 +32,10 @@ pbench-backup-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-
 pbench-verify-backup-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
 --- Finished pbench-verify-backup-tarballs (status=1)
 +++ Running pbench-satellite-cleanup
-pbench-satellite-cleanup: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-satellite-local/logs
+pbench-satellite-cleanup: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-satellite-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server-satellite/lib/config/pbench-server.cfg)
 --- Finished pbench-satellite-cleanup (status=1)
 +++ Running unit test audit
-pbench-audit-server: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs
+pbench-audit-server: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished unit test audit (status=1)
 +++ var/www/html tree state (/var/tmp/pbench-test-server/test-0.1/var-www-html)
 lrwxrwxrwx         64 incoming -> /var/tmp/pbench-test-server/test-0.1/pbench/public_html/incoming

--- a/server/bin/gold/test-0.2.txt
+++ b/server/bin/gold/test-0.2.txt
@@ -1,17 +1,17 @@
 +++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-server-prep-shim-002: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
-pbench-sync-satellite: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-sync-satellite: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
 +++ Running pbench-dispatch
-pbench-dispatch: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-dispatch: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
 +++ Running pbench-unpack-tarballs
-pbench-unpack-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-unpack-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports
-pbench-copy-sosreports: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-copy-sosreports: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-copy-sosreports (status=1)
 +++ Running pbench-index
 pbench-index: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
@@ -20,10 +20,10 @@ pbench-index: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
 pbench-index-tool-data: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
 --- Finished pbench-index (status=3)
 +++ Running pbench-clean-up-dangling-results-links
-pbench-clean-up-dangling-results-links: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-clean-up-dangling-results-links: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-clean-up-dangling-results-links (status=1)
 +++ Running pbench-edit-prefixes
-pbench-edit-prefixes: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-edit-prefixes: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-edit-prefixes (status=1)
 +++ Running pbench-backup-tarballs
 pbench-backup-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
@@ -32,10 +32,10 @@ pbench-backup-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-loca
 pbench-verify-backup-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
 --- Finished pbench-verify-backup-tarballs (status=1)
 +++ Running pbench-satellite-cleanup
-pbench-satellite-cleanup: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-satellite-local/tmp
+pbench-satellite-cleanup: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-satellite-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server-satellite/lib/config/pbench-server.cfg)
 --- Finished pbench-satellite-cleanup (status=1)
 +++ Running unit test audit
-pbench-audit-server: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp
+pbench-audit-server: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished unit test audit (status=1)
 +++ var/www/html tree state (/var/tmp/pbench-test-server/test-0.2/var-www-html)
 lrwxrwxrwx         64 incoming -> /var/tmp/pbench-test-server/test-0.2/pbench/public_html/incoming

--- a/server/bin/gold/test-0.txt
+++ b/server/bin/gold/test-0.txt
@@ -1,17 +1,17 @@
 +++ Running pbench-server-prep-shim-002
-pbench-server-prep-shim-002: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-server-prep-shim-002: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-server-prep-shim-002 (status=1)
 +++ Running pbench-sync-satellite satellite-one
-pbench-sync-satellite: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-sync-satellite: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-sync-satellite (status=1)
 +++ Running pbench-dispatch
-pbench-dispatch: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-dispatch: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
 +++ Running pbench-unpack-tarballs
-pbench-unpack-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-unpack-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports
-pbench-copy-sosreports: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-copy-sosreports: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-copy-sosreports (status=1)
 +++ Running pbench-index
 pbench-index: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
@@ -20,10 +20,10 @@ pbench-index: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
 pbench-index-tool-data: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
 --- Finished pbench-index (status=3)
 +++ Running pbench-clean-up-dangling-results-links
-pbench-clean-up-dangling-results-links: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-clean-up-dangling-results-links: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-clean-up-dangling-results-links (status=1)
 +++ Running pbench-edit-prefixes
-pbench-edit-prefixes: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-edit-prefixes: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-edit-prefixes (status=1)
 +++ Running pbench-backup-tarballs
 pbench-backup-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
@@ -32,10 +32,10 @@ pbench-backup-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
 pbench-verify-backup-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
 --- Finished pbench-verify-backup-tarballs (status=1)
 +++ Running pbench-satellite-cleanup
-pbench-satellite-cleanup: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench-satellite
+pbench-satellite-cleanup: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench-satellite (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server-satellite/lib/config/pbench-server.cfg)
 --- Finished pbench-satellite-cleanup (status=1)
 +++ Running unit test audit
-pbench-audit-server: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench
+pbench-audit-server: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished unit test audit (status=1)
 +++ var/www/html tree state (/var/tmp/pbench-test-server/test-0/var-www-html)
 lrwxrwxrwx         62 incoming -> /var/tmp/pbench-test-server/test-0/pbench/public_html/incoming

--- a/server/bin/pbench-base.py
+++ b/server/bin/pbench-base.py
@@ -46,7 +46,7 @@ from pbench import PbenchConfig, BadConfig
 try:
     config = PbenchConfig(config_name)
 except BadConfig as e:
-    print("{}: {}".format(_prog, e), file=sys.stderr)
+    print("{}: {} (config file {})".format(_prog, e, config_name), file=sys.stderr)
     sys.exit(1)
 
 # Exclude the "files" and "conf" attributes from being exported


### PR DESCRIPTION
When reporting bad configuration file errors, add the name of the config file that failed.