### PR TITLE
Preserve search state to enable multi-controller search

### DIFF
--- a/web-server/v0.4/mock/api.js
+++ b/web-server/v0.4/mock/api.js
@@ -90,16 +90,13 @@ export const mockSearch = {
     total: 1,
     hits: [
       {
-        _source: {
-          run: {
-            config: 'test-size-1',
-            name: 'test_run',
-            script: 'test',
-            user: 'test_user',
-          },
-          '@metadata': {
-            controller_dir: 'test_controller',
-          },
+        _id: '1111',
+        fields: {
+          'run.config': ['test-size-1'],
+          'run.name': ['test_run'],
+          'run.script': ['test_controller'],
+          'run.user': ['test_user'],
+          '@metadata.controller_dir': ['test_controller'],
         },
       },
     ],

--- a/web-server/v0.4/src/components/MonthSelect/index.js
+++ b/web-server/v0.4/src/components/MonthSelect/index.js
@@ -54,7 +54,7 @@ export default class MonthSelect extends PureComponent {
 
     return (
       <div>
-        <FormItem label="Selected Months" colon={false} style={{ fontWeight: '500' }}>
+        <FormItem>
           <Select
             mode="multiple"
             style={{ width: '100%' }}

--- a/web-server/v0.4/src/e2e/search.e2e.js
+++ b/web-server/v0.4/src/e2e/search.e2e.js
@@ -46,55 +46,61 @@ afterAll(() => {
 
 describe('search page component', () => {
   test('should load month indices', async () => {
-    await page.waitForSelector(
-      '.ant-form-item-control > .ant-form-item-children > .ant-select > .ant-select-selection > .ant-select-selection__rendered'
-    );
+    await page.waitForSelector('.ant-select:nth-child(1) > .ant-select-selection');
     const testMonth = await page.$eval(
-      '.ant-select-selection > .ant-select-selection__rendered > ul > li.ant-select-selection__choice',
+      '.ant-select:nth-child(1) > .ant-select-selection > .ant-select-selection__rendered > ul > .ant-select-selection__choice',
       elem => elem.getAttribute('title')
     );
     expect(testMonth).toBe(mockIndices[0].index.split('.').pop());
   });
 
   test('should load mappings', async () => {
-    await page.waitForSelector(
-      'div.ant-col.ant-col-md-24.ant-col-lg-7 > div > div.ant-card-body > div:nth-child(2) > p:nth-child(2) > span:nth-child(1)'
-    );
+    await page.waitForSelector('.ant-select:nth-child(2) > .ant-select-selection');
     const testField = await page.$eval(
-      'div.ant-col.ant-col-md-24.ant-col-lg-7 > div > div.ant-card-body > div:nth-child(2) > p:nth-child(2) > span:nth-child(1)',
-      elem => elem.innerHTML
+      '.ant-select:nth-child(2) > .ant-select-selection > .ant-select-selection__rendered > ul > .ant-select-selection__choice',
+      elem => elem.getAttribute('title')
     );
-    expect(testField).toBe('config');
+    expect(testField).toBe('run.name');
   });
 
   test('should select month index', async () => {
-    await page.waitForSelector('.ant-select-selection', { visible: true });
-    await page.click('.ant-select-selection');
+    await page.waitForSelector('.ant-select:nth-child(1) > .ant-select-selection', {
+      visible: true,
+    });
+    await page.click('.ant-select:nth-child(1) > .ant-select-selection');
     await page.click('.ant-select-dropdown-menu-item');
     await page.click('.ant-select-dropdown-menu-item[aria-selected="false"]');
   });
 
   test('should select field tag', async () => {
-    await page.waitForSelector('.ant-tag', { visible: true });
-    await page.click('.ant-tag');
+    await page.waitForSelector('.ant-select:nth-child(2) > .ant-select-selection', {
+      visible: true,
+    });
+    await page.click('.ant-select:nth-child(2) > .ant-select-selection');
+    await page.waitForSelector(
+      '.ant-select-dropdown-menu > .ant-select-dropdown-menu-item-active',
+      {
+        visible: true,
+      }
+    );
+    await page.click('.ant-select-dropdown-menu > .ant-select-dropdown-menu-item-active');
+    await page.click(
+      '.ant-select-dropdown-menu > .ant-select-dropdown-menu-item-active[aria-selected="false"]'
+    );
   });
 
   test('should apply filter changes', async () => {
     await page.waitForSelector(
-      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn-primary'
+      '.ant-spin-container > .ant-form > .ant-row > div > .ant-btn-primary'
     );
-    await page.click(
-      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn-primary'
-    );
+    await page.click('.ant-spin-container > .ant-form > .ant-row > div > .ant-btn-primary');
   });
 
   test('should reset filter changes', async () => {
     await page.waitForSelector(
-      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn:nth-child(1)'
+      '.ant-spin-container > .ant-form > .ant-row > div > .ant-btn-secondary'
     );
-    await page.click(
-      '.ant-card-head > .ant-card-head-wrapper > .ant-card-extra > div > .ant-btn:nth-child(1)'
-    );
+    await page.click('.ant-spin-container > .ant-form > .ant-row > div > .ant-btn-secondary');
   });
 
   test('should input search query', async () => {

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -52,14 +52,14 @@ export default {
         const parsedResult = {};
 
         selectedFields.forEach(field => {
-          parsedResult[field] = result._source[field.split('.')[0]][field.split('.')[1]];
+          if (typeof result.fields[field] !== 'undefined') {
+            const fieldValue = result.fields[field][0];
+            parsedResult[field] = fieldValue;
+          }
         });
 
-        if (typeof result._source.run.prefix !== 'undefined') {
-          parsedResult['run.prefix'] = result._source.run.prefix;
-        }
-        if (typeof result._source.run.id !== 'undefined') {
-          parsedResult.key = result._source.run.id;
+        if (typeof result._id !== 'undefined') {
+          parsedResult.key = result._id;
         }
 
         parsedResults.push(parsedResult);

--- a/web-server/v0.4/src/services/search.js
+++ b/web-server/v0.4/src/services/search.js
@@ -19,25 +19,29 @@ export async function searchQuery(params) {
   });
 
   const endpoint = `${datastoreConfig.elasticsearch}/${indices}/_search`;
-  let queryEndpoint = '_type:pbench-run AND (';
-
-  selectedFields.forEach((field, i) => {
-    if (i < selectedFields.length - 1) {
-      queryEndpoint = queryEndpoint.concat(`${field}:*${query}* OR `);
-    } else {
-      queryEndpoint = queryEndpoint.concat(`${field}:*${query}*)`);
-    }
-  });
 
   return request.post(endpoint, {
     data: {
+      size: 10000,
+      sort: [
+        {
+          '@timestamp': {
+            order: 'desc',
+            unmapped_type: 'boolean',
+          },
+        },
+      ],
       query: {
-        query_string: {
-          analyze_wildcard: true,
-          query: queryEndpoint,
+        filtered: {
+          query: {
+            query_string: {
+              query: `*${query}*`,
+              analyze_wildcard: true,
+            },
+          },
         },
       },
-      size: 1000,
+      fields: selectedFields,
     },
   });
 }


### PR DESCRIPTION
**Summary**

Selected runs within the Search page component are now "preserved" within the component state when the user executes a search query and later "committed" when the user initiates a run comparison or executes a new search query. 

In addition, the search filters aggregated via the Elasticsearch mappings have been moved under the search input in order to provide enhanced viewability of the search results table. 