### PR TITLE
Remove unique IDs from gold files

### DIFF
--- a/server/bin/gold/test-10.txt
+++ b/server/bin/gold/test-10.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "d6a16a9a452070d0d06c11930dbd1bfc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-11.txt
+++ b/server/bin/gold/test-11.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "57316855600430dfef8e4fc08971ff01",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-13.txt
+++ b/server/bin/gold/test-13.txt
@@ -6,7 +6,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-15.txt
+++ b/server/bin/gold/test-15.txt
@@ -6,7 +6,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-16.txt
+++ b/server/bin/gold/test-16.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "d217d806e7399763648fc422e229ee3e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-17.txt
+++ b/server/bin/gold/test-17.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "a970c95d89317b57a6578af1b9bcb203",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-2.txt
+++ b/server/bin/gold/test-2.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5810bf8001250da7167566f19dd34dd5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -106,7 +106,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -136,7 +136,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-20.txt
+++ b/server/bin/gold/test-20.txt
@@ -7,7 +7,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "17b98f8724dd9ded3f56879b2cddba02",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-21.txt
+++ b/server/bin/gold/test-21.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-22.txt
+++ b/server/bin/gold/test-22.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "77d9bd0246e072e101da7ba9603fcf88",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b3fc3ee3f98f06a461a92eb341e6019a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-24.txt
+++ b/server/bin/gold/test-24.txt
@@ -81,7 +81,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-25.txt
+++ b/server/bin/gold/test-25.txt
@@ -35,7 +35,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-26.1.txt
+++ b/server/bin/gold/test-26.1.txt
@@ -6,7 +6,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-26.2.txt
+++ b/server/bin/gold/test-26.2.txt
@@ -6,7 +6,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-26.4.txt
+++ b/server/bin/gold/test-26.4.txt
@@ -6,7 +6,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-3.txt
+++ b/server/bin/gold/test-3.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5810bf8001250da7167566f19dd34dd5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -97,7 +97,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f28085a0e8c19385d99566acb05aa17e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -134,7 +134,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -164,7 +164,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-4.txt
+++ b/server/bin/gold/test-4.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5810bf8001250da7167566f19dd34dd5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -97,7 +97,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f28085a0e8c19385d99566acb05aa17e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -133,7 +133,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -163,7 +163,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5810bf8001250da7167566f19dd34dd5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -94,7 +94,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "720f90852c34701ef9fbabfeb1842c8a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -124,7 +124,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f28085a0e8c19385d99566acb05aa17e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -160,7 +160,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -190,7 +190,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -222,7 +222,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "59023acbd504ee0fc4cedc063978b1e4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3426d78374c5972674f59a3d10d2668f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c2d47d637c8ef5620b3cbd80c248b74f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -94,7 +94,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "23db3700dd5f5866228f9ed61c85e0fa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -124,7 +124,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8a92f273739180d553336b3b2d4d9dae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -163,7 +163,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -196,7 +196,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "7832ca188bd8fdbad4bc690b1d4bae43",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -230,7 +230,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c85efb5cd15fb7818339dad895fd0620",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -260,7 +260,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -292,7 +292,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b8fe07c24cd3e2e4aaefda79a7087bca",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5810bf8001250da7167566f19dd34dd5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2275a09f9d9e6774e1d3e7d3d9e3b1d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -64,7 +64,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1954a4a01b0ef42179fad20e86192e0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -94,7 +94,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "720f90852c34701ef9fbabfeb1842c8a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -124,7 +124,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f28085a0e8c19385d99566acb05aa17e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -160,7 +160,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -190,7 +190,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -222,7 +222,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.10.txt
+++ b/server/bin/gold/test-6.10.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8f3be9fe410df487a112062a36b971da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.11.txt
+++ b/server/bin/gold/test-6.11.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8f3be9fe410df487a112062a36b971da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.12.txt
+++ b/server/bin/gold/test-6.12.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8f3be9fe410df487a112062a36b971da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.13.txt
+++ b/server/bin/gold/test-6.13.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "0e2614842f84c49bb9a7264595915f62",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.14.txt
+++ b/server/bin/gold/test-6.14.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "0e2614842f84c49bb9a7264595915f62",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.15.txt
+++ b/server/bin/gold/test-6.15.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8f3be9fe410df487a112062a36b971da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.16.txt
+++ b/server/bin/gold/test-6.16.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "ecc4d057c72dc3260fa3c984467e8608",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.17.txt
+++ b/server/bin/gold/test-6.17.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "ecc4d057c72dc3260fa3c984467e8608",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.3.txt
+++ b/server/bin/gold/test-6.3.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.4.txt
+++ b/server/bin/gold/test-6.4.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "16033055bb8b60d6d6ab79a01aadc1da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.5.txt
+++ b/server/bin/gold/test-6.5.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "16033055bb8b60d6d6ab79a01aadc1da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.6.txt
+++ b/server/bin/gold/test-6.6.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "99cd21f62cb2a82439e7f33e94f1f552",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.7.txt
+++ b/server/bin/gold/test-6.7.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "ade415a46472953d9988a9b1e40d5696",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.8.txt
+++ b/server/bin/gold/test-6.8.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.9.txt
+++ b/server/bin/gold/test-6.9.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "abb9b8c4bb42101285b7174a30a2fa2a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-6.txt
+++ b/server/bin/gold/test-6.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e0d03e3beadbc2ccadc815ea97f8d293",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.0.0.txt
+++ b/server/bin/gold/test-7.0.0.txt
@@ -27,7 +27,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.0.1.txt
+++ b/server/bin/gold/test-7.0.1.txt
@@ -3658,7 +3658,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.1.txt
+++ b/server/bin/gold/test-7.1.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,7 +76,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "63b8bff331e1bca3eb0ed5573fb613c6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -108,7 +108,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.10.txt
+++ b/server/bin/gold/test-7.10.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2018-02 48
 len(actions) = 30
 [
     {
-        "_id": "4689ac905cf35910d5d110ea6724d5f3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "dhcp31-44",
                 "file-date": "2019-03-07T02:14:21",
@@ -178,10 +178,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "43ea6a5f442f6daa1b3431488e4b68ef",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "directory": "/",
@@ -250,10 +250,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7a03e52ff28e8296d28df67fc9fde313",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "directory": "/1-tcp_rr-64B-8i",
@@ -302,10 +302,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6f3efe68da6eab2f3253e4e3f167e17e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -357,10 +357,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8d6dbcd7db016016a694906223d8ee04",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -392,10 +392,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0ea6a57c177a39a1c45d05a8b440e4f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -411,10 +411,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "486b26c1c458511aaf6c23ba4c4d5f1f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -431,10 +431,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1016657ad71ea3f14bf265e291769c7d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -489,10 +489,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0e4753a903276bd9224fe512cd31ddbb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -562,10 +562,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "244ba47b7a554cda01f0e6d6ca35be2e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -634,10 +634,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "643148d0c775e5c4c6a27b01cb3263b5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -672,10 +672,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "369860cff77e538f675589b9158ce971",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -737,10 +737,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7d0bc7add03de4273fdaaa765cdc4fc2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -768,10 +768,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7626a7073bed24488deca1450cb31167",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -882,10 +882,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b66bb8b32810d57c661aa235027ab098",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "4689ac905cf35910d5d110ea6724d5f3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:04.723258",
             "ancestor_path_elements": [
@@ -969,11 +969,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.411000",
             "@timestamp_original": "1517605093411",
             "benchmark": {
@@ -1028,10 +1028,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "2c862e2775391175ad04e31fa05359b3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:13.411000",
             "@timestamp_original": "1517605093411",
@@ -1059,10 +1059,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "d96a051de5e371f39156c6da6049541d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:14.412000",
             "@timestamp_original": "1517605094412",
@@ -1090,10 +1090,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "0bdef40a59edc3b740b16ca4a3d3c74f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:15.413000",
             "@timestamp_original": "1517605095413",
@@ -1121,10 +1121,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "2471c43b408440dfa9afc2beadb90a75",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:16.414000",
             "@timestamp_original": "1517605096414",
@@ -1152,10 +1152,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "8aa05da04d33a428cb54d0b6a3807d57",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:17.416000",
             "@timestamp_original": "1517605097416",
@@ -1183,10 +1183,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "160772679d42caeb596d92f422fb9e58",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:18.417000",
             "@timestamp_original": "1517605098417",
@@ -1214,10 +1214,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "68968d76da881d317998ab7145832b1c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:19.417000",
             "@timestamp_original": "1517605099417",
@@ -1245,10 +1245,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "31d330ebecc327d3106d31f3cfbdfb89",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:20.418000",
             "@timestamp_original": "1517605100418",
@@ -1276,10 +1276,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a67e0d9df85a631b977621f4ef06daf4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:21.419000",
             "@timestamp_original": "1517605101419",
@@ -1307,10 +1307,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "9d55226cab311a0df5bbbc0d3c419c26",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:22.420000",
             "@timestamp_original": "1517605102420",
@@ -1338,10 +1338,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "7815e24fc3d5f6482aa781d77dd21afa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:23.421000",
             "@timestamp_original": "1517605103421",
@@ -1369,10 +1369,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a20b50ad07c06fc378379efce99f94c2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:24.422000",
             "@timestamp_original": "1517605104422",
@@ -1400,10 +1400,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a7f6200fe24846c76d2291c3ba3be8aa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:25.423000",
             "@timestamp_original": "1517605105423",
@@ -1431,10 +1431,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "82c62904752f695fd8462c2962fd4334",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-02",
         "_op_type": "create",
-        "_parent": "b2e3445bf15bf9fdb7342d4f974a95b9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-02T20:58:26.425000",
             "@timestamp_original": "1517605106425",
@@ -1476,7 +1476,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c5b3327b9991b4b8d43f6915ee2dfb40",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1515,7 +1515,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1552,11 +1552,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02 42
 len(actions) = 75
 [
     {
-        "_id": "88154dfc7f6c7ab9ad0094e4a5997444",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:10.000000",
             "@timestamp_original": "1517605090000",
             "iostat": {
@@ -1605,11 +1605,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "d65be242424608ca1fe639bd3111456d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:10.000000",
             "@timestamp_original": "1517605090000",
             "iostat": {
@@ -1658,11 +1658,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c326dbb0dedf1a05affdfacc3cb40bb1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:10.000000",
             "@timestamp_original": "1517605090000",
             "iostat": {
@@ -1711,11 +1711,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "41ea9c052c5eee362680111b1af4e881",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.000000",
             "@timestamp_original": "1517605093000",
             "iostat": {
@@ -1764,11 +1764,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "1b99c0aff930c60560e64a618fb1c0af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.000000",
             "@timestamp_original": "1517605093000",
             "iostat": {
@@ -1817,11 +1817,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "cad304f9e207176556c8fc13f4452968",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.000000",
             "@timestamp_original": "1517605093000",
             "iostat": {
@@ -1870,11 +1870,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "87453ad772dc762339a0612a05b0b29b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:16.000000",
             "@timestamp_original": "1517605096000",
             "iostat": {
@@ -1923,11 +1923,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "7d9436dcc2bee7ac8f88d38b0655a82f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:16.000000",
             "@timestamp_original": "1517605096000",
             "iostat": {
@@ -1976,11 +1976,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "70d0b2dc0b8fd4c93498309a136040cf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:16.000000",
             "@timestamp_original": "1517605096000",
             "iostat": {
@@ -2029,11 +2029,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "2cc6495eea3907cc0c6cbbf127ec9b70",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:19.000000",
             "@timestamp_original": "1517605099000",
             "iostat": {
@@ -2082,11 +2082,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "83c9548ae09d8c076e7242e1b05743e5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:19.000000",
             "@timestamp_original": "1517605099000",
             "iostat": {
@@ -2135,11 +2135,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "dba01b84011787acdb8ea5f1ba6a25fb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:19.000000",
             "@timestamp_original": "1517605099000",
             "iostat": {
@@ -2188,11 +2188,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f375d7f44e89298ae22527b35a9a201f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:22.000000",
             "@timestamp_original": "1517605102000",
             "iostat": {
@@ -2241,11 +2241,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "80673408645cd4a8bcab142213f3f977",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:22.000000",
             "@timestamp_original": "1517605102000",
             "iostat": {
@@ -2294,11 +2294,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e27bc5a655538289cd79c09daf592a2e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:22.000000",
             "@timestamp_original": "1517605102000",
             "iostat": {
@@ -2347,11 +2347,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "cf341ca0f0e67334594af44ee287a2a2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:10.000000",
             "@timestamp_original": "1517605090000",
             "iteration": {
@@ -2392,11 +2392,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1930c8251f9408b2a666b58c708b83b3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.000000",
             "@timestamp_original": "1517605093000",
             "iteration": {
@@ -2437,11 +2437,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "864498b88a5d968099a867638d73ef48",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:16.000000",
             "@timestamp_original": "1517605096000",
             "iteration": {
@@ -2482,11 +2482,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "5e890727b131b120ece3bafee1bb9f65",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:19.000000",
             "@timestamp_original": "1517605099000",
             "iteration": {
@@ -2527,11 +2527,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "06dde54450cb5b6d16e5cde9a6f6162c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:22.000000",
             "@timestamp_original": "1517605102000",
             "iteration": {
@@ -2572,11 +2572,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "a1f8258207cf9b3a2614e3d67a8f2fa4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:25.000000",
             "@timestamp_original": "1517605105000",
             "iteration": {
@@ -2617,11 +2617,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "191a8d743b2019fc99d94cb11fdaff4f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:28.000000",
             "@timestamp_original": "1517605108000",
             "iteration": {
@@ -2662,11 +2662,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "2c5cc6b89b5c72c98147535cdd8d6244",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:31.000000",
             "@timestamp_original": "1517605111000",
             "iteration": {
@@ -2707,11 +2707,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "3984b56596a1085f1fdcfb59bc744669",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:34.000000",
             "@timestamp_original": "1517605114000",
             "iteration": {
@@ -2752,11 +2752,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "d25e86065296f3ffbf7b10f3a37617e5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -2797,11 +2797,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "06f6700a72f27ef49f48b68fb840d044",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:40.000000",
             "@timestamp_original": "1517605120000",
             "iteration": {
@@ -2842,11 +2842,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "fbd87cbbeef3b93a1366ca5e330a7b69",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:43.000000",
             "@timestamp_original": "1517605123000",
             "iteration": {
@@ -2887,11 +2887,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "bac9a66cdbf89d021c63e96078c6e52b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:46.000000",
             "@timestamp_original": "1517605126000",
             "iteration": {
@@ -2932,11 +2932,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "de2810a6f01e45365a22735c4a9b50b2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:49.000000",
             "@timestamp_original": "1517605129000",
             "iteration": {
@@ -2977,11 +2977,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "ef704f384c3fca73abc458e9cf04bcaa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:52.000000",
             "@timestamp_original": "1517605132000",
             "iteration": {
@@ -3022,11 +3022,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "84eb4d382e9e04cec566b1ed758d1ccd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3075,11 +3075,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "dcd035d2a9caedd4fc3b21efddc63ded",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3128,11 +3128,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "e190aff75add65e898756e3f163f14cd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3181,11 +3181,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "2593cd65507381ba0867381eed2bd24c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3234,11 +3234,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "2f4ae3937ebdf8e88e63cd60926f573a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3287,11 +3287,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "38c6413b04c22b892755b61816d46b1b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3340,11 +3340,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "5cc39850678e76d29658bcb876453ee6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3393,11 +3393,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "de964e6d09160d90397e0b79a2a1060b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3446,11 +3446,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "047cff74d75e5798434b6034cc3e854e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3499,11 +3499,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "e12daa67974b2800ce3f3cc1153aa70a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3552,11 +3552,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "bcfa78d8bb1fbbea36e5d1c77008ec80",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3605,11 +3605,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "38f1e70eeaca2e055812d5b99c73aa24",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3658,11 +3658,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "961838e6198b52f970d072c786c382e7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3711,11 +3711,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "506ecdbec88bfe5789c06071d709c159",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3764,11 +3764,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "8610ca7d10f8b6cad7b0c6c679a32552",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.000000",
             "@timestamp_original": "1517605117000",
             "iteration": {
@@ -3817,11 +3817,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "10828b85a238ba125b1d6203de068954",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -3854,11 +3854,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "139e46e563634f23a8ce82e1d57bbf96",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -3891,11 +3891,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "298cb5c2d629dcbead5bfdd58667d8ae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -3928,11 +3928,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "421f8556b02820dcf90de6ae18a495d1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -3965,11 +3965,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "709b92e0cb55b89103f7f019f48186a8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4002,11 +4002,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "5c21b7f65a2c53f7cad09457959de237",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4039,11 +4039,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4a8e70a5023368310a10c200e912c6d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4076,11 +4076,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "93c77a020abfc85e75a3ad905e7b866c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4113,11 +4113,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1da9707524297b41f842795e4067b376",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4150,11 +4150,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1039382ec46ebcebe50eaf126a08ef6f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4187,11 +4187,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "745c7c8528d7ba8abf25f0f7a1b12e74",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4224,11 +4224,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c126f90cee070246f975668a24e5fa48",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4261,11 +4261,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "8e32bbfcac5731be2dbf1494ba69a6dc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4298,11 +4298,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "bb157ba52709eb307afb2a154b2fc4b1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4335,11 +4335,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ec71208de4c63a38e986c4bb210642ed",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.434270",
             "@timestamp_original": "1517605087.4342701",
             "iteration": {
@@ -4372,11 +4372,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "da9973c96a6eb7c26bbdf1220faaa432",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:07.467263",
             "@timestamp_original": "1517605087.4672635",
             "iteration": {
@@ -4574,11 +4574,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "df6f60c7c3587f6093218a411cdc8032",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:10.474774",
             "@timestamp_original": "1517605090.474774",
             "iteration": {
@@ -4945,11 +4945,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "54c3ee7bffb4ba6ef67f0fd160eec656",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:13.476189",
             "@timestamp_original": "1517605093.4761894",
             "iteration": {
@@ -5316,11 +5316,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "31ae608ccf8d1c024aa86698d0256e3f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:16.477567",
             "@timestamp_original": "1517605096.4775674",
             "iteration": {
@@ -5687,11 +5687,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "896a17abca95aa0529330177f0884dab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:19.479063",
             "@timestamp_original": "1517605099.4790628",
             "iteration": {
@@ -6058,11 +6058,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "b7c6c55684e5ec9dabb534686cbf763f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:22.480448",
             "@timestamp_original": "1517605102.4804482",
             "iteration": {
@@ -6429,11 +6429,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "ca8c1dad53cae448c4b3bbaafd63a667",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:25.482045",
             "@timestamp_original": "1517605105.4820454",
             "iteration": {
@@ -6800,11 +6800,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "ee7d78d8293220c9886dd8c954411abd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:28.483519",
             "@timestamp_original": "1517605108.4835188",
             "iteration": {
@@ -7171,11 +7171,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5ac09a0a7e3977aeaa9204b18bdf616c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:31.485079",
             "@timestamp_original": "1517605111.4850786",
             "iteration": {
@@ -7542,11 +7542,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "2d6dc7d7d0f57a400af37a9be7bb4962",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:34.486434",
             "@timestamp_original": "1517605114.4864337",
             "iteration": {
@@ -7913,11 +7913,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "bb5dea9f650a321856587379f18b0770",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:37.489497",
             "@timestamp_original": "1517605117.4894974",
             "iteration": {
@@ -8284,11 +8284,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "3160511681eeb73c0bfeb228153779d2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:40.490952",
             "@timestamp_original": "1517605120.4909515",
             "iteration": {
@@ -8655,11 +8655,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "b652944f7e078df588e8bcc9ad7fa99b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:43.492414",
             "@timestamp_original": "1517605123.4924142",
             "iteration": {
@@ -9026,11 +9026,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "7ed6bdc342b46131baaa383a6babff17",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:46.493826",
             "@timestamp_original": "1517605126.4938262",
             "iteration": {
@@ -9397,11 +9397,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5207bfd5b0e8012a26364a3e733f63c3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-02T20:58:49.495322",
             "@timestamp_original": "1517605129.4953215",
             "iteration": {
@@ -9782,7 +9782,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "6b623d9bd2b0f567b8a130f2f4931aee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -9812,7 +9812,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.11.txt
+++ b/server/bin/gold/test-7.11.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2018-02 30
 len(actions) = 30
 [
     {
-        "_id": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "dhcp31-44",
                 "file-date": "2019-03-07T02:14:46",
@@ -178,10 +178,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "1bd9e8b854f7784e30bc36aec3e019ee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "directory": "/",
@@ -243,10 +243,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "054a8a65c114470abd5f391fad292691",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "directory": "/1-rw-4KiB",
@@ -274,10 +274,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "182df30d20d5163f28a493a8eb698d10",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -343,10 +343,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "997c493945fbf78659f0f218c31eed99",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -362,10 +362,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a36ad7a00be4da90bcdcad4b0ed17aae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -426,10 +426,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1728d40a6063303eb109e969bc34c3b1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -475,10 +475,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "07a447b095fbdf1a1eabb9fb81acc62e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -494,10 +494,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "95b0318e16e641661851df7d38d72be3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -514,10 +514,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6f1d015d95246e06a260e89fc393c91c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -572,10 +572,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6edb44103b88af2eaf19c2370374e3c8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -645,10 +645,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "e60d25c6ff4f1b2d440dbc0549c8bfb4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -717,10 +717,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "846c409519e4a262d227a952c824afdb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -755,10 +755,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "e0a8792d3340a32c9875418f4dc8d52f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -820,10 +820,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "52013cc215d337a89f71736c111c50ee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "22a4bc5748b920c6ce271eb68f08d91c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:00.276959",
             "ancestor_path_elements": [
@@ -851,11 +851,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0415fad0330e40268636fa39456cfbbf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.277959",
             "@timestamp_original": "1001",
             "benchmark": {
@@ -901,10 +901,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "80882ad9928b66ae24fa8ed4ccf743b1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:01.277959",
             "@timestamp_original": "1001",
@@ -933,10 +933,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6d348793f1d0df2fae73a32fc9fbc161",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:01.277959",
             "@timestamp_original": "1001",
@@ -965,10 +965,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "393642868d543197b4616ac04fe59f33",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:02.276959",
             "@timestamp_original": "2000",
@@ -997,10 +997,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a37407721a289fd3de8520b9407f0056",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:02.276959",
             "@timestamp_original": "2000",
@@ -1029,10 +1029,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "feda625f39fb1b842d2b2034ca83d014",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:03.276959",
             "@timestamp_original": "3000",
@@ -1061,10 +1061,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "feb1b79f83bfb4cfb4834c3e7c3a10bb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:03.276959",
             "@timestamp_original": "3000",
@@ -1093,10 +1093,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "8da49d8fc530089330bdb94f90ba3988",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:04.276959",
             "@timestamp_original": "4000",
@@ -1125,10 +1125,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "78b244aac6570ebb77093ee7fc5b757b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:04.276959",
             "@timestamp_original": "4000",
@@ -1157,10 +1157,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e30fff6c662861d7d27a605ab888cd8f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:05.276959",
             "@timestamp_original": "5000",
@@ -1189,10 +1189,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "b33f1cd6afb808bdb441d28dd05833b4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:05.276959",
             "@timestamp_original": "5000",
@@ -1221,10 +1221,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "eb33581ddb410674e7ea7ed11a582419",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:06.276959",
             "@timestamp_original": "6000",
@@ -1253,10 +1253,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "9973ec486455aa25530c7ff45366f4b3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:06.276959",
             "@timestamp_original": "6000",
@@ -1285,10 +1285,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "809c103a2aca84f777465d9c5f73d39f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:07.276959",
             "@timestamp_original": "7000",
@@ -1317,10 +1317,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a1768594d0419c1723729d2e482615fd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-02-01",
         "_op_type": "create",
-        "_parent": "0415fad0330e40268636fa39456cfbbf",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-01T22:41:07.276959",
             "@timestamp_original": "7000",
@@ -1363,7 +1363,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3129858ce1d9d3e466256d2b18743182",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1402,7 +1402,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1438,11 +1438,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01 6
 len(actions) = 46
 [
     {
-        "_id": "6d3c2f0d1b63cf6214d52a22550becea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:03.000000",
             "@timestamp_original": "1517524863000",
             "iostat": {
@@ -1491,11 +1491,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "38b22b951641b57c7c131a30182ae96f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:03.000000",
             "@timestamp_original": "1517524863000",
             "iostat": {
@@ -1544,11 +1544,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "14b63e4f72cf59eff3409cf5df443bc7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:03.000000",
             "@timestamp_original": "1517524863000",
             "iostat": {
@@ -1597,11 +1597,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "6bb0576eff43dfe081982d71c0cdd303",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:06.000000",
             "@timestamp_original": "1517524866000",
             "iostat": {
@@ -1650,11 +1650,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "d72b07cd862ffbf90b239da003adf6b5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:06.000000",
             "@timestamp_original": "1517524866000",
             "iostat": {
@@ -1703,11 +1703,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "fdbce1a23cafc972eaf5ea2fe99c4402",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:06.000000",
             "@timestamp_original": "1517524866000",
             "iostat": {
@@ -1756,11 +1756,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "2e42484dc779cc5f2b1447c4cd4045ae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:09.000000",
             "@timestamp_original": "1517524869000",
             "iostat": {
@@ -1809,11 +1809,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "ce7d6f20bf35942ef9568889c4be728f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:09.000000",
             "@timestamp_original": "1517524869000",
             "iostat": {
@@ -1862,11 +1862,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e2ec01e1847e180bf04e8d5e045ae1bd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:09.000000",
             "@timestamp_original": "1517524869000",
             "iostat": {
@@ -1915,11 +1915,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "b10fa311f9ecb5f496751d180722847d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:12.000000",
             "@timestamp_original": "1517524872000",
             "iostat": {
@@ -1968,11 +1968,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "994b573fc3ab7d6e03b763dfeefe43cd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:12.000000",
             "@timestamp_original": "1517524872000",
             "iostat": {
@@ -2021,11 +2021,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "320f0a7ea61329e3cf9c2f360fd221c5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:12.000000",
             "@timestamp_original": "1517524872000",
             "iostat": {
@@ -2074,11 +2074,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f115a5680e693f384a1258ad0bc739c2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:15.000000",
             "@timestamp_original": "1517524875000",
             "iostat": {
@@ -2127,11 +2127,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8d5b45147ee0f8fce0211557c27060cd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:15.000000",
             "@timestamp_original": "1517524875000",
             "iostat": {
@@ -2180,11 +2180,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "4e14df81a5f77fdb6d7fe706eb306186",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:15.000000",
             "@timestamp_original": "1517524875000",
             "iostat": {
@@ -2233,11 +2233,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "b73a1e1da48b209f71a3f8592cce6282",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:04.000000",
             "@timestamp_original": "1517524864000",
             "iteration": {
@@ -2278,11 +2278,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "2f104bfb7bc735d3900b94070813f6b0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:07.000000",
             "@timestamp_original": "1517524867000",
             "iteration": {
@@ -2323,11 +2323,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "268ac69405be99e4a752d00462545b17",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:10.000000",
             "@timestamp_original": "1517524870000",
             "iteration": {
@@ -2368,11 +2368,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "d1dc323c509dadc9be494d8bd6252e5c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:13.000000",
             "@timestamp_original": "1517524873000",
             "iteration": {
@@ -2413,11 +2413,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "bcf4c850eacecae087d6634bb9f5fc7b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:16.000000",
             "@timestamp_original": "1517524876000",
             "iteration": {
@@ -2458,11 +2458,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "e81d56aceac6b139c6663b228a5c8e45",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:04.000000",
             "@timestamp_original": "1517524864000",
             "iteration": {
@@ -2503,11 +2503,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "61b8187b60ef0be47bdf6fc52d948a04",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:07.000000",
             "@timestamp_original": "1517524867000",
             "iteration": {
@@ -2548,11 +2548,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "bed102fd0dd774778084171d2a1d610d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:10.000000",
             "@timestamp_original": "1517524870000",
             "iteration": {
@@ -2593,11 +2593,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "b2fdcdd30263131b55b83f987e302ddd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:13.000000",
             "@timestamp_original": "1517524873000",
             "iteration": {
@@ -2638,11 +2638,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "91339f44b9b95be9ce95c9738e6156a4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:16.000000",
             "@timestamp_original": "1517524876000",
             "iteration": {
@@ -2683,11 +2683,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "40a7618db6f3528bbe99762eebf65b99",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2720,11 +2720,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "7f3755d14f9f9824fb98113c258ea957",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2757,11 +2757,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "bcd763918d99237b639811b6b525a788",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2794,11 +2794,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6474f48ada10ee7803bdf2d48c4d62d7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2831,11 +2831,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "84236ec48ba3907a6a8c4a9c6b362072",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2868,11 +2868,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "87cfdda6aa2dbc4bdf5c75680f977aa6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2905,11 +2905,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "2289091fb4dd9b8f7ed9848b423b07ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2942,11 +2942,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "bafc87e2d6a50e80e87e72d7c8d10431",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -2979,11 +2979,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "b20e4a78e5dba060103f1e685341a9a0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3016,11 +3016,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "58449ac1d01ae543c9eb52f8f32fb925",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3053,11 +3053,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6a0e0d86ee7a733223bee1386f57f5ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3090,11 +3090,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "8d8bab5c46ae8d026c3bea23c1a2086e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3127,11 +3127,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "5601a2c84b9f084dd6782c09ee606596",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3164,11 +3164,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "318e0e00ba7b9eea8913c3d4e2822314",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3201,11 +3201,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "bf1428082c2011121e99c1d73d7bccff",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.270328",
             "@timestamp_original": "1517524861.270328",
             "iteration": {
@@ -3238,11 +3238,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "bcb0ddcfc6c13759c2fa3c04583d9451",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:01.322294",
             "@timestamp_original": "1517524861.3222935",
             "iteration": {
@@ -3440,11 +3440,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "481809391c9f75e693f3a4d5694467d9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:04.331455",
             "@timestamp_original": "1517524864.3314548",
             "iteration": {
@@ -3811,11 +3811,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "dacaff8a5bf057a6e58eebb6f715a063",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:07.333773",
             "@timestamp_original": "1517524867.3337727",
             "iteration": {
@@ -4182,11 +4182,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "617bff61260e99fa2e73c650f829942d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:10.335414",
             "@timestamp_original": "1517524870.3354142",
             "iteration": {
@@ -4553,11 +4553,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "7d596783f0179f9501b681f84eec72a0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:13.337584",
             "@timestamp_original": "1517524873.3375843",
             "iteration": {
@@ -4924,11 +4924,11 @@ len(actions) = 46
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "f09b5d99b8d5779b2bbaf46b69329ba1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-02-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-01T22:41:16.339268",
             "@timestamp_original": "1517524876.3392684",
             "iteration": {
@@ -5309,7 +5309,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "114b37f02addd972d29f22de6a99cb0b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5339,7 +5339,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.12.txt
+++ b/server/bin/gold/test-7.12.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2018-02 58
 len(actions) = 15
 [
     {
-        "_id": "168d7c14773f67f2befb7614c1c199d9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "EC2::ip-172-31-52-154",
                 "file-date": "2019-03-07T02:15:23",
@@ -287,10 +287,10 @@ len(actions) = 15
         "_type": "pbench-run"
     },
     {
-        "_id": "d17bfc2e3d022bfecbf834bc6484f035",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "directory": "/",
@@ -331,10 +331,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7db28ceecd5e9e13ec439b18a062ecba",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "directory": "/1",
@@ -346,10 +346,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1422fd184de001cdba37246cdd890dba",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -373,10 +373,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fcba27144a2a3398f5e5a2b2284b2480",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -392,10 +392,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ad194d825ed872e0c93479ce03b2e9bf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -412,10 +412,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "421df93b1834a492cb5bf3dd1b401b79",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -470,10 +470,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6b2e2573ddad5acab13d7df37769f2dc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -536,10 +536,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "176e1b77faecb27bc7907fa92ced2a6d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1385,10 +1385,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "37cacb687e74239a23cd57c812f1e0dc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1407,10 +1407,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4daa68dc4ba50911548dcdd4586608aa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1446,10 +1446,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ee96ccafd08e5d033a98b4d0a6048c8c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1485,10 +1485,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d30f5fe1fbfe36d9cb2d8895343d27bf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1950,10 +1950,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0c57a79d62cc04b55e9d46bc8c8c4b9c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -1972,10 +1972,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8f0831c5f7583784ade6e8aaf90fa40f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-02",
         "_op_type": "create",
-        "_parent": "168d7c14773f67f2befb7614c1c199d9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-02-05T20:35:36.317245",
             "ancestor_path_elements": [
@@ -2025,7 +2025,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b1d09ee8a22ed776b6d147a85612b1f6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2064,7 +2064,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2099,11 +2099,11 @@ Index:  pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05 43005
 len(actions) = 45
 [
     {
-        "_id": "4c59b6aeb289b35cf7a754bfbf5111ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iostat": {
@@ -2151,11 +2151,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "9d62f83d0018929380a3fe399021166b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iostat": {
@@ -2203,11 +2203,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "413eabf6a11d05fc8456943986f3e3a7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:59.000000",
             "@timestamp_original": "1517862959000",
             "iostat": {
@@ -2255,11 +2255,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f2a920c649cfee618a5557afaefbabb6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:59.000000",
             "@timestamp_original": "1517862959000",
             "iostat": {
@@ -2307,11 +2307,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "a6f81779ea1fec377ac8638969df6cf0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:09.000000",
             "@timestamp_original": "1517862969000",
             "iostat": {
@@ -2359,11 +2359,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "3879099a70153a4b72f5e425fb3f512a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:09.000000",
             "@timestamp_original": "1517862969000",
             "iostat": {
@@ -2411,11 +2411,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f5f9f25f032d9792571e4c8864595203",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:19.000000",
             "@timestamp_original": "1517862979000",
             "iostat": {
@@ -2463,11 +2463,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "24b49076d6c9014c74ed8278305af840",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:19.000000",
             "@timestamp_original": "1517862979000",
             "iostat": {
@@ -2515,11 +2515,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e006a2221da62ae0d80047b6b4541164",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:29.000000",
             "@timestamp_original": "1517862989000",
             "iostat": {
@@ -2567,11 +2567,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c2a8c20d20a15473f236e9bed14d9c20",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:29.000000",
             "@timestamp_original": "1517862989000",
             "iostat": {
@@ -2619,11 +2619,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "5e5b8c48c0688acb5ac8f6d6689b42dd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:39.000000",
             "@timestamp_original": "1517862999000",
             "iostat": {
@@ -2671,11 +2671,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e9aa9cf5e582919b3aad828153945c57",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:36:39.000000",
             "@timestamp_original": "1517862999000",
             "iostat": {
@@ -2723,11 +2723,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "76b9c937cb464ae75469991f76bfd0f9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -2775,11 +2775,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "7da9476cd2bc33b419c3b3c991240d6a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -2827,11 +2827,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c563e22aec1eb538fd04ed2c0ab3488d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -2879,11 +2879,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "dfb4182d580b05ac1a2e178ea0f65087",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -2931,11 +2931,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "dcdc40e2a634c5ec73f5e5ff88d30096",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -2983,11 +2983,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "7592699f69af95d42e00f6ff7eabea46",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3035,11 +3035,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "584a053275554bf60f300f5884b38f92",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3087,11 +3087,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "2da5f1ccbc0bce58f040ca01377fcb20",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3139,11 +3139,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "043e425fd5b7e84fddb1fc254b9c4034",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3191,11 +3191,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "fd0edeede0ee6cba948680ba00bc1d6b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3243,11 +3243,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "e79ae3a45873fdb6a4c748bccaef0418",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3295,11 +3295,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "0c59d7f18153efed693dda2b07a79151",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3347,11 +3347,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "0b397dce66c278d47a146caed871940c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3399,11 +3399,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "99374554f681b3a4d1f04fb93ee1a479",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3451,11 +3451,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c23b71e7c9732ee7e7f7358d9e04a237",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iteration": {
@@ -3503,11 +3503,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "42e8ba70b420224b15c31b029fe8beb8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3538,11 +3538,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "8746a0ef83102f8bbbece5f00c05aa56",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3576,11 +3576,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "4be4df6891235e05ecffe34a6920458e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3614,11 +3614,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "80f9f6b181e7bfb4d1688b92e11d8535",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3652,11 +3652,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "c70a41bad37c58d283864f39e318f511",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3690,11 +3690,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "5d0e0e0a152d2dfe5307f16d568308d3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3728,11 +3728,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "39718eeacf232fcaaefff7203543e7ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3766,11 +3766,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "0eaa7fa0813e87467af134fd8fef0766",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3804,11 +3804,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "d600af1f265674c92819f1f63636cb64",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3842,11 +3842,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "d5b7b82955e2182e54ae714b91c30a7a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3880,11 +3880,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "7b394a9ff045ec05e95a3eb75a6a7162",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3918,11 +3918,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "f98897120e4aded83247e6d8b45a1867",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3956,11 +3956,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "da9e27c69e6ce59a4cfc882cdf3f5d80",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -3997,11 +3997,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "292aea8a7ee978f4c82acf9d5f852df9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -4038,11 +4038,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "a5bd64a036ca57c1bcff31ea2d626958",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-prometheus-metrics.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:40.000000",
             "@timestamp_original": "1517862940",
             "iteration": {
@@ -4079,11 +4079,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-prometheus-metrics"
     },
     {
-        "_id": "725560ef8d8ddc61603ded35ea0fbb6e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iostat": {
@@ -4131,11 +4131,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "0b5801676f203c83ecffe7a9272ec34a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:49.000000",
             "@timestamp_original": "1517862949000",
             "iostat": {
@@ -4183,11 +4183,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "faa2779edad1e912239b1c40a29d30ca",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-02-05",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-02-05T20:35:59.000000",
             "@timestamp_original": "1517862959000",
             "iostat": {
@@ -4249,7 +4249,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "84470faad8893ced42a29d997a3331a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -4279,7 +4279,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.13.txt
+++ b/server/bin/gold/test-7.13.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2018-04 27
 len(actions) = 15
 [
     {
-        "_id": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "b03-h01-1029p",
                 "file-date": "2019-05-15T17:19:39",
@@ -263,10 +263,10 @@ len(actions) = 15
         "_type": "pbench-run"
     },
     {
-        "_id": "e2d676f140734f792533761ca9a66964",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "directory": "/",
@@ -307,10 +307,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ab1dd00efbc107b04748520156494c1c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "directory": "/1",
@@ -322,10 +322,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3bf4979b71fe103f940c0213421fc6de",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -349,10 +349,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4eeca493e1cc105d0b59273ee7f9319d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -368,10 +368,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9a4a3dbbf0746f25830eae7e8ded5fc6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -388,10 +388,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "35ecb0a7d61a58cf3e50f8b2bb1bbfa8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -453,10 +453,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9a4dd03f532a5b220ef6035467a16c21",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -925,10 +925,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3a5e38d0c29de66ccd963eac2d6f5c12",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -1011,10 +1011,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fcdd84bf3aea2756844067a3144638c5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -4171,10 +4171,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "96b7b6f74450dfc3c3653084861b2ae0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -4229,10 +4229,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "f071a0929b9b3dfe9ef99d9fe8703cb7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -4372,10 +4372,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ed44840cab7f174f07a24cb51bc8742e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -4507,10 +4507,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "dc9491659744cdc1e29e0ef0ad9043e9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -5119,10 +5119,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "34ce756d29db3275e7796f7002175efc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "a9019fa5e4128a77c5910fccddbb5de3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -5177,7 +5177,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e40a2bba66b93c5f19a03188db89aaaa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5216,7 +5216,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5250,11 +5250,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10 43
 len(actions) = 30
 [
     {
-        "_id": "9628f211ee36262e8fe207761c6e0200",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5287,11 +5287,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f159b5d578611f8e6e1e0122b2c17ead",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5324,11 +5324,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "8c431a37ce351a36b2859add57e8a7b7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5361,11 +5361,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f38ff0e23ddaa5ae66be981f3161d1a6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5398,11 +5398,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1733809bf1d1bcba3bcd1262443d3d6a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5435,11 +5435,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c19d86b46011fcea0c698e2cb0693518",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5472,11 +5472,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "16968f9e2dca40f7c825a7344cf99fa7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5509,11 +5509,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1be661b8106f020681d8656fdebfd8bc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5546,11 +5546,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e11071c74ad07c066db8c12bf4dd7591",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5583,11 +5583,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "aa690797f3f325fcacfd86ac02802fdf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5620,11 +5620,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4747b743c73427498da77669a0dbd411",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5657,11 +5657,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "379954cefd7ab66481a6e2935a81a15a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5694,11 +5694,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c591da8faaf5b845ed8d78627046b1b3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5731,11 +5731,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c349e7fd4aadcaae1f3f221729a41e0a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5768,11 +5768,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "caeda010f27cc1baf48f5e8482a82e84",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -5805,11 +5805,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "10f6e1674a109449cda6666678817a99",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.050889",
             "@timestamp_original": "1523386881.0508895",
             "iteration": {
@@ -5991,11 +5991,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "0419ebfc636698688f84a13018513716",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:24.054128",
             "@timestamp_original": "1523386884.0541282",
             "iteration": {
@@ -6330,11 +6330,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "ae5d7a967c7583274cbd5567135104ab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:27.056722",
             "@timestamp_original": "1523386887.0567222",
             "iteration": {
@@ -6669,11 +6669,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5455b97610667e55bca3e0cd79d46fce",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:30.059692",
             "@timestamp_original": "1523386890.0596917",
             "iteration": {
@@ -7008,11 +7008,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1ab5f4e03dade2c0f6ec53bd603923af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:33.062879",
             "@timestamp_original": "1523386893.0628786",
             "iteration": {
@@ -7347,11 +7347,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "d95d0a91b0540c2950b580fd64082aa7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:36.065718",
             "@timestamp_original": "1523386896.0657184",
             "iteration": {
@@ -7686,11 +7686,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "97e2fa23d998c8dbfbbc07e5a2277f9d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:39.069022",
             "@timestamp_original": "1523386899.0690217",
             "iteration": {
@@ -8025,11 +8025,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "78e197c9609c2a45993f77993d2254bb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:42.071981",
             "@timestamp_original": "1523386902.0719812",
             "iteration": {
@@ -8364,11 +8364,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "8f5b7b8e880c60cc68ff9a08c0f9f9c3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:45.075373",
             "@timestamp_original": "1523386905.075373",
             "iteration": {
@@ -8703,11 +8703,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "289f8db334db4da6d87fe49095ba26af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:48.078676",
             "@timestamp_original": "1523386908.0786757",
             "iteration": {
@@ -9042,11 +9042,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "673ff785d31b7a31e89077e8ab76493b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:51.081840",
             "@timestamp_original": "1523386911.0818398",
             "iteration": {
@@ -9381,11 +9381,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "ce11728451375e106174abbff821bc3c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:54.084811",
             "@timestamp_original": "1523386914.0848112",
             "iteration": {
@@ -9720,11 +9720,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "b60ecc415084aa1a43f766c28bf91542",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:57.087302",
             "@timestamp_original": "1523386917.0873024",
             "iteration": {
@@ -10059,11 +10059,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "6c95cb934e2dd2b91381f7a04c39b3d1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:02:00.090138",
             "@timestamp_original": "1523386920.0901384",
             "iteration": {
@@ -10398,11 +10398,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "c3fc1fbc7f3df1e6508bcd4f4739dd51",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:02:03.092754",
             "@timestamp_original": "1523386923.0927541",
             "iteration": {
@@ -10751,7 +10751,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "4b1a56fd914b402bc6e9cd6db66f15d9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -10781,7 +10781,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.14.txt
+++ b/server/bin/gold/test-7.14.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2018-04 27
 len(actions) = 15
 [
     {
-        "_id": "f38462917c6b0545e8afd67cb8c393f9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "b03-h01-1029p",
                 "file-date": "2019-05-15T18:32:45",
@@ -263,10 +263,10 @@ len(actions) = 15
         "_type": "pbench-run"
     },
     {
-        "_id": "c5a1cb30b8e00d76a1cf9afe681ddf28",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "directory": "/",
@@ -307,10 +307,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "5db921530af8885e607d95c2fd371cfc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "directory": "/1",
@@ -322,10 +322,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3b39d65f26e041aecfa22bf2c0c06947",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -349,10 +349,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "84894bbbc60b6b70ddece0b5ad772d97",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -368,10 +368,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "17d41a9464cb4d9071cff2273ec4930b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -388,10 +388,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "90fecabd865ac3e7a0c9b1e578c1269e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -1342,10 +1342,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "5abbe7f70d8b6b92cce0d244e90acc3b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -1821,10 +1821,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "f602f5b54597a119e65c848867864958",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -1886,10 +1886,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3099d821a2a776f3a4c1ac65814c103e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -2358,10 +2358,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c842333b6e8a631afec5a34ef98218bc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -2444,10 +2444,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d7d31039c0e5628cf2e33f0bd677f271",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -5604,10 +5604,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7431d98e50841bdbbc071e72a7bad6a4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -5739,10 +5739,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bb529a2dcf1489243516187fb437ed09",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -6351,10 +6351,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fd1c3a729cd200caa0c414dcd341380e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-04",
         "_op_type": "create",
-        "_parent": "f38462917c6b0545e8afd67cb8c393f9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-04-10T19:01:19.927438",
             "ancestor_path_elements": [
@@ -6409,7 +6409,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8fa7bb0c15f105692c5dfc22bc6654d8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -6448,7 +6448,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -6482,11 +6482,11 @@ Index:  pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10 73350
 len(actions) = 30
 [
     {
-        "_id": "d1bd9941d26b22eb5619d5f94498b1a1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:24.000000",
             "@timestamp_original": "1523386884000",
             "iteration": {
@@ -6527,11 +6527,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "9a9dd8c33db040b8027984305322e8e6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:27.000000",
             "@timestamp_original": "1523386887000",
             "iteration": {
@@ -6572,11 +6572,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "752f8c683cbd475104e9faf7f2da3a01",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:30.000000",
             "@timestamp_original": "1523386890000",
             "iteration": {
@@ -6617,11 +6617,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "ff3fd9249320e9feb6a2352c643506f0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:33.000000",
             "@timestamp_original": "1523386893000",
             "iteration": {
@@ -6662,11 +6662,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "af272d2b06f5a95358729babbfae6eda",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:36.000000",
             "@timestamp_original": "1523386896000",
             "iteration": {
@@ -6707,11 +6707,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "db944e0240712f095ee998524e98c25a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:39.000000",
             "@timestamp_original": "1523386899000",
             "iteration": {
@@ -6752,11 +6752,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "6d59303087558c820dd28a3e6e3010a2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:42.000000",
             "@timestamp_original": "1523386902000",
             "iteration": {
@@ -6797,11 +6797,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "724c899bc8dfaf28e3510a27aa5b4418",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:45.000000",
             "@timestamp_original": "1523386905000",
             "iteration": {
@@ -6842,11 +6842,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "6388b01454651f9ca1945e0d96c41f7b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:48.000000",
             "@timestamp_original": "1523386908000",
             "iteration": {
@@ -6887,11 +6887,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "6430afc4ca053d440c4993da78125380",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:51.000000",
             "@timestamp_original": "1523386911000",
             "iteration": {
@@ -6932,11 +6932,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "af0848fb823255d97c3922b95ac023cf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:54.000000",
             "@timestamp_original": "1523386914000",
             "iteration": {
@@ -6977,11 +6977,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "93957841228eef2d6d2eb7ee3bf5aafb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:57.000000",
             "@timestamp_original": "1523386917000",
             "iteration": {
@@ -7022,11 +7022,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "36d55347604bdcea2411d93e16000ecb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:02:00.000000",
             "@timestamp_original": "1523386920000",
             "iteration": {
@@ -7067,11 +7067,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "9de6ebc2216d0b11337d652526dec430",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:02:03.000000",
             "@timestamp_original": "1523386923000",
             "iteration": {
@@ -7112,11 +7112,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "ea1e03bc7610f58d3aed9ee9238ec442",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:02:06.000000",
             "@timestamp_original": "1523386926000",
             "iteration": {
@@ -7157,11 +7157,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "04f9635b769c392582d63e919571c5df",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7194,11 +7194,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "9b404570da063f8eb009322dc993cc63",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7231,11 +7231,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "b5de6b438ea91780f4a9cce6c5c352fc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7268,11 +7268,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e560c2f272755abf26ca7c6e2b17b564",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7305,11 +7305,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "68cebfe07970ba226bb48aeadb107c7f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7342,11 +7342,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c7e414f9cbd705ce228ef36c91350962",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7379,11 +7379,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "3f5ffeb67d1fc784d07fe17b7068896b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7416,11 +7416,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "98738e2a361f19603bdd447e8bed2a04",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7453,11 +7453,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6e82bea694221ae80bed0f8eae723551",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7490,11 +7490,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "5cc322c34dd1fe3327955a0a0b0c1355",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7527,11 +7527,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "85c672348af7857800d46ee117fa535c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7564,11 +7564,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "8371971bf2bd947fb4506024e2131fa7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7601,11 +7601,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4b7b2454b00e28fa2560fafe9d338c1c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7638,11 +7638,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "57583945ab4df9b80fd63dbc63e362d7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7675,11 +7675,11 @@ len(actions) = 30
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1ca84cb9fc33de89386690cf55a5f1ee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-04-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-04-10T19:01:21.036391",
             "@timestamp_original": "1523386881.0363908",
             "iteration": {
@@ -7726,7 +7726,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fcf35d689f8a95d15e503a5110dad78f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -7756,7 +7756,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.15.txt
+++ b/server/bin/gold/test-7.15.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2016-10 63
 len(actions) = 30
 [
     {
-        "_id": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "master_40gb",
                 "file-date": "2019-03-07T02:18:04",
@@ -356,10 +356,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "2a72ea6f685a3a63bcbb3ddde55c2818",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "directory": "/",
@@ -428,10 +428,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6c5ef77756e702fba4aa7ca0300697da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "directory": "/1-tcp_stream-16384B-32i",
@@ -480,10 +480,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8a78f215e325a1148de8b04a1ce31601",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -535,10 +535,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1f065ff7e54f3bc03aee6622d56f444d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -563,10 +563,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "39107bb12813265203498a822f83c3fe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -582,10 +582,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "aa5f9404bf7de63e09d44925c56bda83",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -602,10 +602,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1e5dd834813791d2a81853236f79afd0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -660,10 +660,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8022e558df4b8c381837a0e0552eb59c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -733,10 +733,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "577f22d59fbf76078e6813482d6519db",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1015,10 +1015,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "e2e5e751f5aeeb8df25c492b01445978",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1158,10 +1158,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b2fbaa59f7940bcc5b7de50c1b66eb7f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1223,10 +1223,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8b9a49e088fbbaef1a71b404af7ace19",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1359,10 +1359,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1fb8878e60a501aaaacc8b1a0fe31670",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1473,10 +1473,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "be31cd3382e27ff9b224d932d2b403a2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "393e019b97d31ab32999a0b48d4ff0a9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1560,11 +1560,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "47e63ab9f7759abb5e70150a55a12774",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.472000",
             "@timestamp_original": "1475771657472",
             "benchmark": {
@@ -1618,10 +1618,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "258de0ed38f274981ea325078cb3cee1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:17.472000",
             "@timestamp_original": "1475771657472",
@@ -1649,10 +1649,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "66a1013540f0f059d51727a9d0c2377a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:18.473000",
             "@timestamp_original": "1475771658473",
@@ -1680,10 +1680,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "3b5597df32f90ba7ec9ca550c5982edb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:19.474000",
             "@timestamp_original": "1475771659474",
@@ -1711,10 +1711,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c9734be1d685ba7df3f496341cf63c08",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:20.475000",
             "@timestamp_original": "1475771660475",
@@ -1742,10 +1742,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6077f23e7cc39cfeb4735cfa9f5b2241",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:21.476000",
             "@timestamp_original": "1475771661476",
@@ -1773,10 +1773,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c8e82a5c899996526138fe237ead7ee7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:22.478000",
             "@timestamp_original": "1475771662478",
@@ -1804,10 +1804,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "186a3737754961d15dd5e06db30bbf05",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:23.479000",
             "@timestamp_original": "1475771663479",
@@ -1835,10 +1835,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "548f9ab66ba903613ff4aab01db277a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:24.480000",
             "@timestamp_original": "1475771664480",
@@ -1866,10 +1866,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "eea902c8ccb5055f6784e05953a8f6e4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:25.481000",
             "@timestamp_original": "1475771665481",
@@ -1897,10 +1897,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "dcadafbc86bb636b62dc603c6f4516f5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:26.482000",
             "@timestamp_original": "1475771666482",
@@ -1928,10 +1928,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5241ff9b8d9a97dc1e55d401ca96680b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:27.483000",
             "@timestamp_original": "1475771667483",
@@ -1959,10 +1959,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e41e14d024e4281b5cf47f0cca52de03",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:28.484000",
             "@timestamp_original": "1475771668484",
@@ -1990,10 +1990,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "cfcb4e245e7672209d5c886447e889a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:29.485000",
             "@timestamp_original": "1475771669485",
@@ -2021,10 +2021,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "d032b454030f7ad55f0182e517f62a65",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "47e63ab9f7759abb5e70150a55a12774",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:30.486000",
             "@timestamp_original": "1475771670486",
@@ -2066,7 +2066,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f25577a7cbfaaf9bf3625b4b15d77f30",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2105,7 +2105,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2142,11 +2142,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06 12
 len(actions) = 72
 [
     {
-        "_id": "03ad7a0d1cfd19e37e40be749262ec9a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2194,11 +2194,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e49e5d2e1c294594c874b7b165bcf720",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2246,11 +2246,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8d89ae1e02b0da90c6ffb1bec2b9a256",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2298,11 +2298,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "18c0e9cfff6edd9aaab0d48d71a9b137",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2350,11 +2350,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "10fdeed06693ab7381932bfdeb7e37a2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2402,11 +2402,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "750ec2f7864d553c1f08ae49462e3060",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2454,11 +2454,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e266112982c40fc7a4d034f064b2473f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2506,11 +2506,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "83ff5fcaf37e737fe13f1f1855f1b067",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2558,11 +2558,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "06d3082ffad9148c6e19659a94047fc9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2610,11 +2610,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "7f503d1410b94e0f0697bd97f1c0781a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2654,11 +2654,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "bfab3333d747531d8a60a048244858f4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2698,11 +2698,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "90dc8766f51eba666faf4cff8d702767",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -2742,11 +2742,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1d697fad21007d9d3f73499b25cfa17a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2786,11 +2786,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "7491e367541aabcee1fbe621a9b9a925",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2830,11 +2830,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "504ba1c5158ef870f2a9dd58361ca81b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -2874,11 +2874,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "818c47c1c9090e42a771a67575845fda",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2918,11 +2918,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "f4527b19e59cf8b0cd99c8b801d5d3c2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2962,11 +2962,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "47ee43dfe3746d415103b7f93500f2c0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3006,11 +3006,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "692c12a3e4cd10a2028afb7dc70301ab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3050,11 +3050,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "e18c0a939b7558ca2d88bf44fbc9dfdc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -3094,11 +3094,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "24583bd4c20682fcc9170804ca592b01",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3138,11 +3138,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "df30d3472fe24123fc105e9d1caaf98e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3182,11 +3182,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "d3011c4c2b5aa9aa3e33d520ae674b28",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -3226,11 +3226,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "2b645e1452ca40896b5352334dc88324",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3270,11 +3270,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "7171247c548d047bd46fdc732037549a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3322,11 +3322,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "2dbcfb39b902011301f50a60c5a8387e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3374,11 +3374,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "79bec507a8fbbd977454887b5840c8bd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3426,11 +3426,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "f9e649dab175bc9bd04197f4559fe6ba",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3478,11 +3478,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "ced3df0cc123d405fed757a884dea17d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3530,11 +3530,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "ea3a37705185e7dd80863b66035c6ea5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3582,11 +3582,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "dde0301daa8a90f6285bbd3b4a385c39",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3634,11 +3634,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a61ec2329841e05f990f809b728444d7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3686,11 +3686,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "98abcfb320aa0ced11958c2a0b9f588f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3738,11 +3738,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c4993edda14be3e220d60fd3fa4d2899",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3790,11 +3790,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "cdb2abe9c89df5587ac252e27e37473a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3842,11 +3842,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "ec38cece698514245287742651579497",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3894,11 +3894,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "4666806a66ffde6d1d6cec266ad0ac15",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3946,11 +3946,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c875f099acaa9b1482f21d449e74ee71",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3998,11 +3998,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "f5c2ed44b3261a81164d38a550dbeb07",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -4050,11 +4050,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "e70d2a2cdf126cc1f039237760c2f0af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4086,11 +4086,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ed65654ba6dfee92eb89b2dc27bec2d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4122,11 +4122,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c4124bb60c0a46485e9b1188dba34c63",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4158,11 +4158,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "acb8581b0feb4049f4d3a74412d129bc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4194,11 +4194,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ad8f82564dcea008e4c62b8c6cba6860",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4230,11 +4230,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f13e92e5d336dc5b9810b659b5780e4b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4266,11 +4266,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "29b2a951bf7d48c0f2d1e46347015983",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4302,11 +4302,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f50792cd6d8e05e3a0103e8ba56881f2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4338,11 +4338,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f732f3de226a0ee2e563eeecd7a03cbe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4374,11 +4374,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "a50b1dcf4af7d7e0d77756451596c077",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4410,11 +4410,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4c8a5ff7d2282ffdcfa597f6330b1d9f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4446,11 +4446,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "dc9163629e8d0f689ddc79dacd04ee08",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4482,11 +4482,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6721485054996efe3679fcedf0f0709c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4518,11 +4518,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "b25224e8fe597ea44054c09751324a63",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4554,11 +4554,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "dea4bf3d20c50a12d24bdf2c975b2ffc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4590,11 +4590,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "d41cabdd1d54cd02450ec415611aae21",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.362084",
             "@timestamp_original": "1475771651.3620842",
             "iteration": {
@@ -4770,11 +4770,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "65b5ae00c6fc3299431a2bc1b62b2834",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.364391",
             "@timestamp_original": "1475771654.364391",
             "iteration": {
@@ -5098,11 +5098,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "c8de4659375b3417aafdf99ea02bbfdc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.366625",
             "@timestamp_original": "1475771657.3666246",
             "iteration": {
@@ -5426,11 +5426,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "057e64a49e449c079550eeffd7f6eb48",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.368945",
             "@timestamp_original": "1475771660.3689446",
             "iteration": {
@@ -5754,11 +5754,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "0b329d907e35f18d2237ccb9f9300caa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5806,11 +5806,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f524c7e2ecc7edc5812c9c8518feddbf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5858,11 +5858,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "893a27719c88343b6eb93725ec50e577",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5910,11 +5910,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "376b722a32a03a79a7a7617ffcac190d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -5962,11 +5962,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "fc9115cad9f8631620bf82b9c5a24db1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -6014,11 +6014,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "bb9496231e545422dcd911f02418ee43",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -6066,11 +6066,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c3afccf864fe412f8377d38523c54f04",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.404408",
             "@timestamp_original": "1475771651.4044082",
             "iteration": {
@@ -6246,11 +6246,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "e6e4fdef311a3ad6d7dae8c9ae1d1ef9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.406617",
             "@timestamp_original": "1475771654.406617",
             "iteration": {
@@ -6574,11 +6574,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "dd97b06d19183859951ff6709f93561b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.409022",
             "@timestamp_original": "1475771657.4090216",
             "iteration": {
@@ -6902,11 +6902,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5cf4a5f54c30adae56ca50bad97994ec",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.411393",
             "@timestamp_original": "1475771660.4113934",
             "iteration": {
@@ -7230,11 +7230,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "fad1e108c518bb253cc929831005410c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.066326",
             "@timestamp_original": "1475771651.0663261",
             "iteration": {
@@ -7410,11 +7410,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "981d79c07a288358b6c41562ca755f75",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.068630",
             "@timestamp_original": "1475771654.0686305",
             "iteration": {
@@ -7738,11 +7738,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "0ed85d42cf90f4144a13820bf22b6a41",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.071078",
             "@timestamp_original": "1475771657.0710783",
             "iteration": {
@@ -8066,11 +8066,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1f8d7559890917a56326981bf00fa3d1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.073414",
             "@timestamp_original": "1475771660.0734138",
             "iteration": {
@@ -8408,7 +8408,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "25e7f587287c8ee06d58e0cf7177f492",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -8438,7 +8438,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.16.txt
+++ b/server/bin/gold/test-7.16.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -81,11 +81,11 @@ Index:  pbench-unittests.v4.run.2018-10 64
 len(actions) = 30
 [
     {
-        "_id": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "rhel8-4",
                 "file-date": "2019-04-26T19:36:44",
@@ -155,10 +155,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "4704feb6509f3eaf91d98156a2a1d38a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "directory": "/",
@@ -220,10 +220,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c012555954f7934284635f0bf4eac68f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "directory": "/21-tcp_rr-1024B-1i",
@@ -272,10 +272,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8d4d8c4a6f408c09829772fbadd70fd4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -327,10 +327,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "719905a1992693966ddf8da167193e8f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -362,10 +362,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bf166044e0d975f8e467f550f6ff36f5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -381,10 +381,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "187f077f1f04e48d064f36af02dc2502",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -401,10 +401,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7ab8b21d72d70e87a849451743b16c49",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -459,10 +459,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6adf7d121ed390884e5533b2573581a2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -532,10 +532,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1c9f6e487398c10fe3722ee325896a42",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -646,10 +646,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c5302f975494a9f8db912363537f4eaf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -705,10 +705,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bc0148bc54325708bb2a83180fc233cf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -770,10 +770,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fe30938605214828d72c24c5c7883a81",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -822,10 +822,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "69864109f3555ab25dd674757601e229",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -936,10 +936,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "e205be2eeab2c60ba2f9393f6fa500a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "b7377b15e32ba3fa1579cf01cd90b192",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T06:53:52.212763",
             "ancestor_path_elements": [
@@ -1023,11 +1023,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3db575c233f61acbc20563b9859fd2e3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:29.152000",
             "@timestamp_original": "1538656649152",
             "benchmark": {
@@ -1085,10 +1085,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "3d31ab6abae31450cdc94e0245f0cbf7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:29.152000",
             "@timestamp_original": "1538656649152",
@@ -1116,10 +1116,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "aba699a1c69c08f5b6d6b39652554177",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:30.153000",
             "@timestamp_original": "1538656650153",
@@ -1147,10 +1147,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "dff3d14a58e6861cc9261dc791db4d02",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:31.154000",
             "@timestamp_original": "1538656651154",
@@ -1178,10 +1178,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e06df3d6bac3eb6639c8d9dcc259de16",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:32.156000",
             "@timestamp_original": "1538656652156",
@@ -1209,10 +1209,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5b929fd805d42eaad11a7626aea6be9b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:33.157000",
             "@timestamp_original": "1538656653157",
@@ -1240,10 +1240,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "d64d24f522e10bb2d2a371dd006caf3a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:34.158000",
             "@timestamp_original": "1538656654158",
@@ -1271,10 +1271,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "4e38ad5fe51da67b94df35996f02a835",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:35.159000",
             "@timestamp_original": "1538656655159",
@@ -1302,10 +1302,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e28ee35322868ff26b94568c3902f11c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:36.160000",
             "@timestamp_original": "1538656656160",
@@ -1333,10 +1333,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "7b881c93e545ff018ef84ca4ff6cef8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:37.179000",
             "@timestamp_original": "1538656657179",
@@ -1364,10 +1364,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "7e44a9595da0c34802ded294e78f7a9c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:38.180000",
             "@timestamp_original": "1538656658180",
@@ -1395,10 +1395,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "f069198259ad88c9d4e9d44df886c144",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:39.181000",
             "@timestamp_original": "1538656659181",
@@ -1426,10 +1426,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5cc7ea855ce270bd8e4a7d8067c71fa2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:40.182000",
             "@timestamp_original": "1538656660182",
@@ -1457,10 +1457,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "da948f2ed41b74a4d13f935f76746e7b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:41.182000",
             "@timestamp_original": "1538656661182",
@@ -1488,10 +1488,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6cf927f1727a56404bff8ba06a736706",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2018-10-04",
         "_op_type": "create",
-        "_parent": "3db575c233f61acbc20563b9859fd2e3",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-04T12:37:42.183000",
             "@timestamp_original": "1538656662183",
@@ -1533,7 +1533,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "e1fabe537308e9ec8302caea3418c49f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1572,7 +1572,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1609,11 +1609,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04 189
 len(actions) = 75
 [
     {
-        "_id": "c5b4a58833b1e626be6a8a6abe956fd3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:25.000000",
             "@timestamp_original": "1538656645000",
             "iostat": {
@@ -1662,11 +1662,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f5eba42fc0b10a5573b8eb990135bbae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:25.000000",
             "@timestamp_original": "1538656645000",
             "iostat": {
@@ -1715,11 +1715,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c4a87ef28cb0f5dd4bbe5e32d856a4c7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:25.000000",
             "@timestamp_original": "1538656645000",
             "iostat": {
@@ -1768,11 +1768,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f508a334ecb61babb90e046093fa4061",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:28.000000",
             "@timestamp_original": "1538656648000",
             "iostat": {
@@ -1821,11 +1821,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f20b65dcea5a5604e0e3005fd2add9e9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:28.000000",
             "@timestamp_original": "1538656648000",
             "iostat": {
@@ -1874,11 +1874,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "9d1816b3b116b0ef830fdc3c38c62be3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:28.000000",
             "@timestamp_original": "1538656648000",
             "iostat": {
@@ -1927,11 +1927,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f374ab4c0237fd01f9c29f8926388934",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:31.000000",
             "@timestamp_original": "1538656651000",
             "iostat": {
@@ -1980,11 +1980,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "7c11b5b7578303e7b217f4efab90b0a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:31.000000",
             "@timestamp_original": "1538656651000",
             "iostat": {
@@ -2033,11 +2033,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "1630286b02ffe84806d6f98b4cefdeb4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:31.000000",
             "@timestamp_original": "1538656651000",
             "iostat": {
@@ -2086,11 +2086,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "7ae8aeedc244f5dadc276dc93f73c5c1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:34.000000",
             "@timestamp_original": "1538656654000",
             "iostat": {
@@ -2139,11 +2139,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "179fa9ab1801f520bfe3cc43d1c5a05b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:34.000000",
             "@timestamp_original": "1538656654000",
             "iostat": {
@@ -2192,11 +2192,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "77ffb2e60afb909efafaf9e3aff22fc9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:34.000000",
             "@timestamp_original": "1538656654000",
             "iostat": {
@@ -2245,11 +2245,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "9e808f7eb237086da0bbb72b295a8d85",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:37.000000",
             "@timestamp_original": "1538656657000",
             "iostat": {
@@ -2298,11 +2298,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e3b42c9b5c942ee3ba74e797d9b393b4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:37.000000",
             "@timestamp_original": "1538656657000",
             "iostat": {
@@ -2351,11 +2351,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "a10cbe3ad7261ef760ba1761d8454725",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:37.000000",
             "@timestamp_original": "1538656657000",
             "iostat": {
@@ -2404,11 +2404,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8d0aa4ca552e3fb278db787cc10799a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:25.000000",
             "@timestamp_original": "1538656645000",
             "iteration": {
@@ -2449,11 +2449,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "a7427783ea4d3bd82699b0449b5b2ef0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:28.000000",
             "@timestamp_original": "1538656648000",
             "iteration": {
@@ -2494,11 +2494,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "2a9c656e9df1fc48a8d7771344ed9cbe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:31.000000",
             "@timestamp_original": "1538656651000",
             "iteration": {
@@ -2539,11 +2539,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "45c905e53b765a5acf4550a5d749f2d4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:34.000000",
             "@timestamp_original": "1538656654000",
             "iteration": {
@@ -2584,11 +2584,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "c1c61bf23d1ee635e38b20d1da7192d1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:37.000000",
             "@timestamp_original": "1538656657000",
             "iteration": {
@@ -2629,11 +2629,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "0a834544337912008c2ccaac8076710b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:40.000000",
             "@timestamp_original": "1538656660000",
             "iteration": {
@@ -2674,11 +2674,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "95a990d8e0b077a257d8cf72f091325e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:43.000000",
             "@timestamp_original": "1538656663000",
             "iteration": {
@@ -2719,11 +2719,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "94a370496c74d6b388549cebae4a2138",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:46.000000",
             "@timestamp_original": "1538656666000",
             "iteration": {
@@ -2764,11 +2764,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "aae435bc84a1766acfc4956779121e85",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:49.000000",
             "@timestamp_original": "1538656669000",
             "iteration": {
@@ -2809,11 +2809,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "5470a7cef007f3ee3ab586f2b352d83e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -2854,11 +2854,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "47d044c71b90745bbec8653e07914ff9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:55.000000",
             "@timestamp_original": "1538656675000",
             "iteration": {
@@ -2899,11 +2899,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "17ea457770cd4aa3f71f061afde5885d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:58.000000",
             "@timestamp_original": "1538656678000",
             "iteration": {
@@ -2944,11 +2944,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "0e317232d125d57afbd1f1b8515fb043",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:38:01.000000",
             "@timestamp_original": "1538656681000",
             "iteration": {
@@ -2989,11 +2989,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "f0a54dcc102bc4b82086811a04e04ad6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:38:04.000000",
             "@timestamp_original": "1538656684000",
             "iteration": {
@@ -3034,11 +3034,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "78ec5fd58f765e2bc8530e88481c5ff5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:38:07.000000",
             "@timestamp_original": "1538656687000",
             "iteration": {
@@ -3079,11 +3079,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "6dac4aab2c44c954e56a8ea5331f9eb4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3132,11 +3132,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "025e5d6f9fcc59fc8cc27a25fbe91d8a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3185,11 +3185,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "beee0b72a14bddbaffb889ef53a1583a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3238,11 +3238,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "9c720647d6602158b36acf9a138adf57",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3291,11 +3291,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "5db451a32e6ae522a4f686b6ba059a42",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3344,11 +3344,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "783d539913d9ff58799544a448eedd64",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3397,11 +3397,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "b8d7a215512124ed6bfe3104c7e883e2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3450,11 +3450,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c6abeb5492ac4cde796e67fa09030c1c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3503,11 +3503,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a018e58d9e3b7ecc68c37142d9cec4fa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3556,11 +3556,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c9b2a0f4c20bb96253a99528b0334425",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3609,11 +3609,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "2e05fb565e1905d4f519b3749033bbf3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3662,11 +3662,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "f0365c71534ea8cac46115847fd5b265",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3715,11 +3715,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "41cc57c32f0fabef5f9ebe31f0e6fe52",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3768,11 +3768,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "58cd76caeabf87e94fc3fb18e5b92660",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3821,11 +3821,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a670a7fd1af32d222658dec4ef2178ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.000000",
             "@timestamp_original": "1538656672000",
             "iteration": {
@@ -3874,11 +3874,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "08ad87fee2468f04c3496588261074fe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -3911,11 +3911,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "9431cf68c4ffa5b6e10d710785de8197",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -3948,11 +3948,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "37701524a28fbf80a22cd61ec295c487",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -3985,11 +3985,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "8b80b6c0a80e389c399c2967cdcd6981",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4022,11 +4022,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e5b74fc684fea03bdff5a2a788b8f801",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4059,11 +4059,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "9f362eda8a7c3c66a5154a71760df6f0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4096,11 +4096,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "7c07860438438fcbec3f8415d82f9477",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4133,11 +4133,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4a5822087c2ec9eecec6c3fd5a823c95",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4170,11 +4170,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1f9c322f6bc1bfc794849f9ff9936692",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4207,11 +4207,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "dbf7d77339333c0234ee36f6b0c46cdd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4244,11 +4244,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e06892e803ca0890ce7e8fa0579aa6b2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4281,11 +4281,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "65aa8dc565041f968076f255fefaf530",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4318,11 +4318,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c466f603485b201e7a34a178944d7c08",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4355,11 +4355,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "aaa31a73ce7f40ef01a1911627a7b656",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4392,11 +4392,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "d4cb836acb84ed73245d61c628658840",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.783812",
             "@timestamp_original": "1538656642.7838123",
             "iteration": {
@@ -4429,11 +4429,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ed57938617e4b26ce3f694eb6a2f58f8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:22.839122",
             "@timestamp_original": "1538656642.839122",
             "iteration": {
@@ -4637,11 +4637,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "78e2c191fad5df27bd0cff9a9d860c3b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:25.842371",
             "@timestamp_original": "1538656645.8423715",
             "iteration": {
@@ -5020,11 +5020,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "f57741357893d144ed781c5cb23b2fe2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:28.845930",
             "@timestamp_original": "1538656648.8459303",
             "iteration": {
@@ -5403,11 +5403,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "4e72eb34d038fa2c027d9540f0333ed3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:31.849220",
             "@timestamp_original": "1538656651.8492196",
             "iteration": {
@@ -5786,11 +5786,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "63fa44706debce98dd889e5dd214d395",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:34.852475",
             "@timestamp_original": "1538656654.852475",
             "iteration": {
@@ -6169,11 +6169,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "59f7df4a0edde6e760d9dbb153ed4d70",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:37.855739",
             "@timestamp_original": "1538656657.8557394",
             "iteration": {
@@ -6552,11 +6552,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "dbfacc2c1b04eb288d4a212e49bf5c74",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:40.859007",
             "@timestamp_original": "1538656660.859007",
             "iteration": {
@@ -6935,11 +6935,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "bda99875290d51bba1de5376cd739c29",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:43.862335",
             "@timestamp_original": "1538656663.8623354",
             "iteration": {
@@ -7318,11 +7318,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "06f46a0358e91dac3acd57c3489ed2ed",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:46.865469",
             "@timestamp_original": "1538656666.865469",
             "iteration": {
@@ -7701,11 +7701,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "f1f92cc305bc2e8b10bad4112bfd4a70",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:49.868721",
             "@timestamp_original": "1538656669.8687208",
             "iteration": {
@@ -8084,11 +8084,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "01a7bc916a925886614dd618b93c1802",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:52.872014",
             "@timestamp_original": "1538656672.872014",
             "iteration": {
@@ -8467,11 +8467,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "2b1891a51bdb144075bce57a31e47575",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:55.875071",
             "@timestamp_original": "1538656675.8750713",
             "iteration": {
@@ -8850,11 +8850,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "807651385272c4a4a770f9ce6d3e0879",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:37:58.878210",
             "@timestamp_original": "1538656678.87821",
             "iteration": {
@@ -9233,11 +9233,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "62b0cb3be26e9dcafa545b1b0641ec2c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:38:01.881485",
             "@timestamp_original": "1538656681.8814852",
             "iteration": {
@@ -9616,11 +9616,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1ef75d8618eb8fc27a79c2dee2448dc9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2018-10-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-04T12:38:04.884761",
             "@timestamp_original": "1538656684.884761",
             "iteration": {
@@ -10013,7 +10013,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3a4d7d097e391683f06561da594d8517",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -10043,7 +10043,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.17.txt
+++ b/server/bin/gold/test-7.17.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2018-10 26
 len(actions) = 15
 [
     {
-        "_id": "45f0e2af41977b89e07bae4303dc9972",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ansible-host",
                 "file-date": "2019-03-07T02:19:08",
@@ -152,10 +152,10 @@ len(actions) = 15
         "_type": "pbench-run"
     },
     {
-        "_id": "09c610b1faf16149ac144cbfc9530d2a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "directory": "/",
@@ -196,10 +196,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "867aa6785453e10a80b81f9d8fc7422c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "directory": "/1",
@@ -211,10 +211,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "45b42d7d9749e64b9a38c31300275e25",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -238,10 +238,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "91fafa6c2fbfc1d65d181b9940533581",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -257,10 +257,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ee5b8aa52013ec6102c83c51ad1c7cbc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -277,10 +277,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "11ff83fe2be512e072500ce7ab48838e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -335,10 +335,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0ab4e336686ea9fed43ad589778869cb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -408,10 +408,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0b20f14eb3a1339a5b0cc73a0cdb44f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -522,10 +522,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "47007fd30b0c0df15f5f113359cf74e8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -609,10 +609,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fce5746a99c76e52c2de7ecc857a0911",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -629,10 +629,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "50d80a78f3bbe457be7e0c9f291b30df",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -687,10 +687,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ac0bb5b0d46462ff0a65571fe3ab75ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -753,10 +753,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0ed9fc137a7b234654eabc1a66c53638",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -773,10 +773,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8bc037a0f83f0aa821041b35097f6aef",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2018-10",
         "_op_type": "create",
-        "_parent": "45f0e2af41977b89e07bae4303dc9972",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2018-10-24T14:38:18.299722",
             "ancestor_path_elements": [
@@ -845,7 +845,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "7db0c324e4466bfb2c25d7c4cd0a0974",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -884,7 +884,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -919,11 +919,11 @@ Index:  pbench-unittests.v3.tool-data-vmstat.2018-10-24 100
 len(actions) = 45
 [
     {
-        "_id": "cdf0275e6dbf95f4a00b3a275fb9ed3f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iostat": {
@@ -972,11 +972,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "f99afbc818f84001ad2289983836d560",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:40:21.000000",
             "@timestamp_original": "1540392021000",
             "iostat": {
@@ -1025,11 +1025,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "487bad5105b2a1efcd0805872a0bce8d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:41:21.000000",
             "@timestamp_original": "1540392081000",
             "iostat": {
@@ -1078,11 +1078,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "45494aff6973f487b964cd4a617fa49f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:42:21.000000",
             "@timestamp_original": "1540392141000",
             "iostat": {
@@ -1131,11 +1131,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "a39ea00f93028e53bec049437ca8ac8a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:43:21.000000",
             "@timestamp_original": "1540392201000",
             "iostat": {
@@ -1184,11 +1184,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "431871b0eb723e70c900c7b3df83bf5d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:44:21.000000",
             "@timestamp_original": "1540392261000",
             "iostat": {
@@ -1237,11 +1237,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8b2bed9a7f0c00c7bd9b8babd0167323",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:45:21.000000",
             "@timestamp_original": "1540392321000",
             "iostat": {
@@ -1290,11 +1290,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "38c01398797fe0cbdc5da622ab019bb8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:46:21.000000",
             "@timestamp_original": "1540392381000",
             "iostat": {
@@ -1343,11 +1343,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "d88327eadda3a80a499f1f01b858925c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:47:21.000000",
             "@timestamp_original": "1540392441000",
             "iostat": {
@@ -1396,11 +1396,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "52b1588832fe201bea8b5554efccbae1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:48:21.000000",
             "@timestamp_original": "1540392501000",
             "iostat": {
@@ -1449,11 +1449,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "d95c36c2bbd417a5e508e1e280c78bc1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:49:21.000000",
             "@timestamp_original": "1540392561000",
             "iostat": {
@@ -1502,11 +1502,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "79a7c61520c123b2b18871d447252555",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:50:21.000000",
             "@timestamp_original": "1540392621000",
             "iostat": {
@@ -1555,11 +1555,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "031ccbaeb8c72dce960006db666a14dc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:51:21.000000",
             "@timestamp_original": "1540392681000",
             "iostat": {
@@ -1608,11 +1608,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "43f5b6556c63c801102ff81b7cf1da32",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:52:21.000000",
             "@timestamp_original": "1540392741000",
             "iostat": {
@@ -1661,11 +1661,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "286f8f5a0c98f0db9ca85b15b3cbf8ac",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:53:21.000000",
             "@timestamp_original": "1540392801000",
             "iostat": {
@@ -1714,11 +1714,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "801ddf0170e6bafc4b955971d0a51169",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -1767,11 +1767,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "06f918a3d2521e9753474887a889a9fc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -1820,11 +1820,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "1b5bbfe61e6edb2f40d0b604d7829803",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -1873,11 +1873,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "8eb26a76eb3373767366d64a389afaab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -1926,11 +1926,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a6d4b215a65cc3c8f64fbd95f569e6f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -1979,11 +1979,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c83eec2d2b5ac1ca7919a60e16736daf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2032,11 +2032,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "24736e2e11b12e027f67b55df67d15e6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2085,11 +2085,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "99715ead2b76995b5dcb4c11bb8a08c3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2138,11 +2138,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "774d61704ad3f7896d25a653357b769e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2191,11 +2191,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c55dc1618c2d80aa857ac3654842535b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2244,11 +2244,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "441e1e51bd61c2ad3c3aecf19fcec56e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2297,11 +2297,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "307500b982dab099c96928094b859ad2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2350,11 +2350,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "fd4b7121cb0c78f55a86eb80be50df16",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2403,11 +2403,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "35b9ef4618242fcd5ca053f21f577fdb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2456,11 +2456,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "79bf428eef7e8a90ea3ade8b33a00d9e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:21.000000",
             "@timestamp_original": "1540391961000",
             "iteration": {
@@ -2509,11 +2509,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "3ddc69254db2da55fc77b960e409c332",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:39:22.000000",
             "@timestamp_original": "1540391962000",
             "iteration": {
@@ -2571,11 +2571,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "64a8bed4c45cd7e0abbdf4be2d9060d8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:40:22.000000",
             "@timestamp_original": "1540392022000",
             "iteration": {
@@ -2633,11 +2633,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "af8e411ff7bd31be28bb9703ef8fe932",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:41:22.000000",
             "@timestamp_original": "1540392082000",
             "iteration": {
@@ -2695,11 +2695,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "346d2792cb259af0a3f98a19779f16f2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:42:22.000000",
             "@timestamp_original": "1540392142000",
             "iteration": {
@@ -2757,11 +2757,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "663b573493096635cd80bd0115363fbc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:43:22.000000",
             "@timestamp_original": "1540392202000",
             "iteration": {
@@ -2819,11 +2819,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "be548e9b1f405fd44d13e74356ec56ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:44:22.000000",
             "@timestamp_original": "1540392262000",
             "iteration": {
@@ -2881,11 +2881,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "6c424b3fa6306434238fd58ed7059e66",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:45:22.000000",
             "@timestamp_original": "1540392322000",
             "iteration": {
@@ -2943,11 +2943,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "3c5e5641906d9495b9f9e54a58b24da8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:46:22.000000",
             "@timestamp_original": "1540392382000",
             "iteration": {
@@ -3005,11 +3005,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "808bb29d7aafa831671a066c0215436c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:47:22.000000",
             "@timestamp_original": "1540392442000",
             "iteration": {
@@ -3067,11 +3067,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "5c7b903c528e573156496c33affde7ac",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:48:22.000000",
             "@timestamp_original": "1540392502000",
             "iteration": {
@@ -3129,11 +3129,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "a3a88034c7220c96b6646b275fe82fad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:49:22.000000",
             "@timestamp_original": "1540392562000",
             "iteration": {
@@ -3191,11 +3191,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "28c70898afe25d4e2354dceacf1141a6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:50:22.000000",
             "@timestamp_original": "1540392622000",
             "iteration": {
@@ -3253,11 +3253,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "9be8ce4ff528acc3217f4697906b0e66",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:51:22.000000",
             "@timestamp_original": "1540392682000",
             "iteration": {
@@ -3315,11 +3315,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "2cb4c7c6ede1342543007e4621c63b52",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:52:22.000000",
             "@timestamp_original": "1540392742000",
             "iteration": {
@@ -3377,11 +3377,11 @@ len(actions) = 45
         "_type": "pbench-tool-data-vmstat"
     },
     {
-        "_id": "d4e1accbd04d507e088d9b7a7c3f596a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-vmstat.2018-10-24",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2018-10-24T14:53:22.000000",
             "@timestamp_original": "1540392802000",
             "iteration": {
@@ -3453,7 +3453,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1f1e0a65842c85d6b889344a71a192f6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -3483,7 +3483,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.18.txt
+++ b/server/bin/gold/test-7.18.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f08564160439fb42773dc3a3316a65ae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,7 +76,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "2cb3f1b6426c2487f89a2543cd7b19e9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -108,7 +108,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.19.txt
+++ b/server/bin/gold/test-7.19.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2019-08 8
 len(actions) = 23
 [
     {
-        "_id": "7b1d050eab2b577f772b152aeb100fa1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "perf122",
                 "file-date": "2019-09-07T01:54:23",
@@ -116,10 +116,10 @@ len(actions) = 23
         "_type": "pbench-run"
     },
     {
-        "_id": "01b8e5e1bb365124c2719da1ea48f73a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "directory": "/",
@@ -195,10 +195,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "69604d48e09dc14a572e7c5c3939429e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "directory": "/1-forwarding_test.json-5pct_drop",
@@ -240,10 +240,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "f57cb4d9b747503fc70e3411abb63af5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "ancestor_path_elements": [
@@ -876,10 +876,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "da058ec6a14d12a93bf081b52acedbab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "ancestor_path_elements": [
@@ -1226,10 +1226,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4ccc0fa7d2e0cfb972d7b9eed44edcd2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "ancestor_path_elements": [
@@ -1245,10 +1245,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "e1f2843626d5560707fa72742a2fc8eb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "ancestor_path_elements": [
@@ -1265,10 +1265,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8a3d8b929a947730655c514734573c09",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-08",
         "_op_type": "create",
-        "_parent": "7b1d050eab2b577f772b152aeb100fa1",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:00:07.506390",
             "ancestor_path_elements": [
@@ -1309,11 +1309,11 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2019-08-27T15:18:43.666000",
             "@timestamp_original": "1566919123666",
             "benchmark": {
@@ -1627,10 +1627,10 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "77e07e0d8fbbb7799d34774a07890d8a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:43.666000",
             "@timestamp_original": "1566919123666",
@@ -1658,10 +1658,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "b05310cf6025434f6acdbaae41944167",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:46.691000",
             "@timestamp_original": "1566919126691",
@@ -1689,10 +1689,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "fd401005626ab148374ccff4147daaac",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:49.715000",
             "@timestamp_original": "1566919129715",
@@ -1720,10 +1720,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "417474243f2e703b12253b08617f1ada",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:52.740000",
             "@timestamp_original": "1566919132740",
@@ -1751,10 +1751,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "b60c8ab127c00dbcc33d65582a690032",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:55.766000",
             "@timestamp_original": "1566919135766",
@@ -1782,10 +1782,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "06e0fded091f5716786809da5763ce70",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:18:58.790000",
             "@timestamp_original": "1566919138790",
@@ -1813,10 +1813,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a1b520d358069b5ccc86e1d078343b9d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:01.816000",
             "@timestamp_original": "1566919141816",
@@ -1844,10 +1844,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "15dff6ff5a5708ce9263d72793ca3a78",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:04.842000",
             "@timestamp_original": "1566919144842",
@@ -1875,10 +1875,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6e772e3d41311c2a63413e628755b423",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:07.867000",
             "@timestamp_original": "1566919147867",
@@ -1906,10 +1906,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "de4bdfdf57bed38e7270d6c30e78c4de",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:10.892000",
             "@timestamp_original": "1566919150892",
@@ -1937,10 +1937,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "177aa08ee6a98f4858d4e38ac36fa942",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:13.918000",
             "@timestamp_original": "1566919153918",
@@ -1968,10 +1968,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "06f0f9978ea26e6279ca69eedc1d623f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:16.945000",
             "@timestamp_original": "1566919156945",
@@ -1999,10 +1999,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "be307b8a1bde5000f49818e40e475f35",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:19.972000",
             "@timestamp_original": "1566919159972",
@@ -2030,10 +2030,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5726e4863466910ea00146bf59704888",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-08-27",
         "_op_type": "create",
-        "_parent": "9b4cacb771e47f8867d8e4bef0f93f79",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-08-27T15:19:22.999000",
             "@timestamp_original": "1566919162999",
@@ -2075,7 +2075,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8149773560424fb80b24148d93983a5b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2114,7 +2114,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2159,7 +2159,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "4a2dd850b78fd1696be894efd12f14e5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2189,7 +2189,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.2.0.txt
+++ b/server/bin/gold/test-7.2.0.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,7 +76,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c259a4e710814a9867dc79f6287cde8c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -108,7 +108,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.2.1.txt
+++ b/server/bin/gold/test-7.2.1.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,7 +76,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "438ed615e2ae73f1470c747e1c7352a5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -108,7 +108,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.20.txt
+++ b/server/bin/gold/test-7.20.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2020-02 24
 len(actions) = 30
 [
     {
-        "_id": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-02-28T20:19:19",
@@ -120,10 +120,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "fa032cbcf43ea9f3bddc80d120b3a71b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "directory": "/",
@@ -185,10 +185,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b9feaca0eac2ae270bcb2e2bf129560b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "directory": "/0__fio",
@@ -209,10 +209,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "eef56523989e047322e4d984843fc930",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -293,10 +293,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b625f34d8d6ec0c79e4d1e998cd97734",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -312,10 +312,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6c02e9e72bac66b9fa14d7aedeb0e7ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -348,10 +348,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "aff6241b5482fd85be78e565dbb6125d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -390,10 +390,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "36b85a7cc36dac5d1bf9801400c85c93",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -409,10 +409,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d7d987dc0059fcc0bce3f4c87cdf5ebf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -429,10 +429,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1c27dee2b9e67a6fe6ee3843df0af5e1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -473,10 +473,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fc80e546c457be85055baa7ac57e908c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -557,10 +557,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "f64515175e535dd126314b973ae8d151",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -576,10 +576,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b665b1cc133a1970ddc6864ee363189c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -612,10 +612,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "19ebb6b64a992466ea26de890cd5718d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -654,10 +654,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7d61878593d293e98929be6edc4f1b36",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "277a1c15ec04cdbc50efdadb0ed34bbd",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:14.663380",
             "ancestor_path_elements": [
@@ -673,11 +673,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3979881ae611106923010df8747849ac",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-27T22:16:49.572000",
             "@timestamp_original": "1582841809572",
             "benchmark": {
@@ -744,10 +744,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "b6c0c572e099464a609dce7c62764fd7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:49.572000",
             "@timestamp_original": "1582841809572",
@@ -775,10 +775,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "208a33487daab42db0acb75ec04c7c5a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:50.572000",
             "@timestamp_original": "1582841810572",
@@ -806,10 +806,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "ce8cbc80122144b1e2f8d2f7c570f083",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:51.572000",
             "@timestamp_original": "1582841811572",
@@ -837,10 +837,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "05de343d6e75ba1ca9e4da60380be127",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:52.572000",
             "@timestamp_original": "1582841812572",
@@ -868,10 +868,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "3eeb89ae34d9a7d2d85298a966cb86b4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:53.572000",
             "@timestamp_original": "1582841813572",
@@ -899,10 +899,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "45ec090ac8fc23b74cf9d4f7d137b0a5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:54.572000",
             "@timestamp_original": "1582841814572",
@@ -930,10 +930,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e6377b892de8dc4bdd1d503824e5e636",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:55.572000",
             "@timestamp_original": "1582841815572",
@@ -961,10 +961,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c133d06ce6fc6d12a1b82c4175ad93d4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:56.572000",
             "@timestamp_original": "1582841816572",
@@ -992,10 +992,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "4e7016ae8db7f53d045dfc615cb128a5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:57.572000",
             "@timestamp_original": "1582841817572",
@@ -1023,10 +1023,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5d7388e1749adcc50f3586cbc58b1abc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:58.572000",
             "@timestamp_original": "1582841818572",
@@ -1054,10 +1054,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "078937cd19ac205efef6948511cef236",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:16:59.572000",
             "@timestamp_original": "1582841819572",
@@ -1085,10 +1085,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "70852638b89f161bf9b395f1ec243700",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:17:00.572000",
             "@timestamp_original": "1582841820572",
@@ -1116,10 +1116,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a50e8fbf05f6de004a50a49f5eed67ab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:17:01.572000",
             "@timestamp_original": "1582841821572",
@@ -1147,10 +1147,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "e8cf480066f43a03c12ea640ef20b8ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-27",
         "_op_type": "create",
-        "_parent": "3979881ae611106923010df8747849ac",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-27T22:17:02.572000",
             "@timestamp_original": "1582841822572",
@@ -1192,7 +1192,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "463e3c750905b4e2a86abff5b1ed6231",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1231,7 +1231,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1276,7 +1276,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8420a95716aca0df3cff30eed47eb9a5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1306,7 +1306,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.21.txt
+++ b/server/bin/gold/test-7.21.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "f08564160439fb42773dc3a3316a65ae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2020-02 8
 len(actions) = 23
 [
     {
-        "_id": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-02-28T21:29:09",
@@ -112,10 +112,10 @@ len(actions) = 23
         "_type": "pbench-run"
     },
     {
-        "_id": "d94f638e37c8db6e7f02631166f62408",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "directory": "/",
@@ -177,10 +177,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "daa2cf72758b17c73bc35bf881760ad3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1",
@@ -201,10 +201,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "76565ccc6f3f9a40542538ac064628e8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "ancestor_path_elements": [
@@ -270,10 +270,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a760ff3923e5010797276b76e1b07aa6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "ancestor_path_elements": [
@@ -289,10 +289,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "970ef70966885d07f48ecbf1f89e0160",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "ancestor_path_elements": [
@@ -668,10 +668,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6eb32a4482d367101b186dbbdf653364",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "ancestor_path_elements": [
@@ -687,10 +687,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "98b69bc263a8623072e78c43f778c6f1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "ea6b84aa5a882a4e42ee11f7798fb40b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:49:39.887048",
             "ancestor_path_elements": [
@@ -706,11 +706,11 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "40580e04c0d0d02c91285f7877e8e5a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -856,11 +856,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "c06199f78026239497e0c99cb655c87e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1006,11 +1006,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "905655a24d563a482f60afc3f9d4c578",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1157,11 +1157,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "ec9a51c96521342bf841ab4780652b30",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1307,11 +1307,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "7039c9b1768b4a501be2775d05045ffb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1457,11 +1457,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "50b8d7132fe5da743bb6ace58e593237",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1608,11 +1608,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "1a2ae23a67477d396638e107c2b4e2ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1758,11 +1758,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "4c9dc9fbe16c3f57b3135894288a5e79",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -1908,11 +1908,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "3a615509f7004c9412a2776d9c845465",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2059,11 +2059,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "ddc7990fd86c8e38b7fae63b024fe3fe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2209,11 +2209,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "460d6c4017cbcd6b2c048d70bba91292",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2359,11 +2359,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "686ccbea0cb3feab2c4f252aa78635d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2510,11 +2510,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "8b67a45e1deed5b4658a05ff2af6b45e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2660,11 +2660,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "f80d9bb7ad154b082156650ccb5de7b3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2810,11 +2810,11 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "823f25c15fc041edaaa384a1dc795fa7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:49:39.887048",
             "benchmark": {
                 "active_device_pairs": "0:1",
@@ -2976,11 +2976,11 @@ Index:  pbench-unittests.v4.run.2020-02 8
 len(actions) = 23
 [
     {
-        "_id": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-02-28T21:29:27",
@@ -3011,10 +3011,10 @@ len(actions) = 23
         "_type": "pbench-run"
     },
     {
-        "_id": "5997573d33167e1f57777e9267a8eb50",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "directory": "/",
@@ -3083,10 +3083,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "78d6c16b08a0c7e3eda2a05db2006aa6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1",
@@ -3107,10 +3107,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9adddd221a80a1c5004f0c17f84d6267",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "ancestor_path_elements": [
@@ -3176,10 +3176,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bae04ec8cff38432d0af42f035f4077b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "ancestor_path_elements": [
@@ -3195,10 +3195,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "788ce98a18cd1228579067a780b0d76f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "ancestor_path_elements": [
@@ -3686,10 +3686,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c36f6a59ccd57ed630b88501080706df",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "ancestor_path_elements": [
@@ -4190,10 +4190,10 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "82f6f8b00ff9399369c14a6eda7ee4b9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "b683a7a6756abc8f9bff4bddb5679d2c",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:04:29.505587",
             "ancestor_path_elements": [
@@ -4209,11 +4209,11 @@ len(actions) = 23
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b2e73ac725562a13178e81d642da316d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T20:14:29.591000",
             "@timestamp_original": "1582920869591",
             "benchmark": {
@@ -4517,10 +4517,10 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "2a74fcce6d12db76ce22a5c03d09dec5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:29.591000",
             "@timestamp_original": "1582920869591",
@@ -4548,10 +4548,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "1158ded3ccaee55e79cb5d4addd42609",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:32.620000",
             "@timestamp_original": "1582920872620",
@@ -4579,10 +4579,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "24685e736b508587f1d9f12fdf0463ab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:35.649000",
             "@timestamp_original": "1582920875649",
@@ -4610,10 +4610,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "ccf85af2e7b84e48da0be38784c41024",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:38.677000",
             "@timestamp_original": "1582920878677",
@@ -4641,10 +4641,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a556666fd22e31ca145e27e1c110a6ee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:41.705000",
             "@timestamp_original": "1582920881705",
@@ -4672,10 +4672,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "3c062b1346bec39ee17c36ea98664c60",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:44.734000",
             "@timestamp_original": "1582920884734",
@@ -4703,10 +4703,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c81791e326805ed836694782ce493bd4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:47.763000",
             "@timestamp_original": "1582920887763",
@@ -4734,10 +4734,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "93e1fcf808523dab3b28425c83fdffc0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:50.791000",
             "@timestamp_original": "1582920890791",
@@ -4765,10 +4765,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "67d5fffca6bb783563c9f4bdcb6bb811",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:53.821000",
             "@timestamp_original": "1582920893821",
@@ -4796,10 +4796,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5426ced164fb2a85ec9ea06d7a23434c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "b2e73ac725562a13178e81d642da316d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:56.850000",
             "@timestamp_original": "1582920896850",
@@ -4827,11 +4827,11 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5df095fa4e6a0ba83b859faac4cd5701",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T20:14:29.591000",
             "@timestamp_original": "1582920869591",
             "benchmark": {
@@ -5139,10 +5139,10 @@ len(actions) = 23
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "00591015d07e5ebe129aabf44e60e459",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "5df095fa4e6a0ba83b859faac4cd5701",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:29.591000",
             "@timestamp_original": "1582920869591",
@@ -5170,10 +5170,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "825f70f3ebd173b9904ccd3ba6bead4f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "5df095fa4e6a0ba83b859faac4cd5701",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:32.620000",
             "@timestamp_original": "1582920872620",
@@ -5201,10 +5201,10 @@ len(actions) = 23
         "_type": "pbench-result-data"
     },
     {
-        "_id": "3f6f13982aa8068426ec23f045b5d5a0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
-        "_parent": "5df095fa4e6a0ba83b859faac4cd5701",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T20:14:35.649000",
             "@timestamp_original": "1582920875649",
@@ -5246,7 +5246,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "54015fe932e0378ea6d25c08f2313993",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5285,7 +5285,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5342,7 +5342,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b5bdd7582d4f0af1ee61fb6d362630aa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -5372,7 +5372,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.22.txt
+++ b/server/bin/gold/test-7.22.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2020-02 20
 len(actions) = 21
 [
     {
-        "_id": "38c50b45fa28a3958e4f4310abe19587",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-03-21T14:07:45",
@@ -120,10 +120,10 @@ len(actions) = 21
         "_type": "pbench-run"
     },
     {
-        "_id": "3ea57ce63cdd6ba40a4365245df43553",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "directory": "/",
@@ -185,10 +185,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0b410c707cdeab2173136475189f1169",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64",
@@ -209,10 +209,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c17a8074c49be0dcb7e87a1133395dc4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -271,10 +271,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c46f28def7a05a69a3d8417f1adda0b0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -290,10 +290,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "6a4724af641564ff4cc854261e3f0cc2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -309,10 +309,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "504acd8ff2eec003c70cfec46b2c122d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -329,10 +329,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "eebc5bbdea8721962251c684e0cac563",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -373,10 +373,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d99a1782f577a27574e63f5f7d080c22",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64",
@@ -397,10 +397,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7248ecd9e6405f865c33bd072e51970b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -459,10 +459,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "43f5bed3926290c54e50df48481bd8ad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -478,10 +478,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "f3e30a345f50dd3b0865ac534a69fa78",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -497,10 +497,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "217165030eabd5537ecd50d4448ccf72",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -517,10 +517,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "91fb60c27bc789fc0fe7cd67cf8a8266",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "ancestor_path_elements": [
@@ -561,10 +561,10 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "dc43487c323354be78979f17b8c78c82",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "38c50b45fa28a3958e4f4310abe19587",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-28T19:10:55.645002",
             "directory": "/2__linpack-binary=:root:linpack:l_mklb_p_2019.6.005:benchmarks_2019:linux:mkl:benchmarks:linpack:xlinpack_xeon64",
@@ -585,11 +585,11 @@ len(actions) = 21
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "76d9eb7b612f0c6b86db12e8ae88303b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -642,11 +642,11 @@ len(actions) = 21
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "b0ba125535b563a48f944a2ef20d07e1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -699,11 +699,11 @@ len(actions) = 21
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "76368af6424b16a32af23fa53f343a9b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -756,11 +756,11 @@ len(actions) = 21
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "0168053ee770b9dbdea3a7d7ce19ae01",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -813,11 +813,11 @@ len(actions) = 21
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "dd9ebe75f09005c491d77cb557e9795f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -870,11 +870,11 @@ len(actions) = 21
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "95be3d60d17ab3acdbc0cfadc65731cc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-28",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-28T19:10:55.645002",
             "benchmark": {
                 "alignment_values": "4",
@@ -941,7 +941,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1522635a6eb70003f0fc2a5549529281",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -980,7 +980,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1025,7 +1025,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "7e867c122671f98b1641922f17f1f9bb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1055,7 +1055,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.23.txt
+++ b/server/bin/gold/test-7.23.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2020-01 92
 len(actions) = 30
 [
     {
-        "_id": "d43e73ad199edb936f9a88c6171d9048",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-03-03T12:57:03",
@@ -120,10 +120,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "ecbcb9214c82188114d1de4cf2c49c33",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "directory": "/",
@@ -199,10 +199,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9a38760801a0016ff02bd991f4e72da0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "directory": "/1-read-4KiB",
@@ -237,10 +237,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a8a97a5c89707d858dcd970ff88bfd16",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -306,10 +306,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "152503a8afa0a23237446fab13efb6e4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -325,10 +325,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "23b915590cd36998b1af62b5654096f6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -389,10 +389,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "98b36f2ac1bcdbcd3367ea2a21670b5d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -475,10 +475,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "465fd02d6e99fca54ad39c954ec7715b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -524,10 +524,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3dead5489d7faec1792dc5a3789aba32",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -608,10 +608,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "269fe72d52d426dc791842fbc910aefe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -627,10 +627,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1205a1f70c9d960c8ce200221f6831c5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -647,10 +647,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b79d922be0d474bb1704547afd3b5830",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -691,10 +691,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4f99d43d003a20ccd39e9a7b216c9e8c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "directory": "/2-read-64KiB",
@@ -729,10 +729,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "87143190324c89dfb2735b0724ae2a5a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -798,10 +798,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4948657578c77c4b1adcff49b3cc90c5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-01",
         "_op_type": "create",
-        "_parent": "d43e73ad199edb936f9a88c6171d9048",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:37.656511",
             "ancestor_path_elements": [
@@ -817,11 +817,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8d52170bd7e3f288995af74f26ca8501",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-01-19T00:19:38.656511",
             "@timestamp_original": "1000",
             "benchmark": {
@@ -883,10 +883,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "d72866ae947419b36d608b7925ef6381",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:38.656511",
             "@timestamp_original": "1000",
@@ -914,10 +914,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "5a08abdaae4c5b266b1188c7236543a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:39.656511",
             "@timestamp_original": "2000",
@@ -945,10 +945,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "48908ac87cc5fe64068163fc8dabca7f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:40.656511",
             "@timestamp_original": "3000",
@@ -976,10 +976,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "64227613ffd3aa971591057d397aea0e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:41.659511",
             "@timestamp_original": "4003",
@@ -1007,10 +1007,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "2eded88c7af2e5cf274c987165a421fc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:42.656511",
             "@timestamp_original": "5000",
@@ -1038,10 +1038,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "bea8dab7ae682de2423013dc0d0ac207",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:43.656511",
             "@timestamp_original": "6000",
@@ -1069,10 +1069,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "64c6cf6ad435cd49f92ef67fec37ec67",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:44.656511",
             "@timestamp_original": "7000",
@@ -1100,10 +1100,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "50dc866358b9017fb641b3b62aa5ed0a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:45.656511",
             "@timestamp_original": "8000",
@@ -1131,10 +1131,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "45b59bdfb3d9480b6759287c6ce29901",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:46.656511",
             "@timestamp_original": "9000",
@@ -1162,10 +1162,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "7826b650a71e69e67d4cfe2da7708f5d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:47.656511",
             "@timestamp_original": "10000",
@@ -1193,10 +1193,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "ff3c18f9c2a614a1a9e2026af5f2d12d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:48.656511",
             "@timestamp_original": "11000",
@@ -1224,10 +1224,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "cfd328182b6f8d4524de514ba7d70b0f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:49.656511",
             "@timestamp_original": "12000",
@@ -1255,10 +1255,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "093d9dc2112d5e31fa0bb3d420d3de21",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:50.656511",
             "@timestamp_original": "13000",
@@ -1286,10 +1286,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "23e0d64b96602ca1b4e4212bcf0d1a70",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-01-19",
         "_op_type": "create",
-        "_parent": "8d52170bd7e3f288995af74f26ca8501",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-01-19T00:19:51.656511",
             "@timestamp_original": "14000",
@@ -1331,7 +1331,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "cc69c88d084cce623b06313a24d0940f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1370,7 +1370,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1415,7 +1415,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "22eb2df02a5caf2b7f96141cff4a897b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1445,7 +1445,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.24.txt
+++ b/server/bin/gold/test-7.24.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2020-02 12
 len(actions) = 16
 [
     {
-        "_id": "9b31e1ada521b8b1394d011b1d773dad",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "ctlrA",
                 "file-date": "2020-03-16T19:16:24",
@@ -118,10 +118,10 @@ len(actions) = 16
         "_type": "pbench-run"
     },
     {
-        "_id": "fd3bd4caa0a64e1c3ac37ace5a110e32",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "directory": "/",
@@ -176,10 +176,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4c00e92eb8f6cd05cc048f8d41f7b813",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "directory": "/1-10U",
@@ -201,10 +201,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "118059feac27a2fbfa0a6607421f9737",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -256,10 +256,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a3e71a01991337446c9865936b183f42",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -275,10 +275,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "749e405ef9086336d0454dcb00ce4575",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -295,10 +295,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "645be55cd2c80bac38f7da259ae07a9b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -339,10 +339,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "578666daa0d49f19768c78b9bc4e59a7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "directory": "/2-20U",
@@ -364,10 +364,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4d963460daccd02b596c5ff167c822cd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -419,10 +419,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b6f96baa494b1a8d3d878af758b3c848",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -438,10 +438,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ecd46774f1338e72f4694efde5e2b7bf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -458,10 +458,10 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d8f99ece6c1043e8f4ca7e4788c89bf3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2020-02",
         "_op_type": "create",
-        "_parent": "9b31e1ada521b8b1394d011b1d773dad",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T15:26:14.978063",
             "ancestor_path_elements": [
@@ -502,11 +502,11 @@ len(actions) = 16
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "97c78db89beb4b9f01fa9cde60788e1d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-06T10:29:26.000000",
             "@timestamp_original": "2020.02.06.10:29:26",
             "benchmark": {
@@ -553,10 +553,10 @@ len(actions) = 16
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "3c18c27aa259d6baa77779b7abbe87d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-06",
         "_op_type": "create",
-        "_parent": "97c78db89beb4b9f01fa9cde60788e1d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T10:29:26.000000",
             "@timestamp_original": "2020.02.06.10:29:26",
@@ -583,11 +583,11 @@ len(actions) = 16
         "_type": "pbench-result-data"
     },
     {
-        "_id": "82787afd03c95b01d5165247e3b4d5ee",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2020-02-06T10:50:11.000000",
             "@timestamp_original": "2020.02.06.10:50:11",
             "benchmark": {
@@ -634,10 +634,10 @@ len(actions) = 16
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "8e68bedbfc4bc8e0f333145d09d3bd0b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2020-02-06",
         "_op_type": "create",
-        "_parent": "82787afd03c95b01d5165247e3b4d5ee",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2020-02-06T10:50:11.000000",
             "@timestamp_original": "2020.02.06.10:50:11",
@@ -678,7 +678,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b763e0d0d8c2e70a5a7584600103e5d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -717,7 +717,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -762,7 +762,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "c681838714c7a7de845c703a17453e06",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -792,7 +792,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.25.txt
+++ b/server/bin/gold/test-7.25.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2019-06 57
 len(actions) = 30
 [
     {
-        "_id": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "rhel8-1",
                 "file-date": "2020-04-29T00:29:37",
@@ -375,10 +375,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "12df1d10c75e2c22b5ce68888bbfe1ba",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "directory": "/",
@@ -440,10 +440,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "264471106623244fc7494eb2cda86b62",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "directory": "/1-tcp_stream-64B-1i",
@@ -500,10 +500,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a2b85009df4c2d3f837c144ecead4e17",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -562,10 +562,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3d995253ff62dd970beb926f8a40eeed",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -590,10 +590,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "dc5e4119c45b74bfa58b713f394ee187",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -609,10 +609,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c913c80dc42fb6e9cf4bc97f6cfb3df0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -629,10 +629,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1dc031ee1b59b6383a404cf3deaf8d03",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -649,10 +649,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c9a05867d664b29981b3012eb3c87ebe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -693,10 +693,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "04fdc0019ab10e166b4d20beefd21eae",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -713,10 +713,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "610f7eb30045385406c94448ea3dcc0f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -757,10 +757,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b78d2213574e6111e4395c910a6f9473",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -801,10 +801,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "68b44daaa04ee2ed70a0e8ba7dd017d0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -863,10 +863,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "daa9ae6a85ceb67cbeb9453918ab8bfd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -891,10 +891,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "830e1e964f67a2df8b74e509d17fad0f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2019-06",
         "_op_type": "create",
-        "_parent": "4b8da5832aa9c7c6a21dc74123b8968b",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:37.976771",
             "ancestor_path_elements": [
@@ -910,11 +910,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "43dd88aeb972da30a94c7de403530469",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2019-06-21T01:29:48.605000",
             "@timestamp_original": "1561080588605",
             "benchmark": {
@@ -969,10 +969,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "e5e2cf1392e0217e7533f2aafd082d35",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:48.605000",
             "@timestamp_original": "1561080588605",
@@ -1000,10 +1000,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "52bf43add5b8c31b54af9e3e1a07b86d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:49.606000",
             "@timestamp_original": "1561080589606",
@@ -1031,10 +1031,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "3de333746a3b13e6dffccac143db67b9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:50.607000",
             "@timestamp_original": "1561080590607",
@@ -1062,10 +1062,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "1302505ab26efe9a5d962f30bac9d181",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:51.608000",
             "@timestamp_original": "1561080591608",
@@ -1093,10 +1093,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "9527797e378307e82ef575b7e8a5356d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:52.609000",
             "@timestamp_original": "1561080592609",
@@ -1124,10 +1124,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "11e5c8e607c66e1978b1699f5ad6f543",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:53.610000",
             "@timestamp_original": "1561080593610",
@@ -1155,10 +1155,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6987117fea0968c8f48590a87442f092",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:54.611000",
             "@timestamp_original": "1561080594611",
@@ -1186,10 +1186,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "0d883766183dcb9220dc45d791761d3e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:55.612000",
             "@timestamp_original": "1561080595612",
@@ -1217,10 +1217,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "adddbbcf59f589d2b45c33ff31c83af4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:56.613000",
             "@timestamp_original": "1561080596613",
@@ -1248,10 +1248,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "92aab2c4cf5004250e41c16377000ae2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:57.614000",
             "@timestamp_original": "1561080597614",
@@ -1279,10 +1279,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "6e325ed4cd34ac299b1b35660f411557",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:58.615000",
             "@timestamp_original": "1561080598615",
@@ -1310,10 +1310,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c7eb2c4b5e781691c944f84b4027ff3b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:29:59.617000",
             "@timestamp_original": "1561080599617",
@@ -1341,10 +1341,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "c9948db2a60a2f7352453e05ac0b2eb9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:30:00.618000",
             "@timestamp_original": "1561080600618",
@@ -1372,10 +1372,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "b174c71dd8b76c60a760aa97c4960f91",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2019-06-21",
         "_op_type": "create",
-        "_parent": "43dd88aeb972da30a94c7de403530469",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2019-06-21T01:30:01.619000",
             "@timestamp_original": "1561080601619",
@@ -1417,7 +1417,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "dee5686d933125874a47989dd8754acf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1456,7 +1456,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1501,7 +1501,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "eab490a3573dab268ceb3eed683a278e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -1531,7 +1531,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.3.txt
+++ b/server/bin/gold/test-7.3.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,7 +76,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "56dd1aee00fdfea9a09538e1b3dc772c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -108,7 +108,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.4.txt
+++ b/server/bin/gold/test-7.4.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2015-09 5
 len(actions) = 5
 [
     {
-        "_id": "90c3fceba53c859d87ad66edfcc1154e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "alphaville",
                 "file-date": "2019-03-07T02:10:59",
@@ -127,10 +127,10 @@ len(actions) = 5
         "_type": "pbench-run"
     },
     {
-        "_id": "3e0e0de056e264e28e8c1006f056827a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "90c3fceba53c859d87ad66edfcc1154e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/",
@@ -150,10 +150,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a0a07434a3076bd42690746fc9b196af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "90c3fceba53c859d87ad66edfcc1154e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/sysinfo",
@@ -165,10 +165,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "955aaa81cd0dfd911547d68457b2718d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "90c3fceba53c859d87ad66edfcc1154e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -183,10 +183,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "c3cb43b5ae6ee4e2dbcc6feebed000d7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "90c3fceba53c859d87ad66edfcc1154e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -232,7 +232,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "723b4e112efe330670a2ad9eecae077f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -271,7 +271,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -316,7 +316,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "ed2932e69592ac954382c0a79e2e4be6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -346,7 +346,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.5.txt
+++ b/server/bin/gold/test-7.5.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2015-09 5
 len(actions) = 5
 [
     {
-        "_id": "d2e45bae5cee3e1936a07e3beaaf5f75",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "alphaville",
                 "file-date": "2019-03-07T02:11:33",
@@ -127,10 +127,10 @@ len(actions) = 5
         "_type": "pbench-run"
     },
     {
-        "_id": "1523e2e39c5ced4cfda51e51a0db379e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "d2e45bae5cee3e1936a07e3beaaf5f75",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/",
@@ -150,10 +150,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1574007cc661bf2c4bbc54866e9f0226",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "d2e45bae5cee3e1936a07e3beaaf5f75",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/sysinfo",
@@ -165,10 +165,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "0c2a995ecb907d1c569092ad968b29a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "d2e45bae5cee3e1936a07e3beaaf5f75",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -183,10 +183,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "db552e21492029e577d4963335ec8de0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "d2e45bae5cee3e1936a07e3beaaf5f75",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -232,7 +232,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "a090354c638c9c35401c4c19e4ee392c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -271,7 +271,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -316,7 +316,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "5d1e0f27443931ab894c9c66d6f7ddf3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -346,7 +346,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.6.txt
+++ b/server/bin/gold/test-7.6.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2015-09 5
 len(actions) = 5
 [
     {
-        "_id": "3a981319b66a844654ec964067b3850e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "alphaville",
                 "file-date": "2019-03-07T02:11:58",
@@ -128,10 +128,10 @@ len(actions) = 5
         "_type": "pbench-run"
     },
     {
-        "_id": "f80fc2b04b991d5e592b6803e79f7c90",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "3a981319b66a844654ec964067b3850e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/",
@@ -151,10 +151,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "96238f5130ff95c8b14421d73f319aed",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "3a981319b66a844654ec964067b3850e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/sysinfo",
@@ -166,10 +166,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "eda813a9535fac1b065b3c3957465b28",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "3a981319b66a844654ec964067b3850e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -184,10 +184,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "fe9b8472a4acc957088f1b51608e5f42",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "3a981319b66a844654ec964067b3850e",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -233,7 +233,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b42d83e048ccb1465d0852c7c8b41901",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -272,7 +272,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -317,7 +317,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fe09b65bac551b2599160e20961f378a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -347,7 +347,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.7.txt
+++ b/server/bin/gold/test-7.7.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2015-09 5
 len(actions) = 5
 [
     {
-        "_id": "8c30d803bae94ab735a54ddf4976700d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "alphaville",
                 "file-date": "2019-03-07T02:12:24",
@@ -128,10 +128,10 @@ len(actions) = 5
         "_type": "pbench-run"
     },
     {
-        "_id": "a87cfdad0a4736e375082b585388664d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "8c30d803bae94ab735a54ddf4976700d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/",
@@ -151,10 +151,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "4c6e3f58fd08f6f99ad0577e169a9b5d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "8c30d803bae94ab735a54ddf4976700d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "directory": "/sysinfo",
@@ -166,10 +166,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "2fb7ed5584f9ab9e77ed30203c9ef595",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "8c30d803bae94ab735a54ddf4976700d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -184,10 +184,10 @@ len(actions) = 5
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "32fd435a678045d14b11c23503c69d7e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2015-09",
         "_op_type": "create",
-        "_parent": "8c30d803bae94ab735a54ddf4976700d",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2015-09-21T19:31:12.673292",
             "ancestor_path_elements": [
@@ -233,7 +233,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "883805b7202845dcf239a92d3f678a19",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -272,7 +272,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -317,7 +317,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "a709dbc6ed22997da681993ad7e57fac",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -347,7 +347,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.8.txt
+++ b/server/bin/gold/test-7.8.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -77,11 +77,11 @@ Index:  pbench-unittests.v4.run.2016-10 63
 len(actions) = 30
 [
     {
-        "_id": "60440687c87a6f49cbb34653eae36c78",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "master_40gb",
                 "file-date": "2019-07-12T19:20:17",
@@ -356,10 +356,10 @@ len(actions) = 30
         "_type": "pbench-run"
     },
     {
-        "_id": "3663175c214650e42f56bd8934283460",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "directory": "/",
@@ -428,10 +428,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bda3aaaaa228fa3cb621273605412307",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "directory": "/1-tcp_stream-16384B-32i",
@@ -480,10 +480,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9ef1686429b646f90a2fb99563fa9118",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -535,10 +535,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "052d36c13bfeff1d1dc34b5a09c8540e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -563,10 +563,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "8c02a58d2eb3b9d75dcfb757fcba68e5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -582,10 +582,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "dd3da72a12214011e9f088ba9b900e59",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -602,10 +602,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a230ba3bcd2e5534fed71d805751e53b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -660,10 +660,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d8b1d31fb1b4c3d861195959acc7a257",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -733,10 +733,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "3e1a5e845847c6cbdd98ad9bc640f801",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1015,10 +1015,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ca034e78c50de1d9c2b3e4e8a78b2f8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1158,10 +1158,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "363b404b1a56012eecf5703f465d3d4e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1223,10 +1223,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "bd5acbb560e0f7b0573920f8b800b30d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1359,10 +1359,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "a74be58ad2c165e38da079c90a91edc3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1473,10 +1473,10 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7b5b4fa83e73db58d35163305464365e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2016-10",
         "_op_type": "create",
-        "_parent": "60440687c87a6f49cbb34653eae36c78",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:08.098427",
             "ancestor_path_elements": [
@@ -1560,11 +1560,11 @@ len(actions) = 30
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "9ba4c5824ce8d82e815c5f2280695539",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.472000",
             "@timestamp_original": "1475771657472",
             "benchmark": {
@@ -1618,10 +1618,10 @@ len(actions) = 30
         "_type": "pbench-result-data-sample"
     },
     {
-        "_id": "0bdf6e5e9f04c800e998ec620d832ef4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:17.472000",
             "@timestamp_original": "1475771657472",
@@ -1649,10 +1649,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "0cbcf3f9b740d598dc8e0136dd3f68c4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:18.473000",
             "@timestamp_original": "1475771658473",
@@ -1680,10 +1680,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "37d53dccbfe0eaeb70a9c202516cf396",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:19.474000",
             "@timestamp_original": "1475771659474",
@@ -1711,10 +1711,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "9bd799154fcd3375e587d25807e265b0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:20.475000",
             "@timestamp_original": "1475771660475",
@@ -1742,10 +1742,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "a30cee21cd601fa045bdb7a1c4772508",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:21.476000",
             "@timestamp_original": "1475771661476",
@@ -1773,10 +1773,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "4fedd134fc2ac2ddd2765f6123dc0f6f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:22.478000",
             "@timestamp_original": "1475771662478",
@@ -1804,10 +1804,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "beb0c0d8442cd498109c8902e8c58e88",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:23.479000",
             "@timestamp_original": "1475771663479",
@@ -1835,10 +1835,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "f0bc734784ea0e56b1ae8bab77750a5c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:24.480000",
             "@timestamp_original": "1475771664480",
@@ -1866,10 +1866,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "2c1dcdbb89338f8371ad6ff3700cc81b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:25.481000",
             "@timestamp_original": "1475771665481",
@@ -1897,10 +1897,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "23eefd96372e8400dd57877296e6b543",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:26.482000",
             "@timestamp_original": "1475771666482",
@@ -1928,10 +1928,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "84102fcd4c9f55b56fd0b62c644a5701",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:27.483000",
             "@timestamp_original": "1475771667483",
@@ -1959,10 +1959,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "f90be82faf367a24bc054de5f885a011",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:28.484000",
             "@timestamp_original": "1475771668484",
@@ -1990,10 +1990,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "ebcbf175df8b5f544ad459785057b29a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:29.485000",
             "@timestamp_original": "1475771669485",
@@ -2021,10 +2021,10 @@ len(actions) = 30
         "_type": "pbench-result-data"
     },
     {
-        "_id": "87698c1508c2fdd7e12e08e89a8bc2bc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.result-data.2016-10-06",
         "_op_type": "create",
-        "_parent": "9ba4c5824ce8d82e815c5f2280695539",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2016-10-06T16:34:30.486000",
             "@timestamp_original": "1475771670486",
@@ -2066,7 +2066,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "9a65f0235944f0ab690274472581f0ce",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2105,7 +2105,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -2142,11 +2142,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06 12
 len(actions) = 72
 [
     {
-        "_id": "a5543286212e204f9a8e9d60d7adeb62",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2194,11 +2194,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "90c4188f6ece57f8a67ba2e449205725",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2246,11 +2246,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "af3c161e6c3652286813bd429029a041",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -2298,11 +2298,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e1a81aed54716debae8aaad0c2d90421",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2350,11 +2350,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "3a991aee9724b8be2ad280f36a52dc5e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2402,11 +2402,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "c23defb79f03de61dde9770851d589f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -2454,11 +2454,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "fae9887b7d557affef777bdb3eed44b0",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2506,11 +2506,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "cc3cee7a8bbec17f8de7c4094b2a1bb1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2558,11 +2558,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8f7ef01eda2ef5a8ab3947615c9840b5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iostat": {
@@ -2610,11 +2610,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "0b54b316c4ed25a3a8f178874e9f4ed7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2654,11 +2654,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "9d47f261cb045d696024af7496a18f35",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2698,11 +2698,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1ef78b4c2fc6c65415089beaa71519d9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -2742,11 +2742,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "d97b4910acdae09166d34a00370e8df5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2786,11 +2786,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "a6e50296bb42d01cfd0af3b7eab2aa97",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2830,11 +2830,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "567548f8592eb96d5d9db125eea9a4a4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -2874,11 +2874,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "7bcaf972b365f1541aa1e2670edd650a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -2918,11 +2918,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "c3e79fa634b41ef1cfe38145c217a175",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -2962,11 +2962,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1455c706697ca5ba2432b7ac3c804aa8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3006,11 +3006,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "09f107dc3ddcc3c991844dbda8c72d13",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3050,11 +3050,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1496736064e9fa4e68eab5d43f625701",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -3094,11 +3094,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "a804ac3abe6cf1e521320217ceab1de5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3138,11 +3138,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "683e05417bde43f526ab43b41eea001d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3182,11 +3182,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "aa41347db6b77bc5c262b04bcd9d8dce",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iteration": {
@@ -3226,11 +3226,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "845139cf3fdfe8513cdf199e2369341e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.000000",
             "@timestamp_original": "1475771660000",
             "iteration": {
@@ -3270,11 +3270,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "1a97e136389ddc0615456d5c55ff6dc8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3322,11 +3322,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "1d9de3460da7256b2e553804d899b82e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3374,11 +3374,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "97b1fbd788628a9c21dd44255c1133bf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3426,11 +3426,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "4d76024517fcb06e4e80632fc2115040",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3478,11 +3478,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "d051586160db4d432db99d33445f0652",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3530,11 +3530,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "b226d61886bb1e2330556b9c614589d1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3582,11 +3582,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "a039aad34450de06e2648a675f12cbfa",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3634,11 +3634,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "3a4ddfc4c4a821797c789c888fe192b2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3686,11 +3686,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c1758d2ce137253aec1b226d6128d7ff",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3738,11 +3738,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "29e8c410e410805479b6ff4886d20961",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3790,11 +3790,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "349694d5f97d8158ee0c738938211201",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3842,11 +3842,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "8897bc0457507a3749485f5e2b191f2c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3894,11 +3894,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "d5fd7a0a65623b1c263bcc959c32f0af",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3946,11 +3946,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "67cea77e60e3e71c4a0bc9708baab9f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -3998,11 +3998,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "e77ff34f2afdb3d3b3a2aaba580c3d54",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iteration": {
@@ -4050,11 +4050,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "6bfc5bb6d382cfff95c4a3375fd95e84",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4086,11 +4086,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e4b94587f69f5a8af5685596761abeab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4122,11 +4122,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "28e98393a4fdd74b38749dfc77ec06ed",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4158,11 +4158,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6ceb77f2abb4e7b433fa7672ece55fd3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4194,11 +4194,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "87956016570ba4a2c3958c3754daba7a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4230,11 +4230,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "888e7ba87beb3ba7102b35934080da1a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4266,11 +4266,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "322501c7e5dba192c2b6d628fdd76ce7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4302,11 +4302,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "a68984ba6b2ea1f5b5e0e838f4d27bbc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4338,11 +4338,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "16dd71d9c7fd32a1aadea7c417c1c91d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4374,11 +4374,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "4d0eecc441abbc51da1ce34830d20088",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4410,11 +4410,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ee8684dfa38776dc111db7f9eea97407",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4446,11 +4446,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "f1b928f2c0b08e79ff2c7a262056b155",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4482,11 +4482,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "d0427351d417f92a659f35389a5fe7a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4518,11 +4518,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "6ecfed1d199ebb1d55b13478731d54c1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4554,11 +4554,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "ad261bdced4211fff65f505ecb8e32a9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.357526",
             "@timestamp_original": "1475771651.357526",
             "iteration": {
@@ -4590,11 +4590,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "0135af6e32545785a5ce7d3b98f4a1d4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.362084",
             "@timestamp_original": "1475771651.3620842",
             "iteration": {
@@ -4770,11 +4770,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "22cae70392cf580ed91dfe9227f23938",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.364391",
             "@timestamp_original": "1475771654.364391",
             "iteration": {
@@ -5098,11 +5098,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "6c1103dcc4d55705e94fdf28d78619d5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.366625",
             "@timestamp_original": "1475771657.3666246",
             "iteration": {
@@ -5426,11 +5426,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1a1fdfeede420763159652475b0ed360",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.368945",
             "@timestamp_original": "1475771660.3689446",
             "iteration": {
@@ -5754,11 +5754,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "47e64ca43747f65ea527c3b4fa06f554",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5806,11 +5806,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "2c6e9913b012e3a01e31d9732b061aa5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5858,11 +5858,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "06d83cd23f7c8248fbeee68906150d6f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.000000",
             "@timestamp_original": "1475771654000",
             "iostat": {
@@ -5910,11 +5910,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "65bb365a0eed0b23ea486412e3964f9a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -5962,11 +5962,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "1bdfe43b3959df2b8a9d51c55975ab3a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -6014,11 +6014,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "66e23cc7639ff9a4e41a2929cc1a064a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.000000",
             "@timestamp_original": "1475771657000",
             "iostat": {
@@ -6066,11 +6066,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "67662e4e2f02f5be912570c908ba690f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.404408",
             "@timestamp_original": "1475771651.4044082",
             "iteration": {
@@ -6246,11 +6246,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "a96b9d993981049ae678305b4bee7920",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.406617",
             "@timestamp_original": "1475771654.406617",
             "iteration": {
@@ -6574,11 +6574,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "c25c8e2a31e69725c63952b98a637aa3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.409022",
             "@timestamp_original": "1475771657.4090216",
             "iteration": {
@@ -6902,11 +6902,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "584421b1a104f9c587b9bd2edda7232b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.411393",
             "@timestamp_original": "1475771660.4113934",
             "iteration": {
@@ -7230,11 +7230,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "8e19822007df5d81bb8ce9b686abd888",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:11.066326",
             "@timestamp_original": "1475771651.0663261",
             "iteration": {
@@ -7410,11 +7410,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "ebb4c2f019d4ddaa652a536cc5671504",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:14.068630",
             "@timestamp_original": "1475771654.0686305",
             "iteration": {
@@ -7738,11 +7738,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "0216468ff1d823630c40c9a9db009828",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:17.071078",
             "@timestamp_original": "1475771657.0710783",
             "iteration": {
@@ -8066,11 +8066,11 @@ len(actions) = 72
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1d1625564a70d9b260a995b7245234a5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2016-10-06",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2016-10-06T16:34:20.073414",
             "@timestamp_original": "1475771660.0734138",
             "iteration": {
@@ -8408,7 +8408,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "041d36f8c79b2d4e5088778eee603662",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -8438,7 +8438,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-7.9.txt
+++ b/server/bin/gold/test-7.9.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b93953b18f6989015766c339934a6c8e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -43,7 +43,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8aab70198482b229b068fa82873f594f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -76,11 +76,11 @@ Index:  pbench-unittests.v4.run.2017-04 24
 len(actions) = 15
 [
     {
-        "_id": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "8aab70198482b229b068fa82873f594f",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@metadata": {
                 "controller_dir": "dhcp31-144",
                 "file-date": "2019-03-07T02:13:29",
@@ -150,10 +150,10 @@ len(actions) = 15
         "_type": "pbench-run"
     },
     {
-        "_id": "a840091364921c9d70756a7355d3f57c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "directory": "/",
@@ -180,10 +180,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "d0c6035fcccbda31d30e353229d29072",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "directory": "/1",
@@ -195,10 +195,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "1c3346ab941eddfb1b2a991cf22af127",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -222,10 +222,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "66bef871f9e9560d254e2bc9b2c1d5b7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -241,10 +241,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "12c227cb992d73161c2ca9cac6688029",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -261,10 +261,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "7e33b5c693b19f746c40fff8576d5914",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -319,10 +319,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "cf4cee24603cd52eb80d8ab5a2648fe5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -392,10 +392,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "cb78dfb81f7880a0231ef9f8efccc265",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -464,10 +464,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "ec418f48bf4d71b7b6f7548dca0f858b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -502,10 +502,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "91df82972dedee1dd07f5a5715643f7f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -567,10 +567,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "5f9eff7654429b57966aa1acbba6ffcf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -598,10 +598,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "adfedd4f979b9ba84ddbc1048f9d2954",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -712,10 +712,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b7d2c1a25805df26326e0a67151b34fd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -799,10 +799,10 @@ len(actions) = 15
         "_type": "pbench-run-toc-entry"
     },
     {
-        "_id": "b4534a5b74f0212ba4bf6cde8c3b3522",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v4.run.2017-04",
         "_op_type": "create",
-        "_parent": "e67f9a770c94850a06db9c4bbe7f1ff9",
+        "_parent": "babb1e70015c01055a15ca1ab1eb0a75",
         "_source": {
             "@timestamp": "2017-04-21T20:38:16.618515",
             "ancestor_path_elements": [
@@ -885,7 +885,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "4f1fc00ecfdca33e3e985b07a931b7d4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -924,7 +924,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "be2ab3a759dc3058c775a9475cbc9603",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -961,11 +961,11 @@ Index:  pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21 21
 len(actions) = 75
 [
     {
-        "_id": "a5134b8ff709fd3578c948889936f195",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iostat": {
@@ -1013,11 +1013,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "561e5b2aec9100afb3fa7260e954ce4f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iostat": {
@@ -1065,11 +1065,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "459ad832d523a3ff75e11ee9e61c360c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iostat": {
@@ -1117,11 +1117,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "4e2997cf3dd5663bae34e4aace7ba7a8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:24.000000",
             "@timestamp_original": "1492807104000",
             "iostat": {
@@ -1169,11 +1169,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "b1234fc22d68399439dc68498909d6a1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:24.000000",
             "@timestamp_original": "1492807104000",
             "iostat": {
@@ -1221,11 +1221,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "113b2d573314d073361c50a128c0ba3b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:24.000000",
             "@timestamp_original": "1492807104000",
             "iostat": {
@@ -1273,11 +1273,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "e12154edd606635a8aa59fa2b12e81d9",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:27.000000",
             "@timestamp_original": "1492807107000",
             "iostat": {
@@ -1325,11 +1325,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "98aa032bd7dc436796d237e6dbd7123b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:27.000000",
             "@timestamp_original": "1492807107000",
             "iostat": {
@@ -1377,11 +1377,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "13cbb4f5d6b491937436bd67ad68a185",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:27.000000",
             "@timestamp_original": "1492807107000",
             "iostat": {
@@ -1429,11 +1429,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "d25d703cb0bec79dbc21228cb031484b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:30.000000",
             "@timestamp_original": "1492807110000",
             "iostat": {
@@ -1481,11 +1481,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "cfd34c117215cae72d4167e5bd3bffa4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:30.000000",
             "@timestamp_original": "1492807110000",
             "iostat": {
@@ -1533,11 +1533,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "3ff84acbc7179a9646559118c5e5222d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:30.000000",
             "@timestamp_original": "1492807110000",
             "iostat": {
@@ -1585,11 +1585,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "b24cc3d16193467520ea7ca88fa14e7f",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:33.000000",
             "@timestamp_original": "1492807113000",
             "iostat": {
@@ -1637,11 +1637,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "8a3f852658293d6a2fcc7875e32f9fdb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:33.000000",
             "@timestamp_original": "1492807113000",
             "iostat": {
@@ -1689,11 +1689,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "6c36314caedeac9665dd99c88c78bb58",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-iostat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:33.000000",
             "@timestamp_original": "1492807113000",
             "iostat": {
@@ -1741,11 +1741,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-iostat"
     },
     {
-        "_id": "13d16fe1273e3d76ed9affda351bcbdf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -1785,11 +1785,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "84b511042402873300b613d413794151",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:24.000000",
             "@timestamp_original": "1492807104000",
             "iteration": {
@@ -1829,11 +1829,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "089c0d6c1ddfc423f46584111cedf616",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:27.000000",
             "@timestamp_original": "1492807107000",
             "iteration": {
@@ -1873,11 +1873,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "9b616b54ca4b44e5c3f17988b2a3f0b5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:30.000000",
             "@timestamp_original": "1492807110000",
             "iteration": {
@@ -1917,11 +1917,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "a0dcd9f640112b5b7c6622e47a62ce42",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:33.000000",
             "@timestamp_original": "1492807113000",
             "iteration": {
@@ -1961,11 +1961,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "bff5dd55b2bea2944de91c1aef12c4ce",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:36.000000",
             "@timestamp_original": "1492807116000",
             "iteration": {
@@ -2005,11 +2005,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "c145613188c1366d763a0c61b21232da",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:39.000000",
             "@timestamp_original": "1492807119000",
             "iteration": {
@@ -2049,11 +2049,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "aa41f6275eae6648b7106a4096e2ea24",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:42.000000",
             "@timestamp_original": "1492807122000",
             "iteration": {
@@ -2093,11 +2093,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "dcacafd0eaf6ca038fd38277cca208d2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:45.000000",
             "@timestamp_original": "1492807125000",
             "iteration": {
@@ -2137,11 +2137,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "9f02504a8b8881001f716a9fa9e51c3a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:48.000000",
             "@timestamp_original": "1492807128000",
             "iteration": {
@@ -2181,11 +2181,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "8ea03ab37d830b888db18672f719e9e4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:51.000000",
             "@timestamp_original": "1492807131000",
             "iteration": {
@@ -2225,11 +2225,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "164cd22925c48f9bb4595ee74aab72d2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:54.000000",
             "@timestamp_original": "1492807134000",
             "iteration": {
@@ -2269,11 +2269,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "60f5c9bb9cfa66009ce8116e395bb9a3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:57.000000",
             "@timestamp_original": "1492807137000",
             "iteration": {
@@ -2313,11 +2313,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "85096238e3f3965a376a754a06a3eaf5",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:39:00.000000",
             "@timestamp_original": "1492807140000",
             "iteration": {
@@ -2357,11 +2357,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "09fa41afb23314ee1ca9617771813965",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-mpstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:39:03.000000",
             "@timestamp_original": "1492807143000",
             "iteration": {
@@ -2401,11 +2401,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-mpstat"
     },
     {
-        "_id": "13f46a9782ee4df6cc16c8f5042654ea",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2453,11 +2453,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "84eb11246b29a85e79da474a16c7b18d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2505,11 +2505,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "75a9e5ec05436d299f7f40c8da7b9a14",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2557,11 +2557,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "227e0f6c31bf381676926ec894cc684a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2609,11 +2609,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "1c337d2a41b717cdcc470ef29d3ce37d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2661,11 +2661,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "0c394cc7040bc981fb7f9d7976a15723",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2713,11 +2713,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "0ddf279a2c8a0c542a7fad7ab384ab59",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2765,11 +2765,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "f5963f899dd9ec94b5381c530a1e3ae3",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2817,11 +2817,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "75689026d78cd79fb6187b029efc9def",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2869,11 +2869,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "8c40b68cfd917ed80aac3fd83d07e4bd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2921,11 +2921,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "c9278eab6af9cda5e485916062cff3b6",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -2973,11 +2973,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "780d6747f612ce48e4d956fac0f14dd4",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -3025,11 +3025,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "b0f38331df3ffe6361a1c438c93567b1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -3077,11 +3077,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "81c0a75986dff9e0b261436257f8e0f8",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -3129,11 +3129,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "1e355f83861746fcba8f922d3dd6afcd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-pidstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.000000",
             "@timestamp_original": "1492807101000",
             "iteration": {
@@ -3181,11 +3181,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-pidstat"
     },
     {
-        "_id": "b38188bd1e776b5b172042055adc6230",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3217,11 +3217,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "7050f6a08ba7890a955ec04e75b397f7",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3253,11 +3253,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "41f4b2e4781a28a33836068c2a80fb14",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3289,11 +3289,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "23ff5443f542e21caa1d309f2ae2a16b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3325,11 +3325,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "c07a458a3c75fe2c0b262529f2be3ffe",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3361,11 +3361,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "47b2934c6345486888d790d1ddef3314",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3397,11 +3397,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "41286bdf89ad8be61a01bb7baff0f736",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3433,11 +3433,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e56c86b5e6ee50a96ae748d92f3cb0cc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3469,11 +3469,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e344638d99a4e2e4e21ea6c985996a55",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3505,11 +3505,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "a6f82326d793a6bdca3e1d34a9b6478a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3541,11 +3541,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "99d2d04c9b793affd39a73ccc5aaeaa2",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3577,11 +3577,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "1f9bd20343d42ed0b0a9963f94026a3c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3613,11 +3613,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "e7c2c735904c43ac88dd38bc5be2bd33",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3649,11 +3649,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "9a2879cde57047d61c5dec859e394a86",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3685,11 +3685,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "2df7a2ff1f7735a02c9b085448e9ee44",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-interrupts.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.712981",
             "@timestamp_original": "1492807098.7129807",
             "iteration": {
@@ -3721,11 +3721,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-interrupts"
     },
     {
-        "_id": "d5b5716a6cf9aef467bb87eb682fefb1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:18.750093",
             "@timestamp_original": "1492807098.7500932",
             "iteration": {
@@ -3916,11 +3916,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1cccb2b655653d0bd210b9486acbc622",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:21.764053",
             "@timestamp_original": "1492807101.7640526",
             "iteration": {
@@ -4274,11 +4274,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5d73aec6eab8d8077f67c8300e9b713c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:24.766978",
             "@timestamp_original": "1492807104.7669783",
             "iteration": {
@@ -4632,11 +4632,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "1b32388a044c29197a5072d74da3346c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:27.769841",
             "@timestamp_original": "1492807107.7698412",
             "iteration": {
@@ -4990,11 +4990,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "8794c8b26192e1fe600c59321a197b9b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:30.772685",
             "@timestamp_original": "1492807110.7726846",
             "iteration": {
@@ -5348,11 +5348,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "e00d5ae62d901cebc67beef916351a4c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:33.775501",
             "@timestamp_original": "1492807113.7755005",
             "iteration": {
@@ -5706,11 +5706,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "f63288f0ad4e128563f251de912d8370",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:36.778382",
             "@timestamp_original": "1492807116.7783818",
             "iteration": {
@@ -6064,11 +6064,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "220962513cbb7d74c04314b46b4c2777",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:39.781260",
             "@timestamp_original": "1492807119.7812595",
             "iteration": {
@@ -6422,11 +6422,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "bd35f57047aed5dc135b2f51d0c8341a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:42.784167",
             "@timestamp_original": "1492807122.7841673",
             "iteration": {
@@ -6780,11 +6780,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "f4ca5a0639b7841e035fdf329be4ed0c",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:45.787123",
             "@timestamp_original": "1492807125.787123",
             "iteration": {
@@ -7138,11 +7138,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "6e7d980c6b99a00ece5d2756c9cad594",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:48.790011",
             "@timestamp_original": "1492807128.790011",
             "iteration": {
@@ -7496,11 +7496,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5133fb00cbe6f48a111dfe602e388ebd",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:51.792787",
             "@timestamp_original": "1492807131.7927866",
             "iteration": {
@@ -7854,11 +7854,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "a6b999527647d019b9cea2272fe37061",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:54.795752",
             "@timestamp_original": "1492807134.7957523",
             "iteration": {
@@ -8212,11 +8212,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "57c91a50f7247113e33d325fbc5bb491",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:38:57.805671",
             "@timestamp_original": "1492807137.8056715",
             "iteration": {
@@ -8570,11 +8570,11 @@ len(actions) = 75
         "_type": "pbench-tool-data-proc-vmstat"
     },
     {
-        "_id": "5a6a899f7011afb186b7b65d4df24b66",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.tool-data-proc-vmstat.2017-04-21",
         "_op_type": "create",
         "_source": {
-            "@generated-by": "be2ab3a759dc3058c775a9475cbc9603",
+            "@generated-by": "70015f01dedbadbeefc105edcafedead",
             "@timestamp": "2017-04-21T20:39:00.808738",
             "@timestamp_original": "1492807140.808738",
             "iteration": {
@@ -8942,7 +8942,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "b2ddc630a885368139736938f7e5c50a",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -8972,7 +8972,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-8.txt
+++ b/server/bin/gold/test-8.txt
@@ -79,7 +79,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.1.txt
+++ b/server/bin/gold/test-9.1.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "64163da53f2e6379fe9b7bf83095443b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.2.txt
+++ b/server/bin/gold/test-9.2.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "8a2d544bd79ddb6ed5d5752457a033eb",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "997079dc4552b5d2147887fe3778d536",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.3.txt
+++ b/server/bin/gold/test-9.3.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "89154e751dd901704d122df206931f9b",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "1adcfd53bc5efd9eb52db3dddaf0be65",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.4.txt
+++ b/server/bin/gold/test-9.4.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "7a480cb3acc3f33681f96a41b7467f35",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "36142a603021d1d0c429ff5cc4e13fdf",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.5.txt
+++ b/server/bin/gold/test-9.5.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "107addcae31d654660ba07c6291bdbe1",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "223861676c598cba31653e2a6ca013cc",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.6.txt
+++ b/server/bin/gold/test-9.6.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "80989909329ec9f87ce201890d37d57e",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "15b2486de8e7b8e23b5c09b8fc1babab",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.7.txt
+++ b/server/bin/gold/test-9.7.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "454ba7cef801bb049eec3d7552c10f3d",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/gold/test-9.8.txt
+++ b/server/bin/gold/test-9.8.txt
@@ -4,7 +4,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "3b68a3c52146af0da944c13933786c98",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {
@@ -34,7 +34,7 @@ Index:  pbench-unittests.v3.server-reports.1970-01 1
 len(actions) = 1
 [
     {
-        "_id": "fb8eea157f633b56122a0db0334f1218",
+        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
         "_index": "pbench-unittests.v3.server-reports.1970-01",
         "_op_type": "create",
         "_source": {

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -121,7 +121,7 @@ function _local_find {
 
 function _normalize_output {
     # Fix up tmp directory references
-    sed 's;tmp/pbench-\([-a-zA-Z0-9]*\)\.[0-9][0-9]*/;tmp/pbench-\1.NNNN/;' $*
+    sed -E -e 's;tmp/pbench-([-a-zA-Z0-9]+)\.[0-9][0-9]*/;tmp/pbench-\1.NNNN/;' $*
 }
 
 function _save_tree {
@@ -212,17 +212,27 @@ function _dump_logs {
 }
 
 function _verify_output {
-    tname=$1
-    diff -c $_tdir/gold/${tname}.txt $_testout > $_testdiff 2>&1
-    if [[ $? -gt 0 ]]; then
+    tname=${1}
+    # Fix up "_id", "_parent", and "@generated-by" IDs using:
+    #   * 5ca1ab1e70015f100dedfab1ed0ff1ce
+    #    "scalable tools flooded fabled office"
+    #   * babb1e70015c01055a15ca1ab1eb0a75
+    #    "babble tools colossal scalable boats"
+    #   * 70015f01dedbadbeefc105edcafedead
+    #    "tools folded bad beef closed cafe dead"
+    sed -i -E -e 's/"_id": "[0-9a-f]+",/"_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",/' \
+              -e 's/"_parent": "[0-9a-f]+",/"_parent": "babb1e70015c01055a15ca1ab1eb0a75",/' \
+              -e 's/"@generated-by": "[0-9a-f]+",/"@generated-by": "70015f01dedbadbeefc105edcafedead",/' ${_testout}
+    diff -c ${_tdir}/gold/${tname}.txt ${_testout} > ${_testdiff} 2>&1
+    if [[ ${?} -gt 0 ]]; then
         let res=1
-        echo "FAIL" > $_testres
+        echo "FAIL" > ${_testres}
     else
         let res=0
-        echo "PASS" > $_testres
-        rm $_testout $_testdiff
+        echo "PASS" > ${_testres}
+        rm ${_testout} ${_testdiff}
     fi
-    return $res
+    return ${res}
 }
 
 function _setup_state {
@@ -304,7 +314,7 @@ function _setup_state {
     export PATH=$_testopt/unittest-scripts:$_testopt/bin:$PATH
     export PYTHONPATH="${_testopt}/lib:${_testopt}/common/lib:${PYTHONPATH}"
 
-    # Expected location of the final configuration files 
+    # Expected location of the final configuration files
     export _PBENCH_SERVER_CONFIG=$_testopt/lib/config/pbench-server.cfg
     export LOGSDIR=$_testdir_local/logs
     export SATCONFIG=$_testopt_sat/lib/config/pbench-server.cfg
@@ -734,13 +744,13 @@ declare -A cmds=(
     [test-26.1]="_run test_logger_type.py"
 
     # Test to Log messages on devlog
-    [test-26.2]="_run test_logger_type.py" 
+    [test-26.2]="_run test_logger_type.py"
 
     # Test to check error when logger_port and logger_host are not provided with hostport
     [test-26.3]="_run test_logger_type.py"
 
     # Test to Log messages on hostport with logger-host and logger_port
-    [test-26.4]="_run test_logger_type.py"  
+    [test-26.4]="_run test_logger_type.py"
 
 )
 all_tests_sorted=$(for x in ${!cmds[@]} ;do echo $x ;done | sed 's/\./-/' | sort -n -t '-' -k 3 | sort -n -t '-' -k 2 --stable | sed 's/\(.*-[0-9]\+\)-\([0-9]\+\)/\1.\2/')


### PR DESCRIPTION
This was performed by using the following `sed` commands on all the gold files:

```
$ sed -i -E \
-e 's/"(_id)": "[0-9a-f]+",/"\1": "5ca1ab1e70015f100dedfab1ed0ff1ce",/' \
-e 's/"(_parent)": "[0-9a-f]+",/"\1": "babb1e70015c01055a15ca1ab1eb0a75",/' \
-e 's/"(@generated-by)": "[0-9a-f]+",/"\1": "70015f01dedbadbeefc105edcafedead",/' \
gold/test-*.txt`
```