### PR TITLE
Enhance agent container builds

### DIFF
--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/defaults/main.yml
@@ -4,6 +4,7 @@ pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedor
  
 repos:
   - tag: pbench
+    user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/pbench/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/pbench/pubkey.gpg"
     gpgcheck: 1

--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
@@ -1,7 +1,7 @@
 {% for repo in repos %}
 
-[copr-{{ repo.tag }}]
-name=Copr {{ repo.tag }} repo
+[copr-{{ repo.tag }}-{{ repo.user }}]
+name=COPR {{ repo.tag }} ({{ repo.user }}) repo
 baseurl={{ repo.baseurl }}
 skip_if_unavailable=True
 gpgcheck={{ repo.gpgcheck }}

--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -9,12 +9,8 @@ COPY ./{{ pbench_repo_file }} /etc/yum.repos.d/pbench.repo
 # ... and finally, ensure the proper pbench-agent environment variables are set up.
 RUN \
 {% if distro_image.startswith('centos') %}
-    {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm && \
+    {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm{% if distro_image == 'centos:7' %} centos-release-scl-rh centos-release-scl{% endif %} && \
 {% endif %}
-{% if distro_image == 'centos:7' %}
-    {{ pkgmgr }} install -y centos-release-scl-rh centos-release-scl && \
-    {{ pkgmgr }} install -y --enablerepo=centos-sclo-rh rh-python36 && \
-{% endif %}
-    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench pbench-agent && \
+    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}{% if distro_image == 'centos:7' %}--enablerepo=centos-sclo-rh {% endif %} pbench-agent && \
     {{ pkgmgr }} -y clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/{{ pkgmgr }}

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -7,4 +7,4 @@ FROM pbench-agent-base-{{ distro }}:{{ tag }}
 #        Kubernetes or RHV environments.
 RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench {{ rpms }} && \
     {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} -y clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/{% if distro == 'centos-7' %}yum{% else %}dnf{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -176,7 +176,7 @@ fedora-31-base.Dockerfile: Dockerfile.base.j2 fedora-31-pbench.repo
 	jinja2 ${_REPO_TEMPLATE} $*.yml -o $@
 
 %.yml: repo.yml.j2
-	jinja2 repo.yml.j2 -D distro=${@:-pbench.yml=} -D url_prefix=${URL_PREFIX} -D test_suffix=${_TEST_SUFFIX} -o $@
+	jinja2 repo.yml.j2 -D distro=${@:-pbench.yml=} -D url_prefix=${URL_PREFIX} -D test_suffix=${_TEST_SUFFIX} -D user=${USER} -o $@
 
 clean:
 	rm -f *.Dockerfile *.repo *.yml *-tags.lis

--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -1,6 +1,7 @@
 ---
 repos:
   - tag: pbench
+    user: {{ user }}
     baseurl: "{{ url_prefix }}/pbench{{ test_suffix }}/{{ distro }}-$basearch"
     gpgkey: "{{ url_prefix }}/pbench{{ test_suffix }}/pubkey.gpg"
     gpgcheck: 1


### PR DESCRIPTION
We tackle three things with this commit.  This first is that we don't explicitly install `rh-python36`, we simply allow the `pbench-agent` RPM dependencies to drive that installation.

The second change is to make sure we build the name of the user for the COPR repo into the repo name to help debug where RPMs were pulled from at build time.

The last change is to ensure the proper package manager's cache (yum vs dnf) is removed depending on the distribution used.