### PR TITLE
User session sharing feature

### DIFF
--- a/web-server/v0.4/config/router.config.js
+++ b/web-server/v0.4/config/router.config.js
@@ -54,6 +54,11 @@ module.exports = [
         name: 'exception-500',
         component: './Exception/500',
       },
+      {
+        path: '/share/:id',
+        name: 'share',
+        component: './SessionPlaceholder',
+      },
     ],
   },
 ];

--- a/web-server/v0.4/mock/api.js
+++ b/web-server/v0.4/mock/api.js
@@ -102,3 +102,10 @@ export const mockSearch = {
     ],
   },
 };
+
+export const mockStore = {
+  router: {},
+  dashboard: {},
+  search: {},
+  store: {},
+};

--- a/web-server/v0.4/package.json
+++ b/web-server/v0.4/package.json
@@ -47,6 +47,7 @@
     "rc-drawer": "^1.2.0",
     "react": "^16.4.1",
     "react-container-query": "^0.11.0",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-document-title": "^2.0.3",
     "react-dom": "^16.8.3",
     "react-fittext": "^1.0.0",

--- a/web-server/v0.4/src/components/GlobalHeader/index.js
+++ b/web-server/v0.4/src/components/GlobalHeader/index.js
@@ -1,9 +1,14 @@
 import { PureComponent } from 'react';
-import { routerRedux, Link } from 'dva/router';
-import { Icon, Divider, Tooltip } from 'antd';
+import { routerRedux } from 'dva/router';
+import { Icon, Divider, Tooltip, Alert, Badge } from 'antd';
 import Debounce from 'lodash-decorators/debounce';
+import { connect } from 'dva';
 import styles from './index.less';
+import SessionModal from '../SessionModal';
 
