### PR TITLE
Use exec instead of fork for tools were possible

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -47,6 +47,7 @@ case "${tool}" in
 blktrace)
 	devices=""
 	longoptions="${longoptions},devices:"
+	tool_package_name="blktrace"
 	;;
 bpftrace)
 	script=""
@@ -65,7 +66,7 @@ iostat|mpstat|sar)
 	tool_package_name="pbench-sysstat"
 	tool_package_ver="12.0.3"
 	;;
-jmap|jstack|strace)
+jmap|jstack)
 	pid="0"
 	pattern=""
 	longoptions="${longoptions},pid:,pattern:"
@@ -82,6 +83,7 @@ kvmtrace)
 numastat)
 	pattern=""
 	longoptions="${longoptions},pattern:"
+	tool_package_name="numactl"
 	;;
 oc)
 	def_components="rc,ep,pods,pv,pvc,svc,cs"
@@ -126,9 +128,10 @@ prometheus-metrics)
 	longoptions="${longoptions},gopath:,goroot:,inventory:"
 	tool_package_name="golang"
 	;;
-qemu-migrate|virsh-migrate)
+qemu-migrate)
 	vm=""
 	longoptions="${longoptions},vm:"
+	tool_package_name="nmap-ncat"
 	;;
 rabbit)
 	def_username="guest"
@@ -136,6 +139,12 @@ rabbit)
 	def_password="guest"
 	password="${def_password}"
 	longoptions="${longoptions},username:,password:"
+	;;
+strace)
+	pid="0"
+	pattern=""
+	longoptions="${longoptions},pid:,pattern:"
+	tool_package_name="strace"
 	;;
 sysfs)
 	maxdepth=4
@@ -151,6 +160,7 @@ tcpdump)
 	interface=""
 	packets=500
 	longoptions="${longoptions},interface:,packets:"
+	tool_package_name="tcpdump"
 	;;
 turbostat)
 	release="$(awk '{x=$7; split(x, a, "."); print a[1];}' /etc/redhat-release 2> /dev/null)"
@@ -170,6 +180,11 @@ user-tool)
 	stop_script=""
 	tool_name=""
 	longoptions="${longoptions},file-to-capture:,postprocess-script:,start-script:,stop-script:,tool-name:"
+	;;
+virsh-migrate)
+	vm=""
+	longoptions="${longoptions},vm:"
+	tool_package_name="libvirt-client"
 	;;
 esac
 

--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -736,7 +736,7 @@ start)
 		_newpath=""
 	fi
 	# Force LANG=C for all tools
-	printf -- "#!/bin/bash\n# base-tool generated command file\n\nLANG=C PYTHONUNBUFFERED=True%s%s%s %s\n" "${_goroot}" "${_gopath}" "${_newpath}" "${tool_cmd}" > "${tool_cmd_file}"
+	printf -- "#!/bin/bash\n# base-tool generated command file\n\nLANG=C PYTHONUNBUFFERED=True%s%s%s exec %s\n" "${_goroot}" "${_gopath}" "${_newpath}" "${tool_cmd}" > "${tool_cmd_file}"
 	chmod +x "${tool_cmd_file}"
 	printf -- "%s: running \"%s\"\n" "${tool_name}" "${tool_cmd}"
 	tool_stdout_file="${tool_output_dir}/${tool_name}-stdout.txt"
@@ -747,7 +747,7 @@ start)
 	popd > /dev/null
 	;;
 stop)
-	if [[ ! -d ${tool_output_dir} ]]; then
+	if [[ ! -d "${tool_output_dir}" ]]; then
 		printf -- "%s: WARNING - stop - tool output directory, '%s', missing\n" "${tool_name}" "${tool_output_dir}" >&2
 		exit 1
 	fi
@@ -756,16 +756,14 @@ stop)
 	if [[ -s "${tool_pid_file}" ]]; then
 		pid="$(cat ${tool_pid_file})"
 		if [[ ! -z "${pid}" ]] ;then
-			if [[ "${tool_name}" == "kvmtrace" ]]; then
-				if [[ -z "${sleep_cmd}" ]]; then
-					# kill the tool directly with an INT signal
-					safe_kill "${tool_name}" "${pid}" "INT"
+			case "${tool_name}" in
+			kvmtrace)
+				# kill the sleep process if it still exists
+				sleep_pid="$(ps --ppid ${pid} | pgrep sleep)"
+				if [[ ! -z "${sleep_pid}" ]]; then
+					safe_kill "sleep" "${sleep_pid}"
 				else
