### PR TITLE
OVS-Hrdware-Offload flow support in openvswitch-datalog

### DIFF
--- a/agent/tool-scripts/datalog/openvswitch-datalog
+++ b/agent/tool-scripts/datalog/openvswitch-datalog
@@ -48,11 +48,20 @@ for b in ${bridges}; do
 	ports_file=${tool_output_dir}/${b}-port-mappings.txt
 	ovs-ofctl show ${b} ${protocols_string} > ${ports_file}
 done
+
+#Hardware Offload flow on Bridge . Supported from OVS2.13
+for b in ${bridges}; do
+	offload_stats=${tool_output_dir}/${b}-offload-stats.txt
+	ovs-appctl bridge/dump-flows --offload-stats ${b} > ${offload_stats}
+done
+
 rxq_mapping_file=${tool_output_dir}/pmd-rxq-show.txt
 ovs-appctl dpif-netdev/pmd-rxq-show > ${rxq_mapping_file}
 
 stats_file=${tool_output_dir}/ovs-stats.txt
+offload_stats_file=${tool_output_dir}/ovs-offload-stats.txt
 > ${stats_file}
+> ${offload_stats_file}
 if [[ ! -z "${bridges}" ]]; then
 	while true; do
 		printf "\ntimestamp: $(date +%s.%N)\n" >> ${stats_file}
@@ -72,6 +81,10 @@ if [[ ! -z "${bridges}" ]]; then
 		echo "dpdk-stats: pmd-stats-show" >> ${stats_file}
 		ovs-appctl dpif-netdev/pmd-stats-show >> ${stats_file}
 		ovs-appctl dpif-netdev/pmd-stats-clear
+		# OFFLOAD stats
+		printf "\ntimestamp: $(date +%s.%N)\n" >> ${offload_stats_file}
+		echo "ovs-appctl dpctl/dump-flows -m type=offloaded" >> ${offload_stats_file}
+		ovs-appctl dpctl/dump-flows -m type=offloaded >> ${offload_stats_file}
 		sleep ${interval}
 	done
 fi


### PR DESCRIPTION
 **PR Description** 

Currently pbench` openvswitch.datalog` tool-script support to collect metrics from standard openvswitch and ovs-dpdk layer. 
As openvswitch feature extends with TC hardware offload support and during the network performance test with trafficgen is required to review the flows which dump in SMART NIC (e.g., Mellanox Connectx5).

With minor code change in `openvswitch.datalog` script, we are able to collect the OVS hardware offload follows from DUT node. Since ovs-hw-offload in OpenStack 16.x is GA[1]. So it would really help we can include parameter to collect some granular result.

[1] https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/network_functions_virtualization_planning_and_configuration_guide/index#sect-configuring-hw-offload