### PR TITLE
Separate run benchmark iteration names by a space

### DIFF
--- a/agent/lib/PbenchBase.pm
+++ b/agent/lib/PbenchBase.pm
@@ -187,17 +187,16 @@ sub metadata_log_end_run {
     my $mdlog = $benchmark_run_dir . "/metadata.log";
 
     for (my $i=0; $i<@iteration_names; $i++) {
-        $iteration_names = $iteration_names . "," . $iteration_names[$i];
+        $iteration_names = $iteration_names . " " . $iteration_names[$i];
     }
-    $iteration_names =~ s/^,//;
 
     my $benchmark_run_name = $benchmark_run_dir;
     $benchmark_run_name =~ s/.*\///g;
 
     system("echo " . $benchmark_run_name . " | pbench-add-metalog-option " . $mdlog . " pbench name");
-    system("echo " . $iteration_names  . " | pbench-add-metalog-option " . $mdlog . " pbench iterations");
-    system("echo " . $config  . " | pbench-add-metalog-option " . $mdlog . " pbench config");
-    system("echo " . $benchmark_name  . " | pbench-add-metalog-option " . $mdlog . " pbench script");
+    system("echo " . $iteration_names . " | pbench-add-metalog-option " . $mdlog . " pbench iterations");
+    system("echo " . $config . " | pbench-add-metalog-option " . $mdlog . " pbench config");
+    system("echo " . $benchmark_name . " | pbench-add-metalog-option " . $mdlog . " pbench script");
     system("benchmark=" . $benchmark_name . " pbench-metadata-log --group=" . $group . " --dir=" . $benchmark_run_dir . " end");
 }
 


### PR DESCRIPTION
This allows `pbench-add-metalog-option` to contruct the list of iteration names in the expected format (comma separated with a space).