### PR TITLE
Give default values to most of the variables.

### DIFF
--- a/agent/ansible/Inventory/pbench-agent.hosts.example
+++ b/agent/ansible/Inventory/pbench-agent.hosts.example
@@ -12,20 +12,41 @@ host3       ansible_python_interpreter=/usr/bin/python3
 # This section contains site-specific variables. An admin should
 # modify these settings and provide the resulting file as a site-specific
 # example. Once that is done, users should *NOT* have to modify this section at all.
+
+# All but two of the variables below are given default values that should serve most
+# users, but they can be overridden explicitly by uncommenting them and giving them
+# appropriate values.
+
+# The two variables pbench_key_url and pbench_config_url are *not* defaulted: they
+# are specific to a particular environment and they *have* to be defined (here or
+# elsewhere) by the user.
+
 [servers:vars]
-pbench_repo_url_prefix = https://copr-be.cloud.fedoraproject.org/results/<EXAMPLE_USER>
+# We assume that the COPR convention of repo naming is followed. Obviously if the repo
+# is in COPR that assumption holds, but if you decide to use a different repo, you have
+# to follow the convention (or change the pbench-agent-install role).
+# The convention is that the repo name consists of the prefix defined here (or in the
+# defaults of the pbench-agent-install role), followed by a distro designation:
+#     fedora-NN   for Fedora distros
+#     epel-7      for RHEL7 and CentOS 7 distros
+#     epel-8      for RHEL8 and CentOS 8 distros
 
-# where to get the key
+# If you use a COPR repo but under a different user name, you can override the fedoraproject_username
+# variable only and leave the prefix alone.
+# fedoraproject_username = <EXAMPLE_USER>
+# pbench_repo_url_prefix = https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
+
+# Where to get the key - you need to change this appropriately for your environment.
 pbench_key_url = http://EXAMPLE.COM/PATH/TO/agent/{{ pbench_configuration_environment }}/ssh
-# where to put it
-pbench_key_dest = /opt/pbench-agent/
 
-# where to get the config file
+# Where to put it
+# pbench_key_dest = /opt/pbench-agent/
+
+# Where to get the config file - you need to change this appropriately for your environment.
 pbench_config_url = http://EXAMPLE.COM/PATH/TO/agent/{{ pbench_configuration_environment }}/config
-# where to put it
-pbench_config_dest = /opt/pbench-agent/config/
 
-pbench_config_files = '["pbench-agent.cfg"]'
+# Where to put it.
+# pbench_config_dest = /opt/pbench-agent/config/
 
-owner = pbench
-group = pbench
+# List of config files to install.
+# pbench_config_files = '["pbench-agent.cfg"]'

--- a/agent/ansible/pbench-agent-install.yml
+++ b/agent/ansible/pbench-agent-install.yml
@@ -11,6 +11,8 @@
     pbench_configuration_environment: "{{ cenv | default('production') }}"
 
   roles:
+    # uncomment the following line and run with -v to debug the settings of some variables.
+    # - debug-vars
     - pbench-repo-install
     - pbench-agent-install
     - pbench-agent-config

--- a/agent/ansible/roles/debug-vars/tasks/main.yml
+++ b/agent/ansible/roles/debug-vars/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- debug:
+    msg: "pbench_repo_url_prefix: {{ pbench_repo_url_prefix }}"
+    verbosity: 1
+
+- debug:
+    msg: "pbench_config_url: {{ pbench_config_url }}, pbench_key_url: {{ pbench_key_url }}"
+    verbosity: 1
+
+- debug:
+    msg: "pbench_agent_install_dir: {{ pbench_agent_install_dir }}, pbench_owner: {{ pbench_owner }}, pbench_group: {{ pbench_group }}"
+    verbosity: 1
+
+- debug:
+    msg: "pbench_config_files: {{ pbench_config_files }}, pbench_config_dest: {{ pbench_config_dest }}, pbench_key_dest: {{ pbench_key_dest }}"
+    verbosity: 1

--- a/agent/ansible/roles/pbench-agent-config/defaults/main.yml
+++ b/agent/ansible/roles/pbench-agent-config/defaults/main.yml
@@ -2,3 +2,7 @@
 pbench_agent_install_dir: /opt/pbench-agent
 pbench_owner: pbench
 pbench_group: pbench
+pbench_config_files:
+  - pbench-agent.cfg
+pbench_config_dest: "{{ pbench_agent_install_dir }}/config"
+pbench_key_dest: "{{ pbench_agent_install_dir }}"

--- a/agent/ansible/roles/pbench-repo-install/defaults/main.yml
+++ b/agent/ansible/roles/pbench-repo-install/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+fedoraproject_username: ndokos
+pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
+ 
 repos:
   - tag: pbench
     baseurl: "{{ pbench_repo_url_prefix }}/pbench/{{ distrodir }}"


### PR DESCRIPTION
Only `pbench_key_url` and `pbench_config_url` are left to be defined by the user (probably in the inventory file). The rest are defaulted but can be overridden.

Comment out the defaulted values in the example inventory file and add explanatory comments.