### PR TITLE
Enhanced pbench-unpack-tarballs to operate on buckets of tar balls by size, reverse sorted by date

### DIFF
--- a/server/bin/gold/test-0.1.txt
+++ b/server/bin/gold/test-0.1.txt
@@ -7,7 +7,7 @@ pbench-sync-satellite: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-l
 +++ Running pbench-dispatch
 pbench-dispatch: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad LOGSDIR=/var/tmp/pbench-test-server/test-0.1/pbench-local/logs (config file /var/tmp/pbench-test-server/test-0.1/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-0.2.txt
+++ b/server/bin/gold/test-0.2.txt
@@ -7,7 +7,7 @@ pbench-sync-satellite: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local
 +++ Running pbench-dispatch
 pbench-dispatch: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad TMP=/var/tmp/pbench-test-server/test-0.2/pbench-local/tmp (config file /var/tmp/pbench-test-server/test-0.2/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-0.txt
+++ b/server/bin/gold/test-0.txt
@@ -7,7 +7,7 @@ pbench-sync-satellite: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config
 +++ Running pbench-dispatch
 pbench-dispatch: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-dispatch (status=1)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad TOP=/var/tmp/pbench-test-server/test-0/pbench (config file /var/tmp/pbench-test-server/test-0/opt/pbench-server/lib/config/pbench-server.cfg)
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-1.txt
+++ b/server/bin/gold/test-1.txt
@@ -7,7 +7,7 @@ pbench-sync-satellite: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/arc
 +++ Running pbench-dispatch
 pbench-dispatch: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
 --- Finished pbench-dispatch (status=1)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad ARCHIVE=/var/tmp/pbench-test-server/test-1/pbench/archive/fs-version-001
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-11.txt
+++ b/server/bin/gold/test-11.txt
@@ -85,6 +85,7 @@ drwxrwxr-x          - archive/fs-version-001/ONE::controller/TODO
 lrwxrwxrwx        113 archive/fs-version-001/ONE::controller/TODO/fio__2016-08-16_22:03:11.tar.xz -> /var/tmp/pbench-test-server/test-11/pbench/archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ONE::controller/UNPACKED
 drwxrwxr-x          - archive/fs-version-001/ONE::controller/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/ONE::controller/WONT-UNPACK
 -rw-r--r--    1558168 archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz
 -rw-r--r--         66 archive/fs-version-001/ONE::controller/fio__2016-08-16_22:03:11.tar.xz.md5
 -rw-r--r--       7028 archive/fs-version-001/ONE::controller/pbench-user-benchmark_38_2016-05-18_19:36:32.tar.xz

--- a/server/bin/gold/test-16.txt
+++ b/server/bin/gold/test-16.txt
@@ -1,10 +1,10 @@
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "de5feec4c5c4316da70e1dc7de23065c",
+        "_id": "4fb7b08aca49c925a49e80be3341075c",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -19,10 +19,10 @@ len(actions) = 1
             "@timestamp": "1970-01-01T00:00:00",
             "chunk_id": 1,
             "doctype": "status",
-            "name": "pbench-unpack-tarballs",
-            "text": "pbench-unpack-tarballs.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-16/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
+            "name": "pbench-unpack-tarballs-small",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-16/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
             "total_chunks": 1,
-            "total_size": 364
+            "total_size": 370
         },
         "_type": "pbench-server-reports"
     }
@@ -223,9 +223,9 @@ drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--        365 logs/pbench-audit-server/pbench-audit-server.log
-drwxrwxr-x          - logs/pbench-unpack-tarballs
--rw-rw-r--        202 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
--rw-rw-r--       1885 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs-small
+-rw-rw-r--        202 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+-rw-rw-r--       1897 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -279,10 +279,10 @@ drwxrwxr-x          - tmp
 1970-01-01T00:00:00.000000 INFO pbench-audit-server.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-audit-server.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
 run-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-16/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist
------ pbench-unpack-tarballs/pbench-unpack-tarballs.error
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller02/benchmark-result-small_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
@@ -292,9 +292,9 @@ run-1970-01-01T00:00:00-UTC: controller01/benchmark-result-medium_1900-01-01T00:
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 run-1970-01-01T00:00:00-UTC: Processed 3 tarballs
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
------ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 ---- pbench-local/logs
 ++++ pbench-satellite-local/logs
 ---- pbench-satellite-local/logs

--- a/server/bin/gold/test-16.txt
+++ b/server/bin/gold/test-16.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "4fb7b08aca49c925a49e80be3341075c",
+        "_id": "d217d806e7399763648fc422e229ee3e",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -20,7 +20,7 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-unpack-tarballs-small",
-            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-16/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 4 result tar balls, 3 successfully, 0 warnings, 1 errors, and 0 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-16/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
             "total_chunks": 1,
             "total_size": 370
         },
@@ -109,11 +109,12 @@ lrwxrwxrwx        128 archive/fs-version-001/controller00/TO-INDEX/benchmark-res
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-LINK
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-SYNC
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-UNPACK
-lrwxrwxrwx         52 archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller00/TODO
 drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-UNPACK
+lrwxrwxrwx         52 archive/fs-version-001/controller00/WONT-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller01
@@ -143,6 +144,7 @@ drwxrwxr-x          - archive/fs-version-001/controller01/TODO
 drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
 lrwxrwxrwx         53 archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-UNPACK
 -rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller02
@@ -171,6 +173,7 @@ drwxrwxr-x          - archive/fs-version-001/controller02/TODO
 drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-UNPACK
 -rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - public_html
@@ -286,11 +289,11 @@ run-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test
 run-1970-01-01T00:00:00-UTC
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller02/benchmark-result-small_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
+ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
+run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
 ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller01/benchmark-result-medium_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 3180
-ln -s /var/tmp/pbench-test-server/test-16/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-16/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
-run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 run-1970-01-01T00:00:00-UTC: Processed 3 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)

--- a/server/bin/gold/test-17.txt
+++ b/server/bin/gold/test-17.txt
@@ -1,10 +1,10 @@
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "816924e0fce2d2ebe1962f95a8adacf5",
+        "_id": "81d2954849cb20c942b764f7d591fbef",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -19,10 +19,10 @@ len(actions) = 1
             "@timestamp": "1970-01-01T00:00:00",
             "chunk_id": 1,
             "doctype": "status",
-            "name": "pbench-unpack-tarballs",
-            "text": "pbench-unpack-tarballs.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-17/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
+            "name": "pbench-unpack-tarballs-small",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-17/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
             "total_chunks": 1,
-            "total_size": 364
+            "total_size": 370
         },
         "_type": "pbench-server-reports"
     }
@@ -224,9 +224,9 @@ drwxrwxr-x          - logs
 drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--        365 logs/pbench-audit-server/pbench-audit-server.log
-drwxrwxr-x          - logs/pbench-unpack-tarballs
--rw-rw-r--        202 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
--rw-rw-r--       1885 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs-small
+-rw-rw-r--        202 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+-rw-rw-r--       1897 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -280,10 +280,10 @@ drwxrwxr-x          - tmp
 1970-01-01T00:00:00.000000 INFO pbench-audit-server.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-audit-server.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
 run-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-17/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist
------ pbench-unpack-tarballs/pbench-unpack-tarballs.error
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller02/benchmark-result-small_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
@@ -293,9 +293,9 @@ run-1970-01-01T00:00:00-UTC: controller01/benchmark-result-medium_1900-01-01T00:
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 run-1970-01-01T00:00:00-UTC: Processed 3 tarballs
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
------ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 ---- pbench-local/logs
 ++++ pbench-satellite-local/logs
 ---- pbench-satellite-local/logs

--- a/server/bin/gold/test-17.txt
+++ b/server/bin/gold/test-17.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "81d2954849cb20c942b764f7d591fbef",
+        "_id": "a970c95d89317b57a6578af1b9bcb203",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -20,7 +20,7 @@ len(actions) = 1
             "chunk_id": 1,
             "doctype": "status",
             "name": "pbench-unpack-tarballs-small",
-            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 5 result tar balls, 3 successfully, 0 warnings, 1 errors, and 1 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-17/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 1 errors\nProcessed 4 result tar balls, 3 successfully, 0 warnings, 1 errors, and 0 duplicates\n\nrun-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test-17/pbench/archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz does not exist\n",
             "total_chunks": 1,
             "total_size": 370
         },
@@ -109,11 +109,12 @@ lrwxrwxrwx        128 archive/fs-version-001/controller00/TO-INDEX/benchmark-res
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-LINK
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-SYNC
 drwxrwxr-x          - archive/fs-version-001/controller00/TO-UNPACK
-lrwxrwxrwx         52 archive/fs-version-001/controller00/TO-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller00/TODO
 drwxrwxr-x          - archive/fs-version-001/controller00/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/controller00/UNPACKED/benchmark-result-large_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-large_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller00/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller00/WONT-UNPACK
+lrwxrwxrwx         52 archive/fs-version-001/controller00/WONT-UNPACK/benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz -> ../benchmark-doesnotexist_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--       5920 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         84 archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller01
@@ -143,6 +144,7 @@ drwxrwxr-x          - archive/fs-version-001/controller01/TODO
 drwxrwxr-x          - archive/fs-version-001/controller01/UNPACKED
 lrwxrwxrwx         53 archive/fs-version-001/controller01/UNPACKED/benchmark-result-medium_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-medium_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller01/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller01/WONT-UNPACK
 -rw-rw-r--       3180 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         85 archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller02
@@ -171,6 +173,7 @@ drwxrwxr-x          - archive/fs-version-001/controller02/TODO
 drwxrwxr-x          - archive/fs-version-001/controller02/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/controller02/UNPACKED/benchmark-result-small_1900-01-01T00:00:00.tar.xz -> ../benchmark-result-small_1900-01-01T00:00:00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller02/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller02/WONT-UNPACK
 -rw-rw-r--        848 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz
 -rw-rw-r--         84 archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz.md5
 drwxrwxr-x          - public_html
@@ -287,11 +290,11 @@ run-1970-01-01T00:00:00-UTC: symlink target for /var/tmp/pbench-test-server/test
 run-1970-01-01T00:00:00-UTC
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller02/benchmark-result-small_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller02/prefix02/benchmark-result-small_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller02/benchmark-result-small_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 848
+ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
+run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
 ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller01/benchmark-result-medium_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/users/user01/controller01/prefix01/benchmark-result-medium_1900-01-01T00:00:00
 run-1970-01-01T00:00:00-UTC: controller01/benchmark-result-medium_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 3180
-ln -s /var/tmp/pbench-test-server/test-17/pbench/public_html/incoming/controller00/benchmark-result-large_1900-01-01T00:00:00 /var/tmp/pbench-test-server/test-17/pbench/public_html/results/controller00/benchmark-result-large_1900-01-01T00:00:00
-run-1970-01-01T00:00:00-UTC: controller00/benchmark-result-large_1900-01-01T00:00:00: success - elapsed time (secs): 0 - size (bytes): 5920
 run-1970-01-01T00:00:00-UTC: Processed 3 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)