-					# kill the sleep process if it still exists
-					sleep_pid="$(ps --ppid ${pid} | pgrep sleep)"
-					if [[ ! -z "${sleep_pid}" ]]; then
-						safe_kill "${tool_name}" "${sleep_pid}"
-					fi
+					safe_kill "trace-cmd" "${pid}" "INT"
 				fi
 				# wait for the trace-cmd pid to complete
 				while [[ -d /proc/${pid} ]]; do
@@ -773,7 +771,8 @@ stop)
 					sleep 0.5
 				done
 				rc=0
-			elif [[ "${tool_name}" == "perf" ]]; then
+				;;
+			perf)
 				safe_kill "${tool_name}" "${pid}" "INT"
 				# Wait for perf to finish recording.  if you
 				# do not wait, 'perf report' will not be
@@ -784,21 +783,40 @@ stop)
 					printf -- "%s: Waiting for PID '%s' (%s) to finish\n" "${tool_name}" "${pid}" "${pidcmd}"
 					sleep 0.5
 				done
-			else
+				rc=0
+				;;
+			user-tool)
+				if [[ ! -z "${file_to_capture}" ]]; then
+					safe_kill "File-Capture-datalog" "${pid}"
+				else
+					safe_kill "$(basename "${start_script}")" "${pid}"
+				fi
+				rc=${?}
+				;;
+			blktrace|bpftrace|iostat|mpstat|pcp|pidstat|sar|systemtap|tcpdump|turbostat|vmstat)
 				safe_kill "${tool_name}" "${pid}"
 				rc=${?}
-			fi
+				;;
+			proc-interrupts|proc-sched_debug|proc-vmstat)
+				safe_kill "File-Capture-datalog" "${pid}"
+				rc=${?}
+				;;
+			*)
+				safe_kill "${tool_name}-datalog" "${pid}"
+				rc=${?}
+				;;
+			esac
 			if [[ ${rc} -eq 0 ]]; then
 				/bin/rm -f "${tool_pid_file}"
 			fi
 		else
-			printf -- "%s: tool is not running, nothing to kill\n" "${tool_name}" >&2
+			printf -- "%s: tool is not running, nothing to kill (empty pid file)\n" "${tool_name}" >&2
 		fi
 	else
-		printf -- "%s: tool is not running, nothing to kill\n" "${tool_name}" >&2
+		printf -- "%s: tool is not running, nothing to kill (missing or empty pid file)\n" "${tool_name}" >&2
 	fi
 	if [[ ${rc} == 0 ]]; then
-		case ${tool} in
+		case "${tool}" in
 		user-tool)
 			_script_path="${stop_script}"
 			;;
@@ -832,11 +850,11 @@ stop)
 	fi
 	;;
 postprocess)
-	if [[ ! -d ${tool_output_dir} ]]; then
+	if [[ ! -d "${tool_output_dir}" ]]; then
 		printf -- "%s: WARNING - postprocess - tool output directory, '%s', missing\n" "${tool_name}" "${tool_output_dir}" >&2
 		exit 1
 	fi
-	case ${tool} in
+	case "${tool}" in
 	user-tool)
 		_script_path="${postprocess_script}"
 		;;
@@ -844,7 +862,7 @@ postprocess)
 		_script_path="${postprocess_path}/${tool}-postprocess"
 		;;
 	esac
-	if [[ -x ${_script_path} ]]; then
+	if [[ -x "${_script_path}" ]]; then
 		printf -- "%s: post-processing data\n" "${tool_name}"
 		pushd ${tool_output_dir} >/dev/null
 		${_script_path} "${tool_output_dir}" \

--- a/agent/tool-scripts/datalog/blktrace-datalog
+++ b/agent/tool-scripts/datalog/blktrace-datalog
@@ -15,4 +15,4 @@ if [[ ${?} -ne 0 ]]; then
 	exit 1
 fi
 
-blktrace ${devices}
+exec blktrace ${devices}

--- a/agent/tool-scripts/datalog/bpftrace-datalog
+++ b/agent/tool-scripts/datalog/bpftrace-datalog
@@ -15,4 +15,4 @@ if [[ ${?} -ne 0 ]]; then
 	exit 1
 fi
 
