### PR TITLE
Creates flamegraph for perf data

### DIFF
--- a/agent/tool-scripts/perf
+++ b/agent/tool-scripts/perf
@@ -136,7 +136,7 @@ tool_output_file=$tool_output_dir/$tool.txt
 case "$mode" in
 	install)
 		check_install_rpm $tool_package_name
-        	;;
+		;;
 	start)
 		if ! cat /proc/mounts | grep -q debugfs; then
 			mount -t debugfs none /sys/kernel/debug
@@ -146,7 +146,7 @@ case "$mode" in
 			error_log "$script_name: start -- unable to create directory $tool_output_dir"
 			exit 1
 		fi
-	        echo "$tool_cmd" > $tool_cmd_file
+		echo "$tool_cmd" > $tool_cmd_file
 		# call the tool and background it...
 		$tool_cmd --output=$tool_output_dir/perf.data > "$tool_output_dir/perf-stdout.txt" 2> "$tool_output_dir/perf-stderr.txt" & echo $! > "$tool_pid_file"
 		wait
@@ -191,13 +191,13 @@ case "$mode" in
 			popd > /dev/null 2>&1
 			# Generate the initial report.
 			$tool_bin $report_opts -i ${tool_output_dir}/perf.data --stdio > ${tool_output_dir}/perf-report.txt 2> ${tool_output_dir}/perf-report.err
-			xz --threads=0 ${tool_output_dir}/perf.data
-			# only postprocess the perf report if the default options are used
+			# postprocess the perf report according the options used
+			callgraph_opt=""
 			if echo $record_opts | grep -E -q -- -g\|--callgraph; then
-				debug_log "$script_name: not going to run perf postprocess script since this report contains a callgraph"
-			else
-				$script_path/postprocess/$script_name-postprocess ${tool_output_dir}
+				callgraph_opt="callgraph"
 			fi
+			$script_path/postprocess/$script_name-postprocess ${tool_output_dir}  ${callgraph_opt}
+			xz --threads=0 ${tool_output_dir}/perf.data
 			xz --threads=0 ${tool_output_dir}/perf-report.txt
 			# Provide a README file to help users work with perf data locally.
 			cp ${script_path}/${script_name}.README ${tool_output_dir}/README

--- a/agent/tool-scripts/postprocess/perf-postprocess
+++ b/agent/tool-scripts/postprocess/perf-postprocess
@@ -2,50 +2,69 @@
 
 # Author: Andrew Theurer
 #
-# usage: perf-postprocess <dir>  dir = directory where perf-report.txt can be found
+# usage: perf-postprocess <dir> [callgraph]
+#   dir = directory where perf.data and/or perf-report.txt can be found
 #
-# The purpose of this script is to generate a consolidated report per-symbol.
+# The purpose of this script is to generate a consolidated report per-symbol,
+# if not given the "callgraph" argument, and a "flame graph" SVG file if
+# "callgraph" is requested.
 
 use strict;
 use warnings;
 
 my $dir=$ARGV[0];
-my $file="perf-report.txt";
-my $pct;
-my $samples;
-my $bin;
-my $object;
-my $mode;
-my $symbol;
-my %symbol_samples;
-my $total_samples = 0;
+my $callgraph=$ARGV[1];
 
