### PR TITLE
Switch legacy unit tests to use C.UTF-8 locale

### DIFF
--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -1,6 +1,6 @@
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 export _tdir=$(dirname $(readlink -f ${0}))
 
 # We mock our "cat" during our tests, so we fetch the real one first.

--- a/agent/tool-scripts/datalog/unittests
+++ b/agent/tool-scripts/datalog/unittests
@@ -1,6 +1,6 @@
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 
 _tdir="$(dirname $(readlink -f ${0}))"
 cd ${_tdir}

--- a/agent/tool-scripts/postprocess/unittests
+++ b/agent/tool-scripts/postprocess/unittests
@@ -1,6 +1,6 @@
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 
 _tdir=$(dirname $(readlink -f $0))
 cd $_tdir

--- a/agent/tool-scripts/unittests
+++ b/agent/tool-scripts/unittests
@@ -1,6 +1,6 @@
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 _tdir="$(dirname $(readlink -f ${0}))"
 cd ${_tdir}
 

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -1,6 +1,6 @@
 #!/bin/bash
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 _tdir=$(dirname $(readlink -f ${0}))
 
 _testroot=/var/tmp/pbench-test-utils

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -10,8 +10,8 @@ umask 0002
 unset _PBENCH_SERVER_CONFIG
 
 # Ensure we always use the same locale for the unit tests.
-export LANG=C
-export LC_ALL=C
+export LANG=C.UTF-8
+export LC_ALL=C.UTF-8
 
 export _tdir=$(dirname $(readlink -f $0))
 export _gitdir=$(dirname $(dirname $_tdir))


### PR DESCRIPTION
Upcoming work to convert our infrastructure to Python3 will be leveraging python modules which require the `C.UTF-8` locale.

To ensure that such a switch does not affect the existing code, we make that change here in isolation to prove that out.