-bpftrace "${script}"
+exec bpftrace "${script}"

--- a/agent/tool-scripts/datalog/iostat-datalog
+++ b/agent/tool-scripts/datalog/iostat-datalog
@@ -21,4 +21,4 @@ if [[ ! -x ${_tool_bin} ]]; then
 	exit 1
 fi
 
-${_tool_bin} ${default_options} ${options} ${interval}
+exec ${_tool_bin} ${default_options} ${options} ${interval}

--- a/agent/tool-scripts/datalog/kvmtrace-datalog
+++ b/agent/tool-scripts/datalog/kvmtrace-datalog
@@ -27,4 +27,4 @@ if [[ ! -z "${start_delay}" && ${start_delay} > 0 ]]; then
     sleep ${start_delay}
 fi
 
-trace-cmd record -a -e kvm ${sleep_cmd}
+exec trace-cmd record -a -e kvm ${sleep_cmd}

--- a/agent/tool-scripts/datalog/mpstat-datalog
+++ b/agent/tool-scripts/datalog/mpstat-datalog
@@ -21,4 +21,4 @@ if [[ ! -x ${_tool_bin} ]]; then
 	exit 1
 fi
 
-${_tool_bin} ${default_options} ${options} ${interval}
+exec ${_tool_bin} ${default_options} ${options} ${interval}

--- a/agent/tool-scripts/datalog/pcp-datalog
+++ b/agent/tool-scripts/datalog/pcp-datalog
@@ -41,4 +41,4 @@ fi
 # Save the interval for use by post-processing step.
 printf -- "%s\n" "${interval}" > ${tool_output_dir}/interval
 
-pmlogger -c ${tool_output_dir}/pmlogger.conf -t ${interval} archive
+exec pmlogger -c ${tool_output_dir}/pmlogger.conf -t ${interval} archive

--- a/agent/tool-scripts/datalog/perf-datalog
+++ b/agent/tool-scripts/datalog/perf-datalog
@@ -27,4 +27,4 @@ if [[ "${1}" == "record" ]]; then
 fi
 
 echo "${@}" > ${tool_output_dir}/record_opts
-perf record ${@} --output=${tool_output_dir}/perf.data
+exec perf record ${@} --output=${tool_output_dir}/perf.data

--- a/agent/tool-scripts/datalog/pidstat-datalog
+++ b/agent/tool-scripts/datalog/pidstat-datalog
@@ -57,4 +57,4 @@ if [[ "${_PBENCH_UNIT_TESTS}" != "" ]] ;then
     enable -n ulimit
 fi
 # ulimit is for all the files that might be opened by pidstat-convert
-${_tool_bin} ${default_options} ${options} ${interval} | (ulimit -n 102400; $(dirname ${0})/pidstat-convert ${tool_output_dir})
+exec ${_tool_bin} ${default_options} ${options} ${interval} | (ulimit -n 102400; $(dirname ${0})/pidstat-convert ${tool_output_dir})

--- a/agent/tool-scripts/datalog/sar-datalog
+++ b/agent/tool-scripts/datalog/sar-datalog
@@ -27,4 +27,4 @@ if [[ ! -x ${_tool_bin} ]]; then
 	exit 1
 fi
 
-${_tool_bin} ${default_options} ${options} -o ${tool_output_dir}/sar.data ${interval}
+exec ${_tool_bin} ${default_options} ${options} -o ${tool_output_dir}/sar.data ${interval}

--- a/agent/tool-scripts/datalog/systemtap-datalog
+++ b/agent/tool-scripts/datalog/systemtap-datalog
@@ -18,4 +18,4 @@ if [[ ${?} -ne 0 ]]; then
 	exit 1
 fi
 
-staprun "${script}"
+exec staprun "${script}"

--- a/agent/tool-scripts/datalog/tcpdump-datalog
+++ b/agent/tool-scripts/datalog/tcpdump-datalog
@@ -21,4 +21,4 @@ if [[ ${?} -ne 0 ]]; then
 	exit 1
 fi
 
-tcpdump -c ${packets} -ni ${interface}
+exec tcpdump -c ${packets} -ni ${interface}

