### PR TITLE
Refactoring of server ansible playbooks and fixes from the configtools reorg

### DIFF
--- a/server/ansible/Inventory/group_vars/servers
+++ b/server/ansible/Inventory/group_vars/servers
@@ -1,0 +1,16 @@
+# change to taste
+configurl: http://pbench.example.com/server/config/{{ cenv }}
+
+configfiles:
+  - pbench-server.cfg
+  - pbench-server-backup.cfg
+
+# change to taste
+prefix: https://repos.example.com/repos
+
+repos:
+  - tag: pbench
+    baseurl: "{{ prefix }}/pbench/{{ distrodir }}"
+    gpgkey: "{{ prefix }}/pbench/pubkey.gpg"
+    gpgcheck: 1
+    enabled: 1

--- a/server/ansible/Inventory/pbench-server.hosts.example
+++ b/server/ansible/Inventory/pbench-server.hosts.example
@@ -8,11 +8,5 @@
 [servers]
 <pbench-server-host>
 
-# A pbench-server needs to have a pbench-server.cfg file installed
-# in a designated place. The configurl variable below specifies the
-# location of the config file that should be installed on the server
-# above and should be changed to reflect the local setup. This variable
-# is then used by the pbench-server-config role to install the designated
-# config file on the server.
-[servers:vars]
-configurl = http://pbench.example.com/server/config/pbench-server.cfg
+# Variables for this group are defined in ./group_vars/servers
+

--- a/server/ansible/roles/pbench-repo-install/tasks/main.yml
+++ b/server/ansible/roles/pbench-repo-install/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
-# Install pbench.repo
-- name: ensure we have the pbench.repo file properly in place
-  template: src=etc/yum.repos.d/pbench-server.repo.j2 dest=/etc/yum.repos.d/pbench-server.repo owner=root group=root mode=0644
-
+# Install pbench-server.repo
+- name: ensure we have the pbench-server.repo file properly in place
+  template:
+    src: etc/yum.repos.d/pbench-server.repo.j2
+    dest: /etc/yum.repos.d/pbench-server.repo
+    owner: root
+    group: root
+    mode: 0644

--- a/server/ansible/roles/pbench-repo-install/templates/etc/yum.repos.d/pbench-server.repo.j2
+++ b/server/ansible/roles/pbench-repo-install/templates/etc/yum.repos.d/pbench-server.repo.j2
@@ -1,11 +1,13 @@
-###########################################################################
-# pbench "official" repo
-[copr-pbench-server]
-name=Copr repo for pbench-server
-baseurl={{ baseurl }}
+{% for repo in repos %}
+
+[copr-{{ repo.tag }}]
+name=Copr {{ repo.tag }} repo for pbench-server
+baseurl={{ repo.baseurl }}
 skip_if_unavailable=True
-gpgcheck= {{ gpgcheck }}
-gpgkey={{ gpgkey }}
-enabled=1
+gpgcheck= {{ repo.gpgcheck }}
+gpgkey={{ repo.gpgkey }}
+enabled={{ repo.enabled }}
 enabled_metadata=1
 skip_if_unavailable=1
+
+{% endfor %}

--- a/server/ansible/roles/pbench-repo-install/vars/main.yml
+++ b/server/ansible/roles/pbench-repo-install/vars/main.yml
@@ -1,13 +1,7 @@
 ---
-distro: "{{ 'epel' if ansible_distribution == 'RedHat' and ansible_distribution_major_version < '8'
-          else
-            'rhelbeta' if ansible_distribution == 'RedHat' and ansible_distribution_major_version =='8'
+distro: "{{ 'epel' if ansible_distribution == 'RedHat'
           else
             'fedora' if ansible_distribution == 'Fedora'
           else
             '' }}"
 distrodir: "{{ distro }}-{{ ansible_distribution_major_version }}-$basearch"
-prefix: "https://copr-be.cloud.fedoraproject.org/results/ndokos"
-baseurl: "{{ prefix }}/pbench/{{ distrodir }}/"
-gpgkey: "{{ prefix }}/pbench/pubkey.gpg"
-gpgcheck: 1

--- a/server/ansible/roles/pbench-server-activate-create-crontab/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-create-crontab/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: create crontab
-  command: pbench-server-activate-create-crontab "{{ pbench_server_install_dir }}/lib/crontab"
+  command: "{{ scl }} pbench-server-activate-create-crontab {{ pbench_server_install_dir }}/lib/crontab"
   environment:
-     PATH: "{{ ansible_env.PATH }}:{{ pbench_server_install_dir }}/bin"
      _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+     PATH: "{{ ansible_env.PATH }}:{{ pbench_server_install_dir }}/bin"
