### PR TITLE
Add `commit-id' to server config file.

### DIFF
--- a/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: "Update pbench-server.cfg file with commit_id info."
+  ini_file:
+    path: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    section: pbench-server
+    option: commit-id
+    value: "{{ pbench_version }}-{{ pbench_sha1 }}"
+    backup: yes
+

--- a/server/ansible/roles/pbench-server-config/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-config/tasks/main.yml
@@ -13,3 +13,5 @@
     name: pbench-server-activate-create-results-dir-structure
 - import_role:
     name: pbench-server-activate-httpd-setup-restart
+- import_role:
+    name: pbench-server-add-commit-id

--- a/server/ansible/roles/pbench-server-vars/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-vars/tasks/main.yml
@@ -194,5 +194,29 @@
     mailaddr: "{{ cmd_output.stdout_lines[0].strip() }}"
 
 - debug:
-    msg: "{{ pbench_group }}"
+    msg: "{{ mailaddr }}"
+    verbosity: 1
+
+# pbench version
+- name: fetch the pbench version
+  shell: "cat {{ pbench_server_install_dir }}/VERSION"
+  register: cmd_output
+
+- set_fact:
+    pbench_version: "{{ cmd_output.stdout_lines[0].strip() }}"
+
+- debug:
+    msg: "{{ pbench_version }}"
+    verbosity: 1
+
+# pbench SHA1
+- name: fetch the pbench SHA1
+  shell: "cat {{ pbench_server_install_dir }}/SHA1"
+  register: cmd_output
+
+- set_fact:
+    pbench_sha1: "{{ cmd_output.stdout_lines[0].strip() }}"
+
+- debug:
+    msg: "{{ pbench_sha1 }}"
     verbosity: 1


### PR DESCRIPTION
Fixes issue #1624.

Modify the ansible playbook to set the `commit-id' field in the
[pbench-server] section of the server config file on installation.

That is used to tag status reports generated from server scripts.