### PR TITLE
Adds Unit test for RowSelection Component

### DIFF
--- a/web-server/v0.4/src/components/RowSelection/index.test.js
+++ b/web-server/v0.4/src/components/RowSelection/index.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import RowSelection from './index';
+import Button from '../Button';
+
+const mockProps = {
+  selectedItems: ['item-1', 'item-2', 'item-3'],
+  compareActionName: 'mockCompareValue',
+  style: {},
+  onCompare: jest.fn(),
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(<RowSelection dispatch={mockDispatch} {...mockProps} />, {
+  lifecycleExperimental: true,
+});
+
+describe('test rendering of RowSelection page component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('check rendering', () => {
+    expect(wrapper.find(Button).length).toEqual(1);
+  });
+  it('test interaction of Button', () => {
+    const onCompare = jest.fn();
+    wrapper.setProps({ onCompare });
+    wrapper
+      .find(Button)
+      .first()
+      .props()
+      .onClick();
+    expect(onCompare).toHaveBeenCalledTimes(1);
+  });
+  it('test item length of selection', () => {
+    expect(wrapper.find('span').length).toEqual(1);
+    expect(wrapper.find('span').text()).toEqual('Selected 3 items');
+    wrapper.setProps({ selectedItems: [] });
+    expect(wrapper.find('span').text()).toEqual('');
+  });
+});


### PR DESCRIPTION
Code Coverage Report:

```
 File                             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line 
 components/RowSelection          |      100 |      100 |      100 |      100 |                   |
 index.js                         |      100 |      100 |      100 |      100 |                   |

```
Coverage reports are currently retrieved in Jest by running the following command: umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand "--coverage"