### PR TITLE
Fix failing unit tests on some Fedora systems

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.1.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.1.txt
@@ -23,18 +23,18 @@ perf tool is now registered in group default
 --interval=3
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] vmstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] iostat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install perf
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] perf tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.10.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.10.txt
@@ -15,11 +15,11 @@ sar tool is now registered in group default
 --interval=3
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] pidstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] sar tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.12.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.12.txt
@@ -15,12 +15,12 @@ perf tool is now registered in group other
 /var/tmp/pbench-test-utils/pbench/tools-other/vmstat
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group other
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] vmstat tool is now registered in group other
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] iostat tool is now registered in group other
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] perf tool is now registered in group other
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.2.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.2.txt
@@ -23,18 +23,18 @@ perf tool is now registered in group default
 --interval=10
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] vmstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] iostat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install perf
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] perf tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.3.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.3.txt
@@ -27,23 +27,23 @@ perf tool is now registered in group default
 --interval=10
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] iostat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=30
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=30"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] pidstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] sar tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install perf
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] perf tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.4.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.4.txt
@@ -9,13 +9,13 @@
 /var/tmp/pbench-test-utils/pbench/tools-default/remote@one.example.com:
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default -- "${tool_opts[@]}" 2>&1
 --- pbench.log file contents
 +++ test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.5.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.5.txt
@@ -13,19 +13,19 @@
 /var/tmp/pbench-test-utils/pbench/tools-default/remote@c.example.com:
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default -- "${tool_opts[@]}" 2>&1

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.6.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.6.txt
@@ -26,18 +26,18 @@ labelNO
 --interval=3
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] vmstat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] iostat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install perf
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] perf tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.9.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.9.txt
@@ -16,19 +16,19 @@ labelThree
 labelTwo
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default --label=labelOne -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default --label=labelThree -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default --label=labelOne -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default --label=labelThree -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default --label=labelOne -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default --label=labelThree -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default --label=labelOne -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default --label=labelThree -- "${tool_opts[@]}" 2>&1

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.txt
@@ -10,16 +10,16 @@
 /var/tmp/pbench-test-utils/pbench/tmp
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] Failed to register tool mpstat on remote host fubar\n
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=vmstat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] Failed to register tool vmstat on remote host fubar\n
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=3
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--interval=3"; pbench-register-tool --name=iostat --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] Failed to register tool iostat on remote host fubar\n
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --record-opts=record -a --freq=100
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--record-opts=record -a --freq=100"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  tool_opts[0]="--record-opts=record -a --freq=100"; pbench-register-tool --name=perf --group=default -- "${tool_opts[@]}" 2>&1
 /var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] Failed to register tool perf on remote host fubar\n
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-00.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-00.txt
@@ -11,7 +11,7 @@ mpstat tool is now registered in group default
 --interval=10
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=10
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=10"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] checking to see if tool is installed...
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] [check_install_rpm] attempting to install pbench-sysstat-12.0.3
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] mpstat tool is now registered in group default

--- a/agent/util-scripts/gold/pbench-register-tool/test-42.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-42.txt
@@ -11,6 +11,6 @@ vmstat tool is now registered in group default
 --interval=42
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: --interval=42
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42"
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] vmstat tool is now registered in group default
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-43.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-43.txt
@@ -14,14 +14,14 @@ turbostat tool is now registered in group default
 /var/tmp/pbench-test-utils/pbench/tools-default/turbostat:
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: 
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: ""
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] The remote host you have provided, localhost, matches a local interface, so we will register this tool locally only
 /var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] The remote host you have provided, testhost.example.com, matches a local interface, and has already been registered locally
 /var/tmp/pbench-test-utils/pbench/pbench.log:[info][1900-01-01T00:00:00.000000] turbostat tool is now registered in group default
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=turbostat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=turbostat --group=default -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=turbostat --group=default --no-install -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=turbostat --group=default --no-install -- "${tool_opts[@]}" 2>&1
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no one.example.com  pbench-register-tool --name=turbostat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no two.example.com  pbench-register-tool --name=turbostat --group=default -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no one.example.com  pbench-register-tool --name=turbostat --group=default --no-install -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no two.example.com  pbench-register-tool --name=turbostat --group=default --no-install -- "${tool_opts[@]}" 2>&1
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-45.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-45.txt
@@ -21,13 +21,13 @@ two.example.com,labelTwo
 three.example.com
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: 
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000] tool_opts: ""
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default --no-install -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default --no-install --label=labelTwo -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/pbench/pbench.log:[debug][1900-01-01T00:00:00.000000]  pbench-register-tool --name=mpstat --group=default --no-install -- "${tool_opts[@]}" 2>&1
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no one.example.com  pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no two.example.com  pbench-register-tool --name=mpstat --group=default --label=labelTwo -- "${tool_opts[@]}" 2>&1
-/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no three.example.com  pbench-register-tool --name=mpstat --group=default -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no one.example.com  pbench-register-tool --name=mpstat --group=default --no-install -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no two.example.com  pbench-register-tool --name=mpstat --group=default --no-install --label=labelTwo -- "${tool_opts[@]}" 2>&1
+/var/tmp/pbench-test-utils/test-execution.log:/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no three.example.com  pbench-register-tool --name=mpstat --group=default --no-install -- "${tool_opts[@]}" 2>&1
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-46.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-46.txt
@@ -1,5 +1,5 @@
 +++ Running test-46 pbench-register-tool --name=mpstat --no-install --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis
-[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]"
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]" at line #4
 usage:
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here]
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--remotes=@<remotes-file>] -- [all tool specific options here]
@@ -72,5 +72,5 @@ two.example.com,labelTwo
 three.example.com,labelThree,junk
 --- pbench tree state
 +++ pbench.log file contents
-/var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]"
+/var/tmp/pbench-test-utils/pbench/pbench.log:[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]" at line #4
 --- pbench.log file contents

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -152,7 +152,8 @@ if [[ ${remotes_arg::1} == "@" ]]; then
 		IFS=',' read -ra parts <<< "${line}"
 		if [[ ${#parts[@]} == 0 ]]; then
 			# Ignore empty lines
-			:
+			(( lineno++ ))
+			continue
 		elif [[ ${#parts[@]} == 1 ]]; then
 			# Assume the only part is a remote host name.
 			remotes_A[${idx}]=${parts[0]}
@@ -163,7 +164,7 @@ if [[ ${remotes_arg::1} == "@" ]]; then
 			remotes_A[${idx}]=${parts[0]}
 			labels_A[${parts[0]}]=${parts[1]}
 		else
-			error_log "--remotes=@${remotes_file} contains an invalid file format, expected lines with \"<hostname>[,<label>]\""
+			error_log "--remotes=@${remotes_file} contains an invalid file format, expected lines with \"<hostname>[,<label>]\" at line #${lineno}"
 			usage >&2
 			exit 1
 		fi
@@ -225,7 +226,7 @@ tool_opt_array_cmd=""
 for (( i=0; ${i} < ${#tool_opts[@]}; i++ )); do
 	tool_opt_array_cmd="${tool_opt_array_cmd} tool_opts[${i}]=\"${tool_opts[${i}]}\";"
 done
-debug_log "tool_opts: ${tool_opts[@]}"
+debug_log "tool_opts: \"${tool_opts[@]}\""
 
 # At this point all argument processing is complete.
 
@@ -240,7 +241,8 @@ idx=0
 local_hostname=""
 local_label=""
 declare -A remotes
-for remote in ${remotes_A[@]}; do
+for (( i=0; ${i} < ${#remotes_A[@]}; i++ )); do
+	remote="${remotes_A[${i}]}"
 	for local_interface in ${local_interfaces}; do
 		if [[ "${remote}" == "${local_interface}" ]]; then
 			if [[ -z "${local_hostname}" ]]; then
@@ -314,9 +316,10 @@ exit_rc=${rc}
 if [[ ${do_install} == 1 ]]; then
 	install_opt=""
 else
-	isntall_opt="--no-install"
+	install_opt=" --no-install"
 fi
-for remote in ${remotes[@]}; do
+for (( i=0; ${i} < ${#remotes[@]}; i++ )); do
+	remote="${remotes[${i}]}"
 	# Register this tool on a remote host
 	label=${labels_A[${remote}]}
 	if [[ -z "${label}" ]]; then


### PR DESCRIPTION
It looks like newer versions of pass process associative arrays in different orders.  So we consistently use a numeric indexing scheme to avoid that behavior, allowing the unit tests to pass in all cases.

We also add the line number where a remotes file is not formatted as expected.