--- a/server/bin/gold/test-2.txt
+++ b/server/bin/gold/test-2.txt
@@ -60,7 +60,7 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad INCOMING=/var/tmp/pbench-test-server/test-2/pbench/public_html/incoming
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-24.txt
+++ b/server/bin/gold/test-24.txt
@@ -10,7 +10,10 @@ MAILFROM=pbench@pbench.example.com
 * * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-prep-002.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-prep-shim-002
 * * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-prep-003.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-server-prep-shim-003
 * * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-dispatch.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-dispatch
-* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs-small.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs small
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs-medium.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs medium
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs-large.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs large
+* * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-unpack-tarballs-huge.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-unpack-tarballs huge
 41 * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-copy-sosreports.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-copy-sosreports
 * * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-edit-prefixes.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-edit-prefixes
 * * * * *  flock -n /var/tmp/pbench-test-server/test-24/opt/pbench-server/lib/locks/pbench-index.lock /var/tmp/pbench-test-server/test-24/opt/pbench-server/bin/pbench-index

--- a/server/bin/gold/test-25.txt
+++ b/server/bin/gold/test-25.txt
@@ -1,0 +1,200 @@
++++ Running test-find-behavior
+
+Bucket: small -- 0 <= size < 130
+10 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/file.sml
+10 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/file.sml
+10 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/file.sml
+129 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/edge-ub.sml
+
+Bucket: medium -- 130 <= size < 240
+130 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/boundary.med
+131 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/edge-lb.med
+140 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/file.med
+140 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/file.med
+140 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/file.med
+239 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/edge-ub.med
+
+Bucket: large -- 240 <= size < 820
+240 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/boundary.lrg
+241 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/edge-lb.lrg
+250 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/file.lrg
+250 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/file.lrg
+250 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/file.lrg
+819 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/edge-ub.lrg
+
+Bucket: huge -- 820 <= size < INF
+820 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/boundary.hug
+821 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/edge-lb.hug
+830 /var/tmp/pbench-test-server/test-25/pbench/archive/dir0/file.hug
+830 /var/tmp/pbench-test-server/test-25/pbench/archive/dir1/file.hug
+830 /var/tmp/pbench-test-server/test-25/pbench/archive/dir2/file.hug
+--- Finished test-find-behavior (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-25/var-www-html)
+lrwxrwxrwx         63 incoming -> /var/tmp/pbench-test-server/test-25/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        118 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         62 results -> /var/tmp/pbench-test-server/test-25/pbench/public_html/results
+lrwxrwxrwx         61 static -> /var/tmp/pbench-test-server/test-25/pbench/public_html/static
+lrwxrwxrwx         60 users -> /var/tmp/pbench-test-server/test-25/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-25/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-25/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-25/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-25/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-25/var-www-html-satellite)
+lrwxrwxrwx         73 incoming -> /var/tmp/pbench-test-server/test-25/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        138 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         72 results -> /var/tmp/pbench-test-server/test-25/pbench-satellite/public_html/results
+lrwxrwxrwx         71 static -> /var/tmp/pbench-test-server/test-25/pbench-satellite/public_html/static
+lrwxrwxrwx         70 users -> /var/tmp/pbench-test-server/test-25/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-25/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-25/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-25/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-25/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-25/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/dir0
+-rw-rw-r--        130 archive/dir0/boundary.med
+-rw-rw-r--        131 archive/dir0/edge-lb.med
+-rw-rw-r--        129 archive/dir0/edge-ub.sml
+-rw-rw-r--        830 archive/dir0/file.hug
+-rw-rw-r--        250 archive/dir0/file.lrg
+-rw-rw-r--        140 archive/dir0/file.med
+-rw-rw-r--         10 archive/dir0/file.sml
+drwxrwxr-x          - archive/dir1
+-rw-rw-r--        240 archive/dir1/boundary.lrg
+-rw-rw-r--        241 archive/dir1/edge-lb.lrg
+-rw-rw-r--        239 archive/dir1/edge-ub.med
+-rw-rw-r--        830 archive/dir1/file.hug
+-rw-rw-r--        250 archive/dir1/file.lrg
+-rw-rw-r--        140 archive/dir1/file.med
+-rw-rw-r--         10 archive/dir1/file.sml
+drwxrwxr-x          - archive/dir2
+-rw-rw-r--        820 archive/dir2/boundary.hug
+-rw-rw-r--        821 archive/dir2/edge-lb.hug
+-rw-rw-r--        819 archive/dir2/edge-ub.lrg
+-rw-rw-r--        830 archive/dir2/file.hug
+-rw-rw-r--        250 archive/dir2/file.lrg
+-rw-rw-r--        140 archive/dir2/file.med
+-rw-rw-r--         10 archive/dir2/file.sml
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-25/pbench-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--        365 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-25/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-25/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-audit-server.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-audit-server/pbench-audit-server.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/gold/test-3.txt
+++ b/server/bin/gold/test-3.txt
@@ -60,7 +60,7 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad RESULTS=/var/tmp/pbench-test-server/test-3/pbench/public_html/results
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-4.txt
+++ b/server/bin/gold/test-4.txt
@@ -60,7 +60,7 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 pbench-unpack-tarballs: Bad USERS=/var/tmp/pbench-test-server/test-4/pbench/public_html/users
 --- Finished pbench-unpack-tarballs (status=1)
 +++ Running pbench-copy-sosreports

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -60,13 +60,13 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3a5d2772e7740f179f0940f4bceeb7f2",
+        "_id": "720f90852c34701ef9fbabfeb1842c8a",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -81,10 +81,10 @@ len(actions) = 1
             "@timestamp": "1970-01-01T00:00:00",
             "chunk_id": 1,
             "doctype": "status",
-            "name": "pbench-unpack-tarballs",
-            "text": "pbench-unpack-tarballs.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 0 result tar balls, 0 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
+            "name": "pbench-unpack-tarballs-small",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 0 result tar balls, 0 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
             "total_chunks": 1,
-            "total_size": 162
+            "total_size": 168
         },
         "_type": "pbench-server-reports"
     }
@@ -306,9 +306,9 @@ drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
 -rw-rw-r--       2217 logs/pbench-sync-satellite/pbench-sync-satellite.log
-drwxrwxr-x          - logs/pbench-unpack-tarballs
--rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
--rw-rw-r--        449 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs-small
+-rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+-rw-rw-r--        461 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       2057 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -462,14 +462,14 @@ len(actions) = 1
 ]
 1970-01-01T00:00:00.000000 INFO pbench-sync-satellite.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.error
------ pbench-unpack-tarballs/pbench-unpack-tarballs.error
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.log
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
 run-1970-01-01T00:00:00-UTC: Processed 0 tarballs
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
------ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 +++++ pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 1970-01-01T00:00:00.000000 INFO pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- start-run-1970-01-01T00:00:00-UTC
 1970-01-01T00:00:00.000000 DEBUG pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- Starting archive list creation

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -348,6 +348,7 @@ lrwxrwxrwx        126 archive/fs-version-001/ONE::controllerA/UNPACKED/tarball-s
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/WONT-INDEX.4
 lrwxrwxrwx        126 archive/fs-version-001/ONE::controllerA/WONT-INDEX.4/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz
+drwxrwxr-x          - archive/fs-version-001/ONE::controllerA/WONT-UNPACK
 -rw-rw-r--        224 archive/fs-version-001/ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz
 -rw-rw-r--         77 archive/fs-version-001/ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB
@@ -377,6 +378,7 @@ lrwxrwxrwx        126 archive/fs-version-001/ONE::controllerB/UNPACKED/tarball-s
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/WONT-INDEX.4
 lrwxrwxrwx        126 archive/fs-version-001/ONE::controllerB/WONT-INDEX.4/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz
+drwxrwxr-x          - archive/fs-version-001/ONE::controllerB/WONT-UNPACK
 -rw-rw-r--        220 archive/fs-version-001/ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz
 -rw-rw-r--         77 archive/fs-version-001/ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC
@@ -408,6 +410,7 @@ lrwxrwxrwx        133 archive/fs-version-001/ONE::controllerC/UNPACKED/tarball-s
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/WONT-INDEX.4
 lrwxrwxrwx        133 archive/fs-version-001/ONE::controllerC/WONT-INDEX.4/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz
+drwxrwxr-x          - archive/fs-version-001/ONE::controllerC/WONT-UNPACK
 -rw-rw-r--        228 archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz
 -rw-rw-r--         84 archive/fs-version-001/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller-b-with-prefixes
@@ -444,6 +447,7 @@ drwxrwxr-x          - archive/fs-version-001/controller-b-with-prefixes/WONT-IND
 lrwxrwxrwx        130 archive/fs-version-001/controller-b-with-prefixes/WONT-INDEX.4/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz
 lrwxrwxrwx        141 archive/fs-version-001/controller-b-with-prefixes/WONT-INDEX.4/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS.tar.xz
 lrwxrwxrwx        141 archive/fs-version-001/controller-b-with-prefixes/WONT-INDEX.4/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller-b-with-prefixes/WONT-UNPACK
 -rw-rw-r--        212 archive/fs-version-001/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz
 -rw-rw-r--         71 archive/fs-version-001/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS.tar.xz.md5
 -rw-rw-r--        224 archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS.tar.xz
@@ -507,6 +511,7 @@ lrwxrwxrwx        128 archive/fs-version-001/controller-g-normal/UNPACKED/tarbal
 drwxrwxr-x          - archive/fs-version-001/controller-g-normal/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/controller-g-normal/WONT-INDEX.4
 lrwxrwxrwx        128 archive/fs-version-001/controller-g-normal/WONT-INDEX.4/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz -> /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller-g-normal/WONT-UNPACK
 -rw-rw-r--        216 archive/fs-version-001/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz
 -rw-rw-r--         76 archive/fs-version-001/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS.tar.xz.md5
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5
@@ -530,6 +535,7 @@ drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/TO-UNPACK
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/TODO
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/UNPACKED
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/WONT-UNPACK
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/_QUARANTINED
 drwxrwxr-x          - archive/fs-version-001/controller-h-bad-md5/_QUARANTINED/BAD-MD5
 -rw-rw-r--        220 archive/fs-version-001/controller-h-bad-md5/_QUARANTINED/BAD-MD5/tarball-bad-md5_YYYY.MM.DDTHH.MM.SS.tar.xz
@@ -956,20 +962,20 @@ len(actions) = 1
 ----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
 +++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
-ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS
-run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 212
-ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS
-run-1970-01-01T00:00:00-UTC: controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 216
+ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerC/prefix0/prefix1/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss
+run-1970-01-01T00:00:00-UTC: ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss: success - elapsed time (secs): 0 - size (bytes): 228
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss
 run-1970-01-01T00:00:00-UTC: ONE::controllerB/tarball-simple2_YYYY-MM-DDTHH-mm-ss: success - elapsed time (secs): 0 - size (bytes): 220
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss
 run-1970-01-01T00:00:00-UTC: ONE::controllerA/tarball-simple1_YYYY-MM-DDTHH-mm-ss: success - elapsed time (secs): 0 - size (bytes): 224
-ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS
-run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 224
+ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS
+run-1970-01-01T00:00:00-UTC: controller-g-normal/tarball-normal_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 216
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS
 run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-w-prefix-dot_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 224
-ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerC/prefix0/prefix1/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss
-run-1970-01-01T00:00:00-UTC: ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss: success - elapsed time (secs): 0 - size (bytes): 228
+ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS
+run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-w-dot-prefix_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 224
+ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS
+run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 212
 run-1970-01-01T00:00:00-UTC: Processed 7 tarballs
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -60,13 +60,13 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5fce6f0166c1bdd4b2e07e89166d2fbe",
+        "_id": "23db3700dd5f5866228f9ed61c85e0fa",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -81,10 +81,10 @@ len(actions) = 1
             "@timestamp": "1970-01-01T00:00:00",
             "chunk_id": 1,
             "doctype": "status",
-            "name": "pbench-unpack-tarballs",
-            "text": "pbench-unpack-tarballs.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 7 result tar balls, 7 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
+            "name": "pbench-unpack-tarballs-small",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 7 result tar balls, 7 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
             "total_chunks": 1,
-            "total_size": 162
+            "total_size": 168
         },
         "_type": "pbench-server-reports"
     }
@@ -643,9 +643,9 @@ drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--        219 logs/pbench-sync-satellite/pbench-sync-satellite.error
 -rw-rw-r--       2586 logs/pbench-sync-satellite/pbench-sync-satellite.log
-drwxrwxr-x          - logs/pbench-unpack-tarballs
--rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
--rw-rw-r--       3233 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs-small
+-rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+-rw-rw-r--       3245 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       2057 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -952,9 +952,9 @@ len(actions) = 1
 ]
 1970-01-01T00:00:00.000000 INFO pbench-sync-satellite.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.error
------ pbench-unpack-tarballs/pbench-unpack-tarballs.error
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.log
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS
 run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-0_YYYY.MM.DDTHH.MM.SS: success - elapsed time (secs): 0 - size (bytes): 212
@@ -971,9 +971,9 @@ run-1970-01-01T00:00:00-UTC: controller-b-with-prefixes/tarball-w-prefix-dot_YYY
 ln -s /var/tmp/pbench-test-server/test-5.2/pbench/public_html/incoming/ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss /var/tmp/pbench-test-server/test-5.2/pbench/public_html/results/ONE::controllerC/prefix0/prefix1/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss
 run-1970-01-01T00:00:00-UTC: ONE::controllerC/tarball-simple0-prefix_YYYY-MM-DDTHH-mm-ss: success - elapsed time (secs): 0 - size (bytes): 228
 run-1970-01-01T00:00:00-UTC: Processed 7 tarballs
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
------ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 +++++ pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 1970-01-01T00:00:00.000000 INFO pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- start-run-1970-01-01T00:00:00-UTC
 1970-01-01T00:00:00.000000 DEBUG pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- Starting archive list creation

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -60,13 +60,13 @@ len(actions) = 1
     }
 ]
 --- Finished pbench-dispatch (status=0)
-+++ Running pbench-unpack-tarballs
++++ Running pbench-unpack-tarballs small
 Template:  pbench-unittests.v3.server-reports
 Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3a5d2772e7740f179f0940f4bceeb7f2",
+        "_id": "720f90852c34701ef9fbabfeb1842c8a",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -81,10 +81,10 @@ len(actions) = 1
             "@timestamp": "1970-01-01T00:00:00",
             "chunk_id": 1,
             "doctype": "status",
-            "name": "pbench-unpack-tarballs",
-            "text": "pbench-unpack-tarballs.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 0 result tar balls, 0 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
+            "name": "pbench-unpack-tarballs-small",
+            "text": "pbench-unpack-tarballs-small.run-1970-01-01T00:00:00-UTC(unit-test) - w/ 0 errors\nProcessed 0 result tar balls, 0 successfully, 0 warnings, 0 errors, and 0 duplicates\n\n",
             "total_chunks": 1,
-            "total_size": 162
+            "total_size": 168
         },
         "_type": "pbench-server-reports"
     }
@@ -306,9 +306,9 @@ drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--          0 logs/pbench-sync-satellite/ONE/change_state.log
 -rw-rw-r--          0 logs/pbench-sync-satellite/pbench-sync-satellite.error
 -rw-rw-r--       2217 logs/pbench-sync-satellite/pbench-sync-satellite.log
-drwxrwxr-x          - logs/pbench-unpack-tarballs
--rw-rw-r--          0 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.error
--rw-rw-r--        449 logs/pbench-unpack-tarballs/pbench-unpack-tarballs.log
+drwxrwxr-x          - logs/pbench-unpack-tarballs-small
+-rw-rw-r--          0 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+-rw-rw-r--        461 logs/pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 drwxrwxr-x          - logs/pbench-verify-backup-tarballs
 -rw-rw-r--       2057 logs/pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
