### PR TITLE
Render breadcrumbs 

### DIFF
--- a/web-server/v0.4/src/common/menu.js
+++ b/web-server/v0.4/src/common/menu.js
@@ -5,6 +5,28 @@ const menuData = [
     name: 'Dashboard',
     icon: 'dashboard',
     path: '/',
+    routes: [
+      {
+        name: 'Results',
+        path: '/results',
+        routes: [
+          {
+            name: 'Summary',
+            path: '/summary',
+          },
+          {
+            name: 'Comparison Select',
+            path: '/comparison-select',
+            routes: [
+              {
+                name: 'Comparison',
+                path: '/comparison',
+              },
+            ],
+          },
+        ],
+      },
+    ],
   },
   {
     name: 'Search',
@@ -18,7 +40,7 @@ const menuData = [
   },
 ];
 
-function formatter(data, parentPath = '/', parentAuthority) {
+function formatter(data, parentPath = '', parentAuthority) {
   return data.map(item => {
     let { path } = item;
     if (!isUrl(path)) {
@@ -29,8 +51,8 @@ function formatter(data, parentPath = '/', parentAuthority) {
       path,
       authority: item.authority || parentAuthority,
     };
-    if (item.children) {
-      result.children = formatter(item.children, `${parentPath}${item.path}/`, item.authority);
+    if (item.routes) {
+      result.routes = formatter(item.routes, `${parentPath}${item.path}`, item.authority);
     }
     return result;
   });

--- a/web-server/v0.4/src/components/PageHeader/index.test.js
+++ b/web-server/v0.4/src/components/PageHeader/index.test.js
@@ -19,13 +19,13 @@ const mockProps = {
   tabList: ['tab1', 'tab2'],
   routes: ['/1', '/2'],
   params: 'params',
-  location: { pathname: 'location' },
+  location: { pathname: 'url' },
   breadcrumbNameMap: 'breadcrumbNameMap',
   onTabChange: jest.fn(),
   title: 'Titel',
 };
 const mockDispatch = jest.fn();
-const breadcrumbNameMap = { url: { url: 'urlItem' } };
+const breadcrumbNameMap = { url: { path: 'urlItem' } };
 const wrapper = shallow(<PageHeader dispatch={mockDispatch} {...mockProps} />, {
   lifecycleExperimental: true,
 });

--- a/web-server/v0.4/src/components/_utils/pathTools.js
+++ b/web-server/v0.4/src/components/_utils/pathTools.js
@@ -3,3 +3,8 @@ export default function urlToList(url) {
   const urllist = url.split('/').filter(i => i);
   return urllist.map((urlItem, index) => `/${urllist.slice(0, index + 1).join('/')}`);
 }
+
+// '/results/summary' => '/summary'
+export function breadcrumbLinkFromUrl(url) {
+  return `/${url.split('/').pop()}`;
+}

--- a/web-server/v0.4/src/layouts/BasicLayout.js
+++ b/web-server/v0.4/src/layouts/BasicLayout.js
@@ -95,6 +95,8 @@ class BasicLayout extends React.PureComponent {
   static childContextTypes = {
     location: PropTypes.object,
     breadcrumbNameMap: PropTypes.object,
+    routes: PropTypes.array,
+    params: PropTypes.object,
   };
 
   state = {
@@ -111,9 +113,11 @@ class BasicLayout extends React.PureComponent {
 
   getChildContext() {
     const { location } = this.props;
+    const { route } = this.props;
     return {
       location,
       breadcrumbNameMap: this.breadcrumbNameMap,
+      routes: route.routes,
     };
   }
 

--- a/web-server/v0.4/src/layouts/BasicLayout.js
+++ b/web-server/v0.4/src/layouts/BasicLayout.js
@@ -42,8 +42,8 @@ const getBreadcrumbNameMap = memoizeOne(menu => {
   const routerMap = {};
   const mergeMeunAndRouter = menuData => {
     menuData.forEach(menuItem => {
-      if (menuItem.children) {
-        mergeMeunAndRouter(menuItem.children);
+      if (menuItem.routes) {
+        mergeMeunAndRouter(menuItem.routes);
       }
       // Reduce memory usage
       routerMap[menuItem.path] = menuItem;


### PR DESCRIPTION
Previously, we were using `routes` in PageHeader component, however they were always undefined because they were not passed at the first place from top components. 

Also, there was a small bug where we placed a root pathname '/' which was preventing breadcrumbs from rendering in the first place.
That renders breadcrumbs for the pages present in the sidebar, hence is a step towards fixing #1425.