### PR TITLE
Fix uperf "rr" (round-robin) test XML

### DIFF
--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -141,6 +141,7 @@ function gen_xml {
 		echo "    <transaction duration=\"$runtime\">"
 		echo "      <flowop type=\"write\" options=\"size=$size\"/>"
 		echo "      <flowop type=\"read\"  options=\"size=$size\"/>"
+		echo "    </transaction>"
 		echo "    <transaction iterations=\"1\">"
 		echo "      <flowop type=\"disconnect\" />"
 		echo "    </transaction>"


### PR DESCRIPTION
We now properly generate valid XML for the `rr` `${test_type}`, adding the missing `</transaction>` line.