### PR TITLE
Reduce false positives for prefixes from audit

### DIFF
--- a/server/bin/pbench-audit-server.sh
+++ b/server/bin/pbench-audit-server.sh
@@ -360,7 +360,9 @@ function verify_results {
                     prefix_file="$ARCHIVE/${controller}/.prefix/${tb}.prefix"
                     # Version 002 agents use the metadata log to store a
                     # prefix.
-                    prefix=$(getconf.py -C $INCOMING/${controller}/${tb}/metadata.log prefix run)
+                    __prefix=$(getconf.py -C $INCOMING/${controller}/${tb}/metadata.log prefix run)
+                    _prefix=${__prefix#/}
+                    prefix=${_prefix%/}
                     if [[ "${prefix_path}" == "." ]]; then
                         # No prefix, ensure it doesn't have a prefix in the
                         # metadata.log file or in a prefix file.


### PR DESCRIPTION
Some tar ball have a `metadata.log` file where the user specified the prefix using either a leading or a trailing slash (or both).  We remove those slashes first before comparing against the actual prefix found.