@@ -462,14 +462,14 @@ len(actions) = 1
 ]
 1970-01-01T00:00:00.000000 INFO pbench-sync-satellite.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-sync-satellite/pbench-sync-satellite.log
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.error
------ pbench-unpack-tarballs/pbench-unpack-tarballs.error
-+++++ pbench-unpack-tarballs/pbench-unpack-tarballs.log
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.error
++++++ pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 run-1970-01-01T00:00:00-UTC
 run-1970-01-01T00:00:00-UTC: Processed 0 tarballs
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
------ pbench-unpack-tarballs/pbench-unpack-tarballs.log
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.indexer update_templates -- done templates (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
+1970-01-01T00:00:00.000000 INFO pbench-unpack-tarballs-small.report post_status -- posted status (end ts: 1970-01-01T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+----- pbench-unpack-tarballs-small/pbench-unpack-tarballs-small.log
 +++++ pbench-verify-backup-tarballs/pbench-verify-backup-tarballs.log
 1970-01-01T00:00:00.000000 INFO pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- start-run-1970-01-01T00:00:00-UTC
 1970-01-01T00:00:00.000000 DEBUG pbench-verify-backup-tarballs.pbench-verify-backup-tarballs main -- Starting archive list creation

--- a/server/bin/gold/test-7.1.txt
+++ b/server/bin/gold/test-7.1.txt
@@ -188,6 +188,7 @@ lrwxrwxrwx         18 archive/fs-version-001/controller/UNPACKED/test-7.1.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX.7
 lrwxrwxrwx         93 archive/fs-version-001/controller/WONT-INDEX.7/test-7.1.tar.xz -> /var/tmp/pbench-test-server/test-7.1/pbench/archive/fs-version-001/controller/test-7.1.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller/WONT-UNPACK
 -rw-rw-r--       1232 archive/fs-version-001/controller/test-7.1.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/controller/test-7.1.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.10.txt
+++ b/server/bin/gold/test-7.10.txt
@@ -9877,6 +9877,7 @@ drwxrwxr-x          - archive/fs-version-001/dhcp31-44/TODO
 drwxrwxr-x          - archive/fs-version-001/dhcp31-44/UNPACKED
 lrwxrwxrwx         45 archive/fs-version-001/dhcp31-44/UNPACKED/uperf_uperftest_2018.02.02T20.58.00.tar.xz -> ../uperf_uperftest_2018.02.02T20.58.00.tar.xz
 drwxrwxr-x          - archive/fs-version-001/dhcp31-44/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/dhcp31-44/WONT-UNPACK
 -rw-r--r--    2360408 archive/fs-version-001/dhcp31-44/uperf_uperftest_2018.02.02T20.58.00.tar.xz
 -rw-r--r--         77 archive/fs-version-001/dhcp31-44/uperf_uperftest_2018.02.02T20.58.00.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.11.txt
+++ b/server/bin/gold/test-7.11.txt
@@ -5404,6 +5404,7 @@ drwxrwxr-x          - archive/fs-version-001/dhcp31-44/TODO
 drwxrwxr-x          - archive/fs-version-001/dhcp31-44/UNPACKED
 lrwxrwxrwx         36 archive/fs-version-001/dhcp31-44/UNPACKED/fio_rw_2018.02.01T22.40.57.tar.xz -> ../fio_rw_2018.02.01T22.40.57.tar.xz
 drwxrwxr-x          - archive/fs-version-001/dhcp31-44/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/dhcp31-44/WONT-UNPACK
 -rw-r--r--    2166868 archive/fs-version-001/dhcp31-44/fio_rw_2018.02.01T22.40.57.tar.xz
 -rw-r--r--         68 archive/fs-version-001/dhcp31-44/fio_rw_2018.02.01T22.40.57.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.12.txt
+++ b/server/bin/gold/test-7.12.txt
@@ -4344,6 +4344,7 @@ drwxrwxr-x          - archive/fs-version-001/EC2::ip-172-31-52-154/TODO
 drwxrwxr-x          - archive/fs-version-001/EC2::ip-172-31-52-154/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/EC2::ip-172-31-52-154/UNPACKED/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz -> ../pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
 drwxrwxr-x          - archive/fs-version-001/EC2::ip-172-31-52-154/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/EC2::ip-172-31-52-154/WONT-UNPACK
 -rw-r--r--    5258824 archive/fs-version-001/EC2::ip-172-31-52-154/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
 -rw-r--r--         84 archive/fs-version-001/EC2::ip-172-31-52-154/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.13.txt
+++ b/server/bin/gold/test-7.13.txt
@@ -10846,6 +10846,7 @@ drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/TODO
 drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/UNPACKED
 lrwxrwxrwx         66 archive/fs-version-001/b03-h01-1029p/UNPACKED/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz -> ../pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
 drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/WONT-UNPACK
 -rw-rw-r--    3323572 archive/fs-version-001/b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
 -rw-rw-r--         98 archive/fs-version-001/b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.14.txt
+++ b/server/bin/gold/test-7.14.txt
@@ -7821,6 +7821,7 @@ drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/TODO
 drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/UNPACKED
 lrwxrwxrwx         66 archive/fs-version-001/b03-h01-1029p/UNPACKED/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz -> ../pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
 drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/b03-h01-1029p/WONT-UNPACK
 -rw-rw-r--    3324496 archive/fs-version-001/b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz
 -rw-rw-r--         98 archive/fs-version-001/b03-h01-1029p/pbench-user-benchmark_mbruzek-test-2_2018.04.10T19.01.19.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.15.txt
+++ b/server/bin/gold/test-7.15.txt
@@ -8503,6 +8503,7 @@ drwxrwxr-x          - archive/fs-version-001/master_40gb/TODO
 drwxrwxr-x          - archive/fs-version-001/master_40gb/UNPACKED
 lrwxrwxrwx         36 archive/fs-version-001/master_40gb/UNPACKED/uperf__2016-10-06_16:34:03.tar.xz -> ../uperf__2016-10-06_16:34:03.tar.xz
 drwxrwxr-x          - archive/fs-version-001/master_40gb/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/master_40gb/WONT-UNPACK
 -rw-rw-r--    5807176 archive/fs-version-001/master_40gb/uperf__2016-10-06_16:34:03.tar.xz
 -rw-r--r--         68 archive/fs-version-001/master_40gb/uperf__2016-10-06_16:34:03.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.16.txt
+++ b/server/bin/gold/test-7.16.txt
@@ -10108,6 +10108,7 @@ drwxrwxr-x          - archive/fs-version-001/rhel8-4/TODO
 drwxrwxr-x          - archive/fs-version-001/rhel8-4/UNPACKED
 lrwxrwxrwx         65 archive/fs-version-001/rhel8-4/UNPACKED/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz -> ../uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz
 drwxrwxr-x          - archive/fs-version-001/rhel8-4/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/rhel8-4/WONT-UNPACK
 -rw-rw-r--    1584556 archive/fs-version-001/rhel8-4/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz
 -rw-rw-r--         97 archive/fs-version-001/rhel8-4/uperf_rhel8_4.18.0-18.el8_40gb_pass_2018.10.04T06.53.43.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.17.txt
+++ b/server/bin/gold/test-7.17.txt
@@ -3548,6 +3548,7 @@ drwxrwxr-x          - archive/fs-version-001/ansible-host/TODO
 drwxrwxr-x          - archive/fs-version-001/ansible-host/UNPACKED
 lrwxrwxrwx         66 archive/fs-version-001/ansible-host/UNPACKED/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz -> ../pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz
 drwxrwxr-x          - archive/fs-version-001/ansible-host/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/ansible-host/WONT-UNPACK
 -rw-rw-r--      31384 archive/fs-version-001/ansible-host/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz
 -rw-rw-r--         98 archive/fs-version-001/ansible-host/pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.18.txt
+++ b/server/bin/gold/test-7.18.txt
@@ -190,6 +190,7 @@ lrwxrwxrwx         19 archive/fs-version-001/bad-controller/UNPACKED/test-7.18.t
 drwxrwxr-x          - archive/fs-version-001/bad-controller/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/bad-controller/WONT-INDEX.7
 lrwxrwxrwx         99 archive/fs-version-001/bad-controller/WONT-INDEX.7/test-7.18.tar.xz -> /var/tmp/pbench-test-server/test-7.18/pbench/archive/fs-version-001/bad-controller/test-7.18.tar.xz
+drwxrwxr-x          - archive/fs-version-001/bad-controller/WONT-UNPACK
 -rw-rw-r--        232 archive/fs-version-001/bad-controller/pbench-user-benchmark__2018.02.05T20.35.36.tar.xz
 -rw-rw-r--       1496 archive/fs-version-001/bad-controller/test-7.18.tar.xz
 -rw-rw-r--         51 archive/fs-version-001/bad-controller/test-7.18.tar.xz.md5

--- a/server/bin/gold/test-7.19.txt
+++ b/server/bin/gold/test-7.19.txt
@@ -2261,6 +2261,7 @@ drwxrwxr-x          - archive/fs-version-001/perf122/TODO
 drwxrwxr-x          - archive/fs-version-001/perf122/UNPACKED
 lrwxrwxrwx        117 archive/fs-version-001/perf122/UNPACKED/trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38.tar.xz -> ../trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38.tar.xz
 drwxrwxr-x          - archive/fs-version-001/perf122/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/perf122/WONT-UNPACK
 -rw-rw-r--    1030152 archive/fs-version-001/perf122/trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38.tar.xz
 -rw-rw-r--        151 archive/fs-version-001/perf122/trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.2.0.txt
+++ b/server/bin/gold/test-7.2.0.txt
@@ -188,6 +188,7 @@ lrwxrwxrwx         18 archive/fs-version-001/controller/UNPACKED/test-7.2.tar.xz
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX.4
 lrwxrwxrwx         95 archive/fs-version-001/controller/WONT-INDEX.4/test-7.2.tar.xz -> /var/tmp/pbench-test-server/test-7.2.0/pbench/archive/fs-version-001/controller/test-7.2.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller/WONT-UNPACK
 -rw-rw-r--       1204 archive/fs-version-001/controller/test-7.2.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/controller/test-7.2.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.2.1.txt
+++ b/server/bin/gold/test-7.2.1.txt
@@ -188,6 +188,7 @@ lrwxrwxrwx         36 archive/fs-version-001/controller/UNPACKED/uperf__2016-10-
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/controller/WONT-INDEX.4
 lrwxrwxrwx        113 archive/fs-version-001/controller/WONT-INDEX.4/uperf__2016-10-06_16:34:03.tar.xz -> /var/tmp/pbench-test-server/test-7.2.1/pbench/archive/fs-version-001/controller/uperf__2016-10-06_16:34:03.tar.xz
+drwxrwxr-x          - archive/fs-version-001/controller/WONT-UNPACK
 -rw-rw-r--    5809020 archive/fs-version-001/controller/uperf__2016-10-06_16:34:03.tar.xz
 -rw-r--r--         68 archive/fs-version-001/controller/uperf__2016-10-06_16:34:03.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.3.txt
+++ b/server/bin/gold/test-7.3.txt
@@ -188,6 +188,7 @@ lrwxrwxrwx         18 archive/fs-version-001/alphaville/UNPACKED/test-7.3.tar.xz
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX.7
 lrwxrwxrwx         93 archive/fs-version-001/alphaville/WONT-INDEX.7/test-7.3.tar.xz -> /var/tmp/pbench-test-server/test-7.3/pbench/archive/fs-version-001/alphaville/test-7.3.tar.xz
+drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-UNPACK
 -rw-rw-r--       1476 archive/fs-version-001/alphaville/test-7.3.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/alphaville/test-7.3.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.4.txt
+++ b/server/bin/gold/test-7.4.txt
@@ -198,6 +198,7 @@ lrwxrwxrwx         18 archive/fs-version-001/alphaville/UNPACKED/test-7.4.tar.xz
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX.10
 lrwxrwxrwx         93 archive/fs-version-001/alphaville/WONT-INDEX.10/test-7.4.tar.xz -> /var/tmp/pbench-test-server/test-7.4/pbench/archive/fs-version-001/alphaville/test-7.4.tar.xz
+drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-UNPACK
 -rw-rw-r--       1484 archive/fs-version-001/alphaville/test-7.4.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/alphaville/test-7.4.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.5.txt
+++ b/server/bin/gold/test-7.5.txt
@@ -198,6 +198,7 @@ lrwxrwxrwx         18 archive/fs-version-001/alphaville/UNPACKED/test-7.5.tar.xz
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX.10
 lrwxrwxrwx         93 archive/fs-version-001/alphaville/WONT-INDEX.10/test-7.5.tar.xz -> /var/tmp/pbench-test-server/test-7.5/pbench/archive/fs-version-001/alphaville/test-7.5.tar.xz
+drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-UNPACK
 -rw-rw-r--       1496 archive/fs-version-001/alphaville/test-7.5.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/alphaville/test-7.5.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.6.txt
+++ b/server/bin/gold/test-7.6.txt
@@ -422,6 +422,7 @@ drwxrwxr-x          - archive/fs-version-001/alphaville/TODO
 drwxrwxr-x          - archive/fs-version-001/alphaville/UNPACKED
 lrwxrwxrwx         18 archive/fs-version-001/alphaville/UNPACKED/test-7.6.tar.xz -> ../test-7.6.tar.xz
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-UNPACK
 -rw-rw-r--       1492 archive/fs-version-001/alphaville/test-7.6.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/alphaville/test-7.6.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.7.txt
+++ b/server/bin/gold/test-7.7.txt
@@ -422,6 +422,7 @@ drwxrwxr-x          - archive/fs-version-001/alphaville/TODO
 drwxrwxr-x          - archive/fs-version-001/alphaville/UNPACKED
 lrwxrwxrwx         18 archive/fs-version-001/alphaville/UNPACKED/test-7.7.tar.xz -> ../test-7.7.tar.xz
 drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/alphaville/WONT-UNPACK
 -rw-rw-r--       1500 archive/fs-version-001/alphaville/test-7.7.tar.xz
 -rw-rw-r--         50 archive/fs-version-001/alphaville/test-7.7.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.8.txt
+++ b/server/bin/gold/test-7.8.txt
@@ -8503,6 +8503,7 @@ drwxrwxr-x          - archive/fs-version-001/master_40gb/TODO
 drwxrwxr-x          - archive/fs-version-001/master_40gb/UNPACKED
 lrwxrwxrwx         36 archive/fs-version-001/master_40gb/UNPACKED/uperf__2016-10-06_16:34:03.tar.xz -> ../uperf__2016-10-06_16:34:03.tar.xz
 drwxrwxr-x          - archive/fs-version-001/master_40gb/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/master_40gb/WONT-UNPACK
 -rw-rw-r--    5472928 archive/fs-version-001/master_40gb/uperf__2016-10-06_16:34:03.tar.xz
 -rw-r--r--         68 archive/fs-version-001/master_40gb/uperf__2016-10-06_16:34:03.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-7.9.txt
+++ b/server/bin/gold/test-7.9.txt
@@ -9037,6 +9037,7 @@ drwxrwxr-x          - archive/fs-version-001/dhcp31-144/TODO
 drwxrwxr-x          - archive/fs-version-001/dhcp31-144/UNPACKED
 lrwxrwxrwx         52 archive/fs-version-001/dhcp31-144/UNPACKED/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz -> ../pbench-user-benchmark__2017-04-21_20:38:16.tar.xz
 drwxrwxr-x          - archive/fs-version-001/dhcp31-144/WONT-INDEX
+drwxrwxr-x          - archive/fs-version-001/dhcp31-144/WONT-UNPACK
 -rw-r--r--    1137024 archive/fs-version-001/dhcp31-144/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz
 -rw-r--r--         84 archive/fs-version-001/dhcp31-144/pbench-user-benchmark__2017-04-21_20:38:16.tar.xz.md5
 drwxrwxr-x          - public_html

--- a/server/bin/gold/test-8.txt
+++ b/server/bin/gold/test-8.txt
@@ -9,7 +9,10 @@ MAILTO=unit-test-user@example.com
 MAILFROM=pbench@pbench.example.com
 * * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-prep-002.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-server-prep-shim-002
 * * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-dispatch.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-dispatch
-* * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-unpack-tarballs.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-unpack-tarballs
+* * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-unpack-tarballs-small.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-unpack-tarballs small
+* * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-unpack-tarballs-medium.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-unpack-tarballs medium
+* * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-unpack-tarballs-large.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-unpack-tarballs large
+* * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-unpack-tarballs-huge.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-unpack-tarballs huge
 41 * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-copy-sosreports.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-copy-sosreports
 * * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-edit-prefixes.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-edit-prefixes
 * * * * *  flock -n /var/tmp/pbench-test-server/test-8/opt/pbench-server/lib/locks/pbench-index.lock /var/tmp/pbench-test-server/test-8/opt/pbench-server/bin/pbench-index

--- a/server/bin/pbench-base.sh
+++ b/server/bin/pbench-base.sh
@@ -73,6 +73,7 @@ function mk_dirs {
             return 1
         fi
     done
+    return 0
 }
 
 function log_init {

--- a/server/bin/pbench-unpack-tarballs.sh
+++ b/server/bin/pbench-unpack-tarballs.sh
@@ -38,53 +38,48 @@
 
 
 # load common things
-. $dir/pbench-base.sh
+. ${dir}/pbench-base.sh
 
 # check that all the directories exist
-test -d $ARCHIVE || doexit "Bad ARCHIVE=$ARCHIVE"
-test -d $INCOMING || doexit "Bad INCOMING=$INCOMING"
-test -d $RESULTS || doexit "Bad RESULTS=$RESULTS"
-test -d $USERS || doexit "Bad USERS=$USERS"
+test -d ${ARCHIVE} || doexit "Bad ARCHIVE=${ARCHIVE}"
+test -d ${INCOMING} || doexit "Bad INCOMING=${INCOMING}"
+test -d ${RESULTS} || doexit "Bad RESULTS=${RESULTS}"
+test -d ${USERS} || doexit "Bad USERS=${USERS}"
 
-# make sure only one copy is running.
-# Use 'flock -n $LOCKFILE /home/pbench/bin/pbench-unpack-tarballs' in the
-# crontab to ensure that only one copy is running. The script itself
-# does not use any locking.
-
-# the link source and destination(s) for this script
+# The link source and destination(s) for this script.
 linksrc=TO-UNPACK
 linkdest=UNPACKED
 linkdestlist=$(getconf.py -l unpacked-states pbench-server)
 
-tmp=$TMP/$PROG.$$
-trap 'rm -rf $tmp' EXIT INT QUIT
+tmp=${TMP}/${PROG}.${$}
+trap 'rm -rf ${tmp}' EXIT INT QUIT
 
-mkdir -p $tmp || doexit "Failed to create $tmp"
+mkdir -p ${tmp} || doexit "Failed to create ${tmp}"
 
-log_init $PROG
+log_init ${PROG}
 
-echo $TS
+echo ${TS}
 
 # Accumulate errors and logs in files for reporting at the end.
-mail_content=$tmp/mail_content.log
-index_content=$tmp/index_mail_contents
+mail_content=${tmp}/mail_content.log
+index_content=${tmp}/index_mail_contents
 
 # get the list of files we'll be operating on - sort them by size
-list=$tmp/$PROG.list
+list=${tmp}/${PROG}.list
 
-# Find all the links in all the $ARCHIVE/<controller>/$linksrc
+# Find all the links in all the ${ARCHIVE}/<controller>/${linksrc}
 # directories, emitting a list of their full paths with the size
 # in bytes of the file the link points to, and then sort them so
 # that we process the smallest tar balls first.
 > ${list}.unsorted
-# First we find all the $linksrc directories
-for linksrc_dir in $(find $ARCHIVE/ -maxdepth 2 -type d -name $linksrc); do
-    # Find all the links in a given $linksrc directory that are
+# First we find all the ${linksrc} directories
+for linksrc_dir in $(find ${ARCHIVE}/ -maxdepth 2 -type d -name ${linksrc}); do
+    # Find all the links in a given ${linksrc} directory that are
     # links to actual files (bad links are not emitted!).
-    find -L $linksrc_dir -type f -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
-    # Find all the links in the same $linksrc directory that don't
+    find -L ${linksrc_dir} -type f -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
+    # Find all the links in the same ${linksrc} directory that don't
     # link to anything so that we can count them as errors below.
-    find -L $linksrc_dir -type l -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
+    find -L ${linksrc_dir} -type l -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
 done
 sort -n ${list}.unsorted > ${list}
 rm -f ${list}.unsorted
@@ -96,196 +91,178 @@ typeset -i ndups=0
 typeset -i nwarn=0
 
 # Initialize report content
-> $mail_content
-> $index_content
+> ${mail_content}
+> ${index_content}
 
 while read size result ;do
-    ntotal=$ntotal+1
+    ntotal=${ntotal}+1
 
-    link=$(readlink -e $result)
-    if [ -z "$link" ] ;then
-        echo "$TS: symlink target for $result does not exist" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
+    link=$(readlink -e ${result})
+    if [[ -z "${link}" ]]; then
+        echo "${TS}: symlink target for ${result} does not exist" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
         # FIXME: quarantine $result
         continue
     fi
-    resultname=$(basename $result)
+    resultname=$(basename ${result})
     resultname=${resultname%.tar.xz}
 
     # XXXX - for now, if it's a duplicate name, just punt and avoid
     # producing the error
-    if [ ${resultname%%.*} == "DUPLICATE__NAME" ] ;then
-        ndups=$ndups+1
+    if [[ ${resultname%%.*} == "DUPLICATE__NAME" ]]; then
+        ndups=${ndups}+1
         # FIXME: quarantine $result
         continue
     fi
 
-    basedir=$(dirname $link)
-    hostname=$(basename $basedir)
+    basedir=$(dirname ${link})
+    hostname=$(basename ${basedir})
 
-    # make sure that all the relevant state directories exist
-    mk_dirs $hostname
-    # ... and a couple of other necessities.
-    if [[ $? -ne 0 ]] ;then
-        echo "$TS: Creation of $hostname processing directories failed for $result: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
+    # Make sure that all the relevant state directories exist
+    mk_dirs ${hostname}
+    status=${?}
+    if [[ ${?} -ne 0 ]]; then
+        echo "${TS}: Creation of ${hostname} processing directories failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
         continue
     fi
-    mkdir -p $INCOMING/$hostname
-    if [[ $? -ne 0 ]] ;then
-        echo "$TS: Creation of $INCOMING/$hostname failed for $result: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
-        continue
-    fi
-    incoming=$INCOMING/$hostname/$resultname
-    if [ -e $incoming ]; then
-        echo "$TS: Incoming result, $INCOMING/$hostname/$resultname/, already exists, skipping $result" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
+
+    incoming=${INCOMING}/${hostname}/${resultname}
+    if [[ -e ${incoming} ]]; then
+        echo "${TS}: Incoming result, ${incoming}, already exists, skipping ${result}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
         # FIXME: quarantine $result
         continue
     fi
 
-    mkdir -p $INCOMING/$hostname
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: mkdir -p $INCOMING/$hostname failed for $result: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
-        continue
-    fi
-    if [ -e $INCOMING/$hostname/${resultname} ]; then
-        echo "$TS: $INCOMING/$hostname/${resultname} already exists for $result" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
-        continue
-    fi
-
-    mkdir $INCOMING/$hostname/${resultname}.unpack
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: 'mkdir ${resultname}.unpack' failed for $result: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
+    mkdir -p ${incoming}.unpack
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: 'mkdir ${incoming}.unpack' failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
         popd > /dev/null 2>&1
         continue
     fi
     let start_time=$(timestamp-seconds-since-epoch)
-    tar --extract --no-same-owner --touch --delay-directory-restore --file="$result" --force-local --directory="$INCOMING/$hostname/${resultname}.unpack"
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: 'tar -xf $result' failed: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
+    tar --extract --no-same-owner --touch --delay-directory-restore --file="${result}" --force-local --directory="${incoming}.unpack"
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: 'tar -xf ${result}' failed: code ${status}" | tee -a ${mail_content} >&4
+        rm -rf ${incoming}.unpack
+        nerrs=${nerrs}+1
         continue
-    fi
-    mv $INCOMING/$hostname/${resultname}.unpack/${resultname} $INCOMING/$hostname/${resultname}
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: '$result' does not contain ${resultname} directory at the top level; skipping" | tee -a $mail_content >&4
-        rm -rf $INCOMING/$hostname/${resultname}.unpack
-        nerrs=$nerrs+1
-        # FIXME: quarantine $result
-        continue
-    fi
-    rmdir $INCOMING/$hostname/${resultname}.unpack
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: WARNING - '$result' should only contain the ${resultname} directory at the top level, ignoring other content" | tee -a $mail_content >&4
-        rm -rf $INCOMING/$hostname/${resultname}.unpack
-        nwarn=$nwarn+1
     fi
 
     # chmod directories to at least 555
-    find $INCOMING/$hostname/${resultname} -type d -print0 | xargs -0 chmod ugo+rx
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: 'chmod ugo+rx' of subdirs $resultname for $result failed: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        rm -rf $INCOMING/$hostname/$resultname
-        # FIXME: quarantine $result
+    find ${incoming}.unpack/${resultname} -type d -print0 | xargs -0 chmod ugo+rx
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: 'chmod ugo+rx' of subdirs ${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
+        rm -rf ${incoming}.unpack
         continue
     fi
 
     # chmod files to at least 444
-    chmod -R ugo+r $INCOMING/$hostname/$resultname
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: 'chmod -R ugo+r $resultname' for $result failed: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        rm -rf $INCOMING/$hostname/$resultname
+    chmod -R ugo+r ${incoming}.unpack/${resultname}
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: 'chmod -R ugo+r ${resultname}' for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
+        rm -rf ${incoming}.unpack
+        continue
+    fi
+
+    # Move the final unpacked tar ball into place
+    mv ${incoming}.unpack/${resultname} ${INCOMING}/${hostname}/
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: '${result}' does not contain ${resultname} directory at the top level; skipping" | tee -a ${mail_content} >&4
+        rm -rf ${incoming}.unpack
+        nerrs=${nerrs}+1
         # FIXME: quarantine $result
         continue
+    fi
+    rmdir ${incoming}.unpack
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: WARNING - '${result}' should only contain the ${resultname} directory at the top level, ignoring other content" | tee -a ${mail_content} >&4
+        rm -rf ${incoming}.unpack
+        nwarn=${nwarn}+1
     fi
 
     # Version 002 agents use the metadata log to store a prefix.
     # They may also store a user option in the metadata log.
     # We check for both of these here (n.b. if nothing is found
     # they are going to be empty strings):
-    prefix=$(getconf.py -C $INCOMING/$hostname/$resultname/metadata.log prefix run)
-    user=$(getconf.py -C $INCOMING/$hostname/$resultname/metadata.log user run)
+    prefix=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log prefix run)
+    user=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log user run)
 
     # Version 001 agents use a prefix file.  If there is a prefix file,
     # create a link as specified in the prefix file.  pbench-dispatch
     # has already moved it to the .prefix subdir
-    prefixfile=$basedir/.prefix/$resultname.prefix
-    if [ -f $prefixfile ] ;then
-        # add the slash to make both cases uniform in what follows
-        prefix=$(cat $prefixfile)
+    prefixfile=${basedir}/.prefix/${resultname}.prefix
+    if [[ -f ${prefixfile} ]]; then
+        prefix=$(cat ${prefixfile})
     fi
 
     # if non-empty and does not contain a trailing slash, add one
-    if [ ! -z $prefix -a ${prefix%/} = ${prefix} ] ;then
+    if [[ ! -z "${prefix}" && "${prefix%/}" = "${prefix}" ]]; then
         prefix=${prefix}/
     fi
 
-    mkdir -p $RESULTS/$hostname/$prefix
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: mkdir -p $RESULTS/$hostname/$prefix for $result failed: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
-        rm -rf $INCOMING/$hostname/$resultname
+    mkdir -p ${RESULTS}/${hostname}/${prefix}
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: mkdir -p ${RESULTS}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+        rm -rf ${incoming}
+        nerrs=${nerrs}+1
         continue
-    else
-        # make a link in results/
-        echo "ln -s $incoming $RESULTS/$hostname/$prefix$resultname"
-        ln -s $incoming $RESULTS/$hostname/$prefix$resultname
-        status=$?
-        if [[ $status -ne 0 ]] ;then
-            echo "$TS: ln -s $incoming $RESULTS/$hostname/$prefix$resultname for $result failed: code $status" | tee -a $mail_content >&4
-            nerrs=$nerrs+1
-            rm -rf $incoming
-            rm -rf $INCOMING/$hostname/$resultname
+    fi
+    # make a link in results/
+    echo "ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}"
+    ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
+        rm -rf ${incoming}
+        continue
+    fi
+
+    if [[ ! -z ${user} ]]; then
+        # make a link in users/ but first make sure the directory exists
+        mkdir -p ${USERS}/${user}/${hostname}/${prefix}
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: mkdir -p ${USERS}/${user}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+            rm -rf ${incoming}
+            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+            nerrs=${nerrs}+1
             continue
         fi
 
-        if [ ! -z ${user} ] ;then
-            # make a link in users/ but first make sure the directory exists
-            mkdir -p ${USERS}/${user}/${hostname}/${prefix}
-            echo "ln -s ${incoming} $USERS/${user}/${hostname}/${prefix}${resultname}"
-            ln -s ${incoming} $USERS/${user}/${hostname}/${prefix}${resultname}
-            status=$?
-            if [[ $status -ne 0 ]] ;then
-                echo "$TS: code $status: ln -s ${incoming} $USERS/${user}/${hostname}/${prefix}${resultname}" | tee -a $mail_content >&4
-                nerrs=$nerrs+1
-                rm -rf ${incoming}
-                rm -rf ${INCOMING}/${hostname}/${resultname}
-                rm -rf ${RESULTS}/${hostname}/${prefix}${resultname}
-                continue
-            fi
+        echo "ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}"
+        ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: code ${status}: ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            rm -rf ${incoming}
+            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+            continue
         fi
     fi
 
-    mv $ARCHIVE/$hostname/$linksrc/$resultname.tar.xz $ARCHIVE/$hostname/$linkdest/$resultname.tar.xz
-    status=$?
-    if [[ $status -ne 0 ]] ;then
-        echo "$TS: Cannot move symlink to $ARCHIVE/$hostname/$resultname.tar.xz from $linksrc to $linkdest: code $status" | tee -a $mail_content >&4
-        nerrs=$nerrs+1
+    mv ${ARCHIVE}/${hostname}/${linksrc}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${linkdest}/${resultname}.tar.xz
+    status=${?}
+    if [[ ${status} -ne 0 ]]; then
+        echo "${TS}: Cannot move symlink ${ARCHIVE}/${hostname}/${resultname}.tar.xz from ${linksrc} to ${linkdest}: code ${status}" | tee -a ${mail_content} >&4
+        nerrs=${nerrs}+1
         # Cleanup needed here but trap takes care of it.
         rm -rf ${incoming}
-        rm -rf ${INCOMING}/${hostname}/${resultname}
-        rm $RESULTS/$hostname/$prefix$resultname
+        rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+        rm -f ${USERS}/${user}/${hostname}/${prefix}${resultname}
         continue
     fi
 
@@ -295,15 +272,15 @@ while read size result ;do
     let totsuc=0
     for state in ${linkdestlist}; do
         ln -sf ${ARCHIVE}/${hostname}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${state}/${resultname}.tar.xz
-        status=$?
-        if [ ${status} -eq 0 ] ;then
+        status=${?}
+        if [[ ${status} -eq 0 ]]; then
             let totsuc+=1
         else
-            echo "$TS: Cannot create ${ARCHIVE}/${hostname}/${resultname}.tar.xz link to $state: code $status" | tee -a $mail_content >&4
+            echo "${TS}: Cannot create ${ARCHIVE}/${hostname}/${resultname}.tar.xz link in state ${state}: code ${status}" | tee -a ${mail_content} >&4
             let toterr+=1
         fi
     done
-    if [ $toterr -gt 0 ]; then
+    if [[ ${toterr} -gt 0 ]]; then
         # Count N link creations as one error since it is for handling of a
         # single tarball.
         let nerrs+=1
@@ -312,21 +289,21 @@ while read size result ;do
     let end_time=$(timestamp-seconds-since-epoch)
     let duration=end_time-start_time
     # log the success
-    echo "$TS: $hostname/$resultname: success - elapsed time (secs): $duration - size (bytes): $size"
-    ntb=$ntb+1
-done < $list
+    echo "${TS}: ${hostname}/${resultname}: success - elapsed time (secs): ${duration} - size (bytes): ${size}"
+    ntb=${ntb}+1
+done < ${list}
 
-echo "$TS: Processed $ntb tarballs"
+echo "${TS}: Processed ${ntb} tarballs"
 
 log_finish
 
-subj="$PROG.$TS($PBENCH_ENV) - w/ $nerrs errors"
-cat << EOF > $index_content
-$subj
-Processed $ntotal result tar balls, $ntb successfully, $nwarn warnings, $nerrs errors, and $ndups duplicates
+subj="${PROG}.${TS}(${PBENCH_ENV}) - w/ ${nerrs} errors"
+cat << EOF > ${index_content}
+${subj}
+Processed ${ntotal} result tar balls, ${ntb} successfully, ${nwarn} warnings, ${nerrs} errors, and ${ndups} duplicates
 
 EOF
-cat $mail_content >> $index_content
+cat ${mail_content} >> ${index_content}
 pbench-report-status --name ${PROG} --pid ${$} --timestamp $(timestamp) --type status ${index_content}
 
 exit 0

--- a/server/bin/pbench-unpack-tarballs.sh
+++ b/server/bin/pbench-unpack-tarballs.sh
@@ -51,6 +51,37 @@ linksrc=TO-UNPACK
 linkdest=UNPACKED
 linkdestlist=$(getconf.py -l unpacked-states pbench-server)
 
+BUCKET="${1}"
+if [[ -z "${BUCKET}" ]]; then
+    lb_arg=""
+    ub_arg=""
+    lowerbound=0
+    upperbound=""
+    export PROG="${PROG}"
+else
+    lowerbound=$(getconf.py lowerbound pbench-unpack-tarballs/${BUCKET})
+    if [[ -z "${lowerbound}" ]]; then
+        lb_arg=""
+        lowerbound=0
+    else
+        # Convert megabytes to bytes
+        lowerbound=$(( ${lowerbound} * 1024 * 1024 ))
+        lb_arg="-size +$(( ${lowerbound} - 1 ))c"
+    fi
+    upperbound=$(getconf.py upperbound pbench-unpack-tarballs/${BUCKET})
+    if [[ -z "${upperbound}" ]]; then
+        ub_arg=""
+    else
+        # Convert megabytes to bytes
+        upperbound=$(( ${upperbound} * 1024 * 1024 ))
+        ub_arg="-size -$(( ${upperbound} ))c"
+    fi
+    # We rename the PROG to include the bucket since we don't want to conflict
+    # with other unpack tar balls running using different buckets at the same
+    # time.
+    export PROG="${PROG}-${BUCKET}"
+fi
+
 tmp=${TMP}/${PROG}.${$}
 trap 'rm -rf ${tmp}' EXIT INT QUIT
 
@@ -62,27 +93,36 @@ echo ${TS}
 
 # Accumulate errors and logs in files for reporting at the end.
 mail_content=${tmp}/mail_content.log
+> ${mail_content}
 index_content=${tmp}/index_mail_contents
+> ${index_content}
 
 # get the list of files we'll be operating on - sort them by size
 list=${tmp}/${PROG}.list
 
-# Find all the links in all the ${ARCHIVE}/<controller>/${linksrc}
-# directories, emitting a list of their full paths with the size
-# in bytes of the file the link points to, and then sort them so
-# that we process the smallest tar balls first.
-> ${list}.unsorted
-# First we find all the ${linksrc} directories
-for linksrc_dir in $(find ${ARCHIVE}/ -maxdepth 2 -type d -name ${linksrc}); do
-    # Find all the links in a given ${linksrc} directory that are
-    # links to actual files (bad links are not emitted!).
-    find -L ${linksrc_dir} -type f -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
-    # Find all the links in the same ${linksrc} directory that don't
-    # link to anything so that we can count them as errors below.
-    find -L ${linksrc_dir} -type l -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
-done
-sort -n ${list}.unsorted > ${list}
-rm -f ${list}.unsorted
+function gen_work_list() {
+    # Find all the links in all the ${ARCHIVE}/<controller>/${linksrc}
+    # directories, emitting a list of their full paths with the size in bytes
+    # of the file the link points to, and then sort them so that we process
+    # the smallest tar balls first.
+    rm -f ${list}
+    > ${list}.unsorted
+    # First we find all the ${linksrc} directories
+    for linksrc_dir in $(find ${ARCHIVE}/ -maxdepth 2 -type d -name ${linksrc}); do
+        # Find all the links in a given ${linksrc} directory that are links to
+        # actual files (bad links are not emitted!).
+        find -L ${linksrc_dir} -type f -name '*.tar.xz' ${lb_arg} ${ub_arg} -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
+        if [[ ${lowerbound} == 0 ]]; then
+            # Find all the links in the same ${linksrc} directory that don't
+            # link to anything so that we can count them as errors below.
+            find -L $linksrc_dir -type l -name '*.tar.xz' -printf "%s %p\n" 2>/dev/null >> ${list}.unsorted
+        fi
+    done
+    sort -n ${list}.unsorted > ${list}
+    rm -f ${list}.unsorted
+}
+
+gen_work_list
 
 typeset -i ntb=0
 typeset -i ntotal=0
@@ -90,208 +130,208 @@ typeset -i nerrs=0
 typeset -i ndups=0
 typeset -i nwarn=0
 
-# Initialize report content
-> ${mail_content}
-> ${index_content}
+function do_work() {
+    while read size result; do
+        ntotal=${ntotal}+1
 
-while read size result ;do
-    ntotal=${ntotal}+1
+        link=$(readlink -e ${result})
+        if [[ -z "${link}" ]]; then
+            echo "${TS}: symlink target for ${result} does not exist" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            # FIXME: quarantine $result
+            continue
+        fi
+        resultname=$(basename ${result})
+        resultname=${resultname%.tar.xz}
 
-    link=$(readlink -e ${result})
-    if [[ -z "${link}" ]]; then
-        echo "${TS}: symlink target for ${result} does not exist" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        # FIXME: quarantine $result
-        continue
-    fi
-    resultname=$(basename ${result})
-    resultname=${resultname%.tar.xz}
+        # XXXX - for now, if it's a duplicate name, just punt and avoid
+        # producing the error
+        if [[ ${resultname%%.*} == "DUPLICATE__NAME" ]]; then
+            ndups=${ndups}+1
+            # FIXME: quarantine $result
+            continue
+        fi
 
-    # XXXX - for now, if it's a duplicate name, just punt and avoid
-    # producing the error
-    if [[ ${resultname%%.*} == "DUPLICATE__NAME" ]]; then
-        ndups=${ndups}+1
-        # FIXME: quarantine $result
-        continue
-    fi
+        basedir=$(dirname ${link})
+        hostname=$(basename ${basedir})
 
-    basedir=$(dirname ${link})
-    hostname=$(basename ${basedir})
-
-    # Make sure that all the relevant state directories exist
-    mk_dirs ${hostname}
-    status=${?}
-    if [[ ${?} -ne 0 ]]; then
-        echo "${TS}: Creation of ${hostname} processing directories failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        continue
-    fi
-
-    incoming=${INCOMING}/${hostname}/${resultname}
-    if [[ -e ${incoming} ]]; then
-        echo "${TS}: Incoming result, ${incoming}, already exists, skipping ${result}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        # FIXME: quarantine $result
-        continue
-    fi
-
-    mkdir -p ${incoming}.unpack
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: 'mkdir ${incoming}.unpack' failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        popd > /dev/null 2>&1
-        continue
-    fi
-    let start_time=$(timestamp-seconds-since-epoch)
-    tar --extract --no-same-owner --touch --delay-directory-restore --file="${result}" --force-local --directory="${incoming}.unpack"
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: 'tar -xf ${result}' failed: code ${status}" | tee -a ${mail_content} >&4
-        rm -rf ${incoming}.unpack
-        nerrs=${nerrs}+1
-        continue
-    fi
-
-    # chmod directories to at least 555
-    find ${incoming}.unpack/${resultname} -type d -print0 | xargs -0 chmod ugo+rx
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: 'chmod ugo+rx' of subdirs ${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        rm -rf ${incoming}.unpack
-        continue
-    fi
-
-    # chmod files to at least 444
-    chmod -R ugo+r ${incoming}.unpack/${resultname}
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: 'chmod -R ugo+r ${resultname}' for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        rm -rf ${incoming}.unpack
-        continue
-    fi
-
-    # Move the final unpacked tar ball into place
-    mv ${incoming}.unpack/${resultname} ${INCOMING}/${hostname}/
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: '${result}' does not contain ${resultname} directory at the top level; skipping" | tee -a ${mail_content} >&4
-        rm -rf ${incoming}.unpack
-        nerrs=${nerrs}+1
-        # FIXME: quarantine $result
-        continue
-    fi
-    rmdir ${incoming}.unpack
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: WARNING - '${result}' should only contain the ${resultname} directory at the top level, ignoring other content" | tee -a ${mail_content} >&4
-        rm -rf ${incoming}.unpack
-        nwarn=${nwarn}+1
-    fi
-
-    # Version 002 agents use the metadata log to store a prefix.
-    # They may also store a user option in the metadata log.
-    # We check for both of these here (n.b. if nothing is found
-    # they are going to be empty strings):
-    prefix=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log prefix run)
-    user=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log user run)
-
-    # Version 001 agents use a prefix file.  If there is a prefix file,
-    # create a link as specified in the prefix file.  pbench-dispatch
-    # has already moved it to the .prefix subdir
-    prefixfile=${basedir}/.prefix/${resultname}.prefix
-    if [[ -f ${prefixfile} ]]; then
-        prefix=$(cat ${prefixfile})
-    fi
-
-    # if non-empty and does not contain a trailing slash, add one
-    if [[ ! -z "${prefix}" && "${prefix%/}" = "${prefix}" ]]; then
-        prefix=${prefix}/
-    fi
-
-    mkdir -p ${RESULTS}/${hostname}/${prefix}
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: mkdir -p ${RESULTS}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
-        rm -rf ${incoming}
-        nerrs=${nerrs}+1
-        continue
-    fi
-    # make a link in results/
-    echo "ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}"
-    ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        rm -rf ${incoming}
-        continue
-    fi
-
-    if [[ ! -z ${user} ]]; then
-        # make a link in users/ but first make sure the directory exists
-        mkdir -p ${USERS}/${user}/${hostname}/${prefix}
+        # Make sure that all the relevant state directories exist
+        mk_dirs ${hostname}
         status=${?}
-        if [[ ${status} -ne 0 ]]; then
-            echo "${TS}: mkdir -p ${USERS}/${user}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
-            rm -rf ${incoming}
-            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+        if [[ ${?} -ne 0 ]]; then
+            echo "${TS}: Creation of ${hostname} processing directories failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
             nerrs=${nerrs}+1
             continue
         fi
 
-        echo "ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}"
-        ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}
-        status=${?}
-        if [[ ${status} -ne 0 ]]; then
-            echo "${TS}: code ${status}: ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}" | tee -a ${mail_content} >&4
+        incoming=${INCOMING}/${hostname}/${resultname}
+        if [[ -e ${incoming} ]]; then
+            echo "${TS}: Incoming result, ${incoming}, already exists, skipping ${result}" | tee -a ${mail_content} >&4
             nerrs=${nerrs}+1
-            rm -rf ${incoming}
-            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+            # FIXME: quarantine $result
             continue
         fi
-    fi
 
-    mv ${ARCHIVE}/${hostname}/${linksrc}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${linkdest}/${resultname}.tar.xz
-    status=${?}
-    if [[ ${status} -ne 0 ]]; then
-        echo "${TS}: Cannot move symlink ${ARCHIVE}/${hostname}/${resultname}.tar.xz from ${linksrc} to ${linkdest}: code ${status}" | tee -a ${mail_content} >&4
-        nerrs=${nerrs}+1
-        # Cleanup needed here but trap takes care of it.
-        rm -rf ${incoming}
-        rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
-        rm -f ${USERS}/${user}/${hostname}/${prefix}${resultname}
-        continue
-    fi
-
-    # Create a link in each state dir - if any fail, we should delete them all? No, that
-    # would be racy.
-    let toterr=0
-    let totsuc=0
-    for state in ${linkdestlist}; do
-        ln -sf ${ARCHIVE}/${hostname}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${state}/${resultname}.tar.xz
+        mkdir -p ${incoming}.unpack
         status=${?}
-        if [[ ${status} -eq 0 ]]; then
-            let totsuc+=1
-        else
-            echo "${TS}: Cannot create ${ARCHIVE}/${hostname}/${resultname}.tar.xz link in state ${state}: code ${status}" | tee -a ${mail_content} >&4
-            let toterr+=1
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: 'mkdir ${incoming}.unpack' failed for ${result}: code ${status}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            popd > /dev/null 2>&1
+            continue
         fi
+        let start_time=$(timestamp-seconds-since-epoch)
+        tar --extract --no-same-owner --touch --delay-directory-restore --file="${result}" --force-local --directory="${incoming}.unpack"
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: 'tar -xf ${result}' failed: code ${status}" | tee -a ${mail_content} >&4
+            rm -rf ${incoming}.unpack
+            nerrs=${nerrs}+1
+            continue
+        fi
+
+        # chmod directories to at least 555
+        find ${incoming}.unpack/${resultname} -type d -print0 | xargs -0 chmod ugo+rx
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: 'chmod ugo+rx' of subdirs ${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            rm -rf ${incoming}.unpack
+            continue
+        fi
+
+        # chmod files to at least 444
+        chmod -R ugo+r ${incoming}.unpack/${resultname}
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: 'chmod -R ugo+r ${resultname}' for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            rm -rf ${incoming}.unpack
+            continue
+        fi
+
+        # Move the final unpacked tar ball into place
+        mv ${incoming}.unpack/${resultname} ${INCOMING}/${hostname}/
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: '${result}' does not contain ${resultname} directory at the top level; skipping" | tee -a ${mail_content} >&4
+            rm -rf ${incoming}.unpack
+            nerrs=${nerrs}+1
+            # FIXME: quarantine $result
+            continue
+        fi
+        rmdir ${incoming}.unpack
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: WARNING - '${result}' should only contain the ${resultname} directory at the top level, ignoring other content" | tee -a ${mail_content} >&4
+            rm -rf ${incoming}.unpack
+            nwarn=${nwarn}+1
+        fi
+
+        # Version 002 agents use the metadata log to store a prefix.
+        # They may also store a user option in the metadata log.
+        # We check for both of these here (n.b. if nothing is found
+        # they are going to be empty strings):
+        prefix=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log prefix run)
+        user=$(getconf.py -C ${INCOMING}/${hostname}/${resultname}/metadata.log user run)
+
+        # Version 001 agents use a prefix file.  If there is a prefix file,
+        # create a link as specified in the prefix file.  pbench-dispatch
+        # has already moved it to the .prefix subdir
+        prefixfile=${basedir}/.prefix/${resultname}.prefix
+        if [[ -f ${prefixfile} ]]; then
+            prefix=$(cat ${prefixfile})
+        fi
+
+        # if non-empty and does not contain a trailing slash, add one
+        if [[ ! -z "${prefix}" && "${prefix%/}" = "${prefix}" ]]; then
+            prefix=${prefix}/
+        fi
+
+        mkdir -p ${RESULTS}/${hostname}/${prefix}
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: mkdir -p ${RESULTS}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+            rm -rf ${incoming}
+            nerrs=${nerrs}+1
+            continue
+        fi
+        # make a link in results/
+        echo "ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}"
+        ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname}
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: ln -s ${incoming} ${RESULTS}/${hostname}/${prefix}${resultname} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            rm -rf ${incoming}
+            continue
+        fi
+
+        if [[ ! -z ${user} ]]; then
+            # make a link in users/ but first make sure the directory exists
+            mkdir -p ${USERS}/${user}/${hostname}/${prefix}
+            status=${?}
+            if [[ ${status} -ne 0 ]]; then
+                echo "${TS}: mkdir -p ${USERS}/${user}/${hostname}/${prefix} for ${result} failed: code ${status}" | tee -a ${mail_content} >&4
+                rm -rf ${incoming}
+                rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+                nerrs=${nerrs}+1
+                continue
+            fi
+
+            echo "ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}"
+            ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}
+            status=${?}
+            if [[ ${status} -ne 0 ]]; then
+                echo "${TS}: code ${status}: ln -s ${incoming} ${USERS}/${user}/${hostname}/${prefix}${resultname}" | tee -a ${mail_content} >&4
+                nerrs=${nerrs}+1
+                rm -rf ${incoming}
+                rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+                continue
+            fi
+        fi
+
+        mv ${ARCHIVE}/${hostname}/${linksrc}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${linkdest}/${resultname}.tar.xz
+        status=${?}
+        if [[ ${status} -ne 0 ]]; then
+            echo "${TS}: Cannot move symlink ${ARCHIVE}/${hostname}/${resultname}.tar.xz from ${linksrc} to ${linkdest}: code ${status}" | tee -a ${mail_content} >&4
+            nerrs=${nerrs}+1
+            # Cleanup needed here but trap takes care of it.
+            rm -rf ${incoming}
+            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
+            rm -f ${USERS}/${user}/${hostname}/${prefix}${resultname}
+            continue
+        fi
+
+        # Create a link in each state dir - if any fail, we should delete them all? No, that
+        # would be racy.
+        let toterr=0
+        let totsuc=0
+        for state in ${linkdestlist}; do
+            ln -sf ${ARCHIVE}/${hostname}/${resultname}.tar.xz ${ARCHIVE}/${hostname}/${state}/${resultname}.tar.xz
+            status=${?}
+            if [[ ${status} -eq 0 ]]; then
+                let totsuc+=1
+            else
+                echo "${TS}: Cannot create ${ARCHIVE}/${hostname}/${resultname}.tar.xz link in state ${state}: code ${status}" | tee -a ${mail_content} >&4
+                let toterr+=1
+            fi
+        done
+        if [[ ${toterr} -gt 0 ]]; then
+            # Count N link creations as one error since it is for handling of a
+            # single tarball.
+            let nerrs+=1
+        fi
+
+        let end_time=$(timestamp-seconds-since-epoch)
+        let duration=end_time-start_time
+        # log the success
+        echo "${TS}: ${hostname}/${resultname}: success - elapsed time (secs): ${duration} - size (bytes): ${size}"
+        ntb=${ntb}+1
     done
