### PR TITLE
Prevent overwriting of iteration data by referencing result index

### DIFF
--- a/web-server/v0.4/src/components/MonthSelect/index.js
+++ b/web-server/v0.4/src/components/MonthSelect/index.js
@@ -71,7 +71,7 @@ export default class MonthSelect extends PureComponent {
         {updateButtonVisible ? (
           <FormItem>
             <Button name="Update" type="primary" disabled={updateDisabled} onClick={this.reFetch}>
-              {'Update'}
+              Update
             </Button>
           </FormItem>
         ) : (

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -172,7 +172,7 @@ export default {
         },
       });
       yield put({
-        type: 'global/modifySelectedIterationKeys',
+        type: 'global/modifySelectedIterations',
         payload: parsedIterationData.selectedIterationKeys,
       });
     },

--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -7,7 +7,6 @@ export default {
     selectedResults: [],
     selectedControllers: [],
     selectedFields: [],
-    selectedIterationKeys: [],
     selectedIterations: [],
   },
 
@@ -73,12 +72,6 @@ export default {
       return {
         ...state,
         selectedFields: payload,
-      };
-    },
-    modifySelectedIterationKeys(state, { payload }) {
-      return {
-        ...state,
-        selectedIterationKeys: payload,
       };
     },
     modifySelectedIterations(state, { payload }) {

--- a/web-server/v0.4/src/pages/ComparisonSelect/index.js
+++ b/web-server/v0.4/src/pages/ComparisonSelect/index.js
@@ -63,7 +63,7 @@ class ComparisonSelect extends React.Component {
     const { selectedRows, resultIterations } = this.state;
 
     if (selectedRows.length > 0) {
-      this.compareIterations(selectedRows);
+      this.compareIterations(selectedRows.flat());
     } else {
       let selectedIterations = [];
       resultIterations.forEach(result => {
@@ -73,7 +73,9 @@ class ComparisonSelect extends React.Component {
     }
   };
 
-  onSelectChange = selectedRows => {
+  onSelectChange = (selectedIterations, result) => {
+    const { selectedRows } = this.state;
+    selectedRows[result] = selectedIterations;
     this.setState({ selectedRows });
   };
 
@@ -120,10 +122,11 @@ class ComparisonSelect extends React.Component {
               filters={iterationParams}
               ports={iterationPorts}
             />
-            {resultIterations.map(iteration => {
+            {resultIterations.map((iteration, result) => {
               const rowSelection = {
-                onSelect: (record, selected, selectedRows) => this.onSelectChange(selectedRows),
-                onSelectAll: (selected, selectedRows) => this.onSelectAll(selectedRows),
+                onSelect: (record, selected, selectedRows) =>
+                  this.onSelectChange(selectedRows, result),
+                onSelectAll: (selected, selectedRows) => this.onSelectChange(selectedRows, result),
               };
               return (
                 <div key={iteration.resultName} style={{ marginTop: 32 }}>

--- a/web-server/v0.4/src/pages/RunComparison/index.js
+++ b/web-server/v0.4/src/pages/RunComparison/index.js
@@ -345,7 +345,7 @@ class RunComparison extends React.Component {
               ))}
             </Select>
             <Button type="primary" onClick={this.resetIterationClusters} style={{ marginLeft: 8 }}>
-              {'Reset'}
+              Reset
             </Button>
           </div>
         </Description>
@@ -355,7 +355,7 @@ class RunComparison extends React.Component {
     const action = (
       <div>
         <Button type="primary" onClick={this.showExportModal}>
-          {'Export'}
+          Export
         </Button>
       </div>
     );


### PR DESCRIPTION
**Summary**

`onSelectChange()` now references the result index rendered within the `ComparisonSelect` page in order to prevent overwriting of iteration metadata. Previously, this was causing run comparison clusters to represent single iterations per cluster. 