### PR TITLE
Pbench rpm

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -21,7 +21,6 @@ INSTALLOPTS = --directory
 # all the scripts that's fit to install
 util-scripts = \
 	 cdm-get-iterations \
-	 getconf.py \
 	 pbench-add-metalog-option \
 	 pbench-agent-config-activate \
 	 pbench-agent-config-ssh-key \
@@ -30,6 +29,7 @@ util-scripts = \
 	 pbench-clear-results \
 	 pbench-clear-tools \
 	 pbench-collect-sysinfo \
+	 pbench-config \
 	 pbench-copy-results \
 	 pbench-copy-result-tb \
 	 pbench-get-iteration-metrics \
@@ -74,11 +74,142 @@ bench-scripts = \
 	pbench-uperf \
 	pbench-uperf.md \
 	pbench-user-benchmark \
-	postprocess \
 	templates
 
+bench-postprocess = \
+	BenchPostprocess.pm \
+	compare-bench-results \
+	dbench-postprocess \
+	fio-postprocess \
+	fio-postprocess-cdm \
+	fio-postprocess-viz.py \
+	fio-prepare-jobfile \
+	generate-benchmark-summary \
+	linpack-postprocess \
+	linpack-postprocess-cdm \
+	linpack-prepare-input-file \
+	process-iteration-samples \
+	trafficgen-postprocess \
+	trafficgen-postprocess-cdm \
+	uperf-postprocess \
+	user-benchmark-wrapper
 
 tool-scripts = \
+	base-tool \
+	blktrace \
+	bpftrace \
+	cpuacct \
+	disk \
+	dm-cache \
+	docker \
+	docker-info \
+	external-data-source \
+	haproxy-ocp \
+	iostat \
+	jmap \
+	jstack \
+	kvm-spinlock \
+	kvmstat \
+	kvmtrace \
+	lockstat \
+	mpstat \
+	numastat \
+	oc \
+	openvswitch \
+	pcp \
+	perf \
+	perf.README \
+	pidstat \
+	pprof \
+	proc-interrupts \
+	proc-sched_debug \
+	proc-vmstat \
+	prometheus-metrics \
+	qemu-migrate \
+	rabbit \
+	README \
+	sar \
+	strace \
+	sysfs \
+	systemtap \
+	tcpdump \
+	turbostat \
+	user-tool \
+	virsh-migrate \
+	vmstat
+
+tool-datalogs = \
+	blktrace-datalog \
+	bpftrace-datalog \
+	cpuacct-datalog \
+	disk-datalog \
+	dm-cache-datalog \
+	docker-datalog \
+	docker-info-datalog \
+	File-Capture-datalog \
+	haproxy-ocp-datalog \
+	iostat-datalog \
+	jmap-datalog \
+	jstack-datalog \
+	kvm-spinlock-datalog \
+	kvmstat-datalog \
+	kvmtrace-datalog \
+	lockstat-datalog \
+	mpstat-datalog \
+	numastat-datalog \
+	oc-datalog \
+	openvswitch-datalog \
+	pcp-datalog \
+	perf-datalog \
+	pidstat-convert \
+	pidstat-datalog \
+	pprof-datalog \
+	prometheus-metrics-datalog \
+	qemu-migrate-datalog \
+	rabbit-datalog \
+	sar-datalog \
+	strace-datalog \
+	sysfs-datalog \
+	systemtap-datalog \
+	tcpdump-datalog \
+	turbostat-datalog \
+	virsh-migrate-datalog \
+	vmstat-datalog
+
+tool-postprocess = \
+	blktrace-stop-postprocess \
+	cpuacct-postprocess \
+	cpuacct-stop-postprocess \
+	disk-postprocess \
+	docker-postprocess \
+	haproxy-ocp-postprocess \
+	iostat-postprocess \
+	iostat-postprocess-cdm \
+	jmap-postprocess \
+	jstack-postprocess \
+	kvm-spinlock-postprocess \
+	kvmstat-postprocess \
+	kvmtrace-stop-postprocess \
+	mpstat-postprocess \
+	mpstat-postprocess-cdm \
+	mpstat-stop-postprocess \
+	numastat-postprocess \
+	openvswitch-postprocess \
+	pcp-postprocess \
+	perf-stop-postprocess \
+	pidstat-postprocess \
+	pidstat-postprocess-cdm \
+	proc-interrupts-postprocess \
+	proc-sched_debug-postprocess \
+	proc-vmstat-postprocess \
+	prometheus-metrics-postprocess \
+	qemu-migrate-postprocess \
+	rabbit-postprocess \
+	sar-postprocess \
+	sar-postprocess-cdm \
+	sysfs-postprocess \
+	virsh-migrate-postprocess \
+	vmstat-postprocess
 
 # targets
 .PHONY: install \
