### PR TITLE
Upgrade umi and umi plugins to latest version 

### DIFF
--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "precommit": "npm run lint-staged",
-    "start": "umi dev",
+    "start": "cross-env UMI_UI=none umi dev",
     "start:no-mock": "cross-env MOCK=none umi dev",
     "build": "umi build",
     "site": "umi-api-doc static && gh-pages -d dist",
@@ -52,7 +52,7 @@
     "redux": "3.x",
     "redux-persist": "^6.0.0",
     "setprototypeof": "^1.1.0",
-    "umi": "^2.6.16",
+    "umi": "2.11.1",
     "umi-request": "^1.0.7",
     "url-polyfill": "^1.0.10"
   },
@@ -82,7 +82,7 @@
     "stylelint": "^9.2.1",
     "stylelint-config-prettier": "^3.0.4",
     "stylelint-config-standard": "^18.0.0",
-    "umi-plugin-react": "^1.7.5"
+    "umi-plugin-react": "1.13.1"
   },
   "jest": {
     "setupFiles": [

--- a/web-server/v0.4/src/layouts/BasicLayout.js
+++ b/web-server/v0.4/src/layouts/BasicLayout.js
@@ -100,6 +100,8 @@ class BasicLayout extends React.PureComponent {
     super(props);
     this.getPageTitle = memoizeOne(this.getPageTitle);
     this.breadcrumbNameMap = getBreadcrumbNameMap(getMenuData());
+    // eslint-disable-next-line no-underscore-dangle
+    this.persistor = persistStore(window.g_app._store);
   }
 
   getChildContext() {
@@ -233,8 +235,7 @@ class BasicLayout extends React.PureComponent {
           </Header>
           <Content style={{ margin: '24px 24px 0', height: '100%' }}>
             <PersistGate
-              // eslint-disable-next-line no-underscore-dangle
-              persistor={persistStore(window.g_app._store)}
+              persistor={this.persistor}
               loading={
                 <Spin
                   style={{


### PR DESCRIPTION
**Summary**

Upgrading umi and umi plugins to their latest versions ensures compatibility between dependencies. This change also references the `persistStore` via the constructor of `BasicLayout` to ensure the `PersistGate` component opens on initial load.