--- a/agent/tool-scripts/datalog/turbostat-datalog
+++ b/agent/tool-scripts/datalog/turbostat-datalog
@@ -31,4 +31,4 @@ if [[ "${virtenv}" != "none" ]]; then
 	exit 1
 fi
 
-turbostat -i ${interval} | pbench-log-timestamp
+exec turbostat -i ${interval} | pbench-log-timestamp

--- a/agent/tool-scripts/datalog/vmstat-datalog
+++ b/agent/tool-scripts/datalog/vmstat-datalog
@@ -50,4 +50,4 @@ case "${ver}" in
         ;;
 esac
 
-vmstat -a ${opts} ${interval}
+exec vmstat -a ${opts} ${interval}

--- a/agent/tool-scripts/tests/blktrace/gold/tools-group/blktrace/blktrace.cmd
+++ b/agent/tool-scripts/tests/blktrace/gold/tools-group/blktrace/blktrace.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/blktrace-datalog /dev/sda42 /dev/sdb42 /dev/sdc42
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/blktrace-datalog /dev/sda42 /dev/sdb42 /dev/sdc42

--- a/agent/tool-scripts/tests/bpftrace/gold/tools-group/bpftrace/bpftrace.cmd
+++ b/agent/tool-scripts/tests/bpftrace/gold/tools-group/bpftrace/bpftrace.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/bpftrace-datalog my-bpf-script
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/bpftrace-datalog my-bpf-script

--- a/agent/tool-scripts/tests/cpuacct/gold/tools-group/cpuacct/cpuacct.cmd
+++ b/agent/tool-scripts/tests/cpuacct/gold/tools-group/cpuacct/cpuacct.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/cpuacct-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/cpuacct-datalog 10

--- a/agent/tool-scripts/tests/disk/gold/tools-group/disk/disk.cmd
+++ b/agent/tool-scripts/tests/disk/gold/tools-group/disk/disk.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/disk-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/disk-datalog 10

--- a/agent/tool-scripts/tests/dm-cache/gold/tools-group/dm-cache/dm-cache.cmd
+++ b/agent/tool-scripts/tests/dm-cache/gold/tools-group/dm-cache/dm-cache.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/dm-cache-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/dm-cache-datalog 10

--- a/agent/tool-scripts/tests/docker-info/gold/tools-group/docker-info/docker-info.cmd
+++ b/agent/tool-scripts/tests/docker-info/gold/tools-group/docker-info/docker-info.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/docker-info-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/docker-info-datalog 10

--- a/agent/tool-scripts/tests/docker/gold/tools-group/docker/docker.cmd
+++ b/agent/tool-scripts/tests/docker/gold/tools-group/docker/docker.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/docker-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/docker-datalog 10

--- a/agent/tool-scripts/tests/haproxy-ocp/gold/tools-group/haproxy-ocp/haproxy-ocp.cmd
+++ b/agent/tool-scripts/tests/haproxy-ocp/gold/tools-group/haproxy-ocp/haproxy-ocp.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/haproxy-ocp-datalog /var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp 10 false
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/haproxy-ocp-datalog /var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp 10 false

--- a/agent/tool-scripts/tests/iostat/gold/tools-group/iostat/iostat.cmd
+++ b/agent/tool-scripts/tests/iostat/gold/tools-group/iostat/iostat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/iostat-datalog 10 
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/iostat-datalog 10 

--- a/agent/tool-scripts/tests/jmap/gold/tools-group/jmap/jmap.cmd
+++ b/agent/tool-scripts/tests/jmap/gold/tools-group/jmap/jmap.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/jmap-datalog /var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap 10 42 "jmap-pat-42"
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/jmap-datalog /var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap 10 42 "jmap-pat-42"

--- a/agent/tool-scripts/tests/jstack/gold/tools-group/jstack/jstack.cmd
+++ b/agent/tool-scripts/tests/jstack/gold/tools-group/jstack/jstack.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/jstack-datalog /var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack 10 42 "jstack-pat-42"
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/jstack-datalog /var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack 10 42 "jstack-pat-42"

--- a/agent/tool-scripts/tests/kvm-spinlock/gold/tools-group/kvm-spinlock/kvm-spinlock.cmd
+++ b/agent/tool-scripts/tests/kvm-spinlock/gold/tools-group/kvm-spinlock/kvm-spinlock.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvm-spinlock-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvm-spinlock-datalog 10

