### PR TITLE
Avoid hardcoded tools location on bench-scripts

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -268,6 +268,12 @@ function generate_inventory {
     fi
 }
 
+function resolve_benchmark_bin {
+    # Encapsulation of method for resolving the actual benchmark
+    # binary.
+    which --skip-alias --skip-functions "${1}"
+}
+
 if [[ "${_PBENCH_UNIT_TESTS}" == 1 ]] ;then
     # For unit tests, we use a mock kill:
     # disable the built-in.

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -20,10 +20,18 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 
 benchmark_rpm=$script_name
 benchmark="dbench"
-if [[ -z "$benchmark_bin" ]]; then
-	benchmark_bin=/usr/local/bin/$benchmark
+if [[ -z "${benchmark_bin}" ]]; then
+	benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	if [[ -z "${benchmark_bin}" ]]; then
+		error_log "[${script_name}] ${benchmark} executable not found on PATH=${PATH}"
+		exit 1
+	fi
 fi
-ver=4.00
+ver="$(pbench-config version ${benchmark})"
+if [[ -z "${ver}" ]]; then
+	error_log "${script_name}: package version is missing in config file"
+	exit 1
+fi
 
 # Every bench-script follows a similar sequence:
 # 1) process bench script arguments

--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -14,17 +14,21 @@ benchmark="fio"
 benchmark_rpm=${benchmark}
 export benchmark_run_dir=""
 # allow unit tests to override
-if [[ -z "$benchmark_bin" ]]; then
-	benchmark_bin=/usr/local/bin/$benchmark
+if [[ -z "${benchmark_bin}" ]]; then
+        benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	if [[ -z "${benchmark_bin}" ]]; then
+		error_log "[${script_name}] ${benchmark} executable not found on PATH=${PATH}"
+		exit 1
+	fi
 fi
-ver="$(pbench-config version fio)"
+ver="$(pbench-config version ${benchmark})"
 if [[ -z "${ver}" ]]; then
-	error_log "pbench-fio: package version is missing in config file"
+	error_log "${script_name}: package version is missing in config file"
 	exit 1
 fi
-fio_server_port="$(pbench-config server_port fio)"
+fio_server_port="$(pbench-config server_port ${benchmark})"
 if [[ -z "${fio_server_port}" ]]; then
-	error_log "pbench-fio: server_port is missing in config file"
+	error_log "${script_name}: server_port is missing in config file"
 	exit 1
 fi
 

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -22,8 +22,18 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 
 benchmark_rpm=$script_name
 benchmark="iozone"
-benchmark_bin=/usr/local/bin/$benchmark
-ver=3.430
+if [[ -z "${benchmark_bin}" ]]; then
+	benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	if [[ -z "${benchmark_bin}" ]]; then
+		error_log "[${script_name}] ${benchmark} executable not found on PATH=${PATH}"
+		exit 1
+	fi
+fi
+ver="$(pbench-config version ${benchmark})"
+if [[ -z "${ver}" ]]; then
+	error_log "${script_name}: package version is missing in config file"
+	exit 1
+fi
 
 # Every bench-script follows a similar sequence:
 # 1) process bench script arguments

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -36,8 +36,20 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 
 benchmark_rpm=$script_name
 benchmark="netperf"
-benchmark_bin=/usr/bin/$benchmark
-ver=2.7.0
+if [[ -z "${benchmark_bin}" ]]; then
+        benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	if [[ -z "${benchmark_bin}" ]]; then
+		error_log "[${script_name}] ${benchmark} executable not found on PATH=${PATH}"
+		exit 1
+	fi
+fi
+ver="$(pbench-config version ${benchmark})"
+if [[ -z "${ver}" ]]; then
+	error_log "${script_name}: package version is missing in config file"
+	exit 1
+fi
+
+# Formatting spacing for output report.
 spacing=25
 
 # Every bench-script follows a similar sequence:

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -26,10 +26,14 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 
 benchmark="uperf"
 benchmark_rpm=${benchmark}
-if [[ -z "$benchmark_bin" ]]; then
-    benchmark_bin=/usr/bin/$benchmark
+if [[ -z "${benchmark_bin}" ]]; then
+	benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	if [[ -z "${benchmark_bin}" ]]; then
+		error_log "${script_name}: ${benchmark} executable not found on PATH=${PATH}"
+		exit 1
+	fi
 fi
-ver="$(pbench-config version uperf)"
+ver="$(pbench-config version ${benchmark})"
 if [[ -z "${ver}" ]]; then
         error_log "${script_name}: package version is missing in config file"
         exit 1

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -2,6 +2,13 @@
 version = 002
 pbench_web_server = pbench.example.com
 
+[pbench-agent]
+install-dir = %(pbench_install_dir)s
+pbench_user = pbench
+pbench_group = pbench
+pbench_run = /var/lib/pbench-agent
+pbench_log = %(pbench_run)s/pbench.log
+
 [results]
 user = pbench
 host_path = http://%(pbench_result_redirector)s/pbench-archive-host
@@ -17,29 +24,31 @@ api_version = 1
 rest_endpoint = api/v%(api_version)s
 server_rest_url = http://%(webserver)s/%(rest_endpoint)s
 
-[pbench-agent]
-install-dir = %(pbench_install_dir)s
-pbench_user = pbench
-pbench_group = pbench
-pbench_run = /var/lib/pbench-agent
-pbench_log = %(pbench_run)s/pbench.log
-
 [pbench/tools]
 default-tool-set = sar, iostat, mpstat, pidstat, proc-vmstat, proc-interrupts, turbostat, perf
 interval = 3
 
 [tools/pidstat]
+# By default we collect pidstat information at a very course granularity
+# to try to avoid large and unweildy data sets.
 interval = 30
 
-[packages]
-
-[uperf]
-version = 1.0.7
+[dbench]
+version = 4.00
 
 [fio]
 version = 3.19
 server_port = 8765
 histogram_interval_msec = 10000
+
+[iozone]
+version = 3.430
+
+[netperf]
+version = 2.7.0
+
+[uperf]
+version = 1.0.7
 
 [stockpile]
 # stockpile_path, stockpile_log and stockpile_output_path are


### PR DESCRIPTION
In case the `benchmark_bin` is not set the `pbench-fio` script uses `/usr/local/bin/fio` and the `pbench-uperf` script uses `/usr/bin/uperf`.  This is not systematic and could lead to confusion, let's not attempt to be clever and simply rely on the system `PATH` when `benchmark_bin` is not set by the user.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>