### PR TITLE
Modify pbench-user-benchmark to use iteration names

### DIFF
--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -206,17 +206,19 @@ function record_iteration {
 	local iteration_name="${2}"
 	local benchmark_bin="${3}"
 
-	echo "${iteration}" >> ${benchmark_iterations}
-	echo "${iteration_name}" | pbench-add-metalog-option ${mdlog} iterations/${iteration} iteration_name
-	echo "${benchmark_bin}" | pbench-add-metalog-option ${mdlog} iterations/${iteration} user_script
+	echo "${iteration_name}" >> ${benchmark_iterations}
+	echo "${iteration}"      | pbench-add-metalog-option ${mdlog} iterations/${iteration_name} iteration_number
+	echo "${iteration_name}" | pbench-add-metalog-option ${mdlog} iterations/${iteration_name} iteration_name
+	echo "${benchmark_bin}"  | pbench-add-metalog-option ${mdlog} iterations/${iteration_name} user_script
 }
 
 function run_benchmark {
 	local iteration="${1}"
 	local iteration_name="${2}"
+	local arguments="${3}"
 	local iter_benchmark_bin="${benchmark_bin}"
-	if [[ ! -z "${3}" ]]; then
-		iter_benchmark_bin="${iter_benchmark_bin} ${3}"
+	if [[ ! -z "${arguments}" ]]; then
+		iter_benchmark_bin="${iter_benchmark_bin} ${arguments}"
 	fi
 
 	export benchmark_results_dir="${benchmark_run_dir}/${iteration_name}/${sample_name}"
@@ -300,7 +302,6 @@ declare -a parts
 while read -u 3 line; do
 	# Current line number, starting from 1 (not zero)
 	(( lineno++ ))
-	iteration=${iter_num}
 	if [[ ${line::1} == "#" ]]; then
 		# Ignore comments
 		continue
@@ -310,15 +311,18 @@ while read -u 3 line; do
 		# Ignore empty lines
 		continue
 	fi
+
+	iteration=${iter_num}
 	iteration_name="${iter_num}-${parts[0]}"
+	# Setup the *next* iteration number
+	(( iter_num++ ))
+
 	if [[ ${#parts[@]} == 1 ]]; then
 		# Assume the only part is the iteration name.
 		l_args=""
 	else
 		l_args="${parts[@]:1:${#parts[@]}}"
 	fi
-	# Setup the *next* iteration number
-	(( iter_num++ ))
 
 	run_benchmark "${iteration}" "${iteration_name}" "${l_args}"
 	duration=${?}

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-09.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-09.txt
@@ -37,7 +37,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ pbench-user-benchmark_test-09_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, no-file
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-10.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-10.txt
@@ -37,7 +37,8 @@ Running user-benchmark-script no-duration for iteration 1-default
 +++ pbench-user-benchmark_test-10_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, no-duration
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-11.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-11.txt
@@ -37,7 +37,8 @@ Running user-benchmark-script with-duration for iteration 1-default
 +++ pbench-user-benchmark_test-11_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, with-duration
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-12.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-12.txt
@@ -38,7 +38,8 @@ WARNING:root:Unable to load JSON data from /var/tmp/pbench-test-bench/pbench-age
 +++ pbench-user-benchmark_test-12_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, bad-format
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-23.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-23.txt
@@ -73,15 +73,18 @@ sud
 +++ pbench-user-benchmark_test-23_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = tool-trigger-example
 
-[iterations/2]
+[iterations/2-default]
+iteration_number = 2
 iteration_name = 2-default
 user_script = tool-trigger-example
 
-[iterations/3]
+[iterations/3-default]
+iteration_number = 3
 iteration_name = 3-default
 user_script = tool-trigger-example
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-24.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-24.txt
@@ -37,7 +37,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ pbench-user-benchmark_test-24_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, no-file
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-25.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-25.txt
@@ -37,7 +37,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ pbench-user-benchmark_test-25_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-default]
+iteration_number = 1
 iteration_name = 1-default
 user_script = user-benchmark-script, no-file
 

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-38.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-38.txt
@@ -62,15 +62,18 @@ Running bm arg1 arg2 for iteration 3-iter-three
 +++ pbench-user-benchmark_test-38_1900.01.01T00.00.00/metadata.log file contents
 [pbench]
 
-[iterations/1]
+[iterations/1-iter-one]
+iteration_number = 1
 iteration_name = 1-iter-one
 user_script = bm, arg1, arg2, arg3
 
-[iterations/2]
+[iterations/2-iter-two]
+iteration_number = 2
 iteration_name = 2-iter-two
 user_script = bm, arg1
 
-[iterations/3]
+[iterations/3-iter-three]
+iteration_number = 3
 iteration_name = 3-iter-three
 user_script = bm, arg1, arg2
 


### PR DESCRIPTION
All the other benchmarks record the on-disk directory name in the list of iterations.  This change brings `pbench-user-benchmark` in line with the others.

We also add the `iteration_number` field like the other benchmarks have.