### PR TITLE
Pbench Server APIs for ES and GraphQL

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -75,12 +75,14 @@ class PbenchServerConfig(PbenchConfig):
             self._unittests = bool(self._unittests)
 
         try:
-            self.elasticsearch = self.conf.get("elasticsearch", "server")
+            self.elasticsearch = f"{self.conf.get('elasticsearch', 'host')}:{self.conf.get('elasticsearch', 'port')}"
         except (NoOptionError, NoSectionError):
             self.elasticsearch = ""
 
         try:
-            self.graphql = self.conf.get("graphql", "server")
+            self.graphql = (
+                f"{self.conf.get('graphql', 'host')}:{self.conf.get('graphql', 'port')}"
+            )
         except (NoOptionError, NoSectionError):
             self.graphql = ""
 

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -74,6 +74,16 @@ class PbenchServerConfig(PbenchConfig):
         else:
             self._unittests = bool(self._unittests)
 
+        try:
+            self.elasticsearch = self.conf.get("elasticsearch", "server")
+        except (NoOptionError, NoSectionError):
+            self.elasticsearch = ""
+
+        try:
+            self.graphql = self.conf.get("graphql", "server")
+        except (NoOptionError, NoSectionError):
+            self.graphql = ""
+
         if self._unittests:
 
             def mocked_time():

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -543,22 +543,15 @@ def _get_es_hosts(config, logger):
     Return list of dicts (a single dict for now) - that's what ES is expecting.
     """
     try:
-        URL = config.get("Indexing", "server")
-    except NoSectionError:
+        host = config.get("elasticsearch", "host")
+        port = config.get("elasticsearch", "port")
+    except (NoSectionError, NoOptionError):
         logger.warning(
-            "Need an [Indexing] section with host and port defined"
-            " in {} configuration file",
+            "Failed to find an [elasticsearch] section with host and port defined"
+            " in {} configuration file.",
             " ".join(config.files),
         )
         return None
-    except NoOptionError:
-        try:
-            host = config.get("Indexing", "host")
-            port = config.get("Indexing", "port")
-        except NoOptionError:
-            return None
-    else:
-        host, port = URL.rsplit(":", 1)
     timeoutobj = Timeout(total=1200, connect=10, read=_read_timeout)
     return [
         dict(host=host, port=port, timeout=timeoutobj),

--- a/lib/pbench/test/unit/config/pbench-server.cfg
+++ b/lib/pbench/test/unit/config/pbench-server.cfg
@@ -4,12 +4,6 @@ install-dir = ./opt/pbench-server
 [pbench-server]
 pbench-top-dir = ./srv/pbench
 
-[elasticsearch]
-server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
-
-[graphql]
-server = http://graphql.perf.lab.eng.bos.redhat.com:4466
-
 ###########################################################################
 # The rest will come from the default config file.
 [config]

--- a/lib/pbench/test/unit/config/pbench-server.cfg
+++ b/lib/pbench/test/unit/config/pbench-server.cfg
@@ -4,6 +4,12 @@ install-dir = ./opt/pbench-server
 [pbench-server]
 pbench-top-dir = ./srv/pbench
 
+[elasticsearch]
+server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
+
+[graphql]
+server = http://graphql.perf.lab.eng.bos.redhat.com:4466
+
 ###########################################################################
 # The rest will come from the default config file.
 [config]

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -12,6 +12,12 @@ install-dir = {TMP}/opt/pbench-server
 [pbench-server]
 pbench-top-dir = {TMP}/srv/pbench
 
+[elasticsearch]
+server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
+
+[graphql]
+server = http://graphql.perf.lab.eng.bos.redhat.com:4466
+
 ###########################################################################
 # The rest will come from the default config file.
 [config]

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -13,10 +13,12 @@ install-dir = {TMP}/opt/pbench-server
 pbench-top-dir = {TMP}/srv/pbench
 
 [elasticsearch]
-server = http://elasticsearch.perf.lab.eng.bos.redhat.com:9280
+host = elasticsearch.example.com
+port = 0000
 
 [graphql]
-server = http://graphql.perf.lab.eng.bos.redhat.com:4466
+host = graphql.example.com
+port = 0000
 
 ###########################################################################
 # The rest will come from the default config file.

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -19,12 +19,15 @@ class TestHostInfo:
         assert response.json.get("message") == expected_message
 
 
-class TestDownload:
+class TestElasticsearch:
     @staticmethod
     def test_json_object(client):
         response = client.post(f"{client.config['REST_URI']}/elasticsearch")
         assert response.status_code == 400
-        assert response.json.get("message") == "Invalid json object in request"
+        assert (
+            response.json.get("message")
+            == "Elasticsearch: Invalid json object in request"
+        )
 
     @staticmethod
     def test_empty_url_path(client):
@@ -32,18 +35,20 @@ class TestDownload:
             f"{client.config['REST_URI']}/elasticsearch", json={"indices": ""}
         )
         assert response.status_code == 400
-        assert response.json.get("message") == "Missing path in request"
+        assert (
+            response.json.get("message")
+            == "Missing indices path in the Elasticsearch request"
+        )
 
     @staticmethod
-    def test_invalid_url_path(client):
+    def test_bad_request(client):
         response = client.post(
             f"{client.config['REST_URI']}/elasticsearch",
             json={"indices": "some_invalid_url"},
         )
         assert response.status_code == 500
         assert (
-            response.json.get("message")
-            == "There was something wrong with your download request"
+            response.json.get("message") == "Could not post to Elasticsearch endpoint"
         )
 
 
@@ -52,7 +57,7 @@ class TestGraphQL:
     def test_json_object(client):
         response = client.post(f"{client.config['REST_URI']}/graphql")
         assert response.status_code == 400
-        assert response.json.get("message") == "Invalid query object in request"
+        assert response.json.get("message") == "GraphQL: Invalid json object in request"
 
 
 class TestUpload:

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -19,6 +19,42 @@ class TestHostInfo:
         assert response.json.get("message") == expected_message
 
 
+class TestDownload:
+    @staticmethod
+    def test_json_object(client):
+        response = client.post(f"{client.config['REST_URI']}/elasticsearch")
+        assert response.status_code == 400
+        assert response.json.get("message") == "Invalid json object in request"
+
+    @staticmethod
+    def test_empty_url_path(client):
+        response = client.post(
+            f"{client.config['REST_URI']}/elasticsearch", json={"indices": ""}
+        )
+        assert response.status_code == 400
+        assert response.json.get("message") == "Missing path in request"
+
+    @staticmethod
+    def test_invalid_url_path(client):
+        response = client.post(
+            f"{client.config['REST_URI']}/elasticsearch",
+            json={"indices": "some_invalid_url"},
+        )
+        assert response.status_code == 500
+        assert (
+            response.json.get("message")
+            == "There was something wrong with your download request"
+        )
+
+
+class TestGraphQL:
+    @staticmethod
+    def test_json_object(client):
+        response = client.post(f"{client.config['REST_URI']}/graphql")
+        assert response.status_code == 400
+        assert response.json.get("message") == "Invalid query object in request"
+
+
 class TestUpload:
     @staticmethod
     def test_missing_filename_header_upload(client):

--- a/server/bin/state/config/pbench-server.cfg
+++ b/server/bin/state/config/pbench-server.cfg
@@ -21,9 +21,16 @@ secret_access_key = SECRET_ACCESS_KEY
 bucket_name = testbucket
 
 [Indexing]
-server = elasticsearch.example.com:9280
 index_prefix = pbench-unittests
 bulk_action_count = 2000
+
+[elasticsearch]
+host = elasticsearch.example.com
+port = 0000
+
+[graphql]
+host = graphql.example.com
+port = 0000
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/state/test-23.config/pbench-server.cfg
+++ b/server/bin/state/test-23.config/pbench-server.cfg
@@ -21,8 +21,15 @@ secret_access_key = SECRET_ACCESS_KEY
 bucket_name = testbucket
 
 [Indexing]
-server = elasticsearch.example.com:9280
 # No index_prefix so logger should be used in pbench-report-status
+
+[elasticsearch]
+host = elasticsearch.example.com
+port = 0000
+
+[graphql]
+host = graphql.example.com
+port = 0000 
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/state/test-6.13.config/pbench-server.cfg
+++ b/server/bin/state/test-6.13.config/pbench-server.cfg
@@ -21,9 +21,16 @@ secret_access_key = SECRET_ACCESS_KEY
 bucket_name = testbucket
 
 [Indexing]
-server = elasticsearch.example.com:9280
 index_prefix = pbench-unittests
 bulk_action_count = 2000
+
+[elasticsearch]
+host = elasticsearch.example.com
+port = 0000
+
+[graphql]
+host = graphql.example.com
+port = 0000
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/bin/state/test-6.14.config/pbench-server.cfg
+++ b/server/bin/state/test-6.14.config/pbench-server.cfg
@@ -21,9 +21,16 @@ admin-email = unit-test-user@example.com
 # bucket_name = testbucket
 
 [Indexing]
-server = elasticsearch.example.com:9280
 index_prefix = pbench-unittests
 bulk_action_count = 2000
+
+[elasticsearch]
+host = elasticsearch.example.com
+port = 0000
+
+[graphql]
+host = graphql.example.com
+port = 0000
 
 [apache]
 documentroot = %(unittest-dir)s/var-www-html

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -122,6 +122,16 @@ lowerbound = 820
 # index_prefix =
 # bulk_action_count =
 
+# These should be overridden in the env-specific config file.
+# [elasticsearch]
+# host = 
+# port = 
+
+# # These should be overridden in the env-specific config file.
+# [graphql]
+# host = 
+# port = 
+
 # We need to install some stuff in the apache document root so we
 # either get it directly or look in the config file.
 #

--- a/server/lib/config/pbench-server.cfg.example
+++ b/server/lib/config/pbench-server.cfg.example
@@ -34,6 +34,15 @@ server = elasticsearch.example.com:9280
 index_prefix = pbench
 bulk_action_count = 2000
 
+[elasticsearch]
+host = elasticsearch.example.com
+port = 0000
+
+# These should be overridden in the env-specific config file.
+[graphql]
+host = graphql.example.com
+port = 0000
+
 ###########################################################################
 # crontab roles
 


### PR DESCRIPTION
This work is an extension of Fuqing's PR https://github.com/distributed-system-analysis/pbench/pull/1726
Description from Original PR:

> Created a two APIs in Pbench server which serves as a middle ware for dashboard Elasticseach and GraphQL calls.
> The server APIs pulls data from Elasticsearch based on the arguments passed in from front end requests.
> And the dashboard will in the future, call server APIs instead to get data instead of making explicit queries.
> Note: elasticsearch and graphql section needs to be specified in pbench-server.cfg with host and port info