### PR TITLE
Trigger e2e tests after dashboard environment initializes 

### DIFF
--- a/web-server/v0.4/e2etests
+++ b/web-server/v0.4/e2etests
@@ -17,17 +17,7 @@ if [[ $? -ne 0 ]]; then
   echo "yarn failed!" >&2
   exit 1
 fi
-yarn start &
-if [[ $? -ne 0 ]]; then
-  echo "yarn failed!" >&2
-  exit 1
-fi
-sleep 60
-if [[ $? -ne 0 ]]; then
-  echo "sleep failed!" >&2
-  exit 1
-fi
-yarn test:e2e
+yarn start && yarn test:e2e
 if [[ $? -ne 0 ]]; then
   echo "yarn e2e tests failed!" >&2
   exit 1


### PR DESCRIPTION
**Summary**

Currently, e2e tests will occasionally fail if the dashboard environment has not successfully been initialized. As the tests listen for the dashboard running on a port to trigger e2e tests, we need a smarter way to confirm the environment is ready. This is currently being accomplished with a hard coded sleep timer in between commands. 