### PR TITLE
Add seqno to commit-id in [pbench-server].

### DIFF
--- a/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
@@ -4,6 +4,6 @@
     path: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
     section: pbench-server
     option: commit-id
-    value: "{{ pbench_version }}-{{ pbench_sha1 }}"
+    value: "{{ pbench_version }}-{{ pbench_seqno }}{{ pbench_sha1 }}"
     backup: yes
 

--- a/server/ansible/roles/pbench-server-vars/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-vars/tasks/main.yml
@@ -220,3 +220,15 @@
 - debug:
     msg: "{{ pbench_sha1 }}"
     verbosity: 1
+
+# pbench SEQNO
+- name: fetch the pbench SEQNO
+  shell: "cat {{ pbench_server_install_dir }}/SEQNO"
+  register: cmd_output
+
+- set_fact:
+    pbench_seqno: "{{ cmd_output.stdout_lines[0].strip() }}"
+
+- debug:
+    msg: "{{ pbench_seqno }}"
+    verbosity: 1


### PR DESCRIPTION
Supplements PR #1625: the commit-id option
in the [pbench-server] section of the pbench-server.cfg file
now looks like this:

    commit-id=<VERSION>-<SEQNO><SHA1>

e.g.

    commit-id=0.68-1g72ca85a2