### PR TITLE
Fix user-benchmark data indexing for dashboard

### DIFF
--- a/server/bin/gold/test-7.24.txt
+++ b/server/bin/gold/test-7.24.txt
@@ -543,11 +543,16 @@ len(actions) = 16
                 },
                 "closest_sample": 1,
                 "end": "2020-02-06T10:46:32.000000",
+                "mean": 382109,
                 "measurement_idx": 0,
                 "measurement_title": "Tpm",
                 "measurement_type": "number",
                 "name": "sample1",
-                "start": "2020-02-06T10:29:26.000000"
+                "role": "n/a",
+                "start": "2020-02-06T10:29:26.000000",
+                "stddev": 0,
+                "stddevpct": 0,
+                "uid": "1-10U"
             }
         },
         "_type": "pbench-result-data-sample"
@@ -624,11 +629,16 @@ len(actions) = 16
                 },
                 "closest_sample": 1,
                 "end": "2020-02-06T11:07:16.000000",
+                "mean": 657043,
                 "measurement_idx": 0,
                 "measurement_title": "Tpm",
                 "measurement_type": "number",
                 "name": "sample1",
-                "start": "2020-02-06T10:50:11.000000"
+                "role": "n/a",
+                "start": "2020-02-06T10:50:11.000000",
+                "stddev": 0,
+                "stddevpct": 0,
+                "uid": "2-20U"
             }
         },
         "_type": "pbench-result-data-sample"

--- a/server/lib/pbench/indexer.py
+++ b/server/lib/pbench/indexer.py
@@ -1350,6 +1350,17 @@ class ResultData(PbenchData):
                 sample_md = dict()
                 sample_md.update(base_sample_md)
                 sample_md["closest_sample"] = sample_obj.number
+                # There is only one row with a value, so it is also the mean, which
+                # also means there is zero standard deviation or standard deviation
+                # percent.
+                sample_md["mean"] = value = methods[columns[val_col]](row[val_col])
+                sample_md["stddev"] = 0
+                sample_md["stddevpct"] = 0
+                # We re-use the iteration name as the UID for the sample, since we
+                # only ever have one sample per iteration for user benchmark runs.
+                sample_md["uid"] = iter_obj.name
+                # The notion of role is not applicable to a user benchmark sample.
+                sample_md["role"] = "n/a"
                 start_time = self._normalize_timestamp(ts_format, row[start_ts_col])
                 sample_md["start"] = start_time
                 if end_ts_col:
@@ -1388,9 +1399,7 @@ class ResultData(PbenchData):
                 # Construct the result-data document.
                 sample_md = base_sample_md
                 # Add val columns
-                result = _dict_const(
-                    [("@idx", 0), ("value", methods[columns[val_col]](row[val_col]))]
-                )
+                result = _dict_const([("@idx", 0), ("value", value)])
                 source = _dict_const(
                     [
                         ("@timestamp", start_time),


### PR DESCRIPTION
The pbench dashboard expects a few additional fields that were not originally provided when indexing user-benchmark data.