### PR TITLE
Fix handling of pbench-fio iteration name

### DIFF
--- a/agent/bench-scripts/gold/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-04.txt
@@ -680,36 +680,42 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 4
+dev = /tmp/fio
 iteration_name = 1-rw-4KiB
 
 [iterations/2-rw-64KiB]
 iteration_number = 2
 test_type = rw
 block_size_kib = 64
+dev = /tmp/fio
 iteration_name = 2-rw-64KiB
 
 [iterations/3-rw-1024KiB]
 iteration_number = 3
 test_type = rw
 block_size_kib = 1024
+dev = /tmp/fio
 iteration_name = 3-rw-1024KiB
 
 [iterations/4-randrw-4KiB]
 iteration_number = 4
 test_type = randrw
 block_size_kib = 4
+dev = /tmp/fio
 iteration_name = 4-randrw-4KiB
 
 [iterations/5-randrw-64KiB]
 iteration_number = 5
 test_type = randrw
 block_size_kib = 64
+dev = /tmp/fio
 iteration_name = 5-randrw-64KiB
 
 [iterations/6-randrw-1024KiB]
 iteration_number = 6
 test_type = randrw
 block_size_kib = 1024
+dev = /tmp/fio
 iteration_name = 6-randrw-1024KiB
 
 --- fio_test-04_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-05.txt
@@ -235,18 +235,21 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 4
+dev = /tmp/fio
 iteration_name = 1-rw-4KiB
 
 [iterations/2-rw-64KiB]
 iteration_number = 2
 test_type = rw
 block_size_kib = 64
+dev = /tmp/fio
 iteration_name = 2-rw-64KiB
 
 [iterations/3-rw-1024KiB]
 iteration_number = 3
 test_type = rw
 block_size_kib = 1024
+dev = /tmp/fio
 iteration_name = 3-rw-1024KiB
 
 --- fio_test-05_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-06.txt
@@ -260,18 +260,21 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 4
+dev = /tmp/fio
 iteration_name = 1-rw-4KiB
 
 [iterations/2-rw-64KiB]
 iteration_number = 2
 test_type = rw
 block_size_kib = 64
+dev = /tmp/fio
 iteration_name = 2-rw-64KiB
 
 [iterations/3-rw-1024KiB]
 iteration_number = 3
 test_type = rw
 block_size_kib = 1024
+dev = /tmp/fio
 iteration_name = 3-rw-1024KiB
 
 --- fio_test-06_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-07.txt
@@ -314,6 +314,7 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 4
+dev = /dev/rbd0,/dev/rbd1
 iteration_name = 1-read-4KiB
 
 --- fio_test-07_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-08.txt
@@ -296,6 +296,7 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 4
+dev = /mnt/cephfs
 iteration_name = 1-read-4KiB
 
 --- fio_test-08_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-13.txt
@@ -1,6 +1,6 @@
 +++ Running test-13 pbench-fio
 verifying clients have fio installed
-Created the following job file (/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job):
+Created the following job file (/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job):
 [global]
 bs=4k
 runtime=30
@@ -24,37 +24,37 @@ rw=read
 size=64m
 numjobs=1
 
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job (sample1)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job (sample1)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job (sample2)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job (sample2)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job (sample3)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job (sample3)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job (sample4)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job (sample4)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job (sample5)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job (sample5)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-Created the following job file (/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job):
+Created the following job file (/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job):
 [global]
 bs=4k
 runtime=30