+     PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"

--- a/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
@@ -6,9 +6,9 @@
 
 - name: install the config file
   get_url:
-    url: "{{ configurl }}"
+    url: "{{ configurl }}/{{ item }}"
     dest: "{{ pbench_server_config_dest }}"
     mode: 0444
     owner: "{{ pbench_owner }}"
     group: "{{ pbench_group }}"
-
+  with_items: "{{ configfiles }}"

--- a/server/ansible/roles/pbench-server-vars/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-vars/tasks/main.yml
@@ -5,10 +5,12 @@
 
 # pbench install directory
 - name: fetch the pbench install directory from remote
-  shell: getconf.py install-dir pbench-server
+  shell: "{{ scl }} getconf.py install-dir pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -19,10 +21,12 @@
 
 # pbench top level directory
 - name: fetch the top-level pbench directory from remote
-  shell: getconf.py pbench-top-dir pbench-server
+  shell: "{{ scl }} getconf.py pbench-top-dir pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -33,10 +37,12 @@
 
 # pbench logs dir
 - name: fetch the logs directory
-  shell: getconf.py pbench-logs-dir pbench-server
+  shell: "{{ scl }} getconf.py pbench-logs-dir pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_logs_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -47,10 +53,12 @@
 
 # pbench tmp dir
 - name: fetch the tmp directory
-  shell: getconf.py pbench-tmp-dir pbench-server
+  shell: "{{ scl }} getconf.py pbench-tmp-dir pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_tmp_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -61,10 +69,12 @@
 
 # pbench quarantine dir
 - name: fetch the quarantine directory
-  shell: getconf.py pbench-quarantine-dir pbench-server
+  shell: "{{ scl }} getconf.py pbench-quarantine-dir pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_quarantine_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -75,11 +85,13 @@
 
 # pbench hostinfo prefix
 - name: fetch the host info prefix
-  shell: getconf.py host-info-path-prefix results
+  shell: "{{ scl }} getconf.py host-info-path-prefix results"
   register: cmd_output
   ignore_errors: yes
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_host_info_prefix: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -90,11 +102,13 @@
 
 # pbench reception area
 - name: fetch the reception area directory
-  shell: getconf.py pbench-receive-dir-prefix pbench-server
+  shell: "{{ scl }} getconf.py pbench-receive-dir-prefix pbench-server"
   register: cmd_output
   ignore_errors: yes
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_reception_dir_prefix: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -105,10 +119,12 @@
 
 # httpd document root
 - name: fetch the httpd document root directory
-  shell: getconf.py documentroot apache
+  shell: "{{ scl }} getconf.py documentroot apache"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     httpd_document_root_dir: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -119,10 +135,12 @@
 
 # pbench owner
 - name: fetch the pbench owner
-  shell: getconf.py user pbench-server
+  shell: "{{ scl }} getconf.py user pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_user: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -133,10 +151,12 @@
 
 # pbench group
 - name: fetch the pbench group
-  shell: getconf.py group pbench-server
+  shell: "{{ scl }} getconf.py group pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_group: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -147,10 +167,12 @@
 
 # pbench host
 - name: fetch the pbench server
-  shell: getconf.py host pbench-server
+  shell: "{{ scl }} getconf.py host pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     pbench_host: "{{ cmd_output.stdout_lines[0].strip() }}"
@@ -161,10 +183,12 @@
 
 # pbench contact email address
 - name: fetch the contact email address
-  shell: getconf.py admin-email pbench-server
+  shell: "{{ scl }} getconf.py admin-email pbench-server"
   register: cmd_output
   environment:
     _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib:"
 
 - set_fact:
     mailaddr: "{{ cmd_output.stdout_lines[0].strip() }}"

--- a/server/ansible/roles/pbench-server-vars/vars/main.yml
+++ b/server/ansible/roles/pbench-server-vars/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 pbench_server_install_dir: "/opt/pbench-server"
+
+scl: "{{ 'scl enable rh-python36 -- ' if ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'
+         else '' }}"


### PR DESCRIPTION
There are two commits in this PR:

- The first commit refactors the playbooks to move site-specific variables out of the playbooks and into a group_vars file, accessible from the inventory file. There is now a configfiles variable that is a list of config files to install (in addition to the default file that is part of the distribution): we make use of that for the S3 backup information. We also allow multiple repos now: it makes life easier for developers.

-  The second commit deals with the fallout from the configtools reorg (PR #1472 and PR #1457). We need to define PATH, PYTHONPATH and _PBENCH_SERVER_CONFIG in the environment in order to be able to execute some commands (getconf.py in particular). We also need to use scl to execute these commands on RHEL7 systems.