### PR TITLE
Persistent Tools support for Tool Meister

### DIFF
--- a/agent/bench-scripts/pbench-run-benchmark
+++ b/agent/bench-scripts/pbench-run-benchmark
@@ -298,6 +298,10 @@ while (scalar @param_sets > 0) {
         push(@iterations_labels, $iteration_label);
     }
 
+    if (! $pp_only) {
+    	system("pbench-init-tools --group=" . $tool_group . " --dir=" . $base_bench_dir);
+    }
+
     for (my $index=0; $index<@iterations; $index++) {
         my $iteration_params = $iterations[$index];
         my $iteration_label = $iterations_labels[$index];
@@ -389,6 +393,8 @@ while (scalar @param_sets > 0) {
         print BULK_FH "echo Sample processing complete!\n";
         close(BULK_FH);
         system(". ./bulk-sample.sh");
+    } else {
+	system("pbench-end-tools --group=" . $tool_group . " --dir=" . $base_bench_dir);
     }
     $run_doc{'run'}{'end'} = int time * 1000; # time in milliseconds
     put_json_file(\%run_doc, $es_dir . "/run/run" . $run_part . "-" . $run_doc{'run'}{'id'} . ".json");

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -300,6 +300,9 @@ declare -a parts
 # the while loop sub-shell does not share FD 0 (stdin) with the executed
 # benchmark script. Otherwise, benchmarks messing around with FD 0 can lead to
 # problems.
+
+pbench-init-tools --group=${tool_group} --dir=${benchmark_run_dir}
+
 while read -u 3 line; do
 	# Current line number, starting from 1 (not zero)
 	(( lineno++ ))
@@ -333,6 +336,8 @@ done 3< ${benchmark_run_dir}/iteration.lis
 if [[ ${iter_num} -eq 1 ]]; then
 	warn_log "[${script_name}]: iteration file did not contain any iterations!"
 fi
+
+pbench-end-tools --group=${tool_group} --dir=${benchmark_run_dir}
 
 # Now that we have finished running all the iterations, create the
 # reference-result symlinks.

--- a/agent/bench-scripts/test-bin/pbench-end-tools
+++ b/agent/bench-scripts/test-bin/pbench-end-tools
@@ -1,0 +1,1 @@
+mock-cmd

--- a/agent/bench-scripts/test-bin/pbench-init-tools
+++ b/agent/bench-scripts/test-bin/pbench-init-tools
@@ -1,0 +1,1 @@
+mock-cmd

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-09.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-09.txt
@@ -29,6 +29,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-09_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-10.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-10.txt
@@ -29,6 +29,8 @@ Running user-benchmark-script no-duration for iteration 1-default
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-10_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-11.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-11.txt
@@ -29,6 +29,8 @@ Running user-benchmark-script with-duration for iteration 1-default
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-11_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-12.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-12.txt
@@ -30,6 +30,8 @@ WARNING:root:Unable to load JSON data from /var/tmp/pbench-test-bench/pbench-age
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-12_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-23.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-23.txt
@@ -58,6 +58,8 @@ sud
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-23_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-24.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-24.txt
@@ -29,6 +29,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-24_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-25.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-25.txt
@@ -29,6 +29,8 @@ Running user-benchmark-script no-file for iteration 1-default
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-25_1900.01.01T00.00.00/1-default/sample1

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-37.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-37.txt
@@ -23,6 +23,8 @@
 +++ test-execution.log file contents
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-37_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-37_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-37_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-37_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-37_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-tool-meister-start default

--- a/agent/bench-scripts/tests/pbench-user-benchmark/test-38.txt
+++ b/agent/bench-scripts/tests/pbench-user-benchmark/test-38.txt
@@ -48,6 +48,8 @@ Running bm arg1 arg2 for iteration 3-iter-three
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm arg1 arg2 arg3
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00 --sysinfo=default end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-collect-sysinfo --sysinfo=default --check
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-end-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-init-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00 beg
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-metadata-log --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00 end
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/pbench-postprocess-tools --group=default --dir=/var/tmp/pbench-test-bench/pbench-agent/pbench-user-benchmark_test-38_1900.01.01T00.00.00/1-iter-one/sample1

--- a/agent/tool-scripts/dcgm
+++ b/agent/tool-scripts/dcgm
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+
+import sys
+import os
+import logging
+
+PROG = os.path.basename(sys.argv[0])
+logger = logging.getLogger(PROG)
+logger.setLevel(logging.DEBUG)
+sh = logging.StreamHandler()
+sh.setLevel(logging.DEBUG)
+shf = logging.Formatter("%(message)s")
+sh.setFormatter(shf)
+logger.addHandler(sh)
+
+if len(sys.argv) != 2 or sys.argv[1] != "--help":
+    logger.info("This script is deprecated, please run it with --help for info on registering the tool.")
+    logger.info("Run /opt/pbench-agent/tool-scripts/dcgm --help for more info.")
+    exit(0)
+
+if sys.argv[1] == "--help":
+    logger.info("Options:")
+    logger.info("--inst=<LOCATION OF dcgm INSTALL> (required)")

--- a/agent/tool-scripts/meta.json
+++ b/agent/tool-scripts/meta.json
@@ -42,6 +42,7 @@
 	},
 
 	"persistent":{
-		"node-exporter": {"collector": "prometheus", "port": "9100"}
+		"node-exporter": {"collector": "prometheus", "port": "9100"},
+		"dcgm": {"collector": "prometheus", "port": "8000"}
 	}
 }

