### PR TITLE
Setup results-host-info: do not create obsolete -001 structures.

### DIFF
--- a/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
@@ -15,7 +15,6 @@
     group: "{{ pbench_group }}"
     mode:  0444
   with_items:
-    - "001"
     - "002"
 
 - name: "set up maint files"
@@ -26,7 +25,6 @@
     group: "{{ pbench_group }}"
     mode:  0444
   with_items:
-    - "001"
     - "002"
 
 - name: "set up links to the active files"
@@ -35,5 +33,4 @@
     src:  "{{ pbench_host_info_prefix | basename }}{{ item }}.active"
     state: link
   with_items:
-    - "001"
     - "002"


### PR DESCRIPTION
The -001 structures stopped being produced from the pbench-agent (see
PR #1302) since v0.65 (Sep. 2019). It is about time to get rid of those
structures from the server.