### PR TITLE
Fix server ansible roles.

### DIFF
--- a/server/ansible/Inventory/pbench-server.hosts.example
+++ b/server/ansible/Inventory/pbench-server.hosts.example
@@ -3,19 +3,25 @@
 # combinations of RHEL7, RHEL8, or (supported) Fedora
 # versions. Installing on more than one server (e.g.  on a master as
 # well as a satellite server) is possible by overriding variables
-# per host (e.g. satellite servers do not do backups, so the variable
-# `configfiles' can be redefined to contain just one element).
+# per host.
 
 [servers]
 <pbench-server-host>
-<pbench-server-satellite-host>   pbench_config_files='["pbench-server.cfg"]'
+<pbench-server-satellite-host> cenv=satellite
 
 [servers:vars]
+
+# Where the RPMs are built - this is not a real account - make your own.
+
+# This is used to create the /etc/yum.repos.d/pbench.repo file.
+pbench_repo_url_prefix = https://copr-be.cloud.fedoraproject.org/results/some_fedora_copr_user
+
 # pbench_config_url should be set once for a new environment by an administrator
 # to provide access to the config files for whatever server environment(s)
 # are needed.
-# from where to fetch config files
+
+# This tells where to fetch config files from.
 pbench_config_url = http://pbench.example.com/server/config/{{ cenv }}
 
-# list of config files to fetch
+# List of config files to fetch.
 pbench_config_files = '["pbench-server.cfg"]'

--- a/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Clean yum cache
+  command: yum clean all
+

--- a/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -2,3 +2,9 @@
 - name: Clean yum cache
   command: yum clean all
 
+- name: Delete /var/yum/cache directory
+  file:
+    path: /var/yum/cache
+    state: absent
+
+

--- a/server/ansible/roles/pbench-server-change-ownership/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-change-ownership/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Change ownership of the installed tree
+  file:
+    path: "{{ pbench_server_install_dir }}"
+    state: directory
+    recurse: yes
+    owner: "{{ pbench_owner }}"
+    group: "{{ pbench_group }}"
+

--- a/server/ansible/roles/pbench-server-config/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-config/tasks/main.yml
@@ -19,3 +19,5 @@
     name: pbench-server-activate-httpd-setup-restart
 - import_role:
     name: pbench-server-add-commit-id
+- import_role:
+    name: pbench-server-change-ownership

--- a/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
@@ -28,9 +28,9 @@
   copy:
     src:  "{{ tempdir_1.path }}/{{ item }}"
     dest: "{{ pbench_server_config_dest }}"
-    mode: 0444
-    owner: "{{ pbench_owner }}"
-    group: "{{ pbench_group }}"
+    mode: 0644
+    owner: root
+    group: root
   with_items: "{{ pbench_config_files }}"
 
 - name: delete local temp dir

--- a/server/ansible/roles/pbench-server-install/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - import_role:
-    pbench-clean-yum-cache
+    name: pbench-clean-yum-cache
 
 - name: ensure the pbench-server RPM is installed
   package:

--- a/server/ansible/roles/pbench-server-install/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- import_role:
+    pbench-clean-yum-cache
+
 - name: ensure the pbench-server RPM is installed
   package:
     name: pbench-server

--- a/server/ansible/roles/pbench-server-user/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-user/tasks/main.yml
@@ -36,3 +36,10 @@
 
 - name: restore SELinux context
   command: restorecon -R -v /home/{{ pbench_user }}/.ssh
+
+- name: change ownership of config file(s) now that we have a user
+  file:
+    path: "{{ pbench_server_config_dest }}/{{ item }}"
+    owner: "{{ pbench_user }}"
+    group: "{{ pbench_group }}"
+  with_items: "{{ pbench_config_files }}"

--- a/server/ansible/roles/pbench-server-user/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-user/tasks/main.yml
@@ -27,3 +27,12 @@
     owner: "{{ pbench_user }}"
     group: "{{ pbench_group }}"
     state: directory
+
+- name: set SELinux context on /home/<pbench>/.ssh
+  sefcontext:
+    target: /home/{{ pbench_user }}/.ssh
+    setype: ssh_home_t
+    state: present
+
+- name: restore SELinux context
+  command: restorecon -R -v /home/{{ pbench_user }}/.ssh


### PR DESCRIPTION
pbench-clean-yum-cache role: (new)
Add a pbench-clean-yum-cache role: the ansible package module is not
always successful in updating to the latest package, particularly on RHEL7
boxes. This is an attempt to help it do that, but it remains to be seen how
effective it is.

pbench-server-install role:
Import the pbench-clean-yum-cache role so that it is executed before we try
to install/update packages.

pbench-server-user role:
Add some  SELinux settings to the /home/<pbench>/.ssh directory.

Fix comments and add pbench_repo_url_prefix variable to the inventory example
file.