### PR TITLE
Move to support uperf-1.0.7 and fio-3.19 RPM names

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -10,17 +10,21 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
-benchmark_rpm=$script_name
 benchmark="fio"
-fio_server_port=8765
+benchmark_rpm=${benchmark}
 export benchmark_run_dir=""
 # allow unit tests to override
 if [[ -z "$benchmark_bin" ]]; then
 	benchmark_bin=/usr/local/bin/$benchmark
 fi
-ver="$(getconf.py version pbench-fio)"
+ver="$(getconf.py version fio)"
 if [[ -z "${ver}" ]]; then
 	error_log "pbench-fio: package version is missing in config file"
+	exit 1
+fi
+fio_server_port="$(getconf.py server_port fio)"
+if [[ -z "${fio_server_port}" ]]; then
+	error_log "pbench-fio: server_port is missing in config file"
 	exit 1
 fi
 
@@ -488,10 +492,10 @@ function record_iteration {
 
 # Ensure the right version of the benchmark is installed
 function fio_install() {
-	if check_install_rpm $benchmark_rpm $ver; then
-		debug_log "[$script_name]$benchmark_rpm $ver is installed"
+	if check_install_rpm ${benchmark_rpm} ${ver}; then
+		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is installed"
 	else
-		debug_log "[$script_name]$benchmark_rpm $ver installation failed, exiting"
+		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is not installed, exiting"
 		exit 1
 	fi
 	if [ ! -z "$clients" ] ; then

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -24,12 +24,16 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
-benchmark_rpm=$script_name
 benchmark="uperf"
+benchmark_rpm=${benchmark}
 if [[ -z "$benchmark_bin" ]]; then
     benchmark_bin=/usr/local/bin/$benchmark
 fi
-ver=1.0.4
+ver="$(getconf.py version uperf)"
+if [[ -z "${ver}" ]]; then
+        error_log "${script_name}: package version is missing in config file"
+        exit 1
+fi
 
 # Every bench-script follows a similar sequence:
 # 1) process bench script arguments
@@ -182,10 +186,10 @@ function stop_server {
 }
 
 function install_uperf {
-	if check_install_rpm $benchmark_rpm $ver; then
-		debug_log "[$script_name]$benchmark_rpm is installed"
+	if check_install_rpm ${benchmark_rpm} ${ver}; then
+		debug_log "[$script_name] ${benchmark_rpm}-${ver} is installed"
 	else
-		error_log "[$script_name]$benchmark_rpm installation failed, exiting"
+		error_log "[$script_name] ${benchmark_rpm}-${ver} is not installed, exiting"
 		exit 1
 	fi
 }
@@ -568,7 +572,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 									if [ "$log_response_times" == "y" ]; then
 										resp_opt=" -X $benchmark_results_dir/$uperf_identifier--response-times.txt"
 									fi
-									benchmark_client_cmd="${benchmark_bin} -v -m $xml_file -x -a -i 1 $resp_opt -P $server_port >$result_file 2>&1"
+									benchmark_client_cmd="${benchmark_bin} -v -m $xml_file -R -a -i 1 $resp_opt -P $server_port >$result_file 2>&1"
 									# adjust client command for NUMA binding
 									if [ ! -z "$client_node" ]; then
 										if [ $client_node -ge 0 ]; then
@@ -684,7 +688,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 								echo "Not going to run uperf.  Only postprocesing existing data"
 								log "Not going to run uperf.  Only postprocesing existing data"
 							fi
-							echo "$script_path/postprocess/$benchmark-postprocess \"$benchmark_results_dir\" \"$protocol\" \"$message_size\" \"$instance\" \"$test_type\" \"$clients\" \"$servers\" \"$tool_label_pattern\" \"$tool_group\" \"$ver\"" >"$benchmark_results_dir/$benchmark-postprocess.cmd"
+							echo "$script_path/postprocess/$benchmark-postprocess \"$benchmark_results_dir\" \"$protocol\" \"$message_size\" \"$instance\" \"$test_type\" \"$clients\" \"$servers\" \"$tool_label_pattern\" \"$tool_group\" \"${ver}\"" >"$benchmark_results_dir/$benchmark-postprocess.cmd"
 							chmod +x "$benchmark_results_dir/$benchmark-postprocess.cmd"
 							$benchmark_results_dir/$benchmark-postprocess.cmd
 						done

--- a/agent/bench-scripts/tests/Defaults/pbench-agent.cfg
+++ b/agent/bench-scripts/tests/Defaults/pbench-agent.cfg
@@ -1,6 +1,10 @@
+# The "DEFAULT" section header and pbench_install_dir is provided by
+# the unit tests infrastructure.
+pbench_results_redirector = pbench.results.example.com
+pbench_web_server = pbench.example.com
+
 [packages]
 
-[pbench-fio]
-version = 3.3
-histogram_interval_msec = 10000
-
+[config]
+path = %(pbench_install_dir)s/config
+files = pbench-agent-default.cfg

--- a/agent/bench-scripts/tests/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.txt
@@ -446,8 +446,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.txt
@@ -446,8 +446,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-05.txt
@@ -136,8 +136,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-05.txt
@@ -136,8 +136,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-06.txt
@@ -142,8 +142,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar,baz")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-06.txt
@@ -142,8 +142,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar,baz")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-07.txt
@@ -124,8 +124,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-07.txt
@@ -124,8 +124,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-08.txt
@@ -118,8 +118,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/mnt/cephfs", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-08.txt
@@ -118,8 +118,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/mnt/cephfs", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-13.txt
@@ -220,8 +220,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-13.txt
@@ -220,8 +220,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-15.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-15.txt
@@ -230,8 +230,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-15_1900.01.01T00.00.00/1-rw-42KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-15.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-15.txt
@@ -230,8 +230,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-15_1900.01.01T00.00.00/1-rw-42KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-16.txt
@@ -60,8 +60,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/sda0,/dev/sda1", clients="192.168.1.1")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/sda0 exists on client 192.168.1.1

--- a/agent/bench-scripts/tests/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-16.txt
@@ -60,8 +60,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/sda0,/dev/sda1", clients="192.168.1.1")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/sda0 exists on client 192.168.1.1

--- a/agent/bench-scripts/tests/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-20.txt
@@ -160,8 +160,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/foo,/dev/bar", clients="abc,def,ghi")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/foo exists on client abc

--- a/agent/bench-scripts/tests/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-20.txt
@@ -160,8 +160,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/foo,/dev/bar", clients="abc,def,ghi")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/foo exists on client abc

--- a/agent/bench-scripts/tests/pbench-fio/test-28.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-28.txt
@@ -51,8 +51,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-28_1900.01.01T00.00.00/1-read-8KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-28.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-28.txt
@@ -51,8 +51,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-28_1900.01.01T00.00.00/1-read-8KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-30.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-30.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-31.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-31.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-32.txt
@@ -88,8 +88,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="hist.foo,hist.bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-32.txt
@@ -88,8 +88,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.3 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.3 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio]pbench-fio 3.19 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="hist.foo,hist.bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-uperf/test-00.txt
+++ b/agent/bench-scripts/tests/pbench-uperf/test-00.txt
@@ -53,8 +53,8 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/pbench-uperf.cmd
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-uperf-1.0.4 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-uperf]pbench-uperf is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] uperf-1.0.7 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-uperf] uperf-1.0.7 is installed
 [debug][1900-01-01T00:00:00.000000] checking for uperf on server 127.0.0.1
 [info][1900-01-01T00:00:00.000000] Starting iteration  (1 of 2)
 [info][1900-01-01T00:00:00.000000] test sample 1 of 2
