### PR TITLE
Log messages using logging functions in bash scripts.

### DIFF
--- a/server/bin/pbench-base.sh
+++ b/server/bin/pbench-base.sh
@@ -138,3 +138,19 @@ function quarantine () {
         fi
     done
 }
+
+function log_info {
+    if [[ -z "${2}" ]]; then
+        printf -- "%b\n" "${1}"
+    else
+        printf -- "%b\n" "${1}" | tee -a "${2}"
+    fi
+}
+
+function log_error {
+    if [[ -z "${2}" ]]; then
+        printf -- "%b\n" "${1}" >&4
+    else
+        printf -- "%b\n" "${1}" | tee -a "${2}" >&4
+    fi
+}

--- a/server/bin/pbench-clean-up-dangling-results-links.sh
+++ b/server/bin/pbench-clean-up-dangling-results-links.sh
@@ -19,10 +19,10 @@ for x in $(find . -type l) ; do
         hostname=$(basename $(dirname $y))
         pbench_run_name=$(basename $y)
         if [ -f $ARCHIVE/$hostname/$pbench_run_name.tar.xz ] ;then
-            echo "$x -> $y dangling and $hostname/$pbench_run_name.tar.xz exists - cleaning up the link"
+            log_info "$x -> $y dangling and $hostname/$pbench_run_name.tar.xz exists - cleaning up the link"
             rm -f $x
         else
-            echo "$x -> $y dangling and $hostname/$pbench_run_name.tar.xz does *NOT* exist" >&4
+            log_error "$x -> $y dangling and $hostname/$pbench_run_name.tar.xz does *NOT* exist"
         fi
      fi
 done

--- a/server/bin/pbench-edit-prefixes.sh
+++ b/server/bin/pbench-edit-prefixes.sh
@@ -35,7 +35,7 @@ log_init $PROG
 # the link source for this script
 linksrc=TO-LINK
 
