### PR TITLE
Enhancement to pbench-audit-server.sh to verify $ARCHIVE hierarchy

### DIFF
--- a/server/bin/pbench-audit-server.sh
+++ b/server/bin/pbench-audit-server.sh
@@ -663,6 +663,36 @@ function verify_archive {
     fi
     rm -f ${bad_controllers}
 
+    for x in "${ARCHIVE}"/*; do
+        unpacked=${x}"/UNPACKED"
+        tounpack=${x}"/TO-UNPACK"
+        for y in "${unpacked}"/*; do
+            z=${tounpack}/$(basename ${y})
+            if [[ -e $z ]]; then
+                echo "Symlink exists in both UNPACKED and TO-UNPACK directories"
+            fi
+        done
+
+	synced=${x}"/SYNCED"
+        tosync=${x}"/TO-SYNC"
+        for y in "${synced}"/*; do
+            z=${tosync}/$(basename ${y})
+            if [[ -e $z ]]; then
+                echo "Symlink exists in both SYNCED and TO-SYNC directories"
+            fi
+        done
+
+	satellitedone=${x}"/SATELLITE-DONE"
+        todelete=${x}"/TO-DELETE"
+        for y in "${satellitedone}"/*; do
+            z=${todelete}/$(basename ${y})
+            if [[ -e $z ]]; then
+                echo "Symlink exists in both SATELLITE-DONE and TO-DELETE directories"
+            fi
+        done
+
+    done
+
     # Find all the normal controller directories, ignoring the "." (current)
     # directory (if the $ARCHIVE directory resolves to "."), and ignoring the
     # $ARCHIVE directory itself, while keeping them all in sorted order.


### PR DESCRIPTION
Fixes #1356 

The server today uses symlinks in various "LINKDIRS" directories in the $ARCHIVE hierarchy. We need to enhance the pbench-audit-server.sh code to verify those symlinks are healthy.

Here are a some-what exhaustive list of assertions and audits that can be considered:

- [ ]   Flag any sub-directory of a controller that is not in the expected list of LINKDIRS
- [ ] Assert: any symlink in state directory is a reference to an existing $ARCHIVE tar ball
- [ ] Flag any symlink in a TODO directory that has a symlink in any other initial state directory (not an assertion because pbench-dispatch creates all the other links before removing the TODO link)
- [x] Assert: either a TO-UNPACK or an UNPACKED symlink exists, but not both
- [ ] Audit: check that an "incoming" directory exists if a valid TO-UNPACK symlink exists
- [ ] Assert: a symlink exists in an UNPACKED state when there is an unpacked directory in $INCOMING
- [ ] Assert: a symlink in TO-INDEX, TO-INDEX-TOOL, INDEXED, or WONT-INDEX* only exists in one of those directories
- [ ] Assert: a symlink in TO-INDEX-TOOL or INDEXED means a run document in exists in Elasticsearch
- [ ] Assert: a symlink in COPIED-SOS cannot also be in TO-COPY-SOS
- [ ] Assert: a symlink to a tar ball only exists in one of the "*BACK*UP*" directories
    In pbench-verify-backup-tarballs:
- [ ] Assert: a backed up tar ball should have a symlink in BACKED-UP
- [ ] Assert: a symlink is only in one of these two directories, SATELLITE-MD5-PASSED, SATELLITE-MD5-FAILED
- [ ] Assert: SATELLITE-MD5-FAILED symlink should mean there are no other symlinks for that tar ball
- [ ] Assert: a symlink is only in one of these two directories, TO-DELETE, SATELLITE-DONE
- [ ] Assert: an incoming tar ball directory does not exist for a symlink in SATELLITE-DONE
- [ ] Assert: a tar ball in the $ARCHIVE directory should not have a SATELLITE-DONE symlink
- [ ] Assert: a symlink in SATELLITE-DONE should not have an existing tar ball in the $ARCHIVE tree
- [ ] Assert: a symlink is only in one of these two directories, TO-SYNC, SYNCED