@@ -77,10 +77,10 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/generate-benchmark-summary uperf --config=test-00 --test-types=rr,stream --message-sizes=64 --instances=1 --protocols=tcp --runtime=20 --samples=2 /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/1-tcp_rr-64B-1i trans_sec 5 0 6 n y
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/2-tcp_stream-64B-1i Gb_sec 5 0 6 n y
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1 tcp 64 1 rr  127.0.0.1 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2 tcp 64 1 rr  127.0.0.1 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1 tcp 64 1 stream  127.0.0.1 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample2 tcp 64 1 stream  127.0.0.1 uperf- default 1.0.4
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1 tcp 64 1 rr  127.0.0.1 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2 tcp 64 1 rr  127.0.0.1 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1 tcp 64 1 stream  127.0.0.1 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample2 tcp 64 1 stream  127.0.0.1 uperf- default 1.0.7
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00 --sysinfo=default beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/uperf_test-00_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check

--- a/agent/bench-scripts/tests/pbench-uperf/test-01.txt
+++ b/agent/bench-scripts/tests/pbench-uperf/test-01.txt
@@ -73,8 +73,8 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/pbench-uperf.cmd
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] pbench-uperf-1.0.4 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-uperf]pbench-uperf is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] uperf-1.0.7 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-uperf] uperf-1.0.7 is installed
 [debug][1900-01-01T00:00:00.000000] checking for uperf on client c1
 [debug][1900-01-01T00:00:00.000000] checking for uperf on client c2
 [debug][1900-01-01T00:00:00.000000] checking for uperf on client c3
