### PR TITLE
Kill the pidstat-datalog, not the pidstat process.

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -808,7 +808,7 @@ stop)
 				fi
 				rc=${?}
 				;;
-			blktrace|bpftrace|iostat|mpstat|pcp|pidstat|sar|systemtap|tcpdump|turbostat|vmstat)
+			blktrace|bpftrace|iostat|mpstat|pcp|sar|systemtap|tcpdump|turbostat|vmstat)
 				safe_kill "${tool_name}" "${pid}"
 				rc=${?}
 				;;


### PR DESCRIPTION
Fixes #1575.