### PR TITLE
Refactor indexer module functions into class methods

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 doctests = True
-exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build,*web-server/*,*agent/stockpile/*
+exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build,*web-server/*,*agent/stockpile/*,*agent/bench-scripts/test-bin/fio-histo-log-pctiles.py
 # For a full list see https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes
 # E1 - Indentation
 # E2 - Whitespace
@@ -14,4 +14,4 @@ exclude=.venv,.git,.tox,dist,doc,*lib/python*,*egg,build,*web-server/*,*agent/st
 # W3 - Blank line warning
 # W5 - Line break warning
 # W6 - Deprecation Warning
-ignore = E1, E2, E3, E4, E5, E7, F4, F6, F8, E9, W1, W2, W3, W5, W6, H
+ignore = E1, E2, E3, E4, E5, W1, W2, W3, W5

--- a/agent/bench-scripts/postprocess/fio-postprocess-viz.py
+++ b/agent/bench-scripts/postprocess/fio-postprocess-viz.py
@@ -67,10 +67,11 @@ def main(ctx):
   cp.read(ctx.job_file)
   for s in cp.sections():
     try:
-      epoch = cp.get(s, 'log_unix_epoch')
-      chart_type = "timeseries"
+      cp.get(s, 'log_unix_epoch')
     except Exception:
       pass
+    else:
+      chart_type = "timeseries"
   result_file_name = join(ctx.DIR, 'results.html')
   print("[{}] Chart Type: {} ({})".format(
       _prog, chart_type, result_file_name))

--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -83,7 +83,7 @@ def main(ctx):
     # Override job file options with command line options:
     for a in other_args:
         val = ctx.__dict__[a]
-        if not (val is None or val is ""):
+        if not (val is None or val == ""):
             for k in jobfile.keys():
                 if a in jobfile[k]: # has_key(a)
                         jobfile[k][a] = val

--- a/server/bin/gold/test-26.3.txt
+++ b/server/bin/gold/test-26.3.txt
@@ -1,5 +1,5 @@
 +++ Running test_logger_type.py
-BadConfig exception was raised
+BadConfig exception was raised, 'No option 'logger_host' in section: 'logging''
 --- Finished test_logger_type.py (status=1)
 +++ Running unit test audit
 pbench-audit-server: No option 'logger_host' in section: 'logging' (config file /var/tmp/pbench-test-server/test-26.3/opt/pbench-server/lib/config/pbench-server.cfg)

--- a/server/bin/pbench-backup-tarballs.py
+++ b/server/bin/pbench-backup-tarballs.py
@@ -4,14 +4,9 @@
 import os
 import sys
 import glob
-import base64
-import hashlib
 import shutil
 import tempfile
-from enum import Enum
-from argparse import ArgumentParser
 from s3backup import S3Config, Status
-from botocore.exceptions import ConnectionClosedError, ClientError
 
 from pbench import PbenchConfig, BadConfig, get_pbench_logger, quarantine, \
         rename_tb_link, md5sum

--- a/server/bin/pbench-index.py
+++ b/server/bin/pbench-index.py
@@ -8,15 +8,13 @@ into the configured Elasticsearch V1 instance.
 
 import sys
 import os
-import re
 import glob
 import tarfile
 import tempfile
 from argparse import ArgumentParser
 from configparser import Error as ConfigParserError
 
-from pbench import tstos, BadConfig, get_pbench_logger, \
-        quarantine, rename_tb_link
+from pbench import tstos, BadConfig, quarantine, rename_tb_link
 from pbench.indexer import IdxContext, ConfigFileError, BadDate, \
         UnsupportedTarballFormat, BadMDLogFormat, SosreportHostname, \
         PbenchTarBall, es_index, JsonFileError, TemplateError, VERSION
@@ -97,7 +95,7 @@ def main(options, name):
     idxctx = None
     try:
         idxctx = IdxContext(options, name, _dbg=_DEBUG)
-    except (ConfigFileError, ConfigParserError):
+    except (ConfigFileError, ConfigParserError) as e:
         print("{}: {}".format(name, e), file=sys.stderr)
         return 2
     except BadConfig as e:
@@ -392,7 +390,7 @@ def main(options, name):
                     rename_tb_link(tb, os.path.join(controller_path,
                             linkerrdest), idxctx.logger)
                 idxctx.logger.info("Finished {} (size {:d})", tb, size)
-        except Exception as e:
+        except Exception:
             idxctx.logger.exception("Unexpected setup error")
             res = 12
         else:

--- a/server/bin/pbench-index.py
+++ b/server/bin/pbench-index.py
@@ -19,8 +19,7 @@ from pbench import tstos, BadConfig, get_pbench_logger, \
         quarantine, rename_tb_link
 from pbench.indexer import IdxContext, ConfigFileError, BadDate, \
         UnsupportedTarballFormat, BadMDLogFormat, SosreportHostname, \
-        PbenchTarBall, make_all_actions, mk_tool_data_actions, es_index, \
-        JsonFileError, TemplateError, VERSION
+        PbenchTarBall, es_index, JsonFileError, TemplateError, VERSION
 from pbench.report import Report
 
 
@@ -286,9 +285,9 @@ def main(options, name):
                     # list.
                     idxctx.logger.debug("generator setup")
                     if options.index_tool_data:
-                        actions = mk_tool_data_actions(ptb, idxctx)
+                        actions = ptb.mk_tool_data_actions()
                     else:
-                        actions = make_all_actions(ptb, idxctx)
+                        actions = ptb.make_all_actions()
 
                     # File name for containing all indexing errors that
                     # can't/won't be retried.

--- a/server/bin/pbench-verify-backup-tarballs.py
+++ b/server/bin/pbench-verify-backup-tarballs.py
@@ -43,11 +43,8 @@ import os
 import sys
 import glob
 import errno
-import hashlib
-import shutil
 import tempfile
 from enum import Enum
-from argparse import ArgumentParser
 from s3backup import S3Config, Entry
 
 from pbench import PbenchConfig, BadConfig, get_pbench_logger, md5sum
@@ -152,8 +149,7 @@ class BackupObject(object):
         self.indicator_file_ok = "{}.ok".format(self.indicator_file)
         self.indicator_file_fail = "{}.fail".format(self.indicator_file)
         self.nfailed_md5 = 0
-        with open(self.indicator_file, 'w') as f_list,\
-                open(self.indicator_file_ok, 'w') as f_ok,\
+        with open(self.indicator_file_ok, 'w') as f_ok,\
                 open(self.indicator_file_fail, 'w') as f_fail:
             for tar in self.content_list:
                 md5_returned = md5sum(os.path.join(self.dirname, tar.name))

--- a/server/bin/test-bin/test_logger_type.py
+++ b/server/bin/test-bin/test_logger_type.py
@@ -23,18 +23,18 @@ log_msgs = {
 }
 
 def mock_the_handler(logger, logger_type, fname):
-    
+
     # Assumption: only one Handler is present.
     hdlr = logger.logger.handlers[0]
     logger.logger.removeHandler(hdlr)
 
-    # logger.logger is used: the first logger is used to format 
-    # the logs with the help of _styleAdapter and the second is 
+    # logger.logger is used: the first logger is used to format
+    # the logs with the help of _styleAdapter and the second is
     # used to log the messages
     fh = logging.FileHandler(os.path.join(logdir,fname))
     fh.setLevel(logging.DEBUG)
     logger.logger.addHandler(fh)
-    
+
     return logger
 
 def test_pbench_logger():
@@ -46,7 +46,7 @@ def test_pbench_logger():
 
     logger = mock_the_handler(logger, logger_type, log_files[logger_type])
     logger.debug(log_msgs[logger_type])
-    
+
     if os.path.isfile(os.path.join(logdir,log_files[logger_type])):
         with open(os.path.join(logdir,log_files[logger_type]), 'r') as f:
             assert f.read()[:-1] == log_msgs[logger_type], "Mismatch: the file did not contain the expected message."
@@ -55,5 +55,5 @@ if __name__ == "__main__":
     try:
         test_pbench_logger()
     except BadConfig as bd:
-        print("BadConfig exception was raised")
+        print(f"BadConfig exception was raised, '{bd}'")
         sys.exit(1)

--- a/server/lib/pbench/__init__.py
+++ b/server/lib/pbench/__init__.py
@@ -4,9 +4,6 @@ Simple module level convenience functions.
 
 import sys
 import os
-import time
-import json
-import errno
 import logging
 import configtools
 import shutil
@@ -144,7 +141,7 @@ def get_pbench_logger(caller, config):
 
     We also return a logger that supports "brace" style message formatting,
     e.g. logger.warning("that = {}", that)
-    """ 
+    """
 
     pbench_logger = logging.getLogger(caller)
     if caller not in _handlers:
@@ -164,7 +161,7 @@ def get_pbench_logger(caller, config):
             handler = handlers.SysLogHandler(address=(config.logger_host, int(config.logger_port)))
         else:
             raise Exception("Unsupported logger type")
-        
+
         handler.setLevel(logging.DEBUG)
         if not config._unittests:
             logfmt = "{asctime} {levelname} {process} {thread} {name}.{module} {funcName} {lineno} -- {message}"
@@ -196,15 +193,15 @@ class PbenchConfig(object):
         # Now fetch some default common pbench settings that are required.
         try:
             self.TOP = self.conf.get("pbench-server", "pbench-top-dir")
-            if not os.path.isdir(self.TOP): raise BadConfig("Bad TOP={}".format(self.TOP))
+            if not os.path.isdir(self.TOP): raise BadConfig("Bad TOP={}".format(self.TOP))  # noqa:E701
             self.TMP = self.conf.get("pbench-server", "pbench-tmp-dir")
-            if not os.path.isdir(self.TMP): raise BadConfig("Bad TMP={}".format(self.TMP))
+            if not os.path.isdir(self.TMP): raise BadConfig("Bad TMP={}".format(self.TMP))  # noqa:E701
             self.LOGSDIR = self.conf.get("pbench-server", "pbench-logs-dir")
-            if not os.path.isdir(self.LOGSDIR): raise BadConfig("Bad LOGSDIR={}".format(self.LOGSDIR))
+            if not os.path.isdir(self.LOGSDIR): raise BadConfig("Bad LOGSDIR={}".format(self.LOGSDIR))  # noqa:E701
             self.BINDIR = self.conf.get("pbench-server", "script-dir")
-            if not os.path.isdir(self.BINDIR): raise BadConfig("Bad BINDIR={}".format(self.BINDIR))
+            if not os.path.isdir(self.BINDIR): raise BadConfig("Bad BINDIR={}".format(self.BINDIR))  # noqa:E701
             self.LIBDIR = self.conf.get("pbench-server", "lib-dir")
-            if not os.path.isdir(self.LIBDIR): raise BadConfig("Bad LIBDIR={}".format(self.LIBDIR))
+            if not os.path.isdir(self.LIBDIR): raise BadConfig("Bad LIBDIR={}".format(self.LIBDIR))  # noqa:E701
             # the scripts may use this to send status messages
             self.mail_recipients = self.conf.get("pbench-server", "mailto")
         except (NoOptionError, NoSectionError) as exc:
@@ -225,7 +222,7 @@ class PbenchConfig(object):
             self.COMMIT_ID = self.conf.get("pbench-server", "commit_id")
         except NoOptionError:
             self.COMMIT_ID = "(unknown)"
-        
+
         try:
             self.logger_type = self.conf.get("logging", "logger_type")
         except (NoOptionError, NoSectionError):
@@ -240,7 +237,7 @@ class PbenchConfig(object):
 
         try:
             self._unittests = self.conf.get('pbench-server', 'debug_unittest')
-        except Exception as e:
+        except Exception:
             self._unittests = False
         else:
             self._unittests = bool(self._unittests)

--- a/server/lib/pbench/report.py
+++ b/server/lib/pbench/report.py
@@ -167,9 +167,9 @@ class Report(object):
                             timestamp_noutc)
                     fpath = os.path.join(self.config.LOGSDIR, self.name, fname)
                     with lzma.open(fpath, mode="w", preset=9) as fp:
-                        f.write(the_bytes)
+                        fp.write(the_bytes)
                         for _, _, the_bytes in payload_gen:
-                            f.write(the_bytes)
+                            fp.write(the_bytes)
                 # Always log the first 4,096 bytes
                 self.logger.info("{}", payload[:4096])
             else:

--- a/server/lib/s3backup/__init__.py
+++ b/server/lib/s3backup/__init__.py
@@ -3,15 +3,10 @@ This module provides convenience functions that interface to lower-level service
 """
 import boto3
 import os
-import sys
 import glob
 import base64
 import hashlib
-import shutil
-import time
-import configtools
-from datetime import datetime
-from configparser import ConfigParser, NoSectionError, NoOptionError
+from configparser import NoSectionError, NoOptionError
 from boto3.s3.transfer import TransferConfig
 from botocore.exceptions import ConnectionClosedError, ClientError
 
@@ -47,7 +42,7 @@ class S3Config(object):
     def __init__(self, config, logger):
         try:
             debug_unittest = config.get('pbench-server', 'debug_unittest')
-        except Exception as e:
+        except Exception:
             debug_unittest = False
         else:
             debug_unittest = bool(debug_unittest)


### PR DESCRIPTION
This is a code refactoring of the indexer module to reduce the number of module level functions that effectively operate as class methods. That is, all the functions took a `PbenchTarBall` object via `ptb` variables.

As a result of this clean up, further cleanup within classes can be performed without cascading effects to all the function/method interfaces.

No functionality was changed.

This change also tightens down the `flake8` checks and proposes fixes for both the agent and server side to address problems found by `flake8`.

Of note, `configtools` has had its missing `expand_range` and `parse_range` code restored.