@@ -94,6 +225,7 @@ tool-scripts = \
 
 install: install-dirs install-ansible install-config install-util-scripts install-bench-scripts install-tool-scripts install-lib install-configtools install-stockpile
 	${COPY} VERSION ${DESTDIR}
+	${COPY} Makefile ${DESTDIR}
 	${COPY} base ${DESTDIR}
 	${COPY} profile ${DESTDIR}
 
@@ -110,7 +242,6 @@ install-dirs:
 	${INSTALL} ${INSTALLOPTS} ${TOOLDIR}/postprocess
 	${INSTALL} ${INSTALLOPTS} ${TOOLDIR}/datalog
 	${INSTALL} ${INSTALLOPTS} ${LIBDIR}
-	${INSTALL} ${INSTALLOPTS} ${LIBDIR}/configtools
 	${INSTALL} ${INSTALLOPTS} ${DESTDIR}/stockpile
 
 install-ansible:
@@ -125,7 +256,9 @@ install-util-scripts:
 
 install-bench-scripts:
 	cd bench-scripts; \
-	${COPY} -r ${bench-scripts} ${BENCHDIR}
+	${COPY} ${bench-scripts} ${BENCHDIR}
+	cd bench-scripts/postprocess; \
+	${COPY} ${bench-postprocess} ${BENCHDIR}/postprocess
 	cd ${BENCHDIR}; \
 	ln -sf postprocess/compare-bench-results compare-bench-results
 
@@ -134,7 +267,12 @@ install-bench-scripts:
 # 	${COPY} -r postprocess ${BENCHDIR}
 
 install-tool-scripts:
-	${COPY} -r tool-scripts ${DESTDIR}
+	cd tool-scripts; \
+	${COPY} ${tool-scripts} ${TOOLDIR}
+	cd tool-scripts/datalog; \
+	${COPY} ${tool-datalogs} ${TOOLDIR}/datalog
+	cd tool-scripts/postprocess; \
+	${COPY} ${tool-postprocess} ${TOOLDIR}/postprocess
 
 install-stockpile:
 	${COPY} -r stockpile ${DESTDIR}
@@ -142,16 +280,16 @@ install-stockpile:
 install-lib:
 	${COPY} -r lib ${DESTDIR}
 
+# Yuck!
 install-configtools:
-	${COPY} -r ../lib/configtools ${DESTDIR}/lib
+	if [ ! -d lib/pbench ] ;then ${COPY} -r ../lib/pbench ${LIBDIR} ;fi
 
 # SHA1 and SEQNO - these are used when building an RPM only
 # so we provide a target for the spec file to invoke. This
 # is *NOT* meant to be invoked interactively.
 install-build-artifacts:
