### PR TITLE
Add missing quote

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -91,7 +91,7 @@ function collect_sos {
 	else
 		_quiet="--quiet"
 	fi
-	if [[ ${sos_ver} -lt 3 || ( ${sos_ver} -eq 3 && ( "${sos_ver_minor}" -lt 5 || ( "${sos_ver_minor} -eq 5 && -z "${sos_ver_subminor}" ) ) ) ]]; then
+	if [[ "${sos_ver}" -lt 3 || ( "${sos_ver}" -eq 3 && ( "${sos_ver_minor}" -lt 5 || ( "${sos_ver_minor}" -eq 5 && -z "${sos_ver_subminor}" ) ) ) ]]; then
 		# Pre-v3.5.1+
 		_modules="general lsbrelease"
 	else


### PR DESCRIPTION
Fixes #1846

Also quote a couple of unquoted instances of ${sos_ver} on the same line for
uniformity's sake.