### PR TITLE
Modify the config install action to work with ssh

### DIFF
--- a/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
@@ -4,11 +4,37 @@
 # are specified in the default vars of this role, but can be overridden
 # (if necessary) by specifying them in the inventory file.
 
-- name: install the config file
+- name: create temp dir to store the config locally
+  delegate_to: localhost
+  tempfile:
+    state: directory
+    prefix: "{{ inventory_hostname }}-"
+  register: tempdir_1
+
+- name: relax perms
+  delegate_to: localhost
+  file:
+    path: "{{ tempdir_1.path }}"
+    mode: 0755
+
+- name: install the config file locally
+  delegate_to: localhost
   get_url:
     url: "{{ pbench_config_url }}/{{ item }}"
+    dest: "{{ tempdir_1.path }}/{{ item }}"
+  with_items: "{{ pbench_config_files }}"
+
+- name: copy the config file to the remote
+  copy:
+    src:  "{{ tempdir_1.path }}/{{ item }}"
     dest: "{{ pbench_server_config_dest }}"
     mode: 0444
     owner: "{{ pbench_owner }}"
     group: "{{ pbench_group }}"
   with_items: "{{ pbench_config_files }}"
+
+- name: delete local temp dir
+  delegate_to: localhost
+  file:
+    state: absent
+    path: "{{ tempdir_1.path }}"


### PR DESCRIPTION
Instead of having the remotes use getURL to fetch their config files
(which is not always possible, e.g. if the remote is outside the
firewall), fetch the config files locally and store them under a
temporary directory, named partially after the inventory hostname, and
then copy them using ssh to the remotes.

The assumption is that the ansible control machine is inside the
firewall, so it can use getURL to fetch the config files, but it can
also ssh to the remotes to copy the file(s), even if (some of) the
remotes are outside the firewall.