### PR TITLE
Fix new linting errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist
 .yarnrc
 *.egg-info
 .tox
+.eggs

--- a/lib/configtools/__init__.py
+++ b/lib/configtools/__init__.py
@@ -9,11 +9,11 @@ from configparser import ConfigParser
 from optparse import OptionParser, make_option
 
 
-def uniq(l):
+def uniq(alist):
     # uniquify the list without scrambling it
     seen = set()
     seen_add = seen.add
-    return [x for x in l if x not in seen and not seen_add(x)]
+    return [el for el in alist if el not in seen and not seen_add(el)]
 
 
 def file_list(root):
@@ -168,8 +168,8 @@ def get(conf, option, sections):
     return None
 
 
-def print_list(l, sep):
-    print(sep.join([str(x) for x in l]))
+def print_list(alist, sep):
+    print(sep.join([str(el) for el in alist]))
 
 
 options = [

--- a/run-unittests
+++ b/run-unittests
@@ -1,4 +1,35 @@
 #!/bin/bash
 
-tox -e server
-tox -e agent
+prog="$(basename "${0}")"
+progdir="$(realpath -e $(dirname "${0}"))"
+
+# List of tox environments to run.
+tox_envs="lint agent server"
+
+for toxenv in ${tox_envs}; do
+    if [[ -d ${progdir}/.tox/${toxenv} ]]; then
+        rm -r ${progdir}/.tox/${toxenv}
+    fi
+done
+
+typeset -i errors=0
+for toxenv in ${tox_envs}; do
+    printf -- "#+++ (tox -e %s)\n" "${toxenv}"
+    tox -e ${toxenv}
+    tox_status=${?}
+    if [[ ${tox_status} -ne 0 ]]; then
+        printf -- "#--- (FAILED: %d)\n" "${tox_status}"
+        (( errors++ ))
+    else
+        printf -- "#--- (SUCCESS)\n"
+    fi
+    printf -- "\n\n"
+done
+
+if [[ ${errors} -gt 0 ]]; then
+    printf -- "\n\nUnit tests failed! (%d errors)\n" ${errors}
+    exit 1
+else
+    printf -- "\n\nUnit tests succeeded.\n"
+    exit 0
+fi

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -453,7 +453,7 @@ def main(options):
             file=tfp,
         )
         if total > 0:
-            print(f"\nActions Taken:", file=tfp)
+            print("\nActions Taken:", file=tfp)
         for act_set in actions_taken:
             print(
                 f"  - {act_set.name} ({act_set.errors:d} errors,"

--- a/server/lib/pbench/indexer.py
+++ b/server/lib/pbench/indexer.py
@@ -3555,13 +3555,13 @@ def search_by_ip(sos_d_list, ip):
             host_f = sos_d["hostname-f"]
         except KeyError:
             continue
-        for l in sos_d.values():
-            if not isinstance(l, list):
+        for el in sos_d.values():
+            if not isinstance(el, list):
                 continue
-            for d in l:
-                if not isinstance(d, dict):
+            for sub_el in el:
+                if not isinstance(sub_el, dict):
                     continue
-                if ip == d["ipaddr"]:
+                if ip == sub_el["ipaddr"]:
                     return host_f
     return None
 

--- a/server/lib/pbench/mock.py
+++ b/server/lib/pbench/mock.py
@@ -55,7 +55,7 @@ class _MockPutTemplate(object):
         name = kwargs["name"]
         assert (
             name not in self.mock_collected_templates
-        ), "Duplicate template name, '{}'".format(name, self.name)
+        ), f"Duplicate template name, '{name}'"
         self.mock_collected_templates[name] = kwargs["body"]
         return None
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,11 @@ whitelist_externals =
 
 [testenv:server]
 usedevelop = true
+passenv = PBENCH_UNITTEST_SERVER_MODE
 commands_pre = 
   find {toxinidir} -type f -not -path '{toxinidir}/.tox/*' -path '*/__pycache__/*' -name '*.py[c|o]' -delete
 commands =
-  bash -c "./server/bin/unittests"
+  bash -c "./server/bin/unittests {posargs}"
 
 [testenv:agent]
 usedevelop = true


### PR DESCRIPTION
We also modify `run-unittests` to run all the tox tests and linting, properly removing old tox environments before the runs.