--- a/agent/tool-scripts/meta.json
+++ b/agent/tool-scripts/meta.json
@@ -1,0 +1,47 @@
+{
+	"transient":{
+		"blktrace": null,
+		"bpftrace": null,
+		"cpuacct": null,
+		"disk": null,
+		"dm-cache": null,
+		"docker": null,
+		"docker-info": null,
+		"external-data-source": null,
+		"haproxy-ocp": null,
+		"iostat": null,
+		"jmap": null,
+		"jstack": null,
+		"kvm-spinlock": null,
+		"kvmstat": null,
+		"kvmtrace": null,
+		"lockstat": null,
+		"mpstat": null,
+		"numastat": null,
+		"oc": null,
+		"openvswitch": null,
+		"pcp": null,
+		"perf": null,
+		"pidstat": null,
+		"pprof": null,
+		"proc-interrupts": null,
+		"proc-sched_debug": null,
+		"proc-vmstat": null,
+		"prometheus-metrics": null,
+		"qemu-migrate": null,
+		"rabbit": null,
+		"sar": null,
+		"strace": null,
+		"sysfs": null,
+		"systemtap": null,
+		"tcpdump": null,
+		"turbostat": null,
+		"user-tool": null,
+		"virsh-migrate": null,
+		"vmstat": null
+	},
+
+	"persistent":{
+		"node-exporter": {"collector": "prometheus", "port": "9100"}
+	}
+}

--- a/agent/tool-scripts/node-exporter
+++ b/agent/tool-scripts/node-exporter
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+# -*- mode: python -*-
+
+import os
+import sys
+import logging
+
+PROG = os.path.basename(sys.argv[0])
+logger = logging.getLogger(PROG)
+logger.setLevel(logging.DEBUG)
+sh = logging.StreamHandler()
+sh.setLevel(logging.DEBUG)
+shf = logging.Formatter("%(message)s")
+sh.setFormatter(shf)
+logger.addHandler(sh)
+
+if len(sys.argv) != 2 or sys.argv[1] != "--help":
+    logger.info(
+        "This script is deprecated, please run it with --help for info on registering the tool."
+    )
+    logger.info(
+        "Run /opt/pbench-agent/tool-scripts/node-exporter --help for more info."
+    )
+    exit(0)
+
+if sys.argv[1] == "--help":
+    logger.info("Options:")
+    logger.info(
+        "--inst=</path/to/node_exporter/dir> (required; to create the path of the executable, '/node-exporter' will be appended)"
+    )
+    logger.info("Installation Guide: github.com/prometheus/node_exporter")
+    logger.info("Soon to come: metric enabling/disabling")

