### PR TITLE
Correctly invoke pbench-metadata-log 'beg'

### DIFF
--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -198,7 +198,7 @@ my @iteration_names;
 my %param_sets_common_params = find_common_parameters(@param_sets);
 mkdir($base_bench_dir);
 open(my $fh, ">" . $base_bench_dir . "/iteration-list.txt");
-metadata_log_begin_run($base_bench_dir, $params{"tool-group"});
+metadata_log_begin_run($base_bench_dir, $benchmark, $params{"tool-group"});
 # There can be multiple parts of a run if the user generated multiple parameter-sets
 # (used a "--" in their cmdline).  Each part of the run has it's own run document,
 # but all of the run documents share the same run ID.
@@ -296,7 +296,7 @@ while (scalar @param_sets > 0) {
         }
         my %iter_doc = create_bench_iter_doc(\%run_doc, $iteration_params,);
         put_json_file(\%iter_doc, $es_dir . "/bench/iteration-" . $iter_doc{'iteration'}{'id'} . ".json");
-	my $iteration_name = metadata_log_record_iteration($base_bench_dir, $iteration_id, $iteration_params, $iteration_label);
+        my $iteration_name = metadata_log_record_iteration($base_bench_dir, $iteration_id, $iteration_params, $iteration_label);
         push(@iteration_names, $iteration_name);
         printf $fh "%d %s\n", $iteration_id, $iteration_params;
         printf "\n\n\niteration_ID: %d\niteration_params: %s\n", $iteration_id, $iteration_params;

--- a/agent/lib/PbenchBase.pm
+++ b/agent/lib/PbenchBase.pm
@@ -171,8 +171,9 @@ sub load_benchmark_config {
 
 sub metadata_log_begin_run {
     my $benchmark_run_dir = shift;
+    my $benchmark_name = shift;
     my $group = shift;
-    system("pbench-metadata-log --group=" . $group . " --dir=" . $benchmark_run_dir . " beg");
+    system("benchmark=" . $benchmark_name . " pbench-metadata-log --group=" . $group . " --dir=" . $benchmark_run_dir . " beg");
 }
 
 sub metadata_log_end_run {


### PR DESCRIPTION
Both invocations of `pbench-metadata-log` need the name of the benchmark.  Without the `$benchmark` environment variable being set, `pbench-metadata-log` fails to create the required metadata in the top-level `metadata.log` file.  Without this metadata, server-side indexing will fail.

See also #1512.