-	${COPY} ../SHA1 ${DESTDIR}
-	${COPY} ../SEQNO ${DESTDIR}
-	${COPY} ../MANIFEST ${DESTDIR}
+	${COPY} SHA1 ${DESTDIR}
+	${COPY} SEQNO ${DESTDIR}
 
 clean:
 	rm -rf ${DESTDIR}

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -1,0 +1,64 @@
+# Making a pbench-agent RPM requires a few steps:
+# 1. Get version number.
+# 2. Update the RPM spec file with that version number etc.
+# 3. Update the stockpile  submodule.
+# 4. Do a "make install" of the agent to a temp directory.
+# 5. Generate a tar ball from the directory.
+# 6. Generate a local SRPM that will be uploaded to COPR for building.
+# 7. Optionally generate a local RPM.
+# 8. Clean up the temp directory
+
+CWD = $(shell pwd)
+
+# adjust as necessary
+AGENT = $(dir ${CWD})
+
+VERSION = $(file < ${AGENT}/VERSION)
+
+# temp directory for packing up the tarball
+TMPDIR = /tmp/opt
+
+RPMSRC = ${HOME}/rpmbuild/SOURCES
+RPMSRPM = ${HOME}/rpmbuild/SRPMS
+RPMSPEC = ${HOME}/rpmbuild/SPECS
+
+prog = pbench-agent
+arch = noarch
+
+USE_GIT_SHA1 = yes
+sha1 = $(shell git rev-parse --short HEAD)
+
+all: srpm
+
+srpm: spec patches tarball
+	rm -f ${HOME}/rpmbuild/SRPMS/$(prog)-*.src.rpm
+	rpmbuild -bs ${HOME}/rpmbuild/SPECS/$(prog).spec
+
+rpm:  srpm
+	rpmbuild -bb /home/nick/rpmbuild/SPECS/${prog}.spec
+
+.PHONY: spec
+spec: ${prog}.spec
+	utils/set-version-release ${VERSION} $(prog).spec ${sha1} > ${RPMSPEC}/$<
+
+.PHONY: patches
+patches:
+	if [ -d ${CWD}/patches ] ;then cp ${CWD}/patches/* ${RPMSRC} ;fi
+
+.PHONY: tarball
+tarball:
+	git submodule init
+	git submodule update
+	make -C .. DESTDIR=${TMPDIR}/${prog}-${VERSION}/agent
+	git rev-parse --short HEAD > ${TMPDIR}/${prog}-${VERSION}/agent/SHA1
+	if [ ! -f seqno] ;then echo 1 ;else cat seqno ;fi > ${TMPDIR}/${prog}-${VERSION}/agent/SEQNO
+	tar zcf ${RPMSRC}/pbench-agent-${VERSION}.tar.gz -C ${TMPDIR} ${prog}-${VERSION}
+	rm -rf ${TMPDIR}
+
+# buld RPMS in COPR
+seqno := $(shell if [ -e seqno ] ;then cat seqno ;else 1 ;fi)
+
+
+include utils/rpm.mk
+
+clean:: rpm-clean

--- a/agent/rpm/exclude.pats
+++ b/agent/rpm/exclude.pats
@@ -1,0 +1,8 @@
+gold/
+samples/
+sample-tools/
+test-bin/
+unittests
+tests/
+mock-bin/
+util-scripts/configs/

--- a/agent/rpm/patches/stockpile-shebang.patch
+++ b/agent/rpm/patches/stockpile-shebang.patch
@@ -1,0 +1,16 @@
+--- a/agent/stockpile/roles/openshift-cluster-topology/files/openshift_config_scraper.py	2019-07-03 15:36:28.855974709 -0400
++++ b/agent/stockpile/roles/openshift-cluster-topology/files/openshift_config_scraper.py	2019-07-03 15:36:59.857941348 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ import yaml
+ import sys
+--- a/agent/stockpile/roles/openstack_common/files/openstack-config-parser.py	2019-07-03 15:34:58.803071611 -0400
++++ b/agent/stockpile/roles/openstack_common/files/openstack-config-parser.py	2019-07-03 15:35:09.965059600 -0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #   Licensed under the Apache License, Version 2.0 (the "License");
+ #   you may not use this file except in compliance with the License.
+ #   You may obtain a copy of the License at

--- a/agent/rpm/pbench-agent.spec
+++ b/agent/rpm/pbench-agent.spec
@@ -1,0 +1,127 @@
+Name:           pbench-agent
+Version:     0.60
+%define gdist gc9e89f8f
+Release:     1%{?gdist}%{!?gdist:}
+Summary:        The pbench harness
+
+License:        GPLv3+
+URL:            http://perf1.perf.lab.eng.bos.redhat.com/atheurer/pbench
+Source0:        pbench-agent-%{version}.tar.gz
+Buildarch:      noarch
+
+
+%if 0%{?rhel} == 6
+%define turbostatpkg cpupowerutils
+%else
+%define turbostatpkg kernel-tools
+%endif
+
+%if 0%{?rhel} == 7
+Requires:  scl-utils, rh-python36
+%endif
+
+%if 0%{?rhel} == 8 || 0%{?fedora} >= 29
+Requires:  python3-pip
+%endif
+
+%if 0%{?fedora} == 0
+# NOT fedora
+%define perljsonxs pbench-perl-JSON-XS
+%else
+%define perljsonxs perl-JSON-XS
+%endif
+
+
+Requires:  bzip2, tar, xz, screen
+Requires:  perl, perl-JSON, %{perljsonxs}, perl-Time-HiRes, perl-Data-UUID
+Requires:  net-tools, numactl, perf, psmisc, bc, sos, %{turbostatpkg}
+# The following are needed by UBI containers which are bare bones - most other
+# systems will probably already have them installed.
+Requires:  ansible hostname iproute procps-ng iputils openssh-server openssh-clients rsync
+
+Obsoletes: pbench <= 0.34
+Conflicts: pbench <= 0.34
+# configtools is packaged with pbench-agent, so we specifically do NOT want the configtools
+# RPM installed.
+Conflicts: configtools
+
+Patch0: stockpile-shebang.patch
+
+%define installdir opt/pbench-agent
+
+%description
+The pbench harness
+
+%prep
+
+%setup
+%patch0 -p1
+
+%build
+
+%install
+rm -rf %{buildroot}
+
+mkdir -p %{buildroot}/%{installdir}
+
+cd ./agent
+%{__make} install DESTDIR=%{?buildroot}/%{installdir} INSTALL="%{__install} -p"
+%{__make} install-build-artifacts DESTDIR=%{?buildroot}/%{installdir} INSTALL="%{__install} -p"
+
+# we don't need this
+rm %{?buildroot}/%{installdir}/Makefile
+
+%pre
+# this RPM conflicts with a configtools RPM, but we may have a Pypi
+# configtools installed: zap it.
+%if 0%{?rhel} == 7
+scl enable rh-python36 -- bash -c 'if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi'
+%endif
+
+%if 0%{?rhel} == 8 || 0%{?fedora} >= 29
+if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
+%endif
+
+%post
+# link the pbench profile, so it'll automatically be sourced on login
+ln -sf /%{installdir}/profile /etc/profile.d/pbench-agent.sh
+
+%preun
+# if uninstalling, rather than updating, delete the link
+if [ $1 -eq 0 ] ;then
+    rm -f /etc/profile.d/pbench-agent.sh
+fi
+
+%postun
+# if uninstalling, rather than updating, remove /%{installdir}
+if [ $1 -eq 0 ] ;then
+    rm -rf /%{installdir}
+fi
+
+%posttrans
+
+%files
+%defattr(775,pbench,pbench,775)
+/%{installdir}/config
+
+/%{installdir}/lib
+/%{installdir}/ansible
+/%{installdir}/base
+
+/%{installdir}/VERSION
+/%{installdir}/SEQNO
+/%{installdir}/SHA1
+/%{installdir}/profile
+
+%ghost %attr(0400,pbench,pbench) /%{installdir}/id_rsa
+%ghost %attr(0664,pbench,pbench) /%{installdir}/config/pbench-agent.cfg
+
+%defattr(775,pbench,pbench,775)
+/%{installdir}/util-scripts
+/%{installdir}/tool-scripts
+/%{installdir}/bench-scripts
+
+# stockpile
+%defattr(775,pbench,pbench,775)
+/%{installdir}/stockpile
+

--- a/agent/rpm/utils/rpm.mk
+++ b/agent/rpm/utils/rpm.mk
@@ -1,0 +1,55 @@
+# -*- mode: makefile -*-
+.PHONY: check
+check:
+	if [ "${version}" == "" ] ;then echo "version undefined" > /dev/stderr; exit 1 ;fi
+	if [ "${prog}" == "" ] ;then echo "prog undefined" > /dev/stderr ; exit 2 ;fi
+
+.PHONY: rpm-dirs
+rpm-dirs:
+	for i in BUILD BUILDROOT SPECS SOURCES SRPMS RPMS; do mkdir -p ${HOME}/rpmbuild/$$i ; done
+
+.PHONY: rpm-clean
+rpm-clean: rpm-dirs
+	for i in BUILD BUILDROOT SPECS SOURCES SRPMS RPMS; do rm -rf ${HOME}/rpmbuild/$$i/* ; done
+
+dot-clean:
+	rm -f .rpm-copy .spec-copy .build
+
+.PHONY: spec-copy
+spec-copy: .spec-copy
+.spec-copy:
+	set-version-release ${version} $(prog).spec ${USE_GIT_SHA1} > ${HOME}/rpmbuild/SPECS/${prog}.spec && touch .spec-copy
+
+###########################################################################
+# these are used in the Makefiles that include this file
+RPMSRC = ${HOME}/rpmbuild/SOURCES
+RPMSRPM = ${HOME}/rpmbuild/SRPMS
+RPMSPEC = ${HOME}/rpmbuild/SPECS
+
+###########################################################################
+
+# building on COPR.
+# version and sha1 have to be provided by the including Makefile.
+# The including Makefile also has to provide the srpm target.
+
+.SECONDEXPANSION:
+$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm: srpm
+
+ifdef COPR_USER
+_copr_user = ${COPR_USER}
+else
+_copr_user = ${USER}
+endif
+
+copr\
+copr-test \
+copr-interim \
+copr-index \
+copr-inotify \
+copr-dashboard:	$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
+	copr-cli build $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
+
+# The default clean target
+clean:: dot-clean
+
+veryclean:: clean rpm-clean

--- a/agent/rpm/utils/set-version-release
+++ b/agent/rpm/utils/set-version-release
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+case $# in
+    2|3) ;;
+    *) echo "Usage: set-version-release <version> <prog.spec> [git]" >/dev/stderr
+       exit 1
+       ;;
+esac
+
+version=$1
+file=$2
+
+shopt -s nocasematch
+if [[ -z "$3" || "$3" == "no" || "$3" == "false" ]] ;then
+    use_git_sha1=""
+elif [[ "$3" != "yes" && "$3" != "true" ]] ;then
+    use_git_sha1=g$3
+else
+    use_git_sha1=g$(git rev-parse --short HEAD)
+fi
+if [ -f ./seqno ] ;then
+    # get it and increment it
+    buildnum=$(cat ./seqno)
+    expr $buildnum + 1 > ./seqno
+else
+    buildnum=1
+fi
+
+# Most spec files do not contain a %define gdist line, so the second
+# substitution is a no-op (even if called with a "yes" third
+# argument). In that case the third substitution sets the release to
+# <buildnum>.<distro>.  The pbench spec file does include such a line,
+# *and* it is called with the optional third argument: in that case,
+# gdist is defined to be g<SHA1>.<distro> and the third substitution
+# makes the release <buildnum>.g<SHA1>.<distro>.
+# As I said: ripe for reimplementation...
+
+sed "s/Version: .*/Version:     $version/
+     s/%define version .*/%define version   $version/
+     s/%define gdist .*/%define gdist ${use_git_sha1}/
+     s/Release: .*/Release:     ${buildnum}%{?gdist}%{!?gdist:}/" $file

--- a/agent/util-scripts/pbench-config
+++ b/agent/util-scripts/pbench-config
@@ -1,0 +1,10 @@
+#!/usr/bin/python3
+# PBR Generated from 'console_scripts'
+
+import sys
+
+from pbench.cli.getconf import main
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Pull the RPM making machinery for the agent into the upstream repo.

```
cd agent/rpm
make rpm
```
should work <s>(but it still uses the roundabout upstream-tarball ways - getting rid of that is TBD)</s>. THere are still some ugly hacks, but it's pretty close: the `agent/Makefile` provides an install target that installs to DESTDIR (by default `/opt/pbench-agent`), The spec file uses this target (modifying DESTDIR) in order to build the RPM. The `agent/rpm/Makefile` provides `srpm` and `rpm` targets to build locally and `copr` and `copr-test` targets to build on COPR (you need an account on COPR and you need to set the env variable COPR_USER to the account name).

That's the good. The bad is that the server needs the same treatment and it has not had it yet. The ugly is the ad-hoc way of dealing with `pbench-config` and the python libraries.