### PR TITLE
Fix dashboard unit tests and update README.md

### DIFF
--- a/web-server/v0.4/README.md
+++ b/web-server/v0.4/README.md
@@ -98,6 +98,15 @@ const persistConfig = {
 };
 ```
 
+## Requirements
+
+Install yarn
+
+```
+curl -sL https://dl.yarnpkg.com/rpm/yarn.repo -o /etc/yum.repos.d/yarn.repo
+dnf/yum install yarn
+```
+
 ## Build
 
 Build Application

--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint --fix --ext .js src && npm run lint:style",
     "lint-staged": "lint-staged",
     "lint-staged:js": "eslint --ext .js",
-    "test": "umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand",
+    "test": "umi test ./src/components ./src/pages --verbose --maxWorkers=1 --runInBand --updateSnapshot",
     "test:component": "umi test @",
     "test:e2e": "umi test ./src/e2e --verbose",
     "test:all": "node ./tests/run-tests.js",


### PR DESCRIPTION
We need to add the `--updateSnapshot` switch to the unit tests to make sure Jest updates snapshots across environments.

We also add a description of the README for how to install yarn from on Fedora/CentOS/RHEL boxes.