-echo $TS
+log_info "$TS"
 
 # get the list of files we'll be operating on
 list=$(ls $ARCHIVE/*/$linksrc/*.tar.xz 2>/dev/null)
@@ -45,7 +45,7 @@ typeset -i nep=0
 for result in $list ;do
     link=$(readlink -e $result)
     if [ ! -f $link ] ;then
-        echo "$TS: $link does not exist" >&4
+        log_error "$TS: $link does not exist" 
         continue
     fi
 
@@ -62,14 +62,14 @@ for result in $list ;do
 
     # find the prefix file and execute it - all the checking was done on the client
     prefix=$ARCHIVE/$hostname/.prefix/prefix.${resultname%.tar.xz}
-    echo $prefix
+    log_info $prefix
     cmds=$(cat $prefix)
-    echo $cmds
+    log_info $cmds
     pushd $RESULTS/$hostname > /dev/null 2>&4
     eval "$cmds"
     status=$?
     if [ $status -ne 0 ] ;then
-        echo "$TS: eval $cmds failed - code $status" >&4
+        log_error "$TS: eval $cmds failed - code $status" 
         continue
     fi
     popd > /dev/null 2>&4
@@ -78,16 +78,16 @@ for result in $list ;do
     rm $result
     status=$?
     if [ $status -ne 0 ] ;then
-        echo "$TS: Cannot remove $result link from $linksrc: code $status" >&4
+        log_error "$TS: Cannot remove $result link from $linksrc: code $status" 
         continue
     fi
 
     # log the success
-    echo "$TS: $hostname/$resultname: success - processed $result"
+    log_info "$TS: $hostname/$resultname: success - processed $result"
     nep=$nep+1
 done
 
-echo "$TS: Processed $nep edit-prefix requests"
+log_info "$TS: Processed $nep edit-prefix requests"
 
 log_finish
 exit 0

--- a/server/bin/pbench-satellite-cleanup.sh
+++ b/server/bin/pbench-satellite-cleanup.sh
@@ -13,7 +13,7 @@ trap "rm -rf $tmp" EXIT
 
 log_init $PROG
 
-echo "$TS: $PROG starting"
+log_info "$TS: $PROG starting"
 
 tarballs=$(cd $ARCHIVE > /dev/null; find . -path '*/TO-DELETE/*.tar.xz' -printf '%P\n' | sort)
 hosts="$(for host in $tarballs ;do echo "${host%%/*}" ;done | sort -u )"
@@ -61,8 +61,7 @@ for host in $hosts; do
                 # Note that if we do remove the tarball but fail to change the
                 # state, this error will persist until the state is changed
                 # manually.
-                echo "$TS: Failed to remove $ARCHIVE/$host/$x, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to remove $ARCHIVE/$host/$x, code: $rc" "${mail_content}"
                 ntberrs=$ntberrs+1
                 popd > /dev/null 2>&4
                 continue
@@ -73,8 +72,7 @@ for host in $hosts; do
             rm $x.md5
             rc=$?
             if [ $rc != 0 ]; then
-                echo "$TS: Failed to remove $ARCHIVE/$host/$x.md5, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to remove $ARCHIVE/$host/$x.md5, code: $rc" "${mail_content}"
                 nmd5errs=$nmd5errs+1
             fi
         fi
@@ -83,13 +81,11 @@ for host in $hosts; do
             mv -n TO-DELETE/$x SATELLITE-DONE/
             rc=$?
             if [ $rc != 0 ]; then
-                echo "$TS: Failed to move $ARCHIVE/$host/TO-DELETE/$x to SATELLITE-DONE, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to move $ARCHIVE/$host/TO-DELETE/$x to SATELLITE-DONE, code: $rc" "${mail_content}"
                 nstateerrs=$nstateerrs+1
             else
                 if [ -e TO-DELETE/$x ]; then
-                    echo "$TS: Failed to move $ARCHIVE/$host/TO-DELETE/$x: still exists after successful move to SATELLITE-DONE" |
-                            tee -a $mail_content >&4
+                    log_error "$TS: Failed to move $ARCHIVE/$host/TO-DELETE/$x: still exists after successful move to SATELLITE-DONE" "${mail_content}"
                     nstateerrs=$nstateerrs+1
                 fi
             fi
@@ -99,8 +95,7 @@ for host in $hosts; do
             rm -rf $INCOMING/$host/${x%%.tar.xz}
             rc=$?
             if [ $rc != 0 ]; then
-                echo "$TS: Failed to remove the tarball from incoming directory: $INCOMING/$host/${x%%.tar.xz}, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to remove the tarball from incoming directory: $INCOMING/$host/${x%%.tar.xz}, code: $rc" "${mail_content}"
                 nincomingerrs=$nincomingerrs+1
             fi
         fi
@@ -120,8 +115,7 @@ for host in $hosts; do
             rm $sym_link
             rc=$?
             if [ $rc != 0 ]; then
-                echo "$TS: Failed to remove results symlink: $sym_link, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to remove results symlink: $sym_link, code: $rc" "${mail_content}"
                 nresultserrs=$nresultserrs+1
             fi
         fi
@@ -130,8 +124,7 @@ for host in $hosts; do
             rm $prefix
             rc=$?
             if [ $rc != 0 ]; then
-                echo "$TS: Failed to remove prefix file: $prefix, code: $rc" |
-                        tee -a $mail_content >&4
+                log_error "$TS: Failed to remove prefix file: $prefix, code: $rc" "${mail_content}"
                 nprefixerrs=$nprefixerrs+1
             fi
         fi
@@ -143,7 +136,7 @@ summary="Total $ntb tarballs cleaned up, with $ntberrs tarball removal errors, $
 remove errors, $nstateerrs state change errors, $nincomingerrs incoming removal errors, $nresultserrs \
 result removal errors and $nprefixerrs prefix removal errors."
 
-echo "$TS: $PROG ends: $summary"
+log_info "$TS: $PROG ends: $summary"
 
 log_finish
 

--- a/server/bin/pbench-server-prep-shim-002.sh
+++ b/server/bin/pbench-server-prep-shim-002.sh
@@ -126,7 +126,7 @@ while read tbmd5 ;do
     dest=${ARCHIVE}/${controller}
 
     if [ -f ${dest}/${resultname}.tar.xz -o -f ${dest}/${resultname}.tar.xz.md5 ] ;then
-        echo "$TS: Duplicate: ${tb} duplicate name" >&4
+        log_error "$TS: Duplicate: ${tb} duplicate name"
         quarantine ${duplicates}/${controller} ${tb} ${tbmd5}
         ndups=$ndups+1
         continue
@@ -137,7 +137,7 @@ while read tbmd5 ;do
     sts=$?
     popd > /dev/null 2>&4
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Quarantined: ${tb} failed MD5 check" >&4
+        log_error "$TS: Quarantined: ${tb} failed MD5 check"
         quarantine ${quarantine}/${controller} ${tb} ${tb}.md5
         nquarantined=$nquarantined+1
         continue
@@ -147,8 +147,7 @@ while read tbmd5 ;do
     mkdir -p ${dest}/TODO
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Error: \"mkdir -p ${dest}/TODO\", status $sts" |
-            tee -a $status >&4
+        log_error "$TS: Error: \"mkdir -p ${dest}/TODO\", status $sts" "$status"
         quarantine ${errors}/${controller} ${tb} ${tb}.md5
         nerrs=$nerrs+1
         continue
@@ -157,13 +156,11 @@ while read tbmd5 ;do
     cp ${tb} ${tb}.md5 ${dest}/
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Error: \"cp ${tb} ${tb}.md5 ${dest}/\", status $sts" |
-            tee -a $status >&4
+        log_error "$TS: Error: \"cp ${tb} ${tb}.md5 ${dest}/\", status $sts" "$status"
         rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5
         sts=$?
         if [ $sts -ne 0]; then
-            echo "$TS: Warning: cleanup of copy failure failed itself: \"rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5\", status $sts" |
-                tee -a $status >&4
+            log_error "$TS: Warning: cleanup of copy failure failed itself: \"rm -f ${dest}/${resultname}.tar.xz ${dest}/${resultname}.tar.xz.md5\", status $sts" "$status"
         fi
         quarantine ${errors}/${controller} ${tb} ${tb}.md5
         nerrs=$nerrs+1
@@ -172,15 +169,13 @@ while read tbmd5 ;do
     rm -f ${tb} ${tb}.md5
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Warning: cleanup of successful copy operation failed: \"rm -f ${tb} ${tb}.md5\", status $sts" |
-            tee -a $status >&4
+        log_error "$TS: Warning: cleanup of successful copy operation failed: \"rm -f ${tb} ${tb}.md5\", status $sts" "$status"
     fi
 
     ln -s ${dest}/${resultname}.tar.xz ${dest}/TODO/
     sts=$?
     if [ $sts -ne 0 ] ;then
-        echo "$TS: Error: \"ln -s ${dest}/${resultname}.tar.xz ${dest}/TODO/\", status $sts" |
-            tee -a $status >&4
+        log_error "$TS: Error: \"ln -s ${dest}/${resultname}.tar.xz ${dest}/TODO/\", status $sts" "$status"
         # if we fail to make the link, we quarantine the (already moved)
         # tarball and .md5.
         quarantine ${errors}/${controller} ${dest}/${tb} ${dest}/${tb}.md5


### PR DESCRIPTION
Fixes #1421

Server bash scripts used "echo" and output redirection to log info and error messages to local files.
This PR does two things:

- It defines two functions, "log_info" and "log_error", in pbench-base.sh.
- It replaces uses of "echo" for logging purposes with one or the other of these two functions.

Note that the messages have not been changed at all and neither have the destinations: after the
change, the same messages are logged to the same places. This means that there is *no* change to
the gold files used for unit testing.

In a future PR, we are planning to change the logging functions in pbench-base.sh, so that they
follow the policy that is already used by server python scripts: logging to a centralized log
service. That is going to involve changes to pbench-base.sh and virtually all the gold files,
but it will involve *no* changes to any of the bash scripts.