### PR TITLE
Resolves logging error in pbench-server-prep-shim

### DIFF
--- a/server/bin/gold/test-13.txt
+++ b/server/bin/gold/test-13.txt
@@ -90,8 +90,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--        437 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--        106 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+-rw-rw-r--        215 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine.bad
@@ -144,10 +143,8 @@ drwxrwxr-x          - tmp
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
-Failed: /var/tmp/pbench-test-server/test-13/pbench-local/quarantine does not exist, or is not a directory
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+1970-01-01T00:00:42.000000 ERROR pbench-server-prep-shim-002.pbench-server-prep-shim-002 fetch_config_val -- Failed: /var/tmp/pbench-test-server/test-13/pbench-local/quarantine does not exist, or is not a directory
 ----- pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 ---- pbench-local/logs
 ++++ pbench-satellite-local/logs

--- a/server/bin/gold/test-15.txt
+++ b/server/bin/gold/test-15.txt
@@ -90,8 +90,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.error
 -rw-rw-r--        437 logs/pbench-audit-server/pbench-audit-server.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--        138 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+-rw-rw-r--        247 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002.bad
 drwxrwxr-x          - quarantine
@@ -144,10 +143,8 @@ drwxrwxr-x          - tmp
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
 1970-01-01T00:00:42.000000 DEBUG pbench-audit-server.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-audit-server/pbench-audit-server.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
-Failed: /var/tmp/pbench-test-server/test-15/pbench-local/pbench-move-results-receive/fs-version-002 does not exist, or is not a directory
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+1970-01-01T00:00:42.000000 ERROR pbench-server-prep-shim-002.pbench-server-prep-shim-002 fetch_config_val -- Failed: /var/tmp/pbench-test-server/test-15/pbench-local/pbench-move-results-receive/fs-version-002 does not exist, or is not a directory
 ----- pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 ---- pbench-local/logs
 ++++ pbench-satellite-local/logs

