### PR TITLE
Require pyesbulk 1.0.0 for Pbench 0.71

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,5 +4,5 @@ flask
 flask-restful
 gunicorn
 humanize
-pyesbulk
+pyesbulk==1.0.0
 requests


### PR DESCRIPTION
Let's see whether simply explicitly requiring pyesbulk 1.0.0 helps Travis.

The `pyesbulk 2.0.1` module attempts to dynamically determine and import the module used by its caller to create the `Elasticsearch` object parameter. This mechanism fails on the Pbench unit test mock object as it's not in a normal PyPi style module packaging format. The `pyesbulk` fallback is to import the latest `elasticsearch` version; which will work fine with Pbench once we've upgraded to use Elasticsearch V7 but doesn't work for the current `master` branch or `0.71` as we import `elasticsearch1`.

There's no foolproof way to resolve this in `pyesbulk`. It could attempt to import `elasticsearch` and then try `elasticsearch1` if that failed (or vice versa). However it's quite possible to have both `elasticsearch1` and `elasticsearch` installed, in which case whichever we guess first would import but wouldn't resolve the proper exception classes for the `except` clauses.

Instead, the easiest and most reliable fix is for Pbench to explicitly require `pyesbulk 1.0.0` until we advance to Elasticsearch V7 and the `elasticsearch` module.