### PR TITLE
Make sure pidstat-datalog does not use exec

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -808,7 +808,7 @@ stop)
 				fi
 				rc=${?}
 				;;
-			blktrace|bpftrace|iostat|mpstat|pcp|pidstat|sar|systemtap|tcpdump|turbostat|vmstat)
+			blktrace|bpftrace|iostat|mpstat|pcp|sar|systemtap|tcpdump|turbostat|vmstat)
 				safe_kill "${tool_name}" "${pid}"
 				rc=${?}
 				;;

--- a/agent/tool-scripts/datalog/pidstat-datalog
+++ b/agent/tool-scripts/datalog/pidstat-datalog
@@ -57,4 +57,4 @@ if [[ "${_PBENCH_UNIT_TESTS}" != "" ]] ;then
     enable -n ulimit
 fi
 # ulimit is for all the files that might be opened by pidstat-convert
-exec ${_tool_bin} ${default_options} ${options} ${interval} | (ulimit -n 102400; $(dirname ${0})/pidstat-convert ${tool_output_dir})
+${_tool_bin} ${default_options} ${options} ${interval} | (ulimit -n 102400; $(dirname ${0})/pidstat-convert ${tool_output_dir})


### PR DESCRIPTION
We make sure the `pidstat-datalog` does not `exec` `pidstat`, so that `base-tool` can `kill` the one `pidstat-datalog` parent of the `pidstat` and `pidstat-convert` child processes.  By killing the parent, two
children are also `kill`'d.

This is an alternative to consider in place of #1578.