+@connect(store => ({
+  store,
+}))
 class GlobalHeader extends PureComponent {
   componentWillUnmount() {
     this.triggerResizeEvent.cancel();
@@ -23,49 +28,93 @@ class GlobalHeader extends PureComponent {
     window.dispatchEvent(event);
   }
 
+  exitUserSession = () => {
+    const { dispatch, store } = this.props;
+    const sessionConfig = window.localStorage.getItem('persist:session');
+
+    dispatch({
+      type: 'global/exitUserSession',
+    });
+    dispatch({
+      type: 'global/rehydrateSession',
+      payload: JSON.parse(sessionConfig),
+    });
+    window.localStorage.removeItem('persist:session');
+    dispatch(routerRedux.push('/'));
+  };
+
   render() {
-    const { collapsed, isMobile, logo, dispatch } = this.props;
+    const {
+      collapsed,
+      datastoreConfig,
+      savingSession,
+      sessionBannerVisible,
+      sessionDescription,
+      sessionId,
+      isMobile,
+      logo,
+      dispatch,
+    } = this.props;
 
     return (
-      <div className={styles.header}>
-        <div style={{ display: 'flex', flexDirection: 'row' }}>
-          {isMobile && [
-            <Link to="/" className={styles.logo} key="logo">
-              <img src={logo} alt="logo" width="32" />
-            </Link>,
-            <Divider type="vertical" key="line" />,
-          ]}
-          <Icon
-            className={styles.trigger}
-            type={collapsed ? 'menu-unfold' : 'menu-fold'}
-            onClick={this.toggle}
+      <div>
+        {sessionBannerVisible && (
+          <Alert
+            message={sessionDescription}
+            type="info"
+            description={`Session ID: ${sessionId}`}
+            closeText="Exit Session"
+            icon={<Badge status="processing" />}
+            onClose={this.exitUserSession}
+            banner
           />
-        </div>
-        <div className={styles.right}>
-          <Tooltip
-            title="Search"
-            onClick={() => {
-              dispatch(
-                routerRedux.push({
-                  pathname: '/search',
-                })
-              );
-            }}
-          >
-            <a className={styles.action}>
-              <Icon type="search" />
-            </a>
-          </Tooltip>
-          <Tooltip title="Help">
-            <a
-              target="_blank"
-              href="https://docs.google.com/document/d/1W4-vUpMzClBxQmwODDG4WLENmHXrL-adf-5GOF-NYg8/edit"
-              rel="noopener noreferrer"
-              className={styles.action}
+        )}
+        <div className={styles.header}>
+          <div style={{ display: 'flex', flexDirection: 'row' }}>
+            {isMobile && [
+              <Link to="/" className={styles.logo} key="logo">
+                <img src={logo} alt="logo" width="32" />
+              </Link>,
+              <Divider type="vertical" key="line" />,
+            ]}
+            <Icon
+              className={styles.trigger}
+              type={collapsed ? 'menu-unfold' : 'menu-fold'}
+              onClick={this.toggle}
+            />
+          </div>
+          <div className={styles.right}>
+            <SessionModal
+              datastoreConfig={datastoreConfig}
+              savingSession={savingSession}
+              sessionConfig={this.props.store}
+              dispatch={dispatch}
+            />
+            <Tooltip
+              title="Search"
+              onClick={() => {
+                dispatch(
+                  routerRedux.push({
+                    pathname: '/search',
+                  })
+                );
+              }}
             >
-              <Icon type="question-circle-o" />
-            </a>
-          </Tooltip>
+              <a className={styles.action}>
+                <Icon type="search" />
+              </a>
+            </Tooltip>
+            <Tooltip title="Help">
+              <a
+                target="_blank"
+                href="https://docs.google.com/document/d/1W4-vUpMzClBxQmwODDG4WLENmHXrL-adf-5GOF-NYg8/edit"
+                rel="noopener noreferrer"
+                className={styles.action}
+              >
+                <Icon type="question-circle-o" />
+              </a>
+            </Tooltip>
+          </div>
         </div>
       </div>
     );

--- a/web-server/v0.4/src/components/SessionModal/index.js
+++ b/web-server/v0.4/src/components/SessionModal/index.js
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { Modal, Form, Input, Button, message, Tooltip, Icon } from 'antd';
+import styles from './index.less';
+
+const { TextArea } = Input;
+
+class SessionModal extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      description: '',
+      visible: false,
+      sessionUrl: '',
+    };
+  }
+
+  showSuccess = () => {
+    const { sessionUrl } = this.state;
+
+    Modal.success({
+      title: 'Generated session link',
+      content: (
+        <div style={{ display: 'flex', flex: 1, flexDirection: 'row' }}>
+          <Input value={sessionUrl} />
+          <CopyToClipboard text={sessionUrl}>
+            <Button style={{ marginLeft: 8 }} icon="copy" onClick={this.copyLink}>
+              Copy Link
+            </Button>
+          </CopyToClipboard>
+        </div>
+      ),
+    });
+  };
+
+  handleCancel = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
+  showModal = () => {
+    this.setState({
+      visible: true,
+    });
+  };
+
+  onGenerate = () => {
+    const { dispatch, datastoreConfig } = this.props;
+    let { sessionConfig } = this.props;
+    const { description } = this.state;
+    sessionConfig = JSON.stringify(sessionConfig);
+
+    dispatch({
+      type: 'global/saveUserSession',
+      payload: {
+        sessionConfig,
+        description,
+        datastoreConfig,
+      },
+    }).then(result => {
+      this.setState({
+        visible: false,
+        sessionUrl: `${window.location.origin}/#/dashboard/share/${result.data.createUrl.id}`,
+      });
+      this.showSuccess();
+    });
+  };
+
+  copyLink = () => {
+    const { sessionUrl } = this.state;
+    message.success(`Copied the link: ${sessionUrl}`);
+  };
+
+  changeDescription = e => {
+    this.setState({
+      description: e.target.value,
+    });
+  };
+
+  render() {
+    const { visible, description } = this.state;
+    const { savingSession } = this.props;
+
+    return (
+      <span>
+        <Tooltip title="Share" onClick={this.showModal}>
+          <a className={styles.action}>
+            <Icon type="share-alt" />
+          </a>
+        </Tooltip>
+        <Modal
+          title="Share Session Link"
+          visible={visible}
+          onOk={this.onGenerate}
+          onCancel={this.handleCancel}
+          footer={[
+            <Button key="back" onClick={this.handleCancel}>
+              Cancel
+            </Button>,
+            <Button key="submit" type="primary" onClick={this.onGenerate} loading={savingSession}>
+              Save
+            </Button>,
+          ]}
+        >
+          <Form layout="vertical">
+            <Form.Item label="Description">
+              <TextArea
+                rows={2}
+                id="description"
+                placeholder={description}
+                onChange={this.changeDescription}
+              />
+            </Form.Item>
+          </Form>
+        </Modal>
+      </span>
+    );
+  }
+}
+
+export default SessionModal;