--- a/agent/tool-scripts/tests/kvmstat/gold/tools-group/kvmstat/kvmstat.cmd
+++ b/agent/tool-scripts/tests/kvmstat/gold/tools-group/kvmstat/kvmstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvmstat-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvmstat-datalog 10

--- a/agent/tool-scripts/tests/kvmtrace/gold/tools-group/kvmtrace/kvmtrace.cmd
+++ b/agent/tool-scripts/tests/kvmtrace/gold/tools-group/kvmtrace/kvmtrace.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvmtrace-datalog 42 43
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/kvmtrace-datalog 42 43

--- a/agent/tool-scripts/tests/lockstat/gold/tools-group/lockstat/lockstat.cmd
+++ b/agent/tool-scripts/tests/lockstat/gold/tools-group/lockstat/lockstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/lockstat-datalog /var/tmp/pbench-test-tool-scripts/lockstat/tools-group/lockstat
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/lockstat-datalog /var/tmp/pbench-test-tool-scripts/lockstat/tools-group/lockstat

--- a/agent/tool-scripts/tests/mpstat/gold/tools-group/mpstat/mpstat.cmd
+++ b/agent/tool-scripts/tests/mpstat/gold/tools-group/mpstat/mpstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/mpstat-datalog 10 
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/mpstat-datalog 10 

--- a/agent/tool-scripts/tests/numastat/gold/tools-group/numastat/numastat.cmd
+++ b/agent/tool-scripts/tests/numastat/gold/tools-group/numastat/numastat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/numastat-datalog 10 "pig42"
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/numastat-datalog 10 "pig42"

--- a/agent/tool-scripts/tests/oc/gold/tools-group/oc/oc.cmd
+++ b/agent/tool-scripts/tests/oc/gold/tools-group/oc/oc.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/oc-datalog /var/tmp/pbench-test-tool-scripts/oc/tools-group/oc rc,ep,pods,pv,pvc,svc,cs
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/oc-datalog /var/tmp/pbench-test-tool-scripts/oc/tools-group/oc rc,ep,pods,pv,pvc,svc,cs

--- a/agent/tool-scripts/tests/openvswitch/gold/tools-group/openvswitch/openvswitch.cmd
+++ b/agent/tool-scripts/tests/openvswitch/gold/tools-group/openvswitch/openvswitch.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/openvswitch-datalog /var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/openvswitch-datalog /var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch 10

--- a/agent/tool-scripts/tests/pcp/gold/tools-group/pcp/pcp.cmd
+++ b/agent/tool-scripts/tests/pcp/gold/tools-group/pcp/pcp.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pcp-datalog /var/tmp/pbench-test-tool-scripts/pcp/tools-group/pcp 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pcp-datalog /var/tmp/pbench-test-tool-scripts/pcp/tools-group/pcp 10

--- a/agent/tool-scripts/tests/perf/gold/tools-group/perf/perf.cmd
+++ b/agent/tool-scripts/tests/perf/gold/tools-group/perf/perf.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/perf-datalog /var/tmp/pbench-test-tool-scripts/perf/tools-group/perf '--a42' -g
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/perf-datalog /var/tmp/pbench-test-tool-scripts/perf/tools-group/perf '--a42' -g

--- a/agent/tool-scripts/tests/pidstat/gold/tools-group/pidstat/pidstat.cmd
+++ b/agent/tool-scripts/tests/pidstat/gold/tools-group/pidstat/pidstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pidstat-datalog /var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat 10 true p='one42,two43,three44' '-other-opt'
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pidstat-datalog /var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat 10 true p='one42,two43,three44' '-other-opt'

--- a/agent/tool-scripts/tests/pprof/gold/tools-group/pprof/pprof.cmd
+++ b/agent/tool-scripts/tests/pprof/gold/tools-group/pprof/pprof.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True GOPATH=/var/tmp/pbench-test-tool-scripts/go PATH=${PATH}:${GOPATH}/bin /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pprof-datalog /var/tmp/pbench-test-tool-scripts/pprof/tools-group/pprof 42 tests/pprof/inventory-hosts.lis
+LANG=C PYTHONUNBUFFERED=True GOPATH=/var/tmp/pbench-test-tool-scripts/go PATH=${PATH}:${GOPATH}/bin exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pprof-datalog /var/tmp/pbench-test-tool-scripts/pprof/tools-group/pprof 42 tests/pprof/inventory-hosts.lis

