### PR TITLE
ovs-hw-offload flows support in openvswitch-datalog

### DIFF
--- a/agent/tool-scripts/datalog/openvswitch-datalog
+++ b/agent/tool-scripts/datalog/openvswitch-datalog
@@ -52,7 +52,9 @@ rxq_mapping_file=${tool_output_dir}/pmd-rxq-show.txt
 ovs-appctl dpif-netdev/pmd-rxq-show > ${rxq_mapping_file}
 
 stats_file=${tool_output_dir}/ovs-stats.txt
+offload_stats_file=${tool_output_dir}/ovs-offload-stats.txt
 > ${stats_file}
+> ${offload_stats_file}
 if [[ ! -z "${bridges}" ]]; then
 	while true; do
 		printf "\ntimestamp: $(date +%s.%N)\n" >> ${stats_file}
@@ -72,6 +74,16 @@ if [[ ! -z "${bridges}" ]]; then
 		echo "dpdk-stats: pmd-stats-show" >> ${stats_file}
 		ovs-appctl dpif-netdev/pmd-stats-show >> ${stats_file}
 		ovs-appctl dpif-netdev/pmd-stats-clear
+		# OFFLOAD stats
+		printf "\ntimestamp: $(date +%s.%N)\n" >> ${offload_stats_file}
+                echo "ovs-appctl dpctl/dump-flows -m type=offloaded" >> ${offload_stats_file}
+                ovs-appctl dpctl/dump-flows -m type=offloaded >> ${offload_stats_file}		
 		sleep ${interval}
 	done
 fi
+
+#Hardware Offload flow on Bridge . Supported from OVS2.13
+for b in ${bridges}; do
+        offload_stats=${tool_output_dir}/${b}-offload-stats.txt
+        ovs-appctl bridge/dump-flows --offload-stats ${b} > ${offload_stats}
+done


### PR DESCRIPTION
Currently the pbench `openvswitch-datalog` tool-script support collecting metrics from standard openvswitch and ovs-dpdk layer.
As openvswitch feature extends with TC hardware offload support and during the network performance test with trafficgen is required to review the flows which dump in SMART NIC (e.g., Mellanox Connectx5).

With minor code change in `openvswitch-datalog` script, we are able to collect the OVS hardware offload follows from DUT node. Since ovs-hw-offload in OpenStack 16.x is [GA](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/network_functions_virtualization_planning_and_configuration_guide/index#sect-configuring-hw-offload), so the changes `openvswitch.datalog` can collect flows periodically for further analysis.