### PR TITLE
Adds unit test for SiderMenuWrapper Component

### DIFF
--- a/web-server/v0.4/src/components/SiderMenu/index.test.js
+++ b/web-server/v0.4/src/components/SiderMenu/index.test.js
@@ -6,7 +6,7 @@ import SiderMenu from './SiderMenu';
 
 const mockProps = {
   isMobile: true,
-  collapsed: false,
+  collapsed: true,
 };
 
 const mockDispatch = jest.fn();
@@ -40,5 +40,16 @@ describe('test rendering of Button component', () => {
   it('test the Sider Menu functions', () => {
     wrapper.setProps({ isMobile: true });
     expect(wrapper.find(DrawerMenu).find(SiderMenu)).toHaveLength(1);
+  });
+  it('test the Sider Menu collapsing', () => {
+    wrapper.setProps({ isMobile: true });
+    expect(
+      wrapper
+        .find(DrawerMenu)
+        .find(SiderMenu)
+        .prop('collapsed')
+    ).toBe(false);
+    wrapper.setProps({ isMobile: false });
+    expect(wrapper.find(SiderMenu).prop('collapsed')).toBe(true);
   });
 });

--- a/web-server/v0.4/src/components/SiderMenu/index.test.js
+++ b/web-server/v0.4/src/components/SiderMenu/index.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import DrawerMenu from 'rc-drawer/lib';
+import SiderMenuWrapper from './index';
+import SiderMenu from './SiderMenu';
+
+const mockProps = {
+  isMobile: true,
+  collapsed: false,
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(<SiderMenuWrapper dispatch={mockDispatch} {...mockProps} />);
+
+describe('test rendering of Button component', () => {
+  it('render SiderMenu with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('mounts Drawer & Sider Menu', () => {
+    wrapper.setProps({ isMobile: false });
+    expect(wrapper.find(SiderMenu)).toHaveLength(1);
+    wrapper.setProps({ isMobile: true });
+    expect(wrapper.find(DrawerMenu)).toHaveLength(1);
+  });
+  it('test the Drawer Menu functions', () => {
+    const onCollapse = jest.fn();
+    wrapper.setProps({ isMobile: true, onCollapse });
+    wrapper
+      .find(DrawerMenu)
+      .first()
+      .props()
+      .onHandleClick();
+    wrapper
+      .find(DrawerMenu)
+      .first()
+      .props()
+      .onMaskClick();
+    expect(onCollapse).toHaveBeenCalledTimes(2);
+  });
+  it('test the Sider Menu functions', () => {
+    wrapper.setProps({ isMobile: true });
+    expect(wrapper.find(DrawerMenu).find(SiderMenu)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Fixes #1337 
Code Coverage Report:

```
 File              |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line 
  index.js         |      100 |       75 |      100 |      100 |            21

```
Coverage reports are currently retrieved in Jest by running the following command: umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand "--coverage"