### PR TITLE
Pbench Server API

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -74,6 +74,16 @@ class PbenchServerConfig(PbenchConfig):
         else:
             self._unittests = bool(self._unittests)
 
+        try:
+            self.elasticsearch = self.conf.get("elasticsearch", "server")
+        except (NoOptionError, NoSectionError):
+            self.elasticsearch = ""
+
+        try:
+            self.graphql = self.conf.get("graphql", "server")
+        except (NoOptionError, NoSectionError):
+            self.graphql = ""
+
         if self._unittests:
 
             def mocked_time():

--- a/lib/pbench/test/unit/config/pbench-server.cfg
+++ b/lib/pbench/test/unit/config/pbench-server.cfg
@@ -4,6 +4,12 @@ install-dir = ./opt/pbench-server
 [pbench-server]
 pbench-top-dir = ./srv/pbench
 
+[elasticsearch]
+server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
+
+[graphql]
+server = http://graphql.perf.lab.eng.bos.redhat.com:4466
+
 ###########################################################################
 # The rest will come from the default config file.
 [config]

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -12,6 +12,12 @@ install-dir = {TMP}/opt/pbench-server
 [pbench-server]
 pbench-top-dir = {TMP}/srv/pbench
 
+[elasticsearch]
+server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
+
+[graphql]
+server = http://graphql.perf.lab.eng.bos.redhat.com:4466
+
 ###########################################################################
 # The rest will come from the default config file.
 [config]

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -19,6 +19,42 @@ class TestHostInfo:
         assert response.json.get("message") == expected_message
 
 
+class TestDownload:
+    @staticmethod
+    def test_json_object(client):
+        response = client.post(f"{client.config['REST_URI']}/elasticsearch")
+        assert response.status_code == 400
+        assert response.json.get("message") == "Invalid json object in request"
+
+    @staticmethod
+    def test_empty_url_path(client):
+        response = client.post(
+            f"{client.config['REST_URI']}/elasticsearch", json={"indices": ""}
+        )
+        assert response.status_code == 400
+        assert response.json.get("message") == "Missing path in request"
+
+    @staticmethod
+    def test_invalid_url_path(client):
+        response = client.post(
+            f"{client.config['REST_URI']}/elasticsearch",
+            json={"indices": "some_invalid_url"},
+        )
+        assert response.status_code == 500
+        assert (
+            response.json.get("message")
+            == "There was something wrong with your download request"
+        )
+
+
+class TestGraphQL:
+    @staticmethod
+    def test_json_object(client):
+        response = client.post(f"{client.config['REST_URI']}/graphql")
+        assert response.status_code == 400
+        assert response.json.get("message") == "Invalid query object in request"
+
+
 class TestUpload:
     @staticmethod
     def test_missing_filename_header_upload(client):


### PR DESCRIPTION
Created a two APIs in Pbench server which serves as a middle ware for dashboard Elasticseach and GraphQL calls.
The server APIs pulls data from Elasticsearch based on the arguments passed in from front end requests.
And the dashboard will in the future, call server APIs instead to get data instead of making explicit queries.
Note: elasticsearch and graphql section needs to be specified in pbench-server.cfg 