### PR TITLE
Fixes datalog-cpuacct directory order

### DIFF
--- a/agent/tool-scripts/datalog/cpuacct-datalog
+++ b/agent/tool-scripts/datalog/cpuacct-datalog
@@ -20,7 +20,7 @@ if [[ ${?} -ne 0 ]]; then
 	exit 1
 fi
 
-dirs="$(find -mindepth 1 -type d)"
+dirs="$(find -mindepth 1 -type d | sort)"
 if [[ -z "${dirs}" ]]; then
 	printf -- "%s: CPU accounting appears disabled, no sub-directories found\n" "${PROG}" >&2
 	exit 1


### PR DESCRIPTION
This PR deals with fixing datalog-cpuacct directory sequencing by sorting directories. I have also checked all the scripts in datalog directory and they do not seem to suffer from this problem.