### PR TITLE
Fix for missing templates directory

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -241,6 +241,7 @@ install: install-destdir install-python3-setup install-bench-scripts install-too
 	${COPY} profile ${DESTDIR}
 	${INSTALL} ${INSTALLOPTS} ${STOCKPILEDIR}
 	${COPY} stockpile ${DESTDIR}
+	${COPY} templates ${DESTDIR}
 
 install-destdir:
 	${INSTALL} ${INSTALLOPTS} ${DESTDIR}

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -114,6 +114,7 @@ fi
 
 /%{installdir}/lib
 /%{installdir}/ansible
+/%{installdir}/templates
 /%{installdir}/base
 
 /%{installdir}/VERSION


### PR DESCRIPTION
@Maxusmusti ran into this problem just now: the agent/templates directory (and the prometheus.yml file in it) was not installed.