### PR TITLE
Drop use of screen -Logfile for old screen vers

### DIFF
--- a/agent/bench-scripts/test-bin/mock-cmd
+++ b/agent/bench-scripts/test-bin/mock-cmd
@@ -17,10 +17,10 @@ fi
 last=${args[${lastidx}]}
 if [[ "${prog}" == "pbench-metadata-log" && "${last}" == "beg" ]]; then
     echo [pbench] > ${benchmark_run_dir}/metadata.log
-elif [[ "${prog}" == "screen" && "${args[7]}" == "--start" ]]; then
+elif [[ "${prog}" == "screen" && "${args[5]}" == "--start" ]]; then
     # Mock out creating the tool directory for a tool "start" action
-    _tool="$(basename "${args[6]}")"
-    _dir="${args[8]}"
+    _tool="$(basename "${args[4]}")"
+    _dir="${args[6]}"
     mkdir ${_dir#*=}/${_tool}
     exit ${?}
 fi

--- a/agent/util-scripts/gold/test-tool-trigger/test-19.txt
+++ b/agent/util-scripts/gold/test-tool-trigger/test-19.txt
@@ -45,7 +45,7 @@ baz
 [debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3
 [debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
 [debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3
-[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] "#!/bin/bash  screen -dm -L -Logfile "/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default/pbench-tool-sar-default.log" -S "pbench-tool-sar-default" /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3 "
+[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] "#!/bin/bash  screen -dm -L -S "pbench-tool-sar-default" /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3 "
 [debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
 [debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1
 [debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3
@@ -55,7 +55,7 @@ baz
 [debug][1900-01-01T00:00:00.000000] [pbench-kill-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --kill --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3
 [debug][1900-01-01T00:00:00.000000] [pbench-kill-tools]completed: 
 [debug][1900-01-01T00:00:00.000000] [pbench-start-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3
-[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] "#!/bin/bash  screen -dm -L -Logfile "/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default/pbench-tool-sar-default.log" -S "pbench-tool-sar-default" /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3 "
+[debug][1900-01-01T00:00:00.000000] [pbench-start-tools] "#!/bin/bash  screen -dm -L -S "pbench-tool-sar-default" /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3 "
 [debug][1900-01-01T00:00:00.000000] [pbench-start-tools]completed: 
 [debug][1900-01-01T00:00:00.000000] [pbench-stop-tools]started: --group=default --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1
 [debug][1900-01-01T00:00:00.000000] [pbench-stop-tools] /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --stop --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3
@@ -73,7 +73,7 @@ sar: no post-processing available following stop
 --- mock-run/1-default/sample1/tools-default/stop.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dm -L -Logfile /var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default/pbench-tool-sar-default.log -S pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dm -L -S pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/0-default/sample1/tools-default --interval=3
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -ls
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dm -L -Logfile /var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default/pbench-tool-sar-default.log -S pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/screen -dm -L -S pbench-tool-sar-default /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/sar --start --dir=/var/tmp/pbench-test-utils/pbench/mock-run/1-default/sample1/tools-default --interval=3
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-postprocess-tools
+++ b/agent/util-scripts/pbench-postprocess-tools
@@ -156,13 +156,16 @@ for this_tool_file in `/bin/ls $tool_group_dir`; do
 		if [ "$action" == "start" ]; then
 			# using screen to avoid tty issues and guarantee tool is backgrounded
 			screen_cmd="${tool_output_dir}/${screen_name}.cmd"
-			printf -- "#!/bin/bash\n\nscreen -dm -L -Logfile \"${tool_output_dir}/${screen_name}.log\" -S \"${screen_name}\" ${pbench_bin}/tool-scripts/${name} --${action} --dir=${tool_output_dir} ${tool_opts[@]}\n" > ${screen_cmd}
+			printf -- "#!/bin/bash\n\nscreen -dm -L -S \"${screen_name}\" ${pbench_bin}/tool-scripts/${name} --${action} --dir=${tool_output_dir} ${tool_opts[@]}\n" > ${screen_cmd}
 			chmod +x ${screen_cmd}
 			debug_log "[${script_name}] \"$(cat ${screen_cmd} | tr '\n' ' ')\""
-			${screen_cmd}
+			(cd ${tool_output_dir}; ${screen_cmd})
 			rc=${?}
 			if [[ ${rc} -ne 0 ]]; then
 				error_log "[${script_name}] screen command failed: \"$(cat ${screen_cmd} | tr '\n' ' ')\""
+			fi
+			if [[ -e "${tool_output_dir}/screenlog.0" ]]; then
+ 				mv ${tool_output_dir}/screenlog.0 ${tool_output_dir}/${screen_name}.log
 			fi
 		elif [ "$action" == "kill" ]; then
 			screens_to_kill=`screen -ls | grep "$screen_name" | awk '{print $1}'`


### PR DESCRIPTION
The use of the `-Logfile <file>` parameter for `screen` in not available until v4.5 and later.  Don't depend on that feature of `screen` so that we can support older environments easily.