-my $line;
+if ($callgraph) {
+	my $flamegraph_pl=`rpm -qa flamegraph`;
+	my $stackcollapse_perf_pl=`rpm -qa flamegraph-stackcollapse-perf`;
 
-open(TXT, "$dir/$file") || die "could not find $dir/$file\n";
-while (my $line = <TXT>) {
-	chomp $line;
-	#    32.95%        928412         qemu-kvm  [kernel.kallsyms]             [k] _raw_spin_lock
-	#     5.50%        242887         qemu-kvm  [kernel.kallsyms]             [k] kvm_vcpu_on_spin
-	#     3.66%        261976         qemu-kvm  [kernel.kallsyms]             [k] update_cfs_rq_blocked_load
-
-	if ($line =~ /^\s*(\d+\.\d+)%\s+(\d+)\s+(\S+)\s+\[(\S+)\]\s+\[(\S+)\]\s+(\S+)/) {
-		$pct = $1;
-		$samples = $2;
-		$bin = $3;
-		$object = $4;
-		$mode = $5;
-		$symbol = $6;
-		# print "found pct: [$pct] samples: [$samples] bin: [$bin] object: [$object] mode: [$mode] symbol [$symbol]\n";
-		$symbol_samples{$symbol} += $samples;
-		$total_samples += $samples;
+	if ($flamegraph_pl && $stackcollapse_perf_pl) {
+		`perf script -i ${dir}/perf.data > ${dir}/out.perf`;
+		`stackcollapse-perf.pl ${dir}/out.perf > ${dir}/out.folded`;
+		`flamegraph.pl ${dir}/out.folded > ${dir}/flamegraph.svg`;
+		unlink( "${dir}/out.perf", "${dir}/out.folded" );
+	} else {
+		die "WARNING: FlameGraph support is not present, please check installation";
 	}
-}
-close(TXT);
+} else {
+	my $file="perf-report.txt";
+	my $pct;
+	my $samples;
+	my $bin;
+	my $object;
+	my $mode;
+	my $symbol;
+	my %symbol_samples;
+	my $total_samples = 0;
 
-$file = "perf-report-consolidated.txt";
-open(TXT, ">$dir/$file") || die "could not find $dir/$file\n";
-foreach $symbol (sort { $symbol_samples{$b} <=> $symbol_samples{$a} } keys(%symbol_samples)) {
-	printf TXT "%10d %6.2f%% %s\n", $symbol_samples{$symbol}, (100 * $symbol_samples{$symbol}/$total_samples), $symbol;
+	my $line;
+
+	open(TXT, "$dir/$file") || die "ERROR: could not find $dir/$file\n";
+	while (my $line = <TXT>) {
+		chomp $line;
+		#    32.95%        928412         qemu-kvm  [kernel.kallsyms]             [k] _raw_spin_lock
+		#     5.50%        242887         qemu-kvm  [kernel.kallsyms]             [k] kvm_vcpu_on_spin
+		#     3.66%        261976         qemu-kvm  [kernel.kallsyms]             [k] update_cfs_rq_blocked_load
+
+		if ($line =~ /^\s*(\d+\.\d+)%\s+(\d+)\s+(\S+)\s+\[(\S+)\]\s+\[(\S+)\]\s+(\S+)/) {
+			$pct = $1;
+			$samples = $2;
+			$bin = $3;
+			$object = $4;
+			$mode = $5;
+			$symbol = $6;
+			# print "found pct: [$pct] samples: [$samples] bin: [$bin] object: [$object] mode: [$mode] symbol [$symbol]\n";
+			$symbol_samples{$symbol} += $samples;
+			$total_samples += $samples;
+		}
+	}
+	close(TXT);
+
+	$file = "perf-report-consolidated.txt";
+	open(TXT, ">$dir/$file") || die "could not find $dir/$file\n";
+	foreach $symbol (sort { $symbol_samples{$b} <=> $symbol_samples{$a} } keys(%symbol_samples)) {
+		printf TXT "%10d %6.2f%% %s\n", $symbol_samples{$symbol}, (100 * $symbol_samples{$symbol}/$total_samples), $symbol;
+	}
+	close(TXT);
 }
-close(TXT);


### PR DESCRIPTION
Co-authored-by: sourabhtk37 <sourabhtk37@gmail.com>
Fixes #1297 

The fixe uses [Flamegraph](https://github.com/brendangregg/FlameGraph) an interactive SVG based visualization tool for perf data. For now, we are creating the SVG inside `agent/tool_script/perf` script and the Flamegraph generation files i.e `flamegraph.pl` and `stackcollapse-perf.pl` are also kept in the same directory. (But eventually, it would be better to create a post-process and move the files to appropriate directory _[yet to be discussed]_)
