### PR TITLE
Fixes to ansible playbooks/roles

### DIFF
--- a/agent/ansible/Inventory/pbench-agent.hosts.example
+++ b/agent/ansible/Inventory/pbench-agent.hosts.example
@@ -16,12 +16,12 @@ host3       ansible_python_interpreter=/usr/bin/python3
 pbench_repo_url_prefix = https://copr-be.cloud.fedoraproject.org/results/<EXAMPLE_USER>
 
 # where to get the key
-pbench_key_url = http://EXAMPLE.COM/PATH/TO/agent/{{ cenv }}/ssh
+pbench_key_url = http://EXAMPLE.COM/PATH/TO/agent/{{ pbench_configuration_environment }}/ssh
 # where to put it
 pbench_key_dest = /opt/pbench-agent/
 
 # where to get the config file
-pbench_config_url = http://EXAMPLE.COM/PATH/TO/agent/{{ cenv }}/config
+pbench_config_url = http://EXAMPLE.COM/PATH/TO/agent/{{ pbench_configuration_environment }}/config
 # where to put it
 pbench_config_dest = /opt/pbench-agent/config/
 

--- a/agent/ansible/pbench-agent-config.yml
+++ b/agent/ansible/pbench-agent-config.yml
@@ -5,6 +5,11 @@
   become: yes
   become_user: root
 
+  # The default value ('production') can be overriddent by cenv, a host-specific
+  # inventory variable.
+  vars:
+    pbench_configuration_environment: "{{ cenv | 'production' }}"
+
   roles:
     - pbench-agent-config-install
     - pbench-agent-key-install

--- a/agent/ansible/pbench-agent-install.yml
+++ b/agent/ansible/pbench-agent-install.yml
@@ -5,6 +5,11 @@
   become: yes
   become_user: root
 
+  # The default value ('production') can be overriddent by cenv, a host-specific
+  # inventory variable.
+  vars:
+    pbench_configuration_environment: "{{ cenv | 'production' }}"
+
   roles:
     - pbench-repo-install
     - pbench-agent-install

--- a/agent/ansible/roles/pbench-agent-install/tasks/main.yml
+++ b/agent/ansible/roles/pbench-agent-install/tasks/main.yml
@@ -2,9 +2,11 @@
 - import_role:
     name: pbench-clean-yum-cache
 
-- name: "Install the agent RPM"
+- name: "Install RPMs"
   package:
-    name: pbench-agent
+    name: "{{ item }}"
     state: latest
-
+  with_items:
+    - pbench-agent
+    - pbench-sysstat
 

--- a/agent/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/agent/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Clean yum cache
   command: yum clean all
+  args:
+    warn: False
 
 - name: Delete /var/yum/cache directory
   file:

--- a/agent/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/agent/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -4,9 +4,9 @@
   args:
     warn: False
 
-- name: Delete /var/yum/cache directory
+- name: Delete /var/cache/yum directory
   file:
-    path: /var/yum/cache
+    path: /var/cache/yum
     state: absent
 
 

--- a/agent/ansible/roles/pbench-repo-install/vars/main.yml
+++ b/agent/ansible/roles/pbench-repo-install/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-distro: "{{ 'epel' if ansible_distribution == 'RedHat'
+distro: "{{ 'epel' if ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
           else
             'fedora' if ansible_distribution == 'Fedora'
           else

--- a/server/ansible/Inventory/pbench-server.hosts.example
+++ b/server/ansible/Inventory/pbench-server.hosts.example
@@ -21,7 +21,7 @@ pbench_repo_url_prefix = https://copr-be.cloud.fedoraproject.org/results/some_fe
 # are needed.
 
 # This tells where to fetch config files from.
-pbench_config_url = http://pbench.example.com/server/config/{{ cenv }}
+pbench_config_url = http://pbench.example.com/server/config/{{ pbench_configuration_environment }}
 
 # List of config files to fetch.
 pbench_config_files = '["pbench-server.cfg"]'

--- a/server/ansible/pbench-server-install.yml
+++ b/server/ansible/pbench-server-install.yml
@@ -6,6 +6,7 @@
   become_user: root
 
   vars:
+    pbench_configuration_environment: "{{ cenv | 'production' }}"
     package_state: "latest"
     apache_options: "+Indexes +FollowSymLinks"
 

--- a/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Clean yum cache
   command: yum clean all
+  args:
+    warn: False
 
 - name: Delete /var/yum/cache directory
   file:

--- a/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
+++ b/server/ansible/roles/pbench-clean-yum-cache/tasks/main.yml
@@ -4,9 +4,9 @@
   args:
     warn: False
 
-- name: Delete /var/yum/cache directory
+- name: Delete /var/cache/yum directory
   file:
-    path: /var/yum/cache
+    path: /var/cache/yum
     state: absent
 
 

--- a/server/ansible/roles/pbench-repo-install/vars/main.yml
+++ b/server/ansible/roles/pbench-repo-install/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-distro: "{{ 'epel' if ansible_distribution == 'RedHat'
+distro: "{{ 'epel' if ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
           else
             'fedora' if ansible_distribution == 'Fedora'
           else


### PR DESCRIPTION
 Fixes to agent and server playbooks/roles/sample inventiory files.
    
 - recognize CentOS
 - use pbench_configuration_environment in the sample inventory file and set its value to either a host-specific value or the configured default ('production')
 - stop command from complaining when running `yum clean`

Commits:
1. agent ansible fixes (see above)
2. server ansible fixes (see above)
3. agent ansible: install both pbench-agent and pbench-sysstat