--- a/agent/tool-scripts/tests/proc-interrupts/gold/tools-group/proc-interrupts/proc-interrupts.cmd
+++ b/agent/tool-scripts/tests/proc-interrupts/gold/tools-group/proc-interrupts/proc-interrupts.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/interrupts
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/interrupts

--- a/agent/tool-scripts/tests/proc-sched_debug/gold/tools-group/proc-sched_debug/proc-sched_debug.cmd
+++ b/agent/tool-scripts/tests/proc-sched_debug/gold/tools-group/proc-sched_debug/proc-sched_debug.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/sched_debug
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/sched_debug

--- a/agent/tool-scripts/tests/proc-vmstat/gold/tools-group/proc-vmstat/proc-vmstat.cmd
+++ b/agent/tool-scripts/tests/proc-vmstat/gold/tools-group/proc-vmstat/proc-vmstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/vmstat
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/File-Capture-datalog 10 /proc/vmstat

--- a/agent/tool-scripts/tests/prometheus-metrics/gold/tools-group/prometheus-metrics/prometheus-metrics.cmd
+++ b/agent/tool-scripts/tests/prometheus-metrics/gold/tools-group/prometheus-metrics/prometheus-metrics.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True GOPATH=/var/tmp/pbench-test-tool-scripts/go PATH=${PATH}:${GOPATH}/bin /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/prometheus-metrics-datalog /var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics 42 tests/prometheus-metrics/inventory-hosts.lis
+LANG=C PYTHONUNBUFFERED=True GOPATH=/var/tmp/pbench-test-tool-scripts/go PATH=${PATH}:${GOPATH}/bin exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/prometheus-metrics-datalog /var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics 42 tests/prometheus-metrics/inventory-hosts.lis

--- a/agent/tool-scripts/tests/qemu-migrate/gold/tools-group/qemu-migrate/qemu-migrate.cmd
+++ b/agent/tool-scripts/tests/qemu-migrate/gold/tools-group/qemu-migrate/qemu-migrate.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/qemu-migrate-datalog 10 qemu-vm-42
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/qemu-migrate-datalog 10 qemu-vm-42

--- a/agent/tool-scripts/tests/rabbit/gold/tools-group/rabbit/rabbit.cmd
+++ b/agent/tool-scripts/tests/rabbit/gold/tools-group/rabbit/rabbit.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/rabbit-datalog 10 guest guest
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/rabbit-datalog 10 guest guest

--- a/agent/tool-scripts/tests/sar/gold/tools-group/sar/sar.cmd
+++ b/agent/tool-scripts/tests/sar/gold/tools-group/sar/sar.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/sar-datalog /var/tmp/pbench-test-tool-scripts/sar/tools-group/sar 10 
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/sar-datalog /var/tmp/pbench-test-tool-scripts/sar/tools-group/sar 10 

--- a/agent/tool-scripts/tests/strace/gold/tools-group/strace/strace.cmd
+++ b/agent/tool-scripts/tests/strace/gold/tools-group/strace/strace.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/strace-datalog /var/tmp/pbench-test-tool-scripts/strace/tools-group/strace 42 "forty-two"
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/strace-datalog /var/tmp/pbench-test-tool-scripts/strace/tools-group/strace 42 "forty-two"

--- a/agent/tool-scripts/tests/sysfs/gold/tools-group/sysfs/sysfs.cmd
+++ b/agent/tool-scripts/tests/sysfs/gold/tools-group/sysfs/sysfs.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/sysfs-datalog 10 "kernel" "4" "*"
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/sysfs-datalog 10 "kernel" "4" "*"

--- a/agent/tool-scripts/tests/systemtap/gold/tools-group/systemtap/systemtap.cmd
+++ b/agent/tool-scripts/tests/systemtap/gold/tools-group/systemtap/systemtap.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/systemtap-datalog my-systemtap-script-42
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/systemtap-datalog my-systemtap-script-42

--- a/agent/tool-scripts/tests/tcpdump/gold/tools-group/tcpdump/tcpdump.cmd
+++ b/agent/tool-scripts/tests/tcpdump/gold/tools-group/tcpdump/tcpdump.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/tcpdump-datalog 42 en42
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/tcpdump-datalog 42 en42