@@ -78,31 +78,31 @@ rw=read
 size=64m
 numjobs=1
 
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job (sample1)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job (sample1)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job (sample2)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job (sample2)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job (sample3)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job (sample3)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job (sample4)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job (sample4)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/*/fio_clat_hist.*.log*) to process for histograms
 fio job complete
-running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job (sample5)
+running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job (sample5)
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 [warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -113,102 +113,102 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent
 /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/.iterations
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/process-iteration-samples.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/process-iteration-samples.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4/tools-default
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/clients
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/clients/192.168.121.112
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/clients/192.168.121.158
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/clients/192.168.121.64
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/fio-postprocess.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/fio-result.txt
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/fio.cmd
-/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/process-iteration-samples.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/process-iteration-samples.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4/tools-default
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/clients
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/clients/192.168.121.112
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/clients/192.168.121.158
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/clients/192.168.121.64
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/fio-postprocess.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/fio-result.txt
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/fio.cmd
+/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file
 /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/generate-benchmark-summary.cmd
 /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/metadata.log
@@ -234,7 +234,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -245,7 +245,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -256,7 +256,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -267,7 +267,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -278,7 +278,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -289,7 +289,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -300,7 +300,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -311,7 +311,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -322,7 +322,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -333,7 +333,7 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
-/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job  --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3]
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.64/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.112/fio_clat_hist.*.log*) to process for histograms
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[warn][1900-01-01T00:00:00.000000] log_hist_msec specified in job file but failed to find any log files (.../clients/192.168.121.158/fio_clat_hist.*.log*) to process for histograms
@@ -341,64 +341,64 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/pbench.log:[debug][1900-01-01T00:00:00.000000] post-processing fio result
 --- pbench.log file contents
 +++ test-execution.log file contents
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4 fio- default
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 fio- default
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 fio- default
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/generate-benchmark-summary fio --config=test-13 -c 192.168.121.64,192.168.121.112,192.168.121.158 --job-file=/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/templates/fio.job --job-mode=serial --targets=/dev/rbd0,/dev/rbd1 -b 4 -t read -s 64m /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB readwrite_IOPS 5 0 6 y y
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB readwrite_IOPS 5 0 6 y y
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0 readwrite_IOPS 5 0 6 y y
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1 readwrite_IOPS 5 0 6 y y
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --client=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/fio-client.file --max-jobs=3 --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/fio.job
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00 --sysinfo=default beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00 end
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-start-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=1-read-4KiB-rbd0 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-stop-tools --group=default --iteration=2-read-4KiB-rbd1 --dir=/var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
@@ -422,26 +422,26 @@ fio job complete
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.112 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
@@ -465,26 +465,26 @@ fio job complete
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.158 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
@@ -508,26 +508,26 @@ fio job complete
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/1-read-4KiB-rbd0/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample1 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample2 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
+/var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no 192.168.121.64 pushd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 >/dev/null; screen -dmS fio-server bash -c ''/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm' --server 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done 192.168.121.112 8765
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done 192.168.121.112 8765
 /var/tmp/pbench-test-bench/test-execution.log:/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done 192.168.121.112 8765
@@ -562,16 +562,18 @@ fio job complete
 +++ fio_test-13_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1-read-4KiB]
+[iterations/1-read-4KiB-rbd0]
 iteration_number = 1
 test_type = read
 block_size_kib = 4
-iteration_name = 1-read-4KiB
+dev = /dev/rbd0
+iteration_name = 1-read-4KiB-rbd0
 
-[iterations/2-read-4KiB]
+[iterations/2-read-4KiB-rbd1]
 iteration_number = 2
 test_type = read
 block_size_kib = 4
-iteration_name = 2-read-4KiB
+dev = /dev/rbd1
+iteration_name = 2-read-4KiB-rbd1
 
 --- fio_test-13_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-15.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-15.txt
@@ -296,36 +296,42 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 1-rw-42KiB
 
 [iterations/2-randwrite-42KiB]
 iteration_number = 2
 test_type = randwrite
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 2-randwrite-42KiB
 
 [iterations/3-read-42KiB]
 iteration_number = 3
 test_type = read
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 3-read-42KiB
 
 [iterations/4-randrw-42KiB]
 iteration_number = 4
 test_type = randrw
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 4-randrw-42KiB
 
 [iterations/5-write-42KiB]
 iteration_number = 5
 test_type = write
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 5-write-42KiB
 
 [iterations/6-randread-42KiB]
 iteration_number = 6
 test_type = randread
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 6-randread-42KiB
 
 --- fio_test-15_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-16.txt
@@ -104,6 +104,7 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 42
+dev = /dev/sda0,/dev/sda1
 iteration_name = 1-rw-42KiB
 
 --- fio_test-16_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-20.txt
@@ -290,18 +290,21 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 4
+dev = /dev/foo,/dev/bar
 iteration_name = 1-read-4KiB
 
 [iterations/2-read-64KiB]
 iteration_number = 2
 test_type = read
 block_size_kib = 64
+dev = /dev/foo,/dev/bar
 iteration_name = 2-read-64KiB
 
 [iterations/3-read-1024KiB]
 iteration_number = 3
 test_type = read
 block_size_kib = 1024
+dev = /dev/foo,/dev/bar
 iteration_name = 3-read-1024KiB
 
 --- fio_test-20_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-28.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-28.txt
@@ -78,6 +78,7 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 8
+dev = /tmp/fio
 iteration_name = 1-read-8KiB
 
 --- fio_test-28_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-30.txt
@@ -103,6 +103,7 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 4
+dev = /tmp
 iteration_name = 1-read-4KiB
 
 --- fio_test-30_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-31.txt
@@ -103,6 +103,7 @@ fio job complete
 iteration_number = 1
 test_type = read
 block_size_kib = 4
+dev = /tmp
 iteration_name = 1-read-4KiB
 
 --- fio_test-31_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/gold/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/gold/pbench-fio/test-32.txt
@@ -135,6 +135,7 @@ fio job complete
 iteration_number = 1
 test_type = rw
 block_size_kib = 42
+dev = /tmp/fio
 iteration_name = 1-rw-42KiB
 
 --- fio_test-32_1900.01.01T00.00.00/metadata.log file contents

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -471,17 +471,19 @@ function fio_process_options() {
 }
 
 function record_iteration {
-	local count=$1
-	local test_type=$2
-	local block_size=$3
-	local iteration=$4
+	local count=${1}
+	local test_type=${2}
+	local block_size=${3}
+	local dev=${4}
+	local iteration=${5}
 
-	mdlog=${benchmark_run_dir}/metadata.log
+	local mdlog=${benchmark_run_dir}/metadata.log
 	echo ${iteration} >> ${benchmark_iterations}
-	echo $count | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_number
-	echo $test_type | pbench-add-metalog-option ${mdlog} iterations/${iteration} test_type
-	echo $block_size | pbench-add-metalog-option ${mdlog} iterations/${iteration} block_size_KiB
-	echo $iteration | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
+	echo ${count} | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_number
+	echo ${test_type} | pbench-add-metalog-option ${mdlog} iterations/${iteration} test_type
+	echo ${block_size} | pbench-add-metalog-option ${mdlog} iterations/${iteration} block_size_KiB
+	echo ${dev} | pbench-add-metalog-option ${mdlog} iterations/${iteration} dev
+	echo ${iteration} | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
 }
 
 # Ensure the right version of the benchmark is installed
@@ -749,7 +751,12 @@ function fio_run_benchmark() {
 			for block_size in `echo $block_sizes | sed -e s/,/" "/g`; do
 				job_num=1
 				iteration="${count}-${test_type}-${block_size}KiB"
-				record_iteration ${count} ${test_type} ${block_size} ${iteration}
+				if [ "$job_mode" = "serial" ]; then
+					dev_short_name="`basename $dev`"
+					# easier to identify what job used what device when having 1 job per device
+					iteration="$iteration-${dev_short_name}"
+				fi
+				record_iteration ${count} ${test_type} ${block_size} ${dev} ${iteration}
 				iteration_dir=$benchmark_run_dir/$iteration
 				result_stddevpct=$maxstddevpct # this test case will get a "do-over" if the stddev is not low enough
 				failures=0
@@ -785,11 +792,6 @@ function fio_run_benchmark() {
 						fio_job_file="$iteration_dir/fio.job"
 						#             ARG   1            2           3             4          5         6       7          8           9            10           11                         12     13              14
 						fio_create_jobfile "$test_type" "$ioengine" "$block_size" "$iodepth" "$direct" "$sync" "$runtime" "$ramptime" "$file_size" "$rate_iops" "$histogram_interval_msec" "$dev" "$fio_job_file" "$numjobs"
-						if [ "$job_mode" = "serial" ]; then
-							dev_short_name="`basename $dev`"
-							# easier to identify what job used what device when having 1 job per device
-							iteration="$iteration-${dev_short_name}"
-						fi
 						iteration_failed=0
 						sample_failed=0
 						for sample in `seq 1 $nr_samples`; do


### PR DESCRIPTION
When using the `serial` job mode, the iteration name passed to the start/stop/post-process tools command included the individual device name targets, but the directory on disk did not include them.  This change corrects that making the iteration name handling consistent.