-    if [[ ${toterr} -gt 0 ]]; then
-        # Count N link creations as one error since it is for handling of a
-        # single tarball.
-        let nerrs+=1
-    fi
+}
 
-    let end_time=$(timestamp-seconds-since-epoch)
-    let duration=end_time-start_time
-    # log the success
-    echo "${TS}: ${hostname}/${resultname}: success - elapsed time (secs): ${duration} - size (bytes): ${size}"
-    ntb=${ntb}+1
-done < ${list}
+do_work < ${list}
 
 echo "${TS}: Processed ${ntb} tarballs"
 

--- a/server/bin/state/test-16.setup
+++ b/server/bin/state/test-16.setup
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Make sure all the tar balls are ordered by modification time so we
+# have consistent and expected results from the unit tests.
+
+function _dotouch() {
+    #           CCYYMMDDhhmm.ss
+    touch    -t 201901011242.${1} ${2}
+    return ${?}
+}
+
+_dotouch 04 pbench/archive/fs-version-001/controller01/benchmark-result-medium_1900-01-01T00:00:00.tar.xz || exit ${?}
+_dotouch 03 pbench/archive/fs-version-001/controller00/benchmark-result-large_1900-01-01T00:00:00.tar.xz || exit ${?}
+_dotouch 02 pbench/archive/fs-version-001/controller02/benchmark-result-small_1900-01-01T00:00:00.tar.xz || exit ${?}
+
+exit 0