--- a/agent/tool-scripts/tests/turbostat/gold/tools-group/turbostat/turbostat.cmd
+++ b/agent/tool-scripts/tests/turbostat/gold/tools-group/turbostat/turbostat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/turbostat-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/turbostat-datalog 10

--- a/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42.cmd
+++ b/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.start /var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.start /var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42 10

--- a/agent/tool-scripts/tests/virsh-migrate/gold/tools-group/virsh-migrate/virsh-migrate.cmd
+++ b/agent/tool-scripts/tests/virsh-migrate/gold/tools-group/virsh-migrate/virsh-migrate.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/virsh-migrate-datalog 42 vm42
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/virsh-migrate-datalog 42 vm42

--- a/agent/tool-scripts/tests/vmstat/gold/tools-group/vmstat/vmstat.cmd
+++ b/agent/tool-scripts/tests/vmstat/gold/tools-group/vmstat/vmstat.cmd
@@ -1,4 +1,4 @@
 #!/bin/bash
 # base-tool generated command file
 
-LANG=C PYTHONUNBUFFERED=True /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/vmstat-datalog 10
+LANG=C PYTHONUNBUFFERED=True exec /var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/vmstat-datalog 10

--- a/agent/util-scripts/gold/pbench-stop-tools/test-05.txt
+++ b/agent/util-scripts/gold/pbench-stop-tools/test-05.txt
@@ -22,6 +22,6 @@
 --- pbench.log file contents
 +++ mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents
 turbostat: stopping
-turbostat: tool is not running, nothing to kill
+turbostat: tool is not running, nothing to kill (missing or empty pid file)
 turbostat: no post-processing available following stop
 --- mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents

--- a/agent/util-scripts/gold/pbench-stop-tools/test-06.txt
+++ b/agent/util-scripts/gold/pbench-stop-tools/test-06.txt
@@ -22,6 +22,6 @@
 --- pbench.log file contents
 +++ mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents
 kvmstat: stopping
-kvmstat: tool is not running, nothing to kill
+kvmstat: tool is not running, nothing to kill (missing or empty pid file)
 kvmstat: no post-processing available following stop
 --- mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents

--- a/agent/util-scripts/gold/pbench-stop-tools/test-07.txt
+++ b/agent/util-scripts/gold/pbench-stop-tools/test-07.txt
@@ -22,6 +22,6 @@
 --- pbench.log file contents
 +++ mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents
 vmstat: stopping
-vmstat: tool is not running, nothing to kill
+vmstat: tool is not running, nothing to kill (missing or empty pid file)
 vmstat: no post-processing available following stop
 --- mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents

--- a/agent/util-scripts/gold/pbench-stop-tools/test-08.txt
+++ b/agent/util-scripts/gold/pbench-stop-tools/test-08.txt
@@ -22,6 +22,6 @@
 --- pbench.log file contents
 +++ mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents
 numastat: stopping
-numastat: tool is not running, nothing to kill
+numastat: tool is not running, nothing to kill (missing or empty pid file)
 numastat: no post-processing available following stop
 --- mock-run/mock-iteration/mock-sample/tools-default/stop.log file contents

--- a/agent/util-scripts/gold/test-tool-trigger/test-19.txt
+++ b/agent/util-scripts/gold/test-tool-trigger/test-19.txt
@@ -63,12 +63,12 @@ baz
 --- pbench.log file contents
 +++ mock-run/0-default/sample1/tools-default/stop.log file contents
 sar: stopping
-sar: tool is not running, nothing to kill
+sar: tool is not running, nothing to kill (missing or empty pid file)
 sar: no post-processing available following stop
 --- mock-run/0-default/sample1/tools-default/stop.log file contents
 +++ mock-run/1-default/sample1/tools-default/stop.log file contents
 sar: stopping
-sar: tool is not running, nothing to kill
+sar: tool is not running, nothing to kill (missing or empty pid file)
 sar: no post-processing available following stop
 --- mock-run/1-default/sample1/tools-default/stop.log file contents
 +++ test-execution.log file contents


### PR DESCRIPTION
This allows us to handle special cases for stopping tools correctly, while avoiding extra code to do so.

We also add missing package names for a few tools (addresses #1550).