### PR TITLE
Minimal attempt to remove tool meister commands

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -72,7 +72,7 @@
 [info][1900-01-01T00:00:00.000000] "iostat" tool is now registered for host "testhost.example.com" in group "default"
 --- pbench.log file contents
 +++ mock-run/tm/pbench-tool-data-sink.err file contents
-Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class '__main__.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
+Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Listening on http://0.0.0.0:8080/
 Hit Ctrl-C to quit.
 

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -165,7 +165,7 @@
 [info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_c.example.com" in group "lite"
 --- pbench.log file contents
 +++ mock-run/tm/pbench-tool-data-sink.err file contents
-Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class '__main__.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
+Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Listening on http://0.0.0.0:8080/
 Hit Ctrl-C to quit.
 
@@ -293,7 +293,7 @@ INFO pbench-tool-meister main -- Remove pid file ... (tm-lite-testhost.example.c
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_a.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_b.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_c.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_a.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_b.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_c.example.com
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -165,7 +165,7 @@
 [info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_c.example.com" in group "lite"
 --- pbench.log file contents
 +++ mock-run/tm/pbench-tool-data-sink.err file contents
-Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class '__main__.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
+Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Listening on http://0.0.0.0:8080/
 Hit Ctrl-C to quit.
 
@@ -293,7 +293,7 @@ INFO pbench-tool-meister main -- Remove pid file ... (tm-lite-testhost.example.c
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_a.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_b.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com pbench-tool-meister testhost.example.com 17001 tm-lite-remote_c.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_a.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_b.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister testhost.example.com 17001 tm-lite-remote_c.example.com
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -31,7 +31,7 @@ channel payload, "'{"hostname": "testhost.example.com", "kind": "tm", "pid": NNN
 [info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "testhost.example.com" in group "default"
 --- pbench.log file contents
 +++ mock-run/tm/pbench-tool-data-sink.err file contents
-Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class '__main__.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
+Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Listening on http://0.0.0.0:8080/
 Hit Ctrl-C to quit.
 

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -31,7 +31,7 @@ channel payload, "'{"hostname": "testhost.example.com", "kind": "tm", "pid": NNN
 [info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "testhost.example.com" in group "mygroup"
 --- pbench.log file contents
 +++ mock-run/tm/pbench-tool-data-sink.err file contents
-Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class '__main__.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
+Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Listening on http://0.0.0.0:8080/
 Hit Ctrl-C to quit.
 

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -30,6 +30,9 @@ from pathlib import Path
 
 import redis
 
+from pbench.agent.tool_data_sink import main as tds_main
+from pbench.agent.tool_meister import main as tm_main
+
 
 # Port number is "One Tool" in hex 0x17001
 # FIXME: move to common area
@@ -232,11 +235,24 @@ def kill_redis_server(pid_file):
             return 1
 
 
+def waitpid(pid):
+    """Wrapper for os.waitpid()
+
+    Returns the exit status of the given process ID.
+
+    Raises an exception if the final exit PID is different from the given PID.
+    """
+    exit_pid, _exit_status = os.waitpid(pid, 0)
+    if pid != exit_pid:
+        raise Exception(f"Logic bomb!  exit pid, {exit_pid}, does not match pid, {pid}")
+    exit_status = os.WEXITSTATUS(_exit_status)
+    return exit_status
+
+
 def main(argv):
     """Main program for the tool meister start.
     """
     _prog = Path(argv[0])
-    _prog_dir = _prog.parent
     PROG = _prog.name
     logger = logging.getLogger(PROG)
     if os.environ.get("_PBENCH_TOOL_MEISTER_START_LOG_LEVEL") == "debug":
@@ -355,7 +371,6 @@ def main(argv):
 
     # 3. Start the tool-data-sink process
     #   - leave a PID file for the tool data sink process
-    #   - FIXME: use podman to start a tool-data-sink container
     tds_param_key = "tds-{}".format(group)
     tds = dict(channel=channel, benchmark_run_dir=benchmark_run_dir)
     try:
@@ -365,45 +380,42 @@ def main(argv):
             "failed to create tool data sink parameter key in redis server"
         )
         return kill_redis_server(redis_pid)
-    data_sink = "pbench-tool-data-sink"
-    data_sink_path = _prog_dir / data_sink
     logger.debug("starting tool data sink")
     try:
-        retcode = os.spawnl(
-            os.P_WAIT,
-            data_sink_path,
-            data_sink,
-            "localhost",
-            str(redis_port),
-            tds_param_key,
-        )
+        pid = os.fork()
+        if pid == 0:
+            # In the child: the main() of the Tool Data Sink module will not
+            # return here since it will daemonize itself and this child pid
+            # will be replaced by a new pid.
+            status = tds_main(
+                ["pbench-tool-data-sink", "localhost", str(redis_port), tds_param_key]
+            )
+            sys.exit(status)
+        else:
+            # In the parent: wait for the child to finish daemonizing itself.
+            retcode = waitpid(pid)
+            if retcode != 0:
+                logger.error(
+                    "failed to create pbench data sink, daemonized; return code: %d",
+                    retcode,
+                )
     except Exception:
         logger.exception("failed to create pbench data sink, daemonized")
         return kill_redis_server(redis_pid)
-    else:
-        if retcode != 0:
-            logger.error(
-                "failed to create pbench data sink, daemonized; return code: %d",
-                retcode,
-            )
-            return kill_redis_server(redis_pid)
 
     # 4. Start all the local and remote tool meister processes
     #   - leave a PID file on each local/remote host
-    #   - FIXME: use podman on the remote hosts to start a tool meister
-    #            container
     failures = 0
     successes = 0
-    tool_meister_cmd = "pbench-tool-meister"
+    tool_meister_cmd = _prog.parent / "tool-meister" / "pbench-tool-meister"
     # NOTE: it is assumed that the location of the pbench-tool-meister command
     # is the same on the local host as it is on any remote host.
-    tool_meister_cmd_path = _prog_dir / tool_meister_cmd
     ssh_cmd = "ssh"
     ssh_path = find_executable(ssh_cmd)
     args = [
         ssh_cmd,
         "<host replace me>",
-        tool_meister_cmd,
+        str(tool_meister_cmd),
         full_hostname,
         str(redis_port),
         "<tm param key>",
@@ -436,34 +448,41 @@ def main(argv):
         if host == full_hostname:
             logger.debug("starting localhost tool meister")
             try:
-                retcode = os.spawnl(
-                    os.P_WAIT,
-                    tool_meister_cmd_path,
-                    tool_meister_cmd,
-                    "localhost",
-                    str(redis_port),
-                    tm_param_key,
-                )
+                pid = os.fork()
+                if pid == 0:
+                    # In the child: the main() of the Tool Meister module will
+                    # not return here since it will daemonize itself and this
+                    # child pid will be replaced by a new pid.
+                    status = tm_main(
+                        [
+                            str(tool_meister_cmd),
+                            "localhost",
+                            str(redis_port),
+                            tm_param_key,
+                        ]
+                    )
+                    sys.exit(status)
+                else:
+                    # In the parent: wait for the child to finish daemonizing
+                    # itself.
+                    retcode = waitpid(pid)
+                    if retcode != 0:
+                        logger.error(
+                            "failed to create localhost tool meister,"
+                            " daemonized; return code: %d",
+                            retcode,
+                        )
             except Exception:
                 logger.exception("failed to create localhost tool meister, daemonized")
                 failures += 1
             else:
-                if retcode == 0:
-                    successes += 1
-                else:
-                    logger.error(
-                        "failed to create localhost tool meister,"
-                        " daemonized; return code: %d",
-                        retcode,
-                    )
-                    failures += 1
+                successes += 1
             continue
         args[1] = host
         args[5] = tm_param_key
         logger.debug(
             "starting remote tool meister, ssh_path=%r args=%r", ssh_path, args
         )
-        # FIXME: should we consider using Ansible instead?
         try:
             pid = os.spawnv(os.P_NOWAIT, ssh_path, args)
         except Exception:

--- a/agent/util-scripts/test-bin/ssh
+++ b/agent/util-scripts/test-bin/ssh
@@ -24,7 +24,7 @@ shift
 if [[ "${1}" == "hostname" && "${2}" == "-s" ]]; then
     echo "${remote}"
     exit_code=0
-elif [[ "${1}" == "pbench-tool-meister" ]]; then
+elif [[ "$(basename -- "${1}")" == "pbench-tool-meister" ]]; then
     _dir=$(dirname ${0})
     _tool_bin=${_dir}/mpstat ${1} localhost "${3}" "${4}"
     exit_code=$?

--- a/agent/util-scripts/tool-meister/pbench-tool-meister
+++ b/agent/util-scripts/tool-meister/pbench-tool-meister
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+"""Simple command-line wrapper to keep the tool meister from being in the CLI
+command set, while still allowing it to be invoked remotely via SSH by
+internal code.
+"""
+
+import sys
+
+from pbench.agent.tool_meister import main
+
+
+status = main(sys.argv)
+sys.exit(status)

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -21,7 +21,7 @@ export _testdir=${_testroot}/pbench
 # Copy util-scripts execution environment to _testroot
 _testopt=${_testroot}/opt/pbench-agent
 res=0
-mkdir -p ${_testopt}/config ${_testopt}/util-scripts ${_testopt}/tool-scripts ${_testopt}/lib ${_testopt}/unittest-scripts ${_testopt}/common/lib
+mkdir -p ${_testopt}/config ${_testopt}/util-scripts/tool-meister ${_testopt}/tool-scripts ${_testopt}/lib ${_testopt}/unittest-scripts ${_testopt}/common/lib
 let res=res+${?}
 cp -L ${_tdir}/../base ${_testopt}/
 let res=res+${?}
@@ -30,6 +30,8 @@ cp -rL ${_tdir}/../config/* ${_testopt}/config/
 mv ${_testopt}/config/pbench-agent.cfg ${_testopt}/config/pbench-agent.cfg.orig
 let res=res+${?}
 cp -a ${_tdir}/{require-rpm,pbench-*} ${_testopt}/util-scripts/
+let res=res+${?}
+cp -a ${_tdir}/tool-meister/pbench-* ${_testopt}/util-scripts/tool-meister/
 let res=res+${?}
 scripts="${_tdir}/../tool-scripts/*"
 for script in ${scripts}; do

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -100,7 +100,7 @@ class DataSinkWsgiServer(ServerAdapter):
         self._logger = logger
 
     def run(self, app):
-        assert self._server is None, f"'run' method called twice"
+        assert self._server is None, "'run' method called twice"
         self._logger.debug("Making tool data sink WSGI server ...")
         self._server = make_server(self.host, self.port, app, **self.options)
         self._logger.debug("Running tool data sink WSGI server ...")
@@ -299,7 +299,7 @@ class ToolDataSink(Bottle):
         we are expecting to hear from all registered tool meisters.
         """
         assert self.state == "send", f"expected state 'send' not '{self.state}'"
-        assert self._tm_tracking is not None, f"Logic bomb! self._tm_tracking is None"
+        assert self._tm_tracking is not None, "Logic bomb!  self._tm_tracking is None"
 
         done = False
         while not done:

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -860,8 +860,9 @@ def main(argv):
     Returns 0 on success, > 0 when an error occurs.
 
     """
-    PROG = os.path.basename(argv[0])
-    pbench_bin = os.path.dirname(os.path.dirname(argv[0]))
+    _prog = Path(argv[0])
+    PROG = _prog.name
+    pbench_bin = _prog.parent.parent.parent
 
     try:
         redis_host = argv[1]
@@ -874,7 +875,7 @@ def main(argv):
     global tar_path
     tar_path = find_executable("tar")
     if tar_path is None:
-        print(f"External 'tar' executable not found.", file=sys.stderr)
+        print("External 'tar' executable not found.", file=sys.stderr)
         return 2
 
     logger = logging.getLogger(PROG)


### PR DESCRIPTION
Here we replace the `pbench-tool-data-sink` command line interface entirely replacing it with a `fork()` and invocation of the Tool Data Sink library code directly.  We then do the same for the `pbench-tool-meister` command.

In both cases the original commands are copied as-is to the library side of the tree with no modifications.  The new `pbench-tool-meister` command is a very simple trampoline command file required for our SSH tool meister default orchestration.

This demonstrates that neither the Tool Data Sink or the Tool Meister require a CLI interface for their operation as they only need a simple set of arguments passed to them.