### PR TITLE
Only emit a warning message on missing debugfs (v0.69)

### DIFF
--- a/agent/tool-scripts/datalog/perf-datalog
+++ b/agent/tool-scripts/datalog/perf-datalog
@@ -17,8 +17,7 @@ if [[ ${?} -ne 0 ]]; then
 fi
 
 if ! grep -q debugfs /proc/mounts; then
-        printf -- "%s: required debugfs not mounted\n" "${PROG}" >&2
-        exit 1
+        printf -- "%s: debugfs not mounted, kernel perf data may be incomplete\n" "${PROG}" >&2
 fi
 
 if [[ "${1}" == "record" ]]; then


### PR DESCRIPTION
Fixes #1811 for the `b0.69` branch.

See also #1814.