--- a/web-server/v0.4/src/components/SessionModal/index.less
+++ b/web-server/v0.4/src/components/SessionModal/index.less
@@ -1,0 +1,18 @@
+@import '~antd/lib/style/themes/default.less';
+
+.action {
+  cursor: pointer;
+  padding: 0 12px;
+  display: inline-block;
+  transition: all 0.3s;
+  height: 100%;
+  > i {
+    font-size: 16px;
+    vertical-align: middle;
+    color: @text-color;
+  }
+  &:hover,
+  &:global(.ant-popover-open) {
+    background: @primary-1;
+  }
+}

--- a/web-server/v0.4/src/components/SessionModal/index.test.js
+++ b/web-server/v0.4/src/components/SessionModal/index.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import SessionModal from './index';
+
+const mockProps = {
+  store: {},
+};
+
+const mockDispatch = jest.fn();
+configure({ adapter: new Adapter() });
+const wrapper = shallow(<SessionModal dispatch={mockDispatch} {...mockProps} />);
+
+describe('test rendering of SessionModal component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/web-server/v0.4/src/e2e/session.e2e.js
+++ b/web-server/v0.4/src/e2e/session.e2e.js
@@ -1,0 +1,54 @@
+import puppeteer from 'puppeteer';
+import { mockStore } from '../../mock/api';
+
+let browser;
+let page;
+
+beforeAll(async () => {
+  browser = await puppeteer.launch({
+    headless: false,
+    slowMo: 100,
+    args: ['--no-sandbox'],
+  });
+  page = await browser.newPage();
+  await page.goto('http://localhost:8000/dashboard/#/');
+  await page.setRequestInterception(true);
+  page.on('request', request => {
+    if (request.method() === 'POST' && request.postData().includes('url')) {
+      request.respond({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'Access-Control-Allow-Origin': '*' },
+        body: JSON.stringify(mockStore),
+      });
+    } else {
+      request.continue();
+    }
+  });
+});
+
+afterAll(() => {
+  browser.close();
+});
+
+describe('session flow', () => {
+  test('should generate user session', async () => {
+    await page.waitForSelector('.anticon-share-alt > svg');
+    await page.click('.anticon-share-alt > svg');
+
+    await page.waitForSelector('.ant-input');
+    await page.type('.ant-input', 'controller page test', { delay: 50 });
+
+    await page.waitForSelector(
+      '.ant-modal-wrap > .ant-modal > .ant-modal-content > .ant-modal-footer > .ant-btn-primary'
+    );
+    await page.click(
+      '.ant-modal-wrap > .ant-modal > .ant-modal-content > .ant-modal-footer > .ant-btn-primary'
+    );
+  });
+
+  test('should copy session link', async () => {
+    await page.waitForSelector('.ant-btn');
+    await page.click('.ant-btn');
+  });
+});

--- a/web-server/v0.4/src/layouts/BasicLayout.js
+++ b/web-server/v0.4/src/layouts/BasicLayout.js
@@ -83,8 +83,13 @@ enquireScreen(b => {
   isMobile = b;
 });
 
