### PR TITLE
Add pre-commit hooks for black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,16 @@
+___
+# black complains loudly that fio-histo-log-pctile.py is not a python file
+# because it isnt, so ignore it
+exclude: agent/bench-scripts/test-bin/fio-histo-log-pctiles.py
 repos:
--   repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
-    - id: flake8
-      additional_dependencies: [flake8-typing-imports==1.6.0]
+     - id: flake8
+       additional_dependencies: [flake8-typing-imports==1.6.0]
+  - repo: https://github.com/python/black.git
+    rev: 19.10b0
+    hooks:
+        - id: black
+          language_version: python3
+          args: ["--check"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: bionic
 jobs:
+  allow_failures:
+      - name: "black-tests"
   include:
     - stage: "Agent Unit Tests"
       name: "agent-unit-tests"
@@ -36,3 +38,16 @@ jobs:
       install:
         - pip install flake8
       script: flake8
+
+    - stage: "Python black tests"
+      name: "black-tests"
+      language: python
+      python:
+        - "3.6"
+      before_install:
+        - sudo apt-get update
+      install:
+        - pip install black
+      script: black --check .
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+skip-string-normalization = false
+exclude = '''
+(
+fio-histo-log-pctiles.py
+)
+'''


### PR DESCRIPTION
From the web page:

black is an uncompromising python code formatter.  By using it, you agree to
cede control over minutiae of hand-formatting.  In return, Black gives you speed,
determinism, and freedom from pycodestyle nagging about formatting.
You will save time and mental energy for more important matters.

Don't enforce black at the start because we are not ready to enforce
the changes yet.

Signed-off-by: Chuck Short <chucks@redhat.com>