### PR TITLE
Replace 'echo "" >&4; log_finish; exit n' with log_exit

### DIFF
--- a/server/bin/pbench-base.sh
+++ b/server/bin/pbench-base.sh
@@ -102,9 +102,13 @@ function log_finish {
 }
 
 function log_exit {
-    echo "$PROG: $1" >&4
+    echo "${PROG}: ${1}" >&4
     log_finish
-    exit 1
+    if [[ -z "${2}" ]]; then
+        exit 1
+    else
+        exit ${2}
+    fi
 }
 
 # Function used by the shims to quarantine problematic tarballs.  It
@@ -120,9 +124,7 @@ function quarantine () {
     sts=$?
     if [ $sts -ne 0 ] ;then
         # log error
-        echo "$TS: quarantine $dest $files: \"mkdir -p $dest/\" failed with status $sts" >&4
-        log_finish
-        exit 101
+        log_exit "$TS: quarantine $dest $files: \"mkdir -p $dest/\" failed with status $sts" 101
     fi
     for afile in ${files} ;do
         if [ ! -e $afile -a ! -L $afile ] ;then
@@ -132,9 +134,7 @@ function quarantine () {
         sts=$?
         if [ $sts -ne 0 ] ;then
             # log error
-            echo "$TS: quarantine $dest $files: \"mv $afile $dest/\" failed with status $sts" >&4
-            log_finish
-            exit 102
+            log_exit "$TS: quarantine $dest $files: \"mv $afile $dest/\" failed with status $sts" 102
         fi
     done
 }

--- a/server/bin/pbench-dispatch.sh
+++ b/server/bin/pbench-dispatch.sh
@@ -104,18 +104,14 @@ while read tarball ;do
     if [ "$linksrc" != "$tb_linksrc" ]; then
         # All is NOT well: we expect $linksrc as the parent directory name
         # of the symlink tarball name.
-        echo "$TS: FATAL - unexpected \$linksrc for $tarball" | tee -a $mail_content >&4
-        log_finish
-        exit 57
+        log_exit "$TS: FATAL - unexpected \$linksrc for $tarball" 57
     fi
 
     controller_path=$(dirname $linksrc_path)
     controller=$(basename $controller_path)
     if [ "$ARCHIVE" != "$(dirname $controller_path)" ]; then
         # The controller's parent is not $ARCHIVE!
-        echo "$TS: FATAL - unexpected archive directory for $tarball" | tee -a $mail_content >&4
-        log_finish
-        exit 57
+        log_exit "$TS: FATAL - unexpected archive directory for $tarball" 57
     fi
 
     link=$(readlink -e $tarball)

--- a/server/bin/pbench-server-prep-shim-002.sh
+++ b/server/bin/pbench-server-prep-shim-002.sh
@@ -80,9 +80,7 @@ trap 'rm -rf $tmp' EXIT INT QUIT
 mkdir -p $tmp
 sts=$?
 if [ $sts != 0 ]; then
-    echo "Failed: \"mkdir -p $tmp\", status $sts" >> $errlog
-    log_finish
-    exit 4
+    log_exit "Failed: \"mkdir -p $tmp\", status $sts" 4
 fi
 
 list=$tmp/list.check
@@ -96,16 +94,12 @@ echo $TS
 find ${receive_dir} -maxdepth 2 -name '*.tar.xz.md5' > ${list}.unsorted
 sts=$?
 if [ $sts != 0 ] ;then
-    echo "Failed: \"find ${receive_dir} -maxdepth 2 -name '*.tar.xz.md5'\", status $sts" >&4
-    log_finish
-    exit 5
+    log_exit "Failed: \"find ${receive_dir} -maxdepth 2 -name '*.tar.xz.md5'\", status $sts" 5
 fi
 sort ${list}.unsorted > ${list}
 sts=$?
 if [ $sts != 0 ] ;then
-    echo "Failed: \"sort ${list}.unsorted > ${list}\", status $sts" >&4
-    log_finish
-    exit 6
+    log_exit "Failed: \"sort ${list}.unsorted > ${list}\", status $sts" 6
 fi
 
 typeset -i ntotal=0

--- a/server/bin/pbench-sync-package-tarballs.sh
+++ b/server/bin/pbench-sync-package-tarballs.sh
@@ -59,9 +59,7 @@ calculate_md5_prefix $tar_list > $tmp/files-to-sync
 tar cf - -T $tmp/files-to-sync >&100
 status=$?
 if [[ $status != 0 ]] ;then
-    echo "$TS: Failed: tar --create -T $tmp/files-to-sync" >&4
-    log_finish
-    exit 2
+    log_exit "$TS: Failed: tar --create -T $tmp/files-to-sync" 2
 fi
 
 log_finish

--- a/server/bin/pbench-sync-satellite.sh
+++ b/server/bin/pbench-sync-satellite.sh
@@ -106,9 +106,7 @@ if [ -s ${state_change_log} ] ;then
     do_remote_sat_state_change
     status=$?
     if [[ $status != 0 ]]; then
-        echo "$PROG: unable to complete previous satellite state changes (${state_change_log})" >&4
-        log_finish
-        exit 1
+        log_exit "$PROG: unable to complete previous satellite state changes (${state_change_log})"
     fi
     echo "$PROG: completed previous satellite state changes" | tee -a $mail_content >&4
 else
@@ -124,9 +122,7 @@ typeset -i nerrs=0
 pbench-remote-sync-package-tarballs ${satellite_config} ${tmp}/satellite.${remote_prefix}.tar
 rc=$?
 if [[ $rc != 0 ]] ;then
-    echo "$PROG: pbench-remote-sync-package-tarballs: failed." >&4
-    log_finish
-    exit 2
+    log_exit "$PROG: pbench-remote-sync-package-tarballs: failed." 2
 fi
 
 if [ -s $tmp/satellite.$remote_prefix.tar ]; then


### PR DESCRIPTION
Fixes #1446 

It replace the use of the pattern, echo "" >&4; log_finish; exit 1 with the log_exit method from pbench_base.sh.