-@connect(({ global = {} }) => ({
+@connect(({ global, datastore, loading }) => ({
+  datastoreConfig: datastore.datastoreConfig,
   collapsed: global.collapsed,
+  sessionBannerVisible: global.sessionBannerVisible,
+  sessionDescription: global.sessionDescription,
+  sessionId: global.sessionId,
+  savingSession: loading.effects['global/saveUserSession'],
 }))
 class BasicLayout extends React.PureComponent {
   static childContextTypes = {
@@ -199,7 +204,12 @@ class BasicLayout extends React.PureComponent {
 
   render() {
     const {
+      datastoreConfig,
       collapsed,
+      savingSession,
+      sessionBannerVisible,
+      sessionDescription,
+      sessionId,
       fetchingNotices,
       children,
       location: { pathname },
@@ -226,6 +236,11 @@ class BasicLayout extends React.PureComponent {
               logo={logo}
               fetchingNotices={fetchingNotices}
               collapsed={collapsed}
+              datastoreConfig={datastoreConfig}
+              savingSession={savingSession}
+              sessionBannerVisible={sessionBannerVisible}
+              sessionDescription={sessionDescription}
+              sessionId={sessionId}
               isMobile={mb}
               onNoticeClear={this.handleNoticeClear}
               onCollapse={this.handleMenuCollapse}
@@ -233,7 +248,12 @@ class BasicLayout extends React.PureComponent {
               onNoticeVisibleChange={this.handleNoticeVisibleChange}
             />
           </Header>
-          <Content style={{ margin: '24px 24px 0', height: '100%' }}>
+          <Content
+            style={{
+              margin: sessionBannerVisible ? '104px 24px 0' : '24px 24px 0',
+              height: '100%',
+            }}
+          >
             <PersistGate
               persistor={this.persistor}
               loading={

--- a/web-server/v0.4/src/models/dashboard.js
+++ b/web-server/v0.4/src/models/dashboard.js
@@ -6,7 +6,6 @@ import {
   queryIterations,
   queryTimeseriesData,
 } from '../services/dashboard';
-
 import { parseIterationData } from '../utils/parse';
 import { insertTocTreeData } from '../utils/utils';
 
@@ -25,6 +24,12 @@ export default {
   },
 
   effects: {
+    *rehydrate({ payload }, { put }) {
+      yield put({
+        type: 'rehydrateDashboard',
+        payload,
+      });
+    },
     *fetchControllers({ payload }, { call, put }) {
       const response = yield call(queryControllers, payload);
       const controllers = [];
@@ -189,15 +194,15 @@ export default {
         payload,
       });
     },
-    *updateConfigData({ payload }, { put }) {
-      yield put({
-        type: 'modifyConfigData',
-        payload,
-      });
-    },
   },
 
   reducers: {
+    rehydrateDashboard(state, { payload }) {
+      return {
+        ...state,
+        ...payload,
+      };
+    },
     getControllers(state, { payload }) {
       return {
         ...state,
@@ -244,12 +249,6 @@ export default {
       return {
         ...state,
         iterationParams: payload,
-      };
-    },
-    modifyConfigData(state, { payload }) {
-      return {
-        ...state,
-        configData: payload,
       };
     },
   },

--- a/web-server/v0.4/src/models/datastore.js
+++ b/web-server/v0.4/src/models/datastore.js
@@ -1,4 +1,4 @@
-import { queryDatastoreConfig, queryMonthIndices } from '../services/global';
+import { queryDatastoreConfig, queryMonthIndices } from '../services/datastore';
 
 export default {
   namespace: 'datastore',

--- a/web-server/v0.4/src/models/global.js
+++ b/web-server/v0.4/src/models/global.js
@@ -1,7 +1,12 @@
+import { saveUserSession, queryUserSession } from '../services/global';
+
 export default {
   namespace: 'global',
 
   state: {
+    sessionBannerVisible: false,
+    sessionDescription: '',
+    sessionId: '',
     collapsed: false,
     selectedIndices: [],
     selectedResults: [],
@@ -11,6 +16,20 @@ export default {
   },
 
   effects: {
+    *rehydrateSession({ payload }, { put }) {
+      yield put({
+        type: 'rehydrateGlobal',
+        payload: payload.global,
+      });
+      yield put({
+        type: 'dashboard/rehydrate',
+        payload: payload.global,
+      });
+      yield put({
+        type: 'search/rehydrate',
+        payload: payload.global,
+      });
+    },
     *updateSelectedIndices({ payload }, { put }) {
       yield put({
         type: 'modifySelectedIndices',
@@ -41,13 +60,48 @@ export default {
         payload,
       });
     },
+    *saveUserSession({ payload }, { call }) {
+      const response = yield call(saveUserSession, payload);
+      return response;
+    },
+    *fetchUserSession({ payload }, { call }) {
+      const response = yield call(queryUserSession, payload);
+      const { config } = response.data.url;
+      const parsedSessionConfig = JSON.parse(config);
+      return {
+        sessionConfig: parsedSessionConfig,
+        sessionMetadata: response.data.url,
+      };
+    },
   },
 
   reducers: {
+    rehydrateGlobal(state, { payload }) {
+      return {
+        ...state,
+        ...payload,
+      };
+    },
     changeLayoutCollapsed(state, { payload }) {
       return {
         ...state,
         collapsed: payload,
+      };
+    },
+    startUserSession(state, { payload }) {
+      return {
+        ...state,
+        sessionBannerVisible: payload.render,
+        sessionDescription: payload.sessionDescription,
+        sessionId: payload.sessionId,
+      };
+    },
+    exitUserSession(state) {
+      return {
+        ...state,
+        sessionBannerVisible: false,
+        sessionDescription: '',
+        sessionId: '',
       };
     },
     modifySelectedIndices(state, { payload }) {

--- a/web-server/v0.4/src/models/search.js
+++ b/web-server/v0.4/src/models/search.js
@@ -11,6 +11,12 @@ export default {
   },
 
   effects: {
+    *rehydrate({ payload }, { put }) {
+      yield put({
+        type: 'rehydrateSearch',
+        payload,
+      });
+    },
     *fetchIndexMapping({ payload }, { call, put }) {
       const response = yield call(queryIndexMapping, payload);
       const { datastoreConfig, indices } = payload;
@@ -75,6 +81,12 @@ export default {
   },
 
   reducers: {
+    rehydrateSearch(state, { payload }) {
+      return {
+        ...state,
+        ...payload,
+      };
+    },
     getIndexMapping(state, { payload }) {
       return {
         ...state,

--- a/web-server/v0.4/src/pages/Explore/index.js
+++ b/web-server/v0.4/src/pages/Explore/index.js
@@ -54,10 +54,7 @@ class Explore extends Component {
   startSharedSession = record => {
     const { dispatch } = this.props;
 
-    const parsedConfig = JSON.parse(record.config);
-    window.localStorage.setItem('persist:root', parsedConfig);
-
-    dispatch(routerRedux.push(parsedConfig.routing.location.pathname));
+    dispatch(routerRedux.push(`/share/${record.id}`));
   };
 
   render() {

--- a/web-server/v0.4/src/pages/SessionPlaceholder/index.js
+++ b/web-server/v0.4/src/pages/SessionPlaceholder/index.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { connect } from 'dva';
+import { routerRedux } from 'dva/router';
+import { Spin } from 'antd';
+
+@connect(store => ({
+  datastoreConfig: store.datastore.datastoreConfig,
+  store,
+}))
+class SessionPlaceholder extends React.Component {
+  componentDidMount = () => {
+    this.queryDatastoreConfig();
+  };
+
+  queryDatastoreConfig = async () => {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'datastore/fetchDatastoreConfig',
+    }).then(() => {
+      this.persistCurrentSession();
+    });
+  };
+
+  persistCurrentSession = () => {
+    const { store } = this.props;
+
+    const parsedSessionConfig = JSON.stringify(store);
+    Promise.resolve(window.localStorage.setItem('persist:session', parsedSessionConfig)).then(
+      () => {
+        this.queryUserSession();
+      }
+    );
+  };
+
+  queryUserSession = async () => {
+    const { dispatch, datastoreConfig } = this.props;
+    const path = window.location.href;
+    const id = path.substring(path.lastIndexOf('/') + 1);
+
+    dispatch({
+      type: 'global/fetchUserSession',
+      payload: {
+        id,
+        datastoreConfig,
+      },
+    }).then(response => {
+      this.rehydrateNamespaces(response.sessionConfig, response.sessionMetadata);
+    });
+  };
+
+  rehydrateNamespaces = async (sessionConfig, sessionMetadata) => {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'global/rehydrateSession',
+      payload: sessionConfig,
+    }).then(() => {
+      this.startUserSession(sessionConfig, sessionMetadata);
+    });
+  };
+
+  startUserSession = async (sessionConfig, sessionMetadata) => {
+    const { dispatch } = this.props;
+
+    dispatch({
+      type: 'global/startUserSession',
+      payload: {
+        render: true,
+        sessionDescription: sessionMetadata.description,
+        sessionId: sessionMetadata.id,
+      },
+    });
+    dispatch(routerRedux.push(sessionConfig.routing.location.pathname));
+  };
+
+  render() {
+    return (
+      <div
+        style={{
+          display: 'flex',
+        }}
+      >
+        <Spin
+          style={{
+            flex: 1,
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
+          spinning
+          tip="Retrieving dashboard session..."
+          size="large"
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(() => ({}))(SessionPlaceholder);

--- a/web-server/v0.4/src/pages/SessionPlaceholder/index.test.js
+++ b/web-server/v0.4/src/pages/SessionPlaceholder/index.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import SessionPlaceholder from './index';
+
+const mockProps = {
+  store: [],
+};
+
+const mockDispatch = jest.fn();
+const wrapper = shallow(
+  <SessionPlaceholder.WrappedComponent dispatch={mockDispatch} {...mockProps} />,
+  {
+    disableLifecycleMethods: true,
+  }
+);
+
+describe('test SessionPlaceholder page component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/web-server/v0.4/src/services/datastore.js
+++ b/web-server/v0.4/src/services/datastore.js
@@ -1,0 +1,35 @@
+import request from '../utils/request';
+
+/**
+ * This service references the node environment for retrieval of
+ * the API config file. Node specifies two types of environments
+ * depending on how the dashboard has been run:
+ *
+ * `development` - the dashboard is referencing `dev.config.json`
+ * and has been executed from the root directory using the `start`
+ * script.
+ *
+ * `production` - the dashboard has been bundled to minimized
+ * js, css, and html files using the `build` script and is
+ * deployed on a web server.
+ */
+export async function queryDatastoreConfig() {
+  let configEndpoint = '';
+  const environment = process.env || 'development';
+
+  if (environment === 'development') {
+    configEndpoint = '/dev/datastoreConfig';
+  } else {
+    configEndpoint = '/dashboard/config.json';
+  }
+
+  return request.get(configEndpoint);
+}
+
+export async function queryMonthIndices(params) {
+  const { datastoreConfig } = params;
+
+  const endpoint = `${datastoreConfig.elasticsearch}/_cat/indices?format=json&pretty=true`;
+
+  return request.get(endpoint);
+}

--- a/web-server/v0.4/src/services/global.js
+++ b/web-server/v0.4/src/services/global.js
@@ -1,35 +1,41 @@
 import request from '../utils/request';
 
-/**
- * This service references the node environment for retrieval of
- * the API config file. Node specifies two types of environments
- * depending on how the dashboard has been run:
- *
- * `development` - the dashboard is referencing `dev.config.json`
- * and has been executed from the root directory using the `start`
- * script.
- *
- * `production` - the dashboard has been bundled to minimized
- * js, css, and html files using the `build` script and is
- * deployed on a web server.
- */
-export async function queryDatastoreConfig() {
-  let configEndpoint = '';
-  const environment = process.env || 'development';
-
-  if (environment === 'development') {
-    configEndpoint = '/dev/datastoreConfig';
-  } else {
-    configEndpoint = '/dashboard/config.json';
-  }
-
-  return request.get(configEndpoint);
+export async function saveUserSession(params) {
+  const { sessionConfig, description, datastoreConfig } = params;
+  return request.post(datastoreConfig.graphql, {
+    data: {
+      query: `
+            mutation($config: String!, $description: String!) {
+              createUrl(data: {config: $config, description: $description}) {
+                id
+                config
+                description
+              }
+            }       
+          `,
+      variables: {
+        config: sessionConfig,
+        description,
+      },
+    },
+  });
 }
 
-export async function queryMonthIndices(params) {
-  const { datastoreConfig } = params;
-
-  const endpoint = `${datastoreConfig.elasticsearch}/_cat/indices?format=json&pretty=true`;
-
-  return request.get(endpoint);
+export async function queryUserSession(params) {
+  const { id, datastoreConfig } = params;
+  return request.post(datastoreConfig.graphql, {
+    data: {
+      query: `
+        query($id: ID!) {
+            url(where: {id: $id}) {
+                id
+                config
+                description
+            }
+      }`,
+      variables: {
+        id,
+      },
+    },
+  });
 }


### PR DESCRIPTION
#### Summary

In order to promote sharing of data and insights throughout the platform, sessions are recording by preserving global dashboard state and then stored within the graphql server. This integration involves handoffs between the dashboard and graphql server to generate a unique link that can be shared to reinitialize a session a user has shared. All generated sessions are then made available within the `Explore` page component for discovery. 

#### Important Changes:
- `SessionPlaceholder` page component for acting as a loading gate for initializing sessions when the user has provided a unique ID within the dashboard url 
- `SessionModal` component for capturing session descriptions and allowing user to copy to their browser for sharing
- `Alert` banner component for displaying active session metadata and allowing user to revert to original session
- Unit & e2e tests for `SessionModal` and session sharing workflow