### PR TITLE
Change PYTHONPATH in profile

### DIFF
--- a/agent/profile
+++ b/agent/profile
@@ -26,7 +26,7 @@ then
 else
     pathins ${prefix}/common/bin
 
-    export PYTHONPATH=${prefix}/common/lib:${PYTHONPATH}
+    export PYTHONPATH=${prefix}/lib:${PYTHONPATH}
     export _PBENCH_AGENT_CONFIG=${prefix}/config/pbench-agent.cfg
 
     pathins ${prefix}/bench-scripts


### PR DESCRIPTION
Fixes #1589

The definition of PYTHONPATH in the profile has to match the
directory where the configtools library is in the installed tree.
We changed the latter to simplify the build, so we need to change
the former to match it.