### PR TITLE
Adds ability to write a description for a session in the dashboard

### DIFF
--- a/web-server/v0.4/src/models/explore.js
+++ b/web-server/v0.4/src/models/explore.js
@@ -1,4 +1,4 @@
-import querySharedSessions from '../services/explore';
+import { querySharedSessions, queryEditDescription } from '../services/explore';
 
 export default {
   namespace: 'explore',
@@ -16,6 +16,10 @@ export default {
         type: 'getSharedSessions',
         payload: response.data.urls,
       });
+    },
+    *editDescription({ payload }, { call }) {
+      const response = yield call(queryEditDescription, payload);
+      return response;
     },
   },
 

--- a/web-server/v0.4/src/models/explore.js
+++ b/web-server/v0.4/src/models/explore.js
@@ -1,4 +1,4 @@
-import { querySharedSessions, queryEditDescription } from '../services/explore';
+import { querySharedSessions, updateDescription } from '../services/explore';
 
 export default {
   namespace: 'explore',
@@ -18,7 +18,7 @@ export default {
       });
     },
     *editDescription({ payload }, { call }) {
-      const response = yield call(queryEditDescription, payload);
+      const response = yield call(updateDescription, payload);
       return response;
     },
   },

--- a/web-server/v0.4/src/pages/Explore/index.js
+++ b/web-server/v0.4/src/pages/Explore/index.js
@@ -21,6 +21,7 @@ class Explore extends Component {
       sharedSessions: props.sharedSessions,
       visible: false,
       selectedID: '',
+      editedDesc: '',
     };
   }
 
@@ -74,6 +75,12 @@ class Explore extends Component {
     });
   };
 
