### PR TITLE
clicks on the current pagination value

### DIFF
--- a/web-server/v0.4/src/e2e/controllers.e2e.js
+++ b/web-server/v0.4/src/e2e/controllers.e2e.js
@@ -176,21 +176,21 @@ describe('controller page component', () => {
   });
 
   test('should display 20 controllers on preference', async () => {
-    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-selection-selected-value');
     await page.click('.ant-select-dropdown-menu-item:nth-child(2)');
     const rows = await page.$$('.ant-table-row');
     expect(rows.length).toBe(20);
   });
 
   test('should display 50 controllers on preference', async () => {
-    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-selection-selected-value');
     await page.click('.ant-select-dropdown-menu-item:nth-child(3)');
     const rows = await page.$$('.ant-table-row');
     expect(rows.length).toBe(50);
   });
 
   test('should display 100 controllers on preference', async () => {
-    await page.click('.ant-select-selection.ant-select-selection--single');
+    await page.click('.ant-select-selection-selected-value');
     await page.click('.ant-select-dropdown-menu-item:nth-child(4)');
     const rows = await page.$$('.ant-table-row');
     expect(rows.length).toBe(100);


### PR DESCRIPTION
Currently, the item that we click is not consistent when we run tests each time, that's why some tests pass and some fail. Re-running these tests with an updated item onclick.