### PR TITLE
Tell pbr to stop creating AUTHORS & ChangeLog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ dist
 .tox
 .eggs
 pip-wheel-metadata
-AUTHORS
-ChangeLog
 .idea/
 .pytest_cache/
 .venv

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ deps =
    -r{toxinidir}/test-requirements.txt
 envars =
     PATH = {env:PATH}:{toxinidir}/bin
+    SKIP_GENERATE_AUTHORS = 1
+    SKIP_WRITE_GIT_CHANGELOG = 1
 whitelist_externals =
     bash
     rm
@@ -34,38 +36,32 @@ whitelist_externals =
 
 [testenv:server]
 description = Runs all non-Python3-based server unit/functional tests
-usedevelop = true
 passenv = PBENCH_UNITTEST_SERVER_MODE
 commands =
     bash -c "./server/bin/unittests {posargs}"
 
 [testenv:datalog]
 description = Runs all non-Python3-based agent tool-scripts/datalog unit/functional tests
-usedevelop = true
 commands =
     bash -c "./agent/tool-scripts/datalog/unittests {posargs}"
 
 [testenv:postprocess]
 description = Runs all non-Python3-based agent tool-scripts/postprocess unit/functional tests
-usedevelop = true
 commands =
     bash -c "./agent/tool-scripts/postprocess/unittests {posargs}"
 
 [testenv:tool-scripts]
 description = Runs all non-Python3-based agent tool-scripts unit/functional tests
-usedevelop = true
 commands =
     bash -c "./agent/tool-scripts/unittests {posargs}"
 
 [testenv:util-scripts]
 description = Runs all non-Python3-based agent util-scripts unit/functional tests
-usedevelop = true
 commands =
     bash -c "./agent/util-scripts/unittests {posargs}"
 
 [testenv:bench-scripts]
 description = Runs all non-Python3-based agent bench-scripts unit/functional tests
-usedevelop = true
 commands =
     bash -c "./agent/bench-scripts/unittests {posargs}"
 


### PR DESCRIPTION
When running tests, stop creating the `AUTHORS` and `ChangeLog` files.  See https://docs.openstack.org/pbr/latest/user/packagers.html#versioning.