### PR TITLE
metalog-%-error

### DIFF
--- a/agent/util-scripts/gold/eval/test-48.txt
+++ b/agent/util-scripts/gold/eval/test-48.txt
@@ -1,0 +1,15 @@
++++ Running test-48 eval pbench-add-metalog-option /var/tmp/pbench-test-utils/pbench/metadata.log run percent < /var/tmp/pbench-test-utils/pbench/tmp/foo.txt
+--- Finished test-48 eval (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/metadata.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tmp/foo.txt
+/var/tmp/pbench-test-utils/pbench/tmp/foo.txt:
+30%
+--- pbench tree state
++++ metadata.log file contents
+/var/tmp/pbench-test-utils/pbench/metadata.log:[run]
+/var/tmp/pbench-test-utils/pbench/metadata.log:percent = 30%%
+/var/tmp/pbench-test-utils/pbench/metadata.log:
+--- metadata.log file contents

--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -17,7 +17,7 @@ def main(lfile, section, option):
     config.read(lfile)
     # python3
     # config[section][option] = ', '.join(sys.stdin.read().split())
-    sin = sys.stdin.read()
+    sin = sys.stdin.read().replace("%","%%")
     try:
         config.set(section, option, ', '.join(sin.split()))
     except NoSectionError:

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -259,6 +259,7 @@ declare -A tools=(
     [test-45]="pbench-register-tool"
     [test-46]="pbench-register-tool"
     [test-47]="pbench-register-tool"
+    [test-48]="eval"
 )
 
 declare -A options=(
@@ -326,6 +327,7 @@ declare -A options=(
     [test-45]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis"
     [test-46]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis"
     [test-47]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis --labels=labelOne,labelTwo"
+    [test-48]="pbench-add-metalog-option ${_testdir}/metadata.log run percent < ${_testdir}/tmp/foo.txt"
 )
 
 declare -A expected_status=(
@@ -360,6 +362,7 @@ declare -A pre_hooks=(
     [test-45]='mkdir ${_testdir}/tmp; printf -- "# good list\none.example.com\ntwo.example.com,labelTwo\n\nthree.example.com\n" > ${_testdir}/tmp/remotes.lis'
     [test-46]='mkdir ${_testdir}/tmp; printf -- "# bad list\none.example.com\ntwo.example.com,labelTwo\n\nthree.example.com,labelThree,junk\n" > ${_testdir}/tmp/remotes.lis'
     [test-47]='mkdir ${_testdir}/tmp; printf -- "# good list with no labels\none.example.com\ntwo.example.com\nthree.example.com\n" > ${_testdir}/tmp/remotes.lis'
+    [test-48]='mkdir ${_testdir}/tmp; printf -- "%s\n" "30%" > ${_testdir}/tmp/foo.txt'
 )
 
 declare -A post_hooks=(


### PR DESCRIPTION
Fixes #1329 

The problem is that configparser Interpolation (https://docs.python.org/3/library/configparser.html#configparser.InterpolationError) uses `%` as a marker for the interpolation construct `%(option)s` which replaces the construct by the value of the option. Configparser Interpolation does not accept the `%` symbol in any other context unless it is escaped as a double percent sign. So when we write a value with '%', ex: "30%" in any config file, this error in thrown. To fix this error, whenever the user enters a value that includes a  `%` char,  it will be converted into `%%` (double percent sign) which interpolation treats as a literal single percent sign.