### PR TITLE
Fix breakage

### DIFF
--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -46,6 +46,7 @@ The pbench server scripts.
 %install
 rm -rf %{buildroot}
 
+mkdir -p %{buildroot}/%{installdir}
 cp -a ./server/* %{buildroot}/%{installdir}
 
 mkdir -p %{buildroot}/%{installdir}/html/static
@@ -88,7 +89,6 @@ fi
 /%{installdir}/SEQNO
 /%{installdir}/SHA1
 /%{installdir}/%{static}/VERSION
-/%{installdir}/%{static}/package.json
 /%{installdir}/package.json
 /%{installdir}/requirements.txt
 


### PR DESCRIPTION
- We need to create the %{installdir} before copying  ./server/* to it.
- We move the package.json file from %{installdir}/html/static to
  %{installdir}/, so we need to get rid of the former in the %files
  list.