+  getEditedDesc = value => {
+    this.setState({
+      editedDesc: value,
+    });
+  };
+
   showModal = id => {
     this.setState({
       visible: true,
@@ -82,9 +89,8 @@ class Explore extends Component {
   };
 
   handleSave = () => {
-    const { selectedID } = this.state;
-    const { value } = document.getElementById('editedInput');
-    this.editDescription(selectedID, value);
+    const { selectedID, editedDesc } = this.state;
+    this.editDescription(selectedID, editedDesc);
     this.setState({
       visible: false,
     });
@@ -165,7 +171,11 @@ class Explore extends Component {
             <Button key="back" onClick={this.handleCancel}>
               Cancel
             </Button>,
-            <Button key="submit" type="primary" onClick={this.handleSave}>
+            <Button
+              key="submit"
+              type="primary"
+              onClick={this.getEditedDesc(document.getElementById('editedInput'))}
+            >
               Save
             </Button>,
           ]}

--- a/web-server/v0.4/src/pages/Explore/index.js
+++ b/web-server/v0.4/src/pages/Explore/index.js
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import { connect } from 'dva';
 import { routerRedux } from 'dva/router';
-import { Card, Button, Popconfirm } from 'antd';
+import { Card, Button, Popconfirm, Icon, Form, Modal, Input } from 'antd';
 
 import PageHeaderLayout from '../../layouts/PageHeaderLayout';
 import Table from '@/components/Table';
+
+const { TextArea } = Input;
 
 @connect(({ datastore, explore, loading }) => ({
   sharedSessions: explore.sharedSessions,
@@ -17,6 +19,8 @@ class Explore extends Component {
 
     this.state = {
       sharedSessions: props.sharedSessions,
+      visible: false,
+      selectedID: '',
     };
   }
 
@@ -60,8 +64,40 @@ class Explore extends Component {
     dispatch(routerRedux.push(parsedConfig.routing.location.pathname));
   };
 
+  editDescription = (id, value) => {
+    const { dispatch, datastoreConfig } = this.props;
+    dispatch({
+      type: 'explore/editDescription',
+      payload: { datastoreConfig, id, value },
+    }).then(() => {
+      this.fetchSharedSessions();
+    });
+  };
+
+  showModal = id => {
+    this.setState({
+      visible: true,
+      selectedID: id,
+    });
+  };
+
+  handleSave = () => {
+    const { selectedID } = this.state;
+    const { value } = document.getElementById('editedInput');
+    this.editDescription(selectedID, value);
+    this.setState({
+      visible: false,
+    });
+  };
+
+  handleCancel = () => {
+    this.setState({
+      visible: false,
+    });
+  };
+
   render() {
-    const { sharedSessions } = this.state;
+    const { sharedSessions, visible } = this.state;
     const { loadingSharedSessions } = this.props;
     const sharedSessionColumns = [
       {
@@ -78,8 +114,23 @@ class Explore extends Component {
       },
       {
         title: 'Description',
+        colSpan: 2,
         dataIndex: 'description',
         key: 'description',
+      },
+      {
+        title: 'Edit',
+        colSpan: 0,
+        dataIndex: '',
+        key: 'edit',
+        class: 'editDescription',
+        render: record => {
+          const value = <Icon type="edit" onClick={() => this.showModal(record.id)} />;
+          const obj = {
+            children: value,
+          };
+          return obj;
+        },
       },
       {
         title: 'Action',
@@ -107,6 +158,24 @@ class Explore extends Component {
             loading={loadingSharedSessions}
           />
         </Card>
+        <Modal
+          title="Edit the description"
+          visible={visible}
+          footer={[
+            <Button key="back" onClick={this.handleCancel}>
+              Cancel
+            </Button>,
+            <Button key="submit" type="primary" onClick={this.handleSave}>
+              Save
+            </Button>,
+          ]}
+        >
+          <Form layout="vertical">
+            <Form.Item label="Description">
+              <TextArea id="editedInput" rows={2} />
+            </Form.Item>
+          </Form>
+        </Modal>
       </PageHeaderLayout>
     );
   }

--- a/web-server/v0.4/src/pages/Explore/index.test.js
+++ b/web-server/v0.4/src/pages/Explore/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import Table from '@/components/Table';
+import Explore from './index';
+
+const mockProps = {};
+
+const mockDispatch = jest.fn();
+configure({ adapter: new Adapter() });
+const wrapper = shallow(<Explore.WrappedComponent dispatch={mockDispatch} {...mockProps} />, {
+  disableLifecycleMethods: true,
+});
+
+describe('test Summary page component', () => {
+  it('render with empty props', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});
+
+describe('test delete session feature', () => {
+  it('render of Table component', () => {
+    expect(wrapper.find(Table).length).toEqual(1);
+  });
+  it('render of the edit session description columns', () => {
+    expect(wrapper.find(Table).props().columns.length).toEqual(5);
+    expect(wrapper.find(Table).props().columns[3].title).toEqual('Edit');
+  });
+});

--- a/web-server/v0.4/src/pages/Explore/index.test.js
+++ b/web-server/v0.4/src/pages/Explore/index.test.js
@@ -12,7 +12,7 @@ const wrapper = shallow(<Explore.WrappedComponent dispatch={mockDispatch} {...mo
   disableLifecycleMethods: true,
 });
 
-describe('test Summary page component', () => {
+describe('test Explore page component', () => {
   it('render with empty props', () => {
     expect(wrapper).toMatchSnapshot();
   });

--- a/web-server/v0.4/src/services/explore.js
+++ b/web-server/v0.4/src/services/explore.js
@@ -1,6 +1,6 @@
 import request from '../utils/request';
 
-export default async function querySharedSessions(params) {
+export async function querySharedSessions(params) {
   const { datastoreConfig } = params;
 
   const endpoint = `${datastoreConfig.graphql}`;
@@ -16,6 +16,32 @@ export default async function querySharedSessions(params) {
               createdAt
           }   
         }`,
+    },
+  });
+}
+
+export async function queryEditDescription(params) {
+  const { datastoreConfig, id, value } = params;
+
+  const endpoint = `${datastoreConfig.graphql}`;
+
+  return request.post(endpoint, {
+    data: {
+      query: `
+        mutation($description: String!,$id: ID!) {
+        updateUrl(
+          data: {description: $description}
+          where: {id: $id})
+        {
+          id
+          config
+          description
+        }
+      }`,
+      variables: {
+        id,
+        description: value,
+      },
     },
   });
 }

--- a/web-server/v0.4/src/services/explore.js
+++ b/web-server/v0.4/src/services/explore.js
@@ -1,5 +1,6 @@
 import request from '../utils/request';
 
+// queies all the available shared sessions from the database to display
 export async function querySharedSessions(params) {
   const { datastoreConfig } = params;
 
@@ -20,7 +21,8 @@ export async function querySharedSessions(params) {
   });
 }
 
-export async function queryEditDescription(params) {
+// Updates the description of shared session, provided by the user in the database.
+export async function updateDescription(params) {
   const { datastoreConfig, id, value } = params;
 
   const endpoint = `${datastoreConfig.graphql}`;

--- a/web-server/v0.4/src/services/explore.js
+++ b/web-server/v0.4/src/services/explore.js
@@ -1,6 +1,6 @@
 import request from '../utils/request';
 
-// queies all the available shared sessions from the database to display
+// queries all the available shared sessions from the database to display
 export async function querySharedSessions(params) {
   const { datastoreConfig } = params;
 


### PR DESCRIPTION
Fixes #1427 
Implements UI for adding a description to a saved session in the Dashboard.
![editDescriptipn](https://user-images.githubusercontent.com/16955978/71815598-02543980-30a6-11ea-8bfb-b1fde71c28ed.gif)
