### PR TITLE
logging level settings for the server scripts

### DIFF
--- a/pbench/__init__.py
+++ b/pbench/__init__.py
@@ -153,7 +153,12 @@ def get_pbench_logger(caller, config):
 
     pbench_logger = logging.getLogger(caller)
     if caller not in _handlers:
-        pbench_logger.setLevel(logging.DEBUG)
+        try:
+            logging_level = config.get(caller, "logging_level")
+        except (NoSectionError, NoOptionError):
+            logging_level = config.default_logging_level
+        pbench_logger.setLevel(logging_level)
+
         logdir = os.path.join(config.LOGSDIR, caller)
         try:
             os.mkdir(logdir)
@@ -251,6 +256,11 @@ class PbenchConfig(object):
                     self.logger_port = self.conf.get("logging", "logger_port")
                 except (NoOptionError) as exc:
                     raise BadConfig(str(exc))
+
+        try:
+            self.default_logging_level = self.conf.get("logging", "logging_level")
+        except (NoOptionError, NoSectionError):
+            self.default_logging_level = "INFO"
 
         try:
             self._unittests = self.conf.get("pbench-server", "debug_unittest")

--- a/server/bin/gold/test-27.txt
+++ b/server/bin/gold/test-27.txt
@@ -1,0 +1,158 @@
++++ Running test_logger_level.py
+--- Finished test_logger_level.py (status=0)
++++ Running unit test audit
+Template:  pbench-unittests.v3.server-reports
+Index:  pbench-unittests.v3.server-reports.1970-01 1
+len(actions) = 1
+[
+    {
+        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_index": "pbench-unittests.v3.server-reports.1970-01",
+        "_op_type": "create",
+        "_source": {
+            "@generated-by": {
+                "commit_id": "unit-test",
+                "group_id": 43,
+                "hostname": "example.com",
+                "pid": 42,
+                "user_id": 44,
+                "version": ""
+            },
+            "@timestamp": "1970-01-01T00:00:00",
+            "chunk_id": 1,
+            "doctype": "status",
+            "name": "pbench-audit-server",
+            "text": "pbench-audit-server.run-1970-01-01T00:00:00-UTC(unit-test)\n",
+            "total_chunks": 1,
+            "total_size": 59
+        },
+        "_type": "pbench-server-reports"
+    }
+]
+--- Finished unit test audit (status=0)
++++ var/www/html tree state (/var/tmp/pbench-test-server/test-27/var-www-html)
+lrwxrwxrwx         63 incoming -> /var/tmp/pbench-test-server/test-27/pbench/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        118 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         62 results -> /var/tmp/pbench-test-server/test-27/pbench/public_html/results
+lrwxrwxrwx         61 static -> /var/tmp/pbench-test-server/test-27/pbench/public_html/static
+lrwxrwxrwx         60 users -> /var/tmp/pbench-test-server/test-27/pbench/public_html/users
+--- var/www/html tree state
++++ results host info (/var/tmp/pbench-test-server/test-27/var-www-html/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-27/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench.example.com:/var/tmp/pbench-test-server/test-27/pbench-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-27/var-www-html/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ var/www/html-satellite tree state (/var/tmp/pbench-test-server/test-27/var-www-html-satellite)
+lrwxrwxrwx         73 incoming -> /var/tmp/pbench-test-server/test-27/pbench-satellite/public_html/incoming
+drwxrwxr-x          - pbench-results-host-info.versioned
+lrwxrwxrwx         38 pbench-results-host-info.versioned/pbench-results-host-info.URL002 -> pbench-results-host-info.URL002.active
+-rw-rw-r--        138 pbench-results-host-info.versioned/pbench-results-host-info.URL002.active
+-rw-rw-r--         95 pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint
+lrwxrwxrwx         72 results -> /var/tmp/pbench-test-server/test-27/pbench-satellite/public_html/results
+lrwxrwxrwx         71 static -> /var/tmp/pbench-test-server/test-27/pbench-satellite/public_html/static
+lrwxrwxrwx         70 users -> /var/tmp/pbench-test-server/test-27/pbench-satellite/public_html/users
+--- var/www/html-satellite tree state
++++ results host info (/var/tmp/pbench-test-server/test-27/var-www-html-satellite/pbench-results-host-info.versioned)
+/var/tmp/pbench-test-server/test-27/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.active:pbench@pbench-satellite.example.com:/var/tmp/pbench-test-server/test-27/pbench-satellite-local/pbench-move-results-receive/fs-version-002
+/var/tmp/pbench-test-server/test-27/var-www-html-satellite/pbench-results-host-info.versioned/pbench-results-host-info.URL002.maint:MESSAGE===System Under Maintenance - please retry at a later time (unit-test-user@example.com)
+--- results host info
++++ pbench tree state (/var/tmp/pbench-test-server/test-27/pbench)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench tree state
++++ pbench-local tree state (/var/tmp/pbench-test-server/test-27/pbench-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - logs/pbench-audit-server
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
+-rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
+drwxrwxr-x          - logs/pbench-logger-level-test
+-rw-rw-r--        388 logs/pbench-logger-level-test/pbench-logger-level-test.log
+-rw-rw-r--         71 logs/warn.log
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-local tree state
++++ pbench-satellite tree state (/var/tmp/pbench-test-server/test-27/pbench-satellite)
+drwxrwxr-x          - archive
+drwxrwxr-x          - archive/fs-version-001
+drwxrwxr-x          - public_html
+drwxrwxr-x          - public_html/incoming
+drwxrwxr-x          - public_html/results
+drwxrwxr-x          - public_html/static
+drwxrwxr-x          - public_html/static/css
+drwxrwxr-x          - public_html/static/css/v0.2
+drwxrwxr-x          - public_html/static/css/v0.2/css
+-rw-rw-r--        308 public_html/static/css/v0.2/css/pbench_utils.css
+drwxrwxr-x          - public_html/static/css/v0.3
+drwxrwxr-x          - public_html/static/css/v0.3/css
+-rw-rw-r--      11798 public_html/static/css/v0.3/css/LICENSE.TXT
+-rw-rw-r--       3663 public_html/static/css/v0.3/css/jschart.css
+drwxrwxr-x          - public_html/static/js
+drwxrwxr-x          - public_html/static/js/v0.2
+drwxrwxr-x          - public_html/static/js/v0.2/js
+-rw-rw-r--       9415 public_html/static/js/v0.2/js/app.js
+-rw-rw-r--       5556 public_html/static/js/v0.2/js/pbench_utils.js
+drwxrwxr-x          - public_html/static/js/v0.3
+drwxrwxr-x          - public_html/static/js/v0.3/js
+-rw-rw-r--      11798 public_html/static/js/v0.3/js/LICENSE.TXT
+-rw-rw-r--     143934 public_html/static/js/v0.3/js/jschart.js
+drwxrwxr-x          - public_html/users
+--- pbench-satellite tree state
++++ pbench-satellite-local tree state (/var/tmp/pbench-test-server/test-27/pbench-satellite-local)
+drwxrwxr-x          - logs
+drwxrwxr-x          - pbench-move-results-receive
+drwxrwxr-x          - pbench-move-results-receive/fs-version-002
+drwxrwxr-x          - quarantine
+drwxrwxr-x          - quarantine/duplicates-002
+drwxrwxr-x          - quarantine/errors-002
+drwxrwxr-x          - quarantine/md5-002
+drwxrwxr-x          - tmp
+--- pbench-satellite-local tree state
++++ pbench log file contents
+++++ pbench-local/logs
++++++ pbench-audit-server/pbench-audit-server.error
+----- pbench-audit-server/pbench-audit-server.error
++++++ pbench-audit-server/pbench-audit-server.log
+----- pbench-audit-server/pbench-audit-server.log
++++++ pbench-logger-level-test/pbench-logger-level-test.log
+1970-01-01T00:00:00.000000 WARNING pbench-logger-level-test.test_logger_level test_pbench_logger_level -- logging_level = WARNING
+1970-01-01T00:00:00.000000 ERROR pbench-logger-level-test.test_logger_level test_pbench_logger_level -- logging_level = ERROR
+1970-01-01T00:00:00.000000 CRITICAL pbench-logger-level-test.test_logger_level test_pbench_logger_level -- logging_level = CRITICAL
+----- pbench-logger-level-test/pbench-logger-level-test.log
++++++ warn.log
+logging_level = WARNING
+logging_level = ERROR
+logging_level = CRITICAL
+----- warn.log
+---- pbench-local/logs
+++++ pbench-satellite-local/logs
+---- pbench-satellite-local/logs
+--- pbench log file contents

--- a/server/bin/state/config-satellite/pbench-server.cfg
+++ b/server/bin/state/config-satellite/pbench-server.cfg
@@ -24,6 +24,7 @@ documentroot = %(unittest-dir)s/var-www-html-satellite
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # crontab roles

--- a/server/bin/state/config/pbench-server.cfg
+++ b/server/bin/state/config/pbench-server.cfg
@@ -24,6 +24,7 @@ documentroot = %(unittest-dir)s/var-www-html
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # crontab roles

--- a/server/bin/state/test-23.config/pbench-server.cfg
+++ b/server/bin/state/test-23.config/pbench-server.cfg
@@ -23,6 +23,7 @@ documentroot = %(unittest-dir)s/var-www-html
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # crontab roles

--- a/server/bin/state/test-26.1.config/pbench-server.cfg
+++ b/server/bin/state/test-26.1.config/pbench-server.cfg
@@ -2,6 +2,7 @@ install-dir = %(unittest-dir)s/opt/pbench-server
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-26.3.config/pbench-server.cfg
+++ b/server/bin/state/test-26.3.config/pbench-server.cfg
@@ -2,6 +2,7 @@ install-dir = %(unittest-dir)s/opt/pbench-server
 
 [logging]
 logger_type = hostport
+logging_level = DEBUG
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-26.4.config/pbench-server.cfg
+++ b/server/bin/state/test-26.4.config/pbench-server.cfg
@@ -4,6 +4,7 @@ install-dir = %(unittest-dir)s/opt/pbench-server
 logger_type = hostport
 logger_host = localhost
 logger_port = 514
+logging_level = DEBUG
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-27.config/pbench-server.cfg
+++ b/server/bin/state/test-27.config/pbench-server.cfg
@@ -1,8 +1,8 @@
 install-dir = %(unittest-dir)s/opt/pbench-server
 
 [logging]
-logger_type = devlog
-logging_level = DEBUG
+logger_type = file
+logging_level = WARNING
 
 ###########################################################################
 # The rest will come from the global state config file and the default config file.

--- a/server/bin/state/test-6.13.config/pbench-server.cfg
+++ b/server/bin/state/test-6.13.config/pbench-server.cfg
@@ -30,6 +30,7 @@ secret_access_key = SECRET_ACCESS_KEY
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # crontab roles

--- a/server/bin/state/test-6.14.config/pbench-server.cfg
+++ b/server/bin/state/test-6.14.config/pbench-server.cfg
@@ -30,6 +30,7 @@ documentroot = %(unittest-dir)s/var-www-html
 
 [logging]
 logger_type = file
+logging_level = DEBUG
 
 ###########################################################################
 # crontab roles

--- a/server/bin/test-bin/test_logger_level.py
+++ b/server/bin/test-bin/test_logger_level.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- mode: python -*-
+
+import logging
+import os
+import sys
+
+from pbench import BadConfig, PbenchConfig, get_pbench_logger
+
+_NAME_ = "pbench-logger-level-test"
+cfg_name = os.environ["_PBENCH_SERVER_CONFIG"]
+logdir = os.environ["LOGSDIR"]
+
+log_files = {
+    "NOTSET": "notset.log",
+    "DEBUG": "debug.log",
+    "INFO": "info.log",
+    "WARNING": "warn.log",
+    "ERROR": "error.log",
+    "CRITICAL": "critical.log",
+}
+
+log_msgs = {
+    "0": "logging_level = NOTSET",
+    "10": "logging_level = DEBUG",
+    "20": "logging_level = INFO",
+    "30": "logging_level = WARNING",
+    "40": "logging_level = ERROR",
+    "50": "logging_level = CRITICAL",
+}
+
+
+def mock_the_handler(logger, logging_level, fname):
+
+    # logger.logger is used: the first logger is used to format
+    # the logs with the help of _styleAdapter and the second is
+    # used to log the messages
+    fh = logging.FileHandler(os.path.join(logdir, fname))
+    fh.setLevel(logging_level)
+    logger.logger.addHandler(fh)
+
+    return logger
+
+
+def test_pbench_logger_level():
+
+    config = PbenchConfig(cfg_name)
+    logger = get_pbench_logger(_NAME_, config)
+
+    logging_level = config.get("logging", "logging_level")
+
+    logger = mock_the_handler(logger, logging_level, log_files[logging_level])
+
+    logger.debug(log_msgs["10"])
+    logger.info(log_msgs["20"])
+    logger.warning(log_msgs["30"])
+    logger.error(log_msgs["40"])
+    logger.critical(log_msgs["50"])
+
+
+if __name__ == "__main__":
+    try:
+        test_pbench_logger_level()
+    except BadConfig as bd:
+        print(f"BadConfig exception was raised, '{bd}'")
+        sys.exit(1)

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -735,7 +735,9 @@ declare -A cmds=(
     [test-26.3]="_run test_logger_type.py"
 
     # Test to Log messages on hostport with logger-host and logger_port
-    [test-26.4]="_run test_logger_type.py"  
+    [test-26.4]="_run test_logger_type.py"
+
+    [test-27]="_run test_logger_level.py" 
 
 )
 all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\+\)-\([0-9]\+\)/\1.\2/')

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -129,8 +129,18 @@ webserver = %(default-host)s
 host-info-path-prefix = pbench-results-host-info.versioned/pbench-results-host-info.URL
 host_info_url = http://%(webserver)s/%(host-info-path-prefix)s
 
+# [pbench-backup-tarballs]
+# logging_level = DEBUG
+
+# [pbench-verify-backup-tarballs]
+# logging_level = DEBUG
+
+# [pbench-index]
+# logging_level = DEBUG
+
 [logging]
 logger_type = devlog
+logging_level = INFO
 # hostport logger type uses UDP-based logging.
 # logger_host = localhost
 # logger_port = 514


### PR DESCRIPTION
Fixes #1530 

Setting the logging level as DEBUG for unit-scripts and INFO for production use.