### PR TITLE
Get rid of "use-mail-for-status"

### DIFF
--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -76,10 +76,6 @@ rest_log = %(pbench-logs-dir)s/pbench-server.log
 # Default roles this pbench server takes on, see crontab roles below.
 roles = pbench-maintenance, pbench-prep, pbench-results, pbench-backup
 
-# We now index status into ES, but in some cases we might still want to
-# use mail.
-use-mail-for-status = no
-
 # Optional server environment definition
 #environment = staging
 


### PR DESCRIPTION
Fixes issue #1668

Get rid of "use-mail-for-status" as it is no longer being used.
Either we indexes or logs.