### PR TITLE
Backport container build enhancements to `b0.69`

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -9,13 +9,8 @@ COPY ./{{ pbench_repo_file }} /etc/yum.repos.d/pbench.repo
 # ... and finally, ensure the proper pbench-agent environment variables are set up.
 RUN \
 {% if distro_image.startswith('centos') %}
-    {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm && \
+    {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm{% if distro_image == 'centos:7' %} centos-release-scl-rh centos-release-scl{% endif %} && \
 {% endif %}
-{% if distro_image == 'centos:7' %}
-    {{ pkgmgr }} install -y centos-release-scl-rh centos-release-scl && \
-    {{ pkgmgr }} install -y --enablerepo=centos-sclo-rh rh-python36 && \
-{% endif %}
-    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench pbench-agent && \
+    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}{% if distro_image == 'centos:7' %}--enablerepo=centos-sclo-rh {% endif %} pbench-agent && \
     {{ pkgmgr }} -y clean all && \
-    rm -rf /var/cache/yum && \
-    cp -a /opt/pbench-agent/config/pbench-agent.cfg.example /opt/pbench-agent/config/pbench-agent.cfg
+    rm -rf /var/cache/{{ pkgmgr }}

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -7,4 +7,4 @@ FROM pbench-agent-base-{{ distro }}:{{ tag }}
 #        Kubernetes or RHV environments.
 RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench {{ rpms }} && \
     {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} -y clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/{% if distro == 'centos-7' %}yum{% else %}dnf{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -12,6 +12,12 @@ USER = ndokos
 # using an environment variable as appropriate.
 URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${USER}
 
+# By default we use non-"test" COPR repos named "pbench".  We expect
+# test COPR repos to have a suffix added, typically "test", so that
+# the final repo name would be "pbench-test".
+TEST =
+_TEST_SUFFIX = $(if $(TEST),-$(TEST),"")
+
 # By default we use the pbench Quay.io organization for the image
 # repository.  You can override this default using an environment
 # variable as appropriate.
@@ -23,7 +29,7 @@ _REPO_TEMPLATE = ../../ansible/pbench/agent/roles/pbench_repo_install/templates/
 
 # The list of RPMs which provide the various tools we offer.
 # Not intended to be overridden with an environment variable.
-_TOOL_RPMS = pbench-sysstat perf blktrace bpftrace numactl pcp-system-tools strace kernel-tools tcpdump
+_TOOL_RPMS = blktrace bpftrace cpupowerutils golang kernel-tools libvirt-client nmap-ncat numactl pbench-sysstat pcp-system-tools perf procps-ng strace tcpdump trace-cmd
 
 # The list of RPMs for the default workloads we offer.
 # Not intended to be overridden with an environment variable.
@@ -32,108 +38,115 @@ _WORKLOAD_RPMS = fio uperf
 # Not intended to be overridden with an environment variable.
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 
-# Default we only build images the following distributions:
-all: centos-8-all-tagged centos-7-all-tagged fedora-32-all-tagged fedora-31-all-tagged
+# By default we only build images for the following distributions:
+_DISTROS = centos-8 centos-7 fedora-32 fedora-31
+
+all: $(foreach distro, ${_DISTROS}, ${distro}-all-tagged)
 
 #+
 # Tagging targets
 #-
 
 # Add the "latest" tag to the local images.
-tag-latest: centos-8-tag-latest centos-7-tag-latest fedora-32-tag-latest fedora-31-tag-latest
+tag-latest: $(foreach distro, ${_DISTROS}, ${distro}-tag-latest)
 
 # Add the "v<Major>-latest" tag to the local images.
-tag-major: centos-8-tag-major centos-7-tag-major fedora-32-tag-major fedora-31-tag-major
+tag-major: $(foreach distro, ${_DISTROS}, ${distro}-tag-major)
 
 # Add the "v<Major>.<Minor>-latest" tag to the local images.
-tag-major-minor: centos-8-tag-major-minor centos-7-tag-major-minor fedora-32-tag-major-minor fedora-31-tag-major-minor
+tag-major-minor: $(foreach distro, ${_DISTROS}, ${distro}-tag-major-minor)
 
 #+
 # Push targets
 #-
 
 # Push images with "<git commit hash>" and "v<full RPM version>" tags.
-push: centos-8-push centos-7-push fedora-32-push fedora-31-push
+push: $(foreach distro, ${_DISTROS}, ${distro}-push)
 
 # Push images with the "latest" tag.
-push-latest: centos-8-push-latest centos-7-push-latest fedora-32-push-latest fedora-31-push-latest
+push-latest: $(foreach distro, ${_DISTROS}, ${distro}-push-latest)
 
 # Push images with the "v<Major>-latest" tag.
-push-major: centos-8-push-major centos-7-push-major fedora-32-push-major fedora-31-push-major
+push-major: $(foreach distro, ${_DISTROS}, ${distro}-push-major)
 
 # Push images with the "v<Major>.<Minor>-latest" tag.
-push-major-minor: centos-8-push-major-minor centos-7-push-major-minor fedora-32-push-major-minor fedora-31-push-major-minor
+push-major-minor: $(foreach distro, ${_DISTROS}, ${distro}-push-major-minor)
 
 #+
 # For the following rule patterns, the "%" represents the "distribution" name,
 # as derived from the "all" target's *-distro list.
+#
+# The string matching the "%" is called the "stem", in GNU Make parlance.  The
+# "$*" references are replaced with that stem value.
+#
+# See https://www.gnu.org/software/make/manual/make.html#Automatic-Variables
 #-
 
 %-all-tagged: %-all %-tags.lis
-	./apply-tags pbench-agent-all-${@:-all-tagged=} ${@:-all-tagged=}-tags.lis
+	./apply-tags pbench-agent-all-$* $*-tags.lis
 
 %-all: %-tools-tagged %-workloads-tagged %-all.Dockerfile
-	./build-image all ${@:-all=} ${@:-all=}-tags.lis
+	./build-image all $* $*-tags.lis
 
 %-all.Dockerfile: Dockerfile.layered.j2 %-tags.lis
-	jinja2 Dockerfile.layered.j2 -D distro=${@:-all.Dockerfile=} -D tag="$$(grep -v -E '^v' ${@:-all.Dockerfile=}-tags.lis)" -D kind="all" -D rpms="${_ALL_RPMS}" > ./$@
+	jinja2 Dockerfile.layered.j2 -D distro=$* -D tag="$$(grep -v -E '^v' $*-tags.lis)" -D kind="all" -D rpms="${_ALL_RPMS}" > ./$@
 
 %-tools-tagged: %-tools %-tags.lis
-	./apply-tags pbench-agent-tools-${@:-tools-tagged=} ${@:-tools-tagged=}-tags.lis
+	./apply-tags pbench-agent-tools-$* $*-tags.lis
 
 %-tools: %-base-tagged %-tools.Dockerfile
-	./build-image tools ${@:-tools=} ${@:-tools=}-tags.lis
+	./build-image tools $* $*-tags.lis
 
 %-tools.Dockerfile: Dockerfile.layered.j2 %-tags.lis
-	jinja2 Dockerfile.layered.j2 -D distro=${@:-tools.Dockerfile=} -D tag="$$(grep -v -E '^v' ${@:-tools.Dockerfile=}-tags.lis)" -D kind="tools" -D rpms="${_TOOL_RPMS}" > ./$@
+	jinja2 Dockerfile.layered.j2 -D distro=$* -D tag="$$(grep -v -E '^v' $*-tags.lis)" -D kind="tools" -D rpms="${_TOOL_RPMS}" > ./$@
 
 %-workloads-tagged: %-workloads %-tags.lis
-	./apply-tags pbench-agent-workloads-${@:-workloads-tagged=} ${@:-workloads-tagged=}-tags.lis
+	./apply-tags pbench-agent-workloads-$* $*-tags.lis
 
 %-workloads: %-base-tagged %-workloads.Dockerfile
-	./build-image workloads ${@:-workloads=} ${@:-workloads=}-tags.lis
+	./build-image workloads $* $*-tags.lis
 
 %-workloads.Dockerfile: Dockerfile.layered.j2 %-tags.lis
-	jinja2 Dockerfile.layered.j2 -D distro=${@:-workloads.Dockerfile=} -D tag="$$(grep -v -E '^v' ${@:-workloads.Dockerfile=}-tags.lis)" -D kind="workloads" -D rpms="${_WORKLOAD_RPMS}" > ./$@
+	jinja2 Dockerfile.layered.j2 -D distro=$* -D tag="$$(grep -v -E '^v' $*-tags.lis)" -D kind="workloads" -D rpms="${_WORKLOAD_RPMS}" > ./$@
 
 %-base-tagged: %-base
-	./apply-tags pbench-agent-base-${@:-base-tagged=} ${@:-base-tagged=}-tags.lis
+	./apply-tags pbench-agent-base-$* $*-tags.lis
 
 %-base: %-base.Dockerfile %-tags.lis
-	./build-image base ${@:-base=} ${@:-base=}-tags.lis
+	./build-image base $* $*-tags.lis
 
 #+
 # Push local images for the given tag and distribution.
 #-
 
 %-push: %-tags.lis
-	./push ${IMAGE_REPO} ${@:-push=}
+	./push ${IMAGE_REPO} $*
 
 %-push-latest: %-tags.lis
-	./push ${IMAGE_REPO} ${@:-push-latest=} latest
+	./push ${IMAGE_REPO} $* latest
 
 %-push-major: %-tags.lis
-	./push ${IMAGE_REPO} ${@:-push-major=} _major
+	./push ${IMAGE_REPO} $* _major
 
 %-push-major-minor: %-tags.lis
-	./push ${IMAGE_REPO} ${@:-push-major-minor=} _minor
+	./push ${IMAGE_REPO} $* _minor
 
 #+
 # Tag local images for the given distribution.
 #-
 
 %-tag-latest: %-tags.lis
-	./tagit ${@:-tag-latest=} latest
+	./tagit $* latest
 
 %-tag-major: %-tags.lis
-	./tagit ${@:-tag-major=} major-latest
+	./tagit $* major-latest
 
 %-tag-major-minor: %-tags.lis
-	./tagit ${@:-tag-major-minor=} major-minor-latest
+	./tagit $* major-minor-latest
 
 # Build the tags file for the given distribution.
 %-tags.lis:
-	./gen-tags-from-rpm "${URL_PREFIX}" "${@:-tags.lis=}" "${_ARCH}" > ${@}
+	./gen-tags-from-rpm "${URL_PREFIX}" "$*" "${_ARCH}" "${_TEST_SUFFIX}" > ${@}
 
 #+
 # For the following rules, the various CentOS "base" images need a mapping
@@ -160,10 +173,10 @@ fedora-31-base.Dockerfile: Dockerfile.base.j2 fedora-31-pbench.repo
 %.repo: ${_REPO_TEMPLATE}
 
 %.repo: %.yml
-	jinja2 ${_REPO_TEMPLATE} ${@:.repo=}.yml -o $@
+	jinja2 ${_REPO_TEMPLATE} $*.yml -o $@
 
 %.yml: repo.yml.j2
-	jinja2 repo.yml.j2 -D distro=${@:-pbench.yml=} -D url_prefix=${URL_PREFIX} -o $@
+	jinja2 repo.yml.j2 -D distro=${@:-pbench.yml=} -D url_prefix=${URL_PREFIX} -D test_suffix=${_TEST_SUFFIX} -D user=${USER} -o $@
 
 clean:
 	rm -f *.Dockerfile *.repo *.yml *-tags.lis

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -23,7 +23,8 @@ and `pbench-sysstat` RPMs, build or find proper RPMs for `fio` & `uperf`,
 and place them in a single yum/dnf repository accessible via HTTPS.  By
 default, we use Fedora COPR repos under the `ndokos` user (one can
 override the yum/dnf repos and user via the `URL_PREFIX` and `USER`
-environment variables).
+environment variables, and use `pbench-test` repos by setting the `TEST`
+environment variable to `test`). 
 
 Once the proper RPMs are available in the target repo, the default
 `Makefile` target, `all`, will build all the default images, and tag
@@ -73,11 +74,11 @@ appropriate (these tags are not automatically applied at build time):
 
 Finally, there are "push" targets to copy the locally built and
 tagged images to a non-local container image repository.  By default
-we use `docker://quay.io/pbench` (you can override that via an
-environment variable).  We have separate push targets to allow the
-administrator of the container image repository to label the images
-based on what they have built in relation to what has been published
-already.  The push targets are:
+we use `docker://quay.io/pbench` (you can override that via the
+environment variable `IMAGE_REPO`).  We have separate push targets to
+allow the administrator of the container image repository to label the
+images based on what they have built in relation to what has been
+published already.  The push targets are:
 
  * `push` - pushes all the images by their `<git commit ID>` tag,
    and their RPM version tag
@@ -93,4 +94,4 @@ already.  The push targets are:
 NOTE WELL: Each separate tag for each image needs to be pushed to
 the non-local container image repository.  This does NOT result in
 multiple image copies over the wire using up network bandwidth, as
-`buildah push` is smart enough push the actual image only once.
+`buildah push` is smart enough to push the actual image only once.

--- a/agent/containers/images/gen-tags-from-rpm
+++ b/agent/containers/images/gen-tags-from-rpm
@@ -1,8 +1,30 @@
 #!/bin/bash
 
+# Generate 3 lines of output to stdout containing strings which can be used as
+# image tags.
+#
+# The first line emitted contains one tag representing the Git SHA1 short hash
+# label taken from the RPM's commit ID suffix.
+#
+# The second line contains the full version string without the Git commit ID
+# suffix.
+#
+# The third line contains two separate labels separated by white space, the
+# first being the "latest" label using only the "major" ID from the version
+# string, the second being the "latest" label using the "major" and "minor" ID.
+#
+# For example:
+#
+#   RPM Version String:  0.69.3-1g13ab89fe3
+#
+#   Line 1: 13ab89fe3
+#   Line 2: v0.69.3-1
+#   Line 3: v0-latest v0.69-latest
+
 url_prefix="${1}"
 dist="${2}"
 arch="${3}"
+test="${4}"
 
 if [[ "${dist}" == "centos-8" ]]; then
     dist="epel-8"
@@ -12,13 +34,20 @@ fi
 
 # Ensure we only consider the pbench-agent RPM's version string from the
 # target repo.
-version_string="$(yum list -q --repofrompath pbench,"${url_prefix}/pbench/${dist}-${arch}" pbench-agent.noarch 2>/dev/null | awk 'FNR==2{print $2}')"
+url="${url_prefix}/pbench${test}/${dist}-${arch}"
+version_string="$(yum list -q --repofrompath pbench,"${url}" pbench-agent.noarch 2>/dev/null | awk 'FNR==2{print $2}')"
 if [[ -z "${version_string}" ]]; then
-    printf -- "Failed to fetch pbench-agent.noarch version string from '%s/pbench/%s-%s'\n" "${url_prefix}" "${dist}" "${arch}" >&2
+    printf -- "Failed to fetch pbench-agent.noarch version string from '%s'\n" "${url}" >&2
     exit 1
 fi
 
-# 0.69.3-1
+# Expected tag format (example):
+# version_string = "0.69.3-1g13ab89fe3"
+# ver =            "0.69.3-1"
+# major =          "0"
+# major_minor =    "0.69"
+# commit_id =      "13ab89fe3"
+
 ver="${version_string%g*}"
 major="${ver%%.*}"
 major_minor="${ver%.*}"

--- a/agent/containers/images/push
+++ b/agent/containers/images/push
@@ -2,14 +2,24 @@
 
 image_repo="${1}"
 distro="${2}"
+
+# See gen-tags-from-rpm for the documented file format of a *-tags.lis file.
+
+# The git hash label is the only line in the *-tags.lis file without a leading
+# "v".
 githash="$(grep -v -E "^v" ${distro}-tags.lis)"
+# The full version label (sans git hash) is the line with a leading "v" but
+# without the "latest" label suffix.
 ver="$(grep -E "^v" ${distro}-tags.lis | grep -v latest)"
 
 if [[ "${3}" == "_major" ]]; then
+    # The "v<major>-latest" label is the first of the "latest" labels.
     other="$(grep -E "^v" ${distro}-tags.lis | grep latest | awk '{print $1}')"
 elif [[ "${3}" == "_minor" ]]; then
+    # The "v<major>.<minor>-latest" label is the second of the "latest" labels.
     other="$(grep -E "^v" ${distro}-tags.lis | grep latest | awk '{print $2}')"
 else
+    # Take the third argument as is for a label (quite trusting).
     other="${3}"
 fi
 

--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -1,7 +1,8 @@
 ---
 repos:
   - tag: pbench
-    baseurl: "{{ url_prefix }}/pbench/{{ distro }}-$basearch"
-    gpgkey: "{{ url_prefix }}/pbench/pubkey.gpg"
+    user: {{ user }}
+    baseurl: "{{ url_prefix }}/pbench{{ test_suffix }}/{{ distro }}-$basearch"
+    gpgkey: "{{ url_prefix }}/pbench{{ test_suffix }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1


### PR DESCRIPTION
There have been a number of enhancements to how we build containers that need to be available for building the `b0.69` branch.  We were successful using these changes to build the `v0.69.4-agent` release using them.

We had to remove the `atomic-openshift-clients` RPM dependency from the "tool" image since that repo is really per OpenShift version.