### PR TITLE
Make spelling of commit_id consistent

### DIFF
--- a/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
@@ -3,7 +3,7 @@
   ini_file:
     path: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
     section: pbench-server
-    option: commit-id
+    option: commit_id
     value: "{{ pbench_version }}-{{ pbench_seqno }}{{ pbench_sha1 }}"
     backup: yes
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -27,7 +27,7 @@ group=%(default-group)s
 admin-email=%(user)s@%(host)s
 mailto=%(admin-email)s
 mailfrom=%(user)s@%(host)s
-commit-id=unknown
+commit_id=unknown
 
 # Maximum number of days an unpacked tar ball directory hierarchy will be
 # kept around.


### PR DESCRIPTION
Fixes #1767

The default config file and (more crucially) the ansible roles use "commit-id",
but the rest of the code is looking for "commit_id".

Standardize on the underscore version: "commit_id".