--- a/agent/util-scripts/gold/pbench-end-tools/test-62.txt
+++ b/agent/util-scripts/gold/pbench-end-tools/test-62.txt
@@ -1,0 +1,16 @@
++++ Running test-62 pbench-end-tools --group=default --dir=/var/tmp/pbench-test-utils/pbench/mock-run
+--- Finished test-62 pbench-end-tools (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/mock-run
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-default
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/mpstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/mpstat:
+--interval=3
+--- pbench tree state
++++ test-execution.log file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-tool-meister-client default /var/tmp/pbench-test-utils/pbench/mock-run/tools-default end
+--- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-init-tools/test-61.txt
+++ b/agent/util-scripts/gold/pbench-init-tools/test-61.txt
@@ -1,0 +1,16 @@
++++ Running test-61 pbench-init-tools --group=default --dir=/var/tmp/pbench-test-utils/pbench/mock-run
+--- Finished test-61 pbench-init-tools (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/mock-run
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-default
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/mpstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/mpstat:
+--interval=3
+--- pbench tree state
++++ test-execution.log file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-tool-meister-client default /var/tmp/pbench-test-utils/pbench/mock-run/tools-default init
+--- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-kill-tools/test-09.txt
+++ b/agent/util-scripts/gold/pbench-kill-tools/test-09.txt
@@ -1,5 +1,12 @@
 +++ Running test-09 pbench-kill-tools --group=barfoo
 ERROR: required directory argument missing.
+The following are required:
+
+	-g str --group=str, str = a tool group used in a benchmark
+	                          (the default group is 'default')
+
+	-d str --dir=str, str = a directory where pbench-kill-tools
+	                        will store and process data
 --- Finished test-09 pbench-kill-tools (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-register-tool/test-44.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-44.txt
@@ -55,6 +55,7 @@ Available tools:
 	user-tool
 	virsh-migrate
 	vmstat
+	node-exporter
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/pbench-register-tool/test-44.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-44.txt
@@ -56,6 +56,7 @@ Available tools:
 	virsh-migrate
 	vmstat
 	node-exporter
+	dcgm
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/pbench-register-tool/test-46.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-46.txt
@@ -55,6 +55,7 @@ Available tools:
 	user-tool
 	virsh-migrate
 	vmstat
+	node-exporter
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/pbench-register-tool/test-46.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-46.txt
@@ -56,6 +56,7 @@ Available tools:
 	virsh-migrate
 	vmstat
 	node-exporter
+	dcgm
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/pbench-register-tool/test-47.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-47.txt
@@ -55,6 +55,7 @@ Available tools:
 	user-tool
 	virsh-migrate
 	vmstat
+	node-exporter
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/pbench-register-tool/test-47.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-47.txt
@@ -56,6 +56,7 @@ Available tools:
 	virsh-migrate
 	vmstat
 	node-exporter
+	dcgm
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help

--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -52,6 +52,7 @@
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-default-testhost.example.com.err
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-default-testhost.example.com.log
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-default-testhost.example.com.out
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-default
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-default

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -124,6 +124,7 @@
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.err
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.log
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.out
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -124,6 +124,7 @@
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.err
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.log
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm-lite-testhost.example.com.out
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite

--- a/agent/util-scripts/pbench-end-tools
+++ b/agent/util-scripts/pbench-end-tools
@@ -1,0 +1,1 @@
+pbench-start-tools

--- a/agent/util-scripts/pbench-init-tools
+++ b/agent/util-scripts/pbench-init-tools
@@ -1,0 +1,1 @@
+pbench-start-tools

--- a/agent/util-scripts/pbench-postprocess-tools
+++ b/agent/util-scripts/pbench-postprocess-tools
@@ -17,16 +17,20 @@ def_group="default"
 group="${def_group}"
 dir=""
 
-# Process options and arguments
-
-opts=$(getopt -q -o d:g: --longoptions "dir:,group:" -n "getopt.sh" -- "${@}")
-if [[ ${?} -ne 0 ]]; then
-	printf "\n%s: you specified an invalid option\n\n" "${script_name}"
+function usage {
 	printf "The following are required:\n\n"
 	printf -- "\t-g str --group=str, str = a tool group used in a benchmark\n"
 	printf -- "\t                          (the default group is '%s')\n\n" "${def_group}"
 	printf -- "\t-d str --dir=str, str = a directory where %s\n" "${script_name}"
 	printf -- "\t                        will store and process data\n"
+}
+
+# Process options and arguments
+
+opts=$(getopt -q -o d:g: --longoptions "dir:,group:" -n "getopt.sh" -- "${@}")
+if [[ ${?} -ne 0 ]]; then
+	printf "\n%s: you specified an invalid option\n\n" "${script_name}"
+	usage >&2
 	exit 1
 fi
 eval set -- "${opts}"
@@ -54,11 +58,13 @@ while true; do
 done
 
 if [[ -z "${group}" ]]; then
-	printf -- "ERROR: required tool group parameter missing.\n" >&2
+	printf -- "ERROR: required tool group parameter missing.\n\n" >&2
+	usage >&2
 	exit 1
 fi
 if [[ -z "${dir}" ]]; then
-	printf -- "ERROR: required directory argument missing.\n" >&2
+	printf -- "ERROR: required directory argument missing.\n\n" >&2
+	usage >&2
 	exit 1
 fi
 

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -116,9 +116,7 @@ function usage() {
 	printf -- "\tdenoted by a leading hash, or pound (\"#\"), character.\n"
 	printf -- "\nAvailable tools:\n"
 	local tool=""
-	for tool in $(find ${pbench_bin}/tool-scripts -maxdepth 1 ! -type d ! -name '*README*' ! -name base-tool ! -name unittests -printf "%P\n" 2> /dev/null | sort); do
-		printf -- "\t${tool}\n"
-	done
+	python3 -c "import sys, json; meta = json.load(open(sys.argv[1])); [print(f'\t{tool}') for tool in (*meta['transient'].keys(), *meta['persistent'].keys()) ]" ${pbench_bin}/tool-scripts/meta.json
 	#                     1         2         3         4         5         6         7         8
 	# (no tab)   12345678901234567890123456789012345678901234567890123456789012345678901234567890
 	printf -- "\nFor a list of tool specific options, run:\n"

--- a/agent/util-scripts/pbench-start-tools
+++ b/agent/util-scripts/pbench-start-tools
@@ -10,7 +10,7 @@ action=${_suffix%%-*}
 # source the base script
 . "${pbench_bin}"/base
 
-if [[ "${action}" != "kill" && "${action}" != "send" && "${action}" != "start" && "${action}" != "stop" ]]; then
+if [[ "${action}" != "end" && "${action}" != "init" && "${action}" != "kill" && "${action}" != "send" && "${action}" != "start" && "${action}" != "stop" ]]; then
 	error_log "[${script_name}] action \"${action}\" is not supported"
 	exit 1
 fi
@@ -24,16 +24,20 @@ def_group="default"
 group="${def_group}"
 dir=""
 
-# Process options and arguments
-
-opts=$(getopt -q -o d:g: --longoptions "dir:,group:" -n "getopt.sh" -- "${@}")
-if [[ ${?} -ne 0 ]]; then
-	printf "\n%s: you specified an invalid option\n\n" "${script_name}"
+function usage {
 	printf "The following are required:\n\n"
 	printf -- "\t-g str --group=str, str = a tool group used in a benchmark\n"
 	printf -- "\t                          (the default group is '%s')\n\n" "${def_group}"
 	printf -- "\t-d str --dir=str, str = a directory where %s\n" "${script_name}"
 	printf -- "\t                        will store and process data\n"
+}
+
+# Process options and arguments
+
+opts=$(getopt -q -o d:g: --longoptions "dir:,group:" -n "getopt.sh" -- "${@}")
+if [[ ${?} -ne 0 ]]; then
+	printf "\n%s: you specified an invalid option\n\n" "${script_name}"
+	usage >&2
 	exit 1
 fi
 eval set -- "${opts}"
@@ -62,10 +66,12 @@ done
 
 if [[ -z "${group}" ]]; then
 	printf -- "ERROR: required tool group parameter missing.\n" >&2
+	usage >&2
 	exit 1
 fi
 if [[ -z "${dir}" ]]; then
 	printf -- "ERROR: required directory argument missing.\n" >&2
+	usage >&2
 	exit 1
 fi
 
@@ -86,7 +92,7 @@ fi
 # The tool group's directory which stores tool output for all hosts.
 tool_output_dir="${dir}/tools-${group}"
 
-if [[ "${action}" == "start" ]]; then
+if [[ "${action}" == "start" || "${action}" == "init" ]]; then
 	mkdir -p ${tool_output_dir}
 	if [[ ${?} -ne 0 ]]; then
 		error_log "[${script_name}] failed to create tool output directory, \"${tool_output_dir}\""

--- a/agent/util-scripts/pbench-tool-meister-client
+++ b/agent/util-scripts/pbench-tool-meister-client
@@ -25,7 +25,7 @@ tm_channel = "tool-meister-chan"
 cl_channel = "tool-meister-client"
 
 # List of allowed actions
-allowed_actions = ("start", "stop", "send", "kill")
+allowed_actions = ("end", "init", "send", "start", "stop", "kill")
 
 
 def main(argv):

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -32,6 +32,8 @@ import redis
 
 from pbench.agent.tool_data_sink import main as tds_main
 from pbench.agent.tool_meister import main as tm_main
+from pbench.agent import PbenchAgentConfig
+import pbench.agent.toolmetadata as toolmetadata
 
 
 # Port number is "One Tool" in hex 0x17001
@@ -369,10 +371,32 @@ def main(argv):
         ), f"bad channel: {resp!r}"
         assert resp["data"] == 1, f"bad data: {resp!r}"
 
+    # 2.5. Add tool metadata json to redis
+    try:
+        inst_dir = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"]).pbench_install_dir
+    except BadConfig as exc:
+        logger.error("%s", exc)
+        return 1
+    except Exception:
+        logger.error("Unexpected error encountered logging pbench agent configuration: '%s'", exc)
+        return 1
+
+    try:
+        tm_start_path = Path(inst_dir).resolve(strict=True)
+    except FileNotFoundError:
+        logger.error("Unable to determine proper installation directory, '%s' not found", inst_dir)
+        return 1
+    except Exception as exc:
+        logger.exception("Unexpected error encountered resolving installation directory: '%s'", exc)
+        return 1
+    tool_metadata = toolmetadata.ToolMetadata("json", tm_start_path, logger)
+    tool_metadata.loadIntoRedis(redis_server)
+
+
     # 3. Start the tool-data-sink process
     #   - leave a PID file for the tool data sink process
     tds_param_key = "tds-{}".format(group)
-    tds = dict(channel=channel, benchmark_run_dir=benchmark_run_dir)
+    tds = dict(channel=channel, benchmark_run_dir=benchmark_run_dir, group=group)
     try:
         redis_server.set(tds_param_key, json.dumps(tds, sort_keys=True))
     except Exception:

--- a/agent/util-scripts/samples/pbench-end-tools/test-62
+++ b/agent/util-scripts/samples/pbench-end-tools/test-62
@@ -1,0 +1,1 @@
+../pbench-start-tools/test-05

--- a/agent/util-scripts/samples/pbench-init-tools/test-61
+++ b/agent/util-scripts/samples/pbench-init-tools/test-61
@@ -1,0 +1,1 @@
+../pbench-start-tools/test-05

--- a/agent/util-scripts/test-bin/test-client-tool-meister
+++ b/agent/util-scripts/test-bin/test-client-tool-meister
@@ -68,6 +68,13 @@ if [[ ${status} -ne 0 ]]; then
     exit 1
 fi
 
+_timeout pbench-init-tools --group="${group}" --dir="${benchmark_run_dir}"
+status=${?}
+if [[ ${status} -ne 0 ]]; then
+    printf -- "ERROR - \"pbench-init-tools\" failed to execute successfully (exit code: %s)\n" "${status}" >&2
+    exit 1
+fi
+
 sample="sample42"
 iterations="0-iter-zero 1-iter-one"
 
@@ -111,6 +118,13 @@ if [[ "${3}" == "delayed-send" ]]; then
             exit 1
         fi
     done
+fi
+
+_timeout pbench-end-tools --group="${group}" --dir="${benchmark_run_dir}"
+status=${?}
+if [[ ${status} -ne 0 ]]; then
+    printf -- "ERROR - \"pbench-end-tools\" failed to execute successfully (exit code: %s)\n" "${status}" >&2
+    exit 1
 fi
 
 _timeout pbench-tool-meister-stop

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -367,6 +367,8 @@ declare -A tools=(
     [test-58]="pbench-stop-tools"
     [test-59]="pbench-postprocess-tools"
     [test-60]="pbench-send-tools"
+    [test-61]="pbench-init-tools"
+    [test-62]="pbench-end-tools"
 )
 
 declare -A options=(
@@ -441,6 +443,8 @@ declare -A options=(
     [test-58]="--group=default --dir=42-iter/sample42"
     [test-59]="--group=foobar --dir=42-iter/sample42"
     [test-60]="--group=default --dir=42-iter/sample42"
+    [test-61]="--group=default --dir=${_testdir}/mock-run"
+    [test-62]="--group=default --dir=${_testdir}/mock-run"
 )
 
 declare -A expected_status=(
@@ -478,6 +482,8 @@ declare -A pre_hooks=(
     [test-47]='mkdir ${_testdir}/tmp; printf -- "# good list with no labels\none.example.com\ntwo.example.com\nthree.example.com\n" > ${_testdir}/tmp/remotes.lis'
     [test-48]='mkdir ${_testdir}/tmp; printf -- "%s\n" "30%" > ${_testdir}/tmp/foo.txt'
     [test-55]='pbench-register-tool --name=mpstat --remote=localhost > /dev/null; mkdir ${_testdir}/mock-run'
+    [test-61]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client'
+    [test-62]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client; mkdir -p ${_testdir}/mock-run/tools-default'
 )
 
 declare -A post_hooks=(
@@ -487,6 +493,8 @@ declare -A post_hooks=(
     [test-19]='rm ${_testopt}/unittest-scripts/pbench-tool-meister-client'
     [test-56]='sort ${_testdir}/mock-run/tm/pbench-tool-data-sink.log > ${_testdir}/mock-run/tm/pbench-tool-data-sink.log.sorted; mv ${_testdir}/mock-run/tm/pbench-tool-data-sink.log.sorted ${_testdir}/mock-run/tm/pbench-tool-data-sink.log; sort ${_testlog} > ${_testlog}.sorted; mv ${_testlog}.sorted ${_testlog}'
     [test-57]='sort ${_testdir}/mock-run/tm/pbench-tool-data-sink.log > ${_testdir}/mock-run/tm/pbench-tool-data-sink.log.sorted; mv ${_testdir}/mock-run/tm/pbench-tool-data-sink.log.sorted ${_testdir}/mock-run/tm/pbench-tool-data-sink.log; sort ${_testlog} > ${_testlog}.sorted; mv ${_testlog}.sorted ${_testlog}'
+    [test-61]='rm ${_testopt}/unittest-scripts/pbench-tool-meister-client'
+    [test-62]='rm ${_testopt}/unittest-scripts/pbench-tool-meister-client'
 )
 
 tests="${*}"

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -117,6 +117,22 @@ class PersistentTool:
             self.process = subprocess.Popen(
                 args, stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
             )
+        elif self.name == "dcgm":
+            os.environ["PYTHONPATH"] = (
+                self.install_path
+                + "/bindings:"
+                + self.install_path
+                + "/bindings/common"
+            )
+
+            script_path = self.install_path + "/samples/scripts/dcgm_prometheus.py"
+            if not os.path.isfile(script_path):
+                self.logger.info(script_path + " does not exist")
+                self.failure = True
+                return 0
+
+            args = [f"python2 {script_path}"]
+            self.process = subprocess.Popen(args, shell=True)
         else:
             self.logger.error("INVALID PERSISTENT TOOL NAME")
             self.failure = True

--- a/lib/pbench/agent/toolmetadata.py
+++ b/lib/pbench/agent/toolmetadata.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+import json
+import os
+
+
+class ToolMetadataExc(Exception):
+    pass
+
+
+class ToolMetadata:
+    def __init__(self, mode, context, logger):
+        self.logger = logger
+        assert mode in (
+            "redis",
+            "json",
+        ), f"Logic bomb! Unexpected mode, {mode}, encountered constructing tool meta data"
+        assert (
+            context
+        ), "Logic bomb! No context given on ToolMetadata object construction"
+        self.mode = mode
+        if mode == "redis":
+            self.redis_server = context
+            self.json_file = None
+        else:
+            self.redis_server = None
+            json_path = Path(context, "tool-scripts", "meta.json")
+            try:
+                self.json = json_path.resolve(strict=True)
+            except FileNotFoundError:
+                raise ToolMetadataExc(f"missing {json_path}")
+            except Exception:
+                raise
+        self.data = self.__getInitialData()
+
+    def __getInitialData(self):
+        if self.mode == "json":
+            if not os.path.isfile(self.json):
+                self.logger.error(
+                    "There is no tool-scripts/meta.json in given install dir"
+                )
+                return None
+            with self.json.open("r") as json_file:
+                metadata = json.load(json_file)
+        elif self.mode == "redis":
+            try:
+                meta_raw = self.redis_server.get("tool-metadata")
+            except Exception:
+                self.logger.exception(
+                    "Failure to fetch tool metadata from the Redis server"
+                )
+                raise
+            else:
+                if meta_raw is None:
+                    self.logger.error("Metadata has not been loaded into redis yet")
+                    return None
+            try:
+                metadata = json.loads(meta_raw.decode("utf-8"))
+            except Exception as exc:
+                self.logger.error(
+                    "Bad metadata loaded into Redis server, '%s', json=%r",
+                    exc,
+                    meta_raw,
+                )
+                return None
+        return metadata
+
+    def __dataCheck(self):
+        """Check for existing/loadable data, return True if retreival possible, False otherwise"""
+        if not self.data:
+            self.data == self.__getInitialData()
+            if not self.data:
+                self.logger.error(f"Unable to access data through {self.mode}")
+                return False
+        return True
+
+    def getFullData(self):
+        if self.__dataCheck():
+            return self.data
+        return None
+
+    def getPersistentTools(self):
+        if self.__dataCheck():
+            return list(self.data["persistent"].keys())
+        return None
+
+    def getTransientTools(self):
+        if self.__dataCheck():
+            return list(self.data["transient"].keys())
+        return None
+
+    def getProperties(self, tool):
+        if tool in self.data["persistent"].keys():
+            return self.data["persistent"][tool]
+        elif tool in self.data["transient"].keys():
+            return self.data["transient"][tool]
+
+    def loadIntoRedis(self, info):
+        if self.mode == "redis":
+            try:
+                self.json = Path(info).resolve(strict=True)
+            except FileNotFoundError:
+                raise ToolMetadataExc(f"missing {info}")
+            except Exception:
+                raise
+        elif self.mode == "json":
+            self.redis_server = info
+
+        try:
+            with self.json.open("r") as json_file:
+                metadata = json.load(json_file)
+                self.redis_server.set("tool-metadata", json.dumps(metadata))
+        except Exception:
+            self.logger.error("Failed to load the data into redis")
+            raise
+        return None


### PR DESCRIPTION
Delivery mechanism for Mustafa's & Keshav's commits for "persistent tools" support.  We provide support for Prometheus based metric collection from `node_exporter` and `dcgm`  tools.

Persistent tools are those tools started before any iteration runs, and end after all iterations have completed.

This work incorporates the changes from #1787 as well.