### PR TITLE
Rewritten metalog-%-error testcase

### DIFF
--- a/agent/util-scripts/gold/test-add-metalog-%-option/test-48.txt
+++ b/agent/util-scripts/gold/test-add-metalog-%-option/test-48.txt
@@ -1,5 +1,5 @@
-+++ Running test-48 eval pbench-add-metalog-option /var/tmp/pbench-test-utils/pbench/metadata.log run percent < /var/tmp/pbench-test-utils/pbench/tmp/foo.txt
---- Finished test-48 eval (status=0)
++++ Running test-48 test-add-metalog-%-option 
+--- Finished test-48 test-add-metalog-%-option (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/metadata.log

--- a/agent/util-scripts/test-bin/test-add-metalog-%-option
+++ b/agent/util-scripts/test-bin/test-add-metalog-%-option
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+echo "30%" | pbench-add-metalog-option ${_testdir}/metadata.log run percent
+

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -259,7 +259,7 @@ declare -A tools=(
     [test-45]="pbench-register-tool"
     [test-46]="pbench-register-tool"
     [test-47]="pbench-register-tool"
-    [test-48]="eval"
+    [test-48]="test-add-metalog-%-option"
 )
 
 declare -A options=(
@@ -327,7 +327,6 @@ declare -A options=(
     [test-45]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis"
     [test-46]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis"
     [test-47]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis --labels=labelOne,labelTwo"
-    [test-48]="pbench-add-metalog-option ${_testdir}/metadata.log run percent < ${_testdir}/tmp/foo.txt"
 )
 
 declare -A expected_status=(


### PR DESCRIPTION
Fixes #1329

The problem is that configparser Interpolation (https://docs.python.org/3/library/configparser.html#configparser.InterpolationError) uses % as a marker for the interpolation construct %(option)s which replaces the construct by the value of the option. Configparser Interpolation does not accept the % symbol in any other context unless it is escaped as a double percent sign. So when we write a value with '%', ex: "30%" in any config file, this error in thrown. To fix this error, whenever the user enters a value that includes a % char, it will be converted into %% (double percent sign) which interpolation treats as a literal single percent sign.

This PR deals with the testcase of the problem