@@ -118,10 +118,10 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/generate-benchmark-summary uperf --config=test-01 --test-types=rr,stream --message-sizes=64 --instances=1 --protocols=tcp --runtime=20 --samples=2 --servers=s1,s2,s3 --clients=c1,c2,c3 --server-node=0,-1,2 --client-node=1,-1,3 /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i trans_sec 5 0 6 n y
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i Gb_sec 5 0 6 n y
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1 tcp 64 1 rr c1,c2,c3 s1,s2,s3 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2 tcp 64 1 rr c1,c2,c3 s1,s2,s3 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1 tcp 64 1 stream c1,c2,c3 s1,s2,s3 uperf- default 1.0.4
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample2 tcp 64 1 stream c1,c2,c3 s1,s2,s3 uperf- default 1.0.4
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1 tcp 64 1 rr c1,c2,c3 s1,s2,s3 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2 tcp 64 1 rr c1,c2,c3 s1,s2,s3 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1 tcp 64 1 stream c1,c2,c3 s1,s2,s3 uperf- default 1.0.7
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/uperf-postprocess /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample2 tcp 64 1 stream c1,c2,c3 s1,s2,s3 uperf- default 1.0.7
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00 --sysinfo=default beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -214,7 +214,13 @@ function _setup_state {
         echo "ERROR: failed to create test pbench config directory, \"${_testopt}/config\"" >&2
         exit 1
     fi
-    cp ${_tdir}/tests/Defaults/pbench-agent.cfg ${_testopt}/config/
+    cp ${_tdir}/../config/pbench-agent-default.cfg ${_testopt}/config/
+    if [[ ${?} -ne 0 ]]; then
+        echo "ERROR: failed to create pbench-agent default config file, \"${_testopt}/config/pbench-agent-default.cfg\"" >&2
+        exit 1
+    fi
+    printf -- "[DEFAULT]\npbench_install_dir = %s\n" "${_testopt}" > ${_testopt}/config/pbench-agent.cfg
+    cat ${_tdir}/tests/Defaults/pbench-agent.cfg >> ${_testopt}/config/pbench-agent.cfg
     if [[ ${?} -ne 0 ]]; then
         echo "ERROR: failed to create pbench-agent config file, \"${_testopt}/config/pbench-agent.cfg\"" >&2
         exit 1
@@ -334,7 +340,7 @@ done < ${_testroot}/tests.lis
 
 # Final clean up, if there are no failures, we'll be able to remove the
 # hierarchy entirely.
-rm -rf ${_testroot}/opt ${_testroot}/tests.lis
+rm -rf ${_testroot}/opt ${_testroot}/tests.lis ${_testroot}/run.cmd
 rmdir ${_testroot} > /dev/null 2>&1
 
 if [[ ${errs} -gt 0 ]]; then

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -26,6 +26,9 @@ interval = 30
 
 [packages]
 
+[uperf]
+version = 1.0.7
+
 [pbench-fio]
 version = 3.19
 histogram_interval_msec = 10000

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -29,8 +29,9 @@ interval = 30
 [uperf]
 version = 1.0.7
 
-[pbench-fio]
+[fio]
 version = 3.19
+server_port = 8765
 histogram_interval_msec = 10000
 
 [stockpile]


### PR DESCRIPTION
Fixes #1604.

This changes the expected name of the `uperf` RPM from `pbench-uperf` to just `uperf`, while bumping the expected version to `1.0.7`.

We also add a commit for renaming the `pbench-fio` RPM to just `fio`.