### PR TITLE
Fix generation of sosreport command

### DIFF
--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -123,7 +123,7 @@ function collect_sos {
 	for mod in ${_modules}; do
 		printf -- " -o %s" "${mod}" >> ${_cmd}
 	done
-	printf -- "--batch%s --tmp-dir=\"%s\" --name \"%s\"" "${_quiet}" "${dir}" "${_name}" >> ${_cmd}
+	printf -- " --batch%s --tmp-dir=\"%s\" --name \"%s\"\n" "${_quiet}" "${dir}" "${_name}" >> ${_cmd}
 	chmod +x ${_cmd}
 
 	debug_log "[${script_name}]collecting sosreport"


### PR DESCRIPTION
The fixes to pbench-sysinfo-dump in PR #1819 introduced a problem where the command line options were not properly spaced from each other, causing the sosreport command to fail.

See also issue #1846 and PR #1848.