--- a/server/bin/gold/test-2.txt
+++ b/server/bin/gold/test-2.txt
@@ -240,7 +240,6 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        210 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--        200 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 -rw-rw-r--        816 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
@@ -328,8 +327,6 @@ run-1970-01-01T00:00:42-UTC: Processed 0 result tar balls, 0 successfully (0 par
 +++++ pbench-index/pbench-index.log
 1970-01-01T00:00:42.000000 ERROR pbench-index.__init__ _get_valid_path -- The INCOMING directory, '/var/tmp/pbench-test-server/test-2/pbench/public_html/incoming', does not resolve to a real location
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 main -- run-1970-01-01T00:00:42-UTC: Processed 0 entries, 0 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.

--- a/server/bin/gold/test-3.txt
+++ b/server/bin/gold/test-3.txt
@@ -268,7 +268,6 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        254 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--        224 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 -rw-rw-r--        816 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
@@ -362,8 +361,6 @@ run-1970-01-01T00:00:42-UTC: Processed 0 result tar balls, 0 successfully (0 par
 1970-01-01T00:00:42.000000 DEBUG pbench-index.pbench-index main -- pbench-index.run-1970-01-01T00:00:42-UTC: starting
 1970-01-01T00:00:42.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 main -- run-1970-01-01T00:00:42-UTC: Processed 0 entries, 0 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.

--- a/server/bin/gold/test-4.txt
+++ b/server/bin/gold/test-4.txt
@@ -269,7 +269,6 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        254 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--        224 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 -rw-rw-r--        816 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
@@ -370,8 +369,6 @@ run-1970-01-01T00:00:42-UTC: Processed 0 result tar balls, 0 successfully (0 par
 1970-01-01T00:00:42.000000 DEBUG pbench-index.pbench-index main -- pbench-index.run-1970-01-01T00:00:42-UTC: starting
 1970-01-01T00:00:42.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 main -- run-1970-01-01T00:00:42-UTC: Processed 0 entries, 0 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -354,7 +354,6 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        254 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--        224 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 -rw-rw-r--        816 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
@@ -466,8 +465,6 @@ run-1970-01-01T00:00:42-UTC: Processed 0 result tar balls, 0 successfully (0 par
 1970-01-01T00:00:42.000000 DEBUG pbench-index.pbench-index main -- pbench-index.run-1970-01-01T00:00:42-UTC: starting
 1970-01-01T00:00:42.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 main -- run-1970-01-01T00:00:42-UTC: Processed 0 entries, 0 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -692,8 +692,7 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        254 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--       7305 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--        650 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
--rw-rw-r--       2029 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
+-rw-rw-r--       2988 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
 -rw-rw-r--        219 logs/pbench-sync-satellite/pbench-sync-satellite.error
@@ -1006,18 +1005,16 @@ run-1970-01-01T00:00:42-UTC: Processed 10 result tar balls, 7 successfully (0 pa
 1970-01-01T00:00:42.000000 INFO pbench-index.pbench-index main -- pbench-index.run-1970-01-01T00:00:42-UTC: indexed 0 (skipped 7) results, 0 errors
 1970-01-01T00:00:42.000000 DEBUG pbench-index.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
-run-1970-01-01T00:00:42-UTC: Duplicate: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-d-duplicate/tarball-duplicate_1970.01.01T00.42.00.tar.xz duplicate name
-run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-e-bad-md5/tarball-bad-md5_1970.01.01T00.42.00.tar.xz failed MD5 check
-run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-f-bad-md5/tarball-bad-md5-1_1970.01.01T00.42.00.tar.xz failed MD5 check
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-0_1970.01.01T00.42.00.tar.xz: OK
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz: OK
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz: OK
+1970-01-01T00:00:42.000000 ERROR pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC: Duplicate: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-d-duplicate/tarball-duplicate_1970.01.01T00.42.00.tar.xz duplicate name
+1970-01-01T00:00:42.000000 ERROR pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-e-bad-md5/tarball-bad-md5_1970.01.01T00.42.00.tar.xz failed MD5 check
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-bad-md5_1970.01.01T00.42.00.tar.xz: FAILED
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- md5sum: WARNING: 1 computed checksum did NOT match
+1970-01-01T00:00:42.000000 ERROR pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-f-bad-md5/tarball-bad-md5-1_1970.01.01T00.42.00.tar.xz failed MD5 check
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-bad-md5-1_1970.01.01T00.42.00.tar.xz: FAILED
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- md5sum: WARNING: 1 computed checksum did NOT match
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- tarball-normal_1970.01.01T00.42.00.tar.xz: OK

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -354,7 +354,6 @@ drwxrwxr-x          - logs/pbench-index-tool-data
 -rw-rw-r--        254 logs/pbench-index-tool-data/pbench-index-tool-data.log
 -rw-rw-r--        224 logs/pbench-index/pbench-index.log
 drwxrwxr-x          - logs/pbench-server-prep-shim-002
--rw-rw-r--          0 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 -rw-rw-r--        816 logs/pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 drwxrwxr-x          - logs/pbench-sync-satellite
 drwxrwxr-x          - logs/pbench-sync-satellite/ONE
@@ -466,8 +465,6 @@ run-1970-01-01T00:00:42-UTC: Processed 0 result tar balls, 0 successfully (0 par
 1970-01-01T00:00:42.000000 DEBUG pbench-index.pbench-index main -- pbench-index.run-1970-01-01T00:00:42-UTC: starting
 1970-01-01T00:00:42.000000 INFO pbench-index.pbench-index main -- No tar balls found that need processing
 ----- pbench-index/pbench-index.log
-+++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
------ pbench-server-prep-shim-002/pbench-server-prep-shim-002.error
 +++++ pbench-server-prep-shim-002/pbench-server-prep-shim-002.log
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 process_tb -- run-1970-01-01T00:00:42-UTC
 1970-01-01T00:00:42.000000 INFO pbench-server-prep-shim-002.pbench-server-prep-shim-002 main -- run-1970-01-01T00:00:42-UTC: Processed 0 entries, 0 tarballs successful, 0 quarantined tarballs, 0 duplicately-named tarballs, 0 errors.


### PR DESCRIPTION
Fixes #1877

* logs error in new-style
* instead of using an external errorfile used logger.error