### PR TITLE
Setup base classes

### DIFF
--- a/lib/pbench/cli/agent/core.py
+++ b/lib/pbench/cli/agent/core.py
@@ -1,0 +1,50 @@
+"""
+Base classes for various agent cli commands
+
+Base classes are used so that code can be shared between the same type
+of commands without duplicating the same code everywhere.
+"""
+
+from pbench.agent.base import BaseCommand
+
+
+class ToolCommand(BaseCommand):
+    """Common tool command Class"""
+
+    def __init__(self, context):
+        super().__init__(context)
+
+
+class LogCommand(BaseCommand):
+    """Common logging command class"""
+
+    def __init__(self, context):
+        super().__init__(context)
+
+
+class SysInfoCommand(BaseCommand):
+    """Common sysinfo command class"""
+
+    def __init__(self, context):
+        super().__init__(context)
+
+
+class TriggersCommand(BaseCommand):
+    """Common Triggers command class"""
+
+    def __init__(self, context):
+        super().__init__(BaseCommand)
+
+
+class ToolMeisterCommand(BaseCommand):
+    """Common ToolMeister command class"""
+
+    def __init__(self, context):
+        super().__init__(BaseCommand)
+
+
+class ResultsCommand(BaseCommand):
+    """Common Results command class"""
+
+    def __init__(self, context):
+        super().__init__(BaseCommand)


### PR DESCRIPTION
Stub in base classes for various CLI utils that we will
be replacing shell scripts with python scripts.

Since there are alot of different shell scripts to convert
I grouped the various commands into sub-classes from the BaseCommand
since alot of the shell scripts are re-using the same code as well.
So it made sense to me.

Signed-off-by: Charles Short <chucks@redhat.com>