### PR TITLE
Fixes for server installation failures: RPM and ansible

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -39,6 +39,7 @@ install-dirs:
 
 install-python3-setup: install-bin install-lib
 	mkdir -p ${DESTDIR}/python3
+	${COPY} ../requirements.txt ${DESTDIR}
 	(cd ..; SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py install --prefix=${DESTDIR}/python3)
 	${COPY} ${DESTDIR}/python3/bin/pbench-config ${DESTDIR}/python3/bin/pbench-server ${BINDIR}/
 	${RM} -r ${DESTDIR}/python3

--- a/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-install-config-file/tasks/main.yml
@@ -38,6 +38,7 @@
 
 - name: delete local temp dir
   delegate_to: localhost
+  become: no
   file:
     state: absent
     path: "{{ tempdir_1.path }}"

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -94,6 +94,7 @@ fi
 /%{installdir}/%{static}/VERSION
 /%{installdir}/%{static}/package.json
 /%{installdir}/package.json
+/%{installdir}/requirements.txt
 
 /%{installdir}/lib/config/pbench-server-satellite.cfg.example
 /%{installdir}/lib/config/pbench-server.cfg.example


### PR DESCRIPTION
- The server Makefile installs setup.py, setup.cfg and requirements.txt.
- The spec file includes the above.
- The ansible pbench-server-install-config-file role was missing a
  a `become=no` in the `delete local temp dir' task.
- The ansible pbench-server-systemd-service-role does not distinguish
  between centos/rhel-7 and everything else: everybody does the same
  thing.