### PR TITLE
Require fio 3.21 and later

### DIFF
--- a/agent/bench-scripts/tests/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.txt
@@ -446,8 +446,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-05.txt
@@ -136,8 +136,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-06.txt
@@ -142,8 +142,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar,baz")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-07.txt
@@ -124,8 +124,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-08.txt
@@ -118,8 +118,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/mnt/cephfs", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-13.txt
@@ -220,8 +220,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/rbd0,/dev/rbd1", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd0 exists on client 192.168.121.64

--- a/agent/bench-scripts/tests/pbench-fio/test-15.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-15.txt
@@ -230,8 +230,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-15_1900.01.01T00.00.00/1-rw-42KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-16.txt
@@ -60,8 +60,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/sda0,/dev/sda1", clients="192.168.1.1")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/sda0 exists on client 192.168.1.1

--- a/agent/bench-scripts/tests/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-20.txt
@@ -160,8 +160,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/dev/foo,/dev/bar", clients="abc,def,ghi")
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/foo exists on client abc

--- a/agent/bench-scripts/tests/pbench-fio/test-28.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-28.txt
@@ -51,8 +51,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="")
 [debug][1900-01-01T00:00:00.000000] fio: Going to run [/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --output-format=json /var/tmp/pbench-test-bench/pbench-agent/fio_test-28_1900.01.01T00.00.00/1-read-8KiB/fio.job ]
 [debug][1900-01-01T00:00:00.000000] post-processing fio result

--- a/agent/bench-scripts/tests/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-30.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-31.txt
@@ -56,8 +56,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/bench-scripts/tests/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-32.txt
@@ -88,8 +88,8 @@ fio job complete
 /var/tmp/pbench-test-bench/pbench-agent/tools-default/sar
 --- pbench tree state
 +++ pbench.log file contents
-[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.19 is installed
-[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.19 is installed
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="hist.foo,hist.bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -37,7 +37,7 @@ interval = 30
 version = 4.00
 
 [fio]
-version = 3.19
+version = 3.21
 server_port = 8765
 histogram_interval_msec = 10000
 


### PR DESCRIPTION
The `fio` 3.20 version now properly installs `fio-histo-log-pctiles.py` via `make install`.  The Fedora RPM build of `fio` for the 3.21-1 version is the first build to include that update.

Fixes #1728.