### PR TITLE
Ignore requirement for file extensions within the import path

### DIFF
--- a/web-server/v0.4/.eslintrc.js
+++ b/web-server/v0.4/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
       },
     ],
     'import/no-cycle': 0,
+    'import/extensions': 0,
     'jsx-a11y/no-noninteractive-element-interactions': 0,
     'jsx-a11y/click-events-have-key-events': 0,
     'jsx-a11y/no-static-element-interactions': 0,


### PR DESCRIPTION
#### Summary

UmiJS allows the use of specialized component file extension references with the `@` character. However, `eslint-plugin-import` rules specify strict rules for referencing file extensions for all import statements. In order to support component file extension references, we can disable this rule as we are not concerned with consistent usage of the default file extension. 