### PR TITLE
Adds unit test for PageHeader component

### DIFF
--- a/web-server/v0.4/src/components/PageHeader/index.js
+++ b/web-server/v0.4/src/components/PageHeader/index.js
@@ -209,14 +209,14 @@ export default class PageHeader extends PureComponent {
     if (selectedControllers !== undefined) {
       titleHeader = selectedControllers.map(i => <Tag color="blue">{i}</Tag>);
       titleHeader = (
-        <div>
+        <div id="titleheader">
           <h1 className={styles.title}>Selected Controllers</h1>
           {titleHeader}
         </div>
       );
     } else {
       titleHeader = title && (
-        <div>
+        <div id="titleheader">
           <h1 className={styles.title}>{title}</h1>
         </div>
       );

--- a/web-server/v0.4/src/components/PageHeader/index.test.js
+++ b/web-server/v0.4/src/components/PageHeader/index.test.js
@@ -1,4 +1,7 @@
-import { getBreadcrumb } from './index';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Tag, Tabs, Breadcrumb } from 'antd';
+import PageHeader, { getBreadcrumb } from './index';
 import urlToList from '../_utils/pathTools';
 
 const routerData = {
@@ -10,6 +13,21 @@ const routerData = {
   },
 };
 
+const { TabPane } = Tabs;
+const mockProps = {
+  selectedControllers: undefined,
+  tabList: ['tab1', 'tab2'],
+  routes: ['/1', '/2'],
+  params: 'params',
+  location: { pathname: 'location' },
+  breadcrumbNameMap: 'breadcrumbNameMap',
+  onTabChange: jest.fn(),
+};
+const mockDispatch = jest.fn();
+const wrapper = shallow(<PageHeader dispatch={mockDispatch} {...mockProps} />, {
+  lifecycleExperimental: true,
+});
+
 describe('test getBreadcrumb', () => {
   it('getBreadcrumb name for a simple url', () => {
     expect(getBreadcrumb(routerData, '/dashboard/results').name).toEqual('results');
@@ -18,5 +36,73 @@ describe('test getBreadcrumb', () => {
   it('getBreadcrumb for a single path', () => {
     const urlNameList = urlToList('/search').map(url => getBreadcrumb(routerData, url).name);
     expect(urlNameList).toEqual(['search']);
+  });
+
+  it('check getBreadcrumb function implementation', () => {
+    const breadcrumbNameMap = { url: { url: 'urlItem' } };
+    const url = 'url';
+    const breadcrumb = breadcrumbNameMap[url];
+    expect(getBreadcrumb(breadcrumbNameMap, url)).toBe(breadcrumb);
+  });
+});
+
+describe('test rendering of TableFilterSelection page component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('Check functions implementation', () => {
+    const wrapper2 = shallow(<PageHeader {...mockProps} />);
+    const getBreadcrumbDom = jest.spyOn(wrapper.instance(), 'getBreadcrumbDom');
+    const conversionBreadcrumbList = jest.spyOn(wrapper.instance(), 'conversionBreadcrumbList');
+    const getBreadcrumbProps = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
+    const conversionFromLocation = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
+
+    wrapper2.setProps({ selectedControllers: ['a', 'b', 'c'] });
+    getBreadcrumbDom();
+    expect(wrapper.state('breadcrumb')).toEqual(conversionBreadcrumbList());
+    expect(conversionBreadcrumbList).toHaveBeenCalled();
+
+    expect(getBreadcrumbProps).toHaveBeenCalled();
+
+    // eslint-disable-next-line no-unused-vars
+    const { routes, params, routerLocation, breadcrumbNameMap } = getBreadcrumbProps();
+    expect(wrapper.find(Breadcrumb).props()).not.toBe({});
+    wrapper
+      .find(Breadcrumb)
+      .props()
+      .itemRender('route', 'params', 'routes', 'paths');
+
+    wrapper.setProps({ params: undefined });
+    expect(conversionFromLocation).toHaveBeenCalled();
+  });
+  it('check functions with null props', () => {
+    const conversionBreadcrumbList = jest.spyOn(wrapper.instance(), 'conversionBreadcrumbList');
+    conversionBreadcrumbList();
+    wrapper.setProps({ routes: undefined, location: undefined });
+    expect(wrapper.instance().conversionBreadcrumbList(null)).toBe(null);
+  });
+  it('check with conversionFromProps', () => {
+    const conversionFromProps = jest.spyOn(wrapper.instance(), 'conversionFromProps');
+    wrapper.setProps({ breadcrumbList: ['item-1', 'item-2'], breadcrumbSeparator: [','] });
+    conversionFromProps();
+  });
+  it('check rendering and change simulation', () => {
+    expect(wrapper.find(Tabs).length).toEqual(1);
+    expect(wrapper.find(TabPane)).toHaveLength(2);
+    wrapper
+      .find(Tabs)
+      .at(0)
+      .simulate('change', 'key1');
+    expect(wrapper.instance().props.onTabChange).toHaveBeenCalled();
+  });
+  it('test the titleHeader', () => {
+    wrapper.setProps({ selectedControllers: ['a', 'b', 'c'] });
+    expect(wrapper.find('#titleheader').find(Tag)).toHaveLength(3);
+  });
+  it('test the tabDefaultActiveKey', () => {
+    wrapper.setProps({ tabDefaultActiveKey: ['a'] });
+    wrapper.setProps({ tabActiveKey: ['a', 'b'] });
+    expect(wrapper.find(Tabs).props().defaultActiveKey).toEqual(['a']);
+    expect(wrapper.find(Tabs).props().activeKey).toEqual(['a', 'b']);
   });
 });

--- a/web-server/v0.4/src/components/PageHeader/index.test.js
+++ b/web-server/v0.4/src/components/PageHeader/index.test.js
@@ -15,15 +15,17 @@ const routerData = {
 
 const { TabPane } = Tabs;
 const mockProps = {
-  selectedControllers: undefined,
+  selectedControllers: ['a', 'b'],
   tabList: ['tab1', 'tab2'],
   routes: ['/1', '/2'],
   params: 'params',
   location: { pathname: 'location' },
   breadcrumbNameMap: 'breadcrumbNameMap',
   onTabChange: jest.fn(),
+  title: 'Titel',
 };
 const mockDispatch = jest.fn();
+const breadcrumbNameMap = { url: { url: 'urlItem' } };
 const wrapper = shallow(<PageHeader dispatch={mockDispatch} {...mockProps} />, {
   lifecycleExperimental: true,
 });
@@ -39,7 +41,6 @@ describe('test getBreadcrumb', () => {
   });
 
   it('check getBreadcrumb function implementation', () => {
-    const breadcrumbNameMap = { url: { url: 'urlItem' } };
     const url = 'url';
     const breadcrumb = breadcrumbNameMap[url];
     expect(getBreadcrumb(breadcrumbNameMap, url)).toBe(breadcrumb);
@@ -50,42 +51,6 @@ describe('test rendering of TableFilterSelection page component', () => {
   it('render with empty props', () => {
     expect(wrapper).toMatchSnapshot();
   });
-  it('Check functions implementation', () => {
-    const wrapper2 = shallow(<PageHeader {...mockProps} />);
-    const getBreadcrumbDom = jest.spyOn(wrapper.instance(), 'getBreadcrumbDom');
-    const conversionBreadcrumbList = jest.spyOn(wrapper.instance(), 'conversionBreadcrumbList');
-    const getBreadcrumbProps = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
-    const conversionFromLocation = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
-
-    wrapper2.setProps({ selectedControllers: ['a', 'b', 'c'] });
-    getBreadcrumbDom();
-    expect(wrapper.state('breadcrumb')).toEqual(conversionBreadcrumbList());
-    expect(conversionBreadcrumbList).toHaveBeenCalled();
-
-    expect(getBreadcrumbProps).toHaveBeenCalled();
-
-    // eslint-disable-next-line no-unused-vars
-    const { routes, params, routerLocation, breadcrumbNameMap } = getBreadcrumbProps();
-    expect(wrapper.find(Breadcrumb).props()).not.toBe({});
-    wrapper
-      .find(Breadcrumb)
-      .props()
-      .itemRender('route', 'params', 'routes', 'paths');
-
-    wrapper.setProps({ params: undefined });
-    expect(conversionFromLocation).toHaveBeenCalled();
-  });
-  it('check functions with null props', () => {
-    const conversionBreadcrumbList = jest.spyOn(wrapper.instance(), 'conversionBreadcrumbList');
-    conversionBreadcrumbList();
-    wrapper.setProps({ routes: undefined, location: undefined });
-    expect(wrapper.instance().conversionBreadcrumbList(null)).toBe(null);
-  });
-  it('check with conversionFromProps', () => {
-    const conversionFromProps = jest.spyOn(wrapper.instance(), 'conversionFromProps');
-    wrapper.setProps({ breadcrumbList: ['item-1', 'item-2'], breadcrumbSeparator: [','] });
-    conversionFromProps();
-  });
   it('check rendering and change simulation', () => {
     expect(wrapper.find(Tabs).length).toEqual(1);
     expect(wrapper.find(TabPane)).toHaveLength(2);
@@ -95,14 +60,59 @@ describe('test rendering of TableFilterSelection page component', () => {
       .simulate('change', 'key1');
     expect(wrapper.instance().props.onTabChange).toHaveBeenCalled();
   });
-  it('test the titleHeader', () => {
-    wrapper.setProps({ selectedControllers: ['a', 'b', 'c'] });
-    expect(wrapper.find('#titleheader').find(Tag)).toHaveLength(3);
+  it('should render selected controllers in titleheader', () => {
+    expect(wrapper.find('#titleheader').find(Tag)).toHaveLength(2);
+    wrapper.setProps({ selectedControllers: undefined });
+    expect(wrapper.find('#titleheader').find(Tag)).toHaveLength(0);
   });
   it('test the tabDefaultActiveKey', () => {
     wrapper.setProps({ tabDefaultActiveKey: ['a'] });
     wrapper.setProps({ tabActiveKey: ['a', 'b'] });
     expect(wrapper.find(Tabs).props().defaultActiveKey).toEqual(['a']);
     expect(wrapper.find(Tabs).props().activeKey).toEqual(['a', 'b']);
+  });
+});
+describe('Check function implementation', () => {
+  // const wrapper2 = shallow(<PageHeader {...mockProps} />);
+  const getBreadcrumbDom = jest.spyOn(wrapper.instance(), 'getBreadcrumbDom');
+  const conversionBreadcrumbList = jest.spyOn(wrapper.instance(), 'conversionBreadcrumbList');
+  const getBreadcrumbProps = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
+  const conversionFromLocation = jest.spyOn(wrapper.instance(), 'getBreadcrumbProps');
+
+  it('should assign breadcrumb state ', () => {
+    getBreadcrumbDom();
+    expect(wrapper.state('breadcrumb')).toEqual(conversionBreadcrumbList());
+  });
+  it('should call conversionBreadcrumbList', () => {
+    expect(conversionBreadcrumbList).toHaveBeenCalled();
+    expect(conversionFromLocation).toHaveBeenCalled();
+  });
+  it('should call getBreadcrumbProps', () => {
+    wrapper.setProps({ breadcrumbList: ['breadcrumb1'] });
+    expect(getBreadcrumbProps).toHaveBeenCalled();
+    expect(wrapper.find(Breadcrumb).props()).not.toBe({});
+  });
+  it('should check itemRender prop', () => {
+    wrapper
+      .find(Breadcrumb)
+      .props()
+      .itemRender('route', 'params', 'routes', 'paths');
+  });
+  it('should call conversionFromProps', () => {
+    const conversionFromProps = jest.spyOn(wrapper.instance(), 'conversionFromProps');
+    wrapper.setProps({ breadcrumbList: ['item-1', 'item-2'], breadcrumbSeparator: [','] });
+    conversionBreadcrumbList();
+    expect(conversionFromProps).toHaveBeenCalled();
+  });
+  it('should call conversionFromLocation', () => {
+    wrapper.setProps({ params: undefined, breadcrumbList: undefined });
+    expect(conversionFromLocation).toHaveBeenCalled();
+    wrapper.instance().conversionFromLocation(mockProps.location, breadcrumbNameMap);
+    expect(wrapper.find(Breadcrumb).props()).not.toBe({});
+  });
+  it('check functions with null props', () => {
+    conversionBreadcrumbList();
+    wrapper.setProps({ routes: undefined, location: undefined, breadcrumbList: undefined });
+    expect(wrapper.instance().conversionBreadcrumbList(null)).toBe(null);
   });
 });


### PR DESCRIPTION
Fixes #1337 
Code Coverage Report:
``` 
components/PageHeader           |    98.53 |    69.74 |      100 |    98.51 |                   |
  index.js                      |    98.53 |    69.74 |      100 |    98.51 |                15 |
```

Coverage reports are currently retrieved in Jest by running the following command: `umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand "--coverage"`