### PR TITLE
Enable pagination for Table component

### DIFF
--- a/web-server/v0.4/config/constants.js
+++ b/web-server/v0.4/config/constants.js
@@ -1,0 +1,5 @@
+const constants = {
+  tableSizeOptions: ['10', '20', '50', '100'],
+};
+
+export default constants;

--- a/web-server/v0.4/mock/api.js
+++ b/web-server/v0.4/mock/api.js
@@ -1,22 +1,22 @@
 import config from './datastoreConfig';
+import constants from '../config/constants';
 
-export const mockControllerAggregation = {
+// Generate controllers as per max page size options
+const maxTableSize = parseInt(constants.tableSizeOptions.pop(), 10);
+let generatedBuckets = new Array(maxTableSize).fill({});
+generatedBuckets = generatedBuckets.map((val, index) => {
+  const key = index + 1;
+  return {
+    key: `controller_${key}`,
+    doc_count: key,
+    runs_prev1: { value: null },
+    runs: { value: key, value_as_string: key.toString() },
+  };
+});
+export const generateMockControllerAggregation = {
   aggregations: {
     controllers: {
-      buckets: [
-        {
-          key: 'a_test_controller',
-          doc_count: 1,
-          runs_preV1: { value: null },
-          runs: { value: 1, value_as_string: '1111-11-11' },
-        },
-        {
-          key: 'b_test_controller',
-          doc_count: 2,
-          runs_preV1: { value: null },
-          runs: { value: 2, value_as_string: '2222-22-22' },
-        },
-      ],
+      buckets: generatedBuckets,
     },
   },
 };

--- a/web-server/v0.4/src/components/Table/index.js
+++ b/web-server/v0.4/src/components/Table/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Table as AntdTable } from 'antd';
+import constants from '../../../config/constants';
 
 const Table = props => {
   const { dataSource, columns, loading, onRow, ...childProps } = props;
@@ -14,6 +15,11 @@ const Table = props => {
       onRow={onRow}
       scroll={{
         x: true,
+      }}
+      pagination={{
+        defaultPageSize: 10,
+        showSizeChanger: true,
+        pageSizeOptions: constants.tableSizeOptions,
       }}
       {...childProps}
     />

--- a/web-server/v0.4/src/e2e/controllers.e2e.js
+++ b/web-server/v0.4/src/e2e/controllers.e2e.js
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import { mockControllerAggregation, mockIndices } from '../../mock/api';
+import { generateMockControllerAggregation, mockIndices } from '../../mock/api';
 
 let browser;
 let page;
@@ -18,7 +18,7 @@ beforeAll(async () => {
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify(mockControllerAggregation),
+        body: JSON.stringify(generateMockControllerAggregation),
       });
     } else if (request.method() === 'GET' && request.url().includes('indices')) {
       request.respond({
@@ -45,7 +45,7 @@ describe('controller page component', () => {
       const testController = await page.$eval('.ant-table-row', elem =>
         elem.getAttribute('data-row-key')
       );
-      expect(testController).toBe('a_test_controller');
+      expect(testController).toBe('controller_1');
       done();
     },
     30000
@@ -59,7 +59,7 @@ describe('controller page component', () => {
     await page.type('.ant-input', testController);
     await page.click('.ant-input-search-button');
     testController = await page.$eval('.ant-table-row', elem => elem.getAttribute('data-row-key'));
-    expect(testController).toBe('a_test_controller');
+    expect(testController).toBe('controller_1');
   });
 
   test('should reset search results', async () => {
@@ -72,7 +72,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('a_test_controller');
+    expect(testController).toBe('controller_1');
   });
 
   test('should sort controllers column alphabetically ascending', async () => {
@@ -86,7 +86,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('a_test_controller');
+    expect(testController).toBe('controller_1');
   });
 
   test('should sort controllers column alphabetically descending', async () => {
@@ -99,7 +99,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('b_test_controller');
+    expect(testController).toBe('controller_99');
   });
 
   test('should sort last modified column chronologically ascending', async () => {
@@ -112,7 +112,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('a_test_controller');
+    expect(testController).toBe('controller_1');
   });
 
   test('should sort last modified column chronologically descending', async () => {
@@ -125,7 +125,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('b_test_controller');
+    expect(testController).toBe('controller_100');
   });
 
   test('should sort results column numerically ascending', async () => {
@@ -138,7 +138,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('a_test_controller');
+    expect(testController).toBe('controller_1');
   });
 
   test('should sort results column numerically descending', async () => {
@@ -151,7 +151,7 @@ describe('controller page component', () => {
     const testController = await page.$eval('.ant-table-row', elem =>
       elem.getAttribute('data-row-key')
     );
-    expect(testController).toBe('b_test_controller');
+    expect(testController).toBe('controller_100');
   });
 
   test('should select month index', async () => {
@@ -169,4 +169,30 @@ describe('controller page component', () => {
     },
     30000
   );
+
+  test('should display 10 controllers in the table by default', async () => {
+    const rows = await page.$$('.ant-table-row');
+    expect(rows.length).toBe(10);
+  });
+
+  test('should display 20 controllers on preference', async () => {
+    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-dropdown-menu-item:nth-child(2)');
+    const rows = await page.$$('.ant-table-row');
+    expect(rows.length).toBe(20);
+  });
+
+  test('should display 50 controllers on preference', async () => {
+    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-dropdown-menu-item:nth-child(3)');
+    const rows = await page.$$('.ant-table-row');
+    expect(rows.length).toBe(50);
+  });
+
+  test('should display 100 controllers on preference', async () => {
+    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-dropdown-menu-item:nth-child(4)');
+    const rows = await page.$$('.ant-table-row');
+    expect(rows.length).toBe(100);
+  });
 });

--- a/web-server/v0.4/src/e2e/results.e2e.js
+++ b/web-server/v0.4/src/e2e/results.e2e.js
@@ -1,5 +1,5 @@
 import puppeteer from 'puppeteer';
-import { mockControllerAggregation, mockIndices, mockResults } from '../../mock/api';
+import { generateMockControllerAggregation, mockIndices, mockResults } from '../../mock/api';
 
 let browser;
 let page;
@@ -18,7 +18,7 @@ beforeAll(async () => {
         status: 200,
         contentType: 'application/json',
         headers: { 'Access-Control-Allow-Origin': '*' },
-        body: JSON.stringify(mockControllerAggregation),
+        body: JSON.stringify(generateMockControllerAggregation),
       });
     } else if (request.method() === 'GET' && request.url().includes('indices')) {
       request.respond({
@@ -52,7 +52,7 @@ describe('results page component', () => {
       const testController = await page.$eval('.ant-table-row', elem =>
         elem.getAttribute('data-row-key')
       );
-      expect(testController).toBe('a_test_controller');
+      expect(testController).toBe('controller_1');
       done();
     },
     30000


### PR DESCRIPTION
**Feat-** Allow users to search through various controllers in the dashboard, n(10/20/30) items at a time. 
**Fixes-** #1424