### PR TITLE
Don't emit messages directly to the tty

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -18,9 +18,9 @@ export benchmark_run_dir=""
 if [[ -z "$benchmark_bin" ]]; then
 	benchmark_bin=/usr/local/bin/$benchmark
 fi
-ver=$(getconf.py version pbench-fio)
-if [ -z "$ver" ] ;then
-	echo "pbench-fio: package version is missing in config file" > /dev/tty
+ver="$(getconf.py version pbench-fio)"
+if [[ -z "${ver}" ]]; then
+	error_log "pbench-fio: package version is missing in config file"
 	exit 1
 fi
 

--- a/agent/util-scripts/getconf.py
+++ b/agent/util-scripts/getconf.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
+
 import sys
 import configtools
 

--- a/server/bin/getconf.py
+++ b/server/bin/getconf.py
@@ -1,4 +1,5 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
+
 import sys
 import configtools
 

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -49,7 +49,6 @@ function _run {
     else
         echo "+++ Running ${tname} ${@}" >> ${_testout}
     fi
-    export PYTHONPATH=${_testopt}/lib:$PYTHONPATH
     ${tname} ${@} >> ${_testout} 2>&1
     echo "--- Finished ${tname} (status=${?})" >> ${_testout}
 }
@@ -304,7 +303,7 @@ function _setup_state {
     # are found in $_testopt/unittest-scripts.
     _orig_PATH=$PATH
     export PATH=$_testopt/unittest-scripts:$_testopt/bin:$PATH
-    export PYTHONPATH=$_testopt/common/lib:$PYTHONPATH
+    export PYTHONPATH="${_testopt}/lib:${_testopt}/common/lib:${PYTHONPATH}"
 
     # Expected location of the final configuration files 
     export _PBENCH_SERVER_CONFIG=$_testopt/lib/config/pbench-server.cfg


### PR DESCRIPTION
The `pbench-fio` benchmark script was emitting a message directly to the `tty` when the `fio` version could not be determined.  Instead we add it to the `pbench.log` and emit it on `stderr`.

We also define the `PYTHONPATH` once in the server unit tests, and make the python markers in the `getconf.py` modules uniform with other files.