--- a/server/bin/state/test-17.setup
+++ b/server/bin/state/test-17.setup
@@ -1,0 +1,1 @@
+test-16.setup

--- a/server/bin/state/test-5.1.setup
+++ b/server/bin/state/test-5.1.setup
@@ -1,5 +1,1 @@
-#!/bin/bash
-
-mkdir pbench-local/archive.backup || exit $?
-mkdir -p pbench-local/s3-backup/testbucket || exit $?
-exit $?
+test-5.setup

--- a/server/bin/state/test-5.2.setup
+++ b/server/bin/state/test-5.2.setup
@@ -1,1 +1,1 @@
-test-5.1.setup
+test-5.setup

--- a/server/bin/test-bin/test-find-behavior
+++ b/server/bin/test-bin/test-find-behavior
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+ARCHIVE=${_testdir}/archive
+
+SMALL=0      #   0 <= - < 130   90%
+MEDIUM=130   # 130 <= - < 240   95%
+LARGE=240    # 240 <= - < 820   99%
+HUGE=820     # 820 <= - < INF  100%
+
+# We need to test the behavior of find to see how it works with sizes on
+# the boundaries.
+
+mkdir ${ARCHIVE}/dir0
+truncate -s $(( ${MEDIUM} - 1 )) ${ARCHIVE}/dir0/edge-ub.sml    # Upper bound of SMALL
+truncate -s ${MEDIUM}            ${ARCHIVE}/dir0/boundary.med   # Boundary of SMALL/MEDIUM, placed in MEDIUM
+truncate -s $(( ${MEDIUM} + 1 )) ${ARCHIVE}/dir0/edge-lb.med    # One beyond MEDIUM boundary
+mkdir ${ARCHIVE}/dir1
+truncate -s $(( ${LARGE} - 1 ))  ${ARCHIVE}/dir1/edge-ub.med    # Upper bound of MEDIUM
+truncate -s ${LARGE}             ${ARCHIVE}/dir1/boundary.lrg   # Boundary of MEDIUM/LARGE, placed in LARGE
+truncate -s $(( ${LARGE} + 1 ))  ${ARCHIVE}/dir1/edge-lb.lrg    # One beyond LARGE boundary
+mkdir ${ARCHIVE}/dir2
+truncate -s $(( ${HUGE} - 1 ))   ${ARCHIVE}/dir2/edge-ub.lrg    # Upper bound of LARGE
+truncate -s ${HUGE}              ${ARCHIVE}/dir2/boundary.hug   # Boundary of LARGE/HUGE, placed in HUGE
+truncate -s $(( ${HUGE} + 1 ))   ${ARCHIVE}/dir2/edge-lb.hug    # One beyond HUGE boundary
+
+# We have three directories, each with a boundary file, now add one other file
+# in each of the buckets per directory.
+
+for dir in dir0 dir1 dir2; do
+    truncate -s $(( ${SMALL}  + 10 )) ${ARCHIVE}/${dir}/file.sml
+    truncate -s $(( ${MEDIUM} + 10 )) ${ARCHIVE}/${dir}/file.med
+    truncate -s $(( ${LARGE}  + 10 )) ${ARCHIVE}/${dir}/file.lrg
+    truncate -s $(( ${HUGE}   + 10 )) ${ARCHIVE}/${dir}/file.hug
+done
+
+find -L ${ARCHIVE} \
+       \( -type f                              -size -${MEDIUM}c -fprintf small.lis  "%s %p\n" \) \
+    -o \( -type f -size +$(( ${MEDIUM} - 1 ))c -size -${LARGE}c  -fprintf medium.lis "%s %p\n" \) \
+    -o \( -type f -size +$(( ${LARGE}  - 1 ))c -size -${HUGE}c   -fprintf large.lis  "%s %p\n" \) \
+    -o \( -type f -size +$(( ${HUGE}   - 1 ))c                   -fprintf huge.lis   "%s %p\n" \) \
+    2>/dev/null
+
+tot_files=$(find ${ARCHIVE} -type f | wc -l)
+bkt_files=$(cat *.lis | wc -l)
+
+if [[ "${bkt_files}" != "${tot_files}" ]]; then
+    print "Count of files in buckets, %d, does not match total number of files, %d\n" "${bkt_files}" "${tot_files}"
+fi
+
+declare -A lb=(
+    [small]=${SMALL}
+    [medium]=${MEDIUM}
+    [large]=${LARGE}
+    [huge]=${HUGE}
+    )
+declare -A ub=(
+    [small]=${MEDIUM}
+    [medium]=${LARGE}
+    [large]=${HUGE}
+    [huge]="INF"
+    )
+for bucket in small medium large huge; do
+    printf "\nBucket: %s -- %s <= size < %s\n" "${bucket}" "${lb[${bucket}]}" "${ub[${bucket}]}"
+    sort ${bucket}.lis
+done

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -575,7 +575,7 @@ declare -A cmds=(
     # check for successful local backup if S3 is disabled
     [test-6.13]="_run pbench-backup-tarballs"
     [test-6.14]="_run pbench-backup-tarballs"
-    
+
     # indexing tests are all test-7.*
 
     # Special case of running pbench-index with -I to get a dump
@@ -674,6 +674,10 @@ declare -A cmds=(
 
     # Tests config file that specifies two shims versions
     [test-24]="_run_activate"
+
+    # Tests that the behavior of the find command works as we expect to
+    # ensure that buckets for pbench-unpack-tarballs work properly.
+    [test-25]="_run test-find-behavior"
 )
 all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\+\)-\([0-9]\+\)/\1.\2/')
 

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -93,7 +93,7 @@ function _run_allscripts {
     _run pbench-sync-satellite satellite-one
     # These next five are related and would flow in this order
     _run pbench-dispatch
-    _run pbench-unpack-tarballs
+    _run pbench-unpack-tarballs small
     _run pbench-copy-sosreports
     _run pbench-index
     _run pbench-index --tool-data
@@ -659,8 +659,8 @@ declare -A cmds=(
     [test-15]="_run pbench-server-prep-shim-002"
 
     # pbench-unpack-tarballs unpacking to the incoming directory
-    [test-16]="_run pbench-unpack-tarballs"
-    [test-17]="_run pbench-unpack-tarballs"
+    [test-16]="_run pbench-unpack-tarballs small"
+    [test-17]="_run pbench-unpack-tarballs small"
 
     [test-20]="_run echo audit archive hierarchy"
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -89,6 +89,18 @@ unpacked-states = TO-INDEX, TO-COPY-SOS
 # Satellite servers typically only want to unpack, so just define empty.
 #unpacked-states =
 
+# Upper and lower bounds in MB bytes
+[pbench-unpack-tarballs/small]
+upperbound = 130
+[pbench-unpack-tarballs/medium]
+lowerbound = 130
+upperbound = 240
+[pbench-unpack-tarballs/large]
+lowerbound = 240
+upperbound = 820
+[pbench-unpack-tarballs/huge]
+lowerbound = 820
+
 # We need to install some stuff in the apache document root so we
 # either get it directly or look in the config file.
 #
@@ -125,7 +137,7 @@ shim-version = 002
 host = %(default-host)s
 user = %(default-user)s
 mailfrom = %(user)s@%(host)s
-tasks = pbench-dispatch, pbench-unpack-tarballs, pbench-copy-sosreports, pbench-edit-prefixes, pbench-index, pbench-index-tool-data
+tasks = pbench-dispatch, pbench-unpack-tarballs-small, pbench-unpack-tarballs-medium, pbench-unpack-tarballs-large, pbench-unpack-tarballs-huge, pbench-copy-sosreports, pbench-edit-prefixes, pbench-index, pbench-index-tool-data
 
 [pbench-backup]
 host = %(default-host)s
@@ -150,6 +162,18 @@ crontab = 59 4 * * *  flock -n %(lock-dir)s/pbench-verify-backup-tarballs.lock %
 
 [pbench-unpack-tarballs]
 crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs.lock %(script-dir)s/pbench-unpack-tarballs
+
+[pbench-unpack-tarballs-small]
+crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs-small.lock %(script-dir)s/pbench-unpack-tarballs small
+
+[pbench-unpack-tarballs-medium]
+crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs-medium.lock %(script-dir)s/pbench-unpack-tarballs medium
+
+[pbench-unpack-tarballs-large]
+crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs-large.lock %(script-dir)s/pbench-unpack-tarballs large
+
+[pbench-unpack-tarballs-huge]
+crontab =  * * * * *  flock -n %(lock-dir)s/pbench-unpack-tarballs-huge.lock %(script-dir)s/pbench-unpack-tarballs huge
 
 [pbench-copy-sosreports]
 crontab = 41 * * * *  flock -n %(lock-dir)s/pbench-copy-sosreports.lock %(script-dir)s/pbench-copy-sosreports

--- a/server/lib/pbench/__init__.py
+++ b/server/lib/pbench/__init__.py
@@ -240,7 +240,7 @@ class PbenchConfig(object):
         # needed.  Every related state directories are paired together with
         # their final state at the end.
         self.LINKDIRS = "TODO BAD-MD5" \
-                " TO-UNPACK UNPACKED" \
+                " TO-UNPACK UNPACKED WONT-UNPACK" \
                 " TO-SYNC SYNCED" \
                 " TO-LINK" \
                 " TO-INDEX TO-INDEX-TOOL INDEXED WONT-INDEX" \


### PR DESCRIPTION
Fixes #1398.

We now have four different jobs by default for processing tar ball sizes.  Based on historical pbench result sizes, we set default buckets to capture the first 90%, then next 5% (95th percentile), then the next 4% (99th percentile), and then finally the last 1% (100th percentile).

The algorithm of unpack tar balls now stops processing the list of tar balls to unpack if the time taken to unpack tar balls so far is twice as long as it takes to find tar balls to unpack.  If the time taken to find tar balls takes less than one minute, we just use 60 sec as the minimum since that is the shortest possible interval of time between cronjob invocations.

Further, tar balls are processed now from newest to oldest, so by restarting periodically, more recent results will get unpacked before older results within a size bucket.

Removed the redundant `test-5.1.setup` file replacing it with a symlink to `test-5.setup` (updating `test-5.2.setup` to link to the same).

This PR contains 4 commits to make it easier to review:

1. The first commit introduces a unit test to ensure `find` works as expected independent of these changes
2. The second commit refactors the code a bit to address Bourne Shell style `[ ]` conditionals, where we now uniformly use Bash style `[[ ]]` conditionals, address duplicate code found during reviews, and other clean-ups
3. The third commit refactors parts of the code into functions without other additional behavioral changes to make it easier to review
4. The fourth commit applies the new restart algorithm