### PR TITLE
Use `_pbench_` prefixed env var for host names

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -104,7 +104,7 @@ if [[ -z "${hostname}" ]]; then
     export hostname=$(hostname -s)
 fi
 if [[ -z "${full_hostname}" ]]; then
-    export full_hostname=$(hostname)
+    export full_hostname=$(hostname -f)
 fi
 
 if [[ -z "$ssh_opts" ]]; then

--- a/agent/base
+++ b/agent/base
@@ -59,16 +59,10 @@ export pbench_bspp_dir pbench_lib_dir
 
 TS_FORMAT="%FT%H:%M:%S"
 
-if [[ -z "${_PBENCH_UNIT_TESTS}" ]]; then
-    function timestamp {
-        # use ns in the timestamp
-        echo "$(date --utc +"${TS_FORMAT}.%N")"
-    }
-else
-    function timestamp {
-        echo "1900-01-01T00:00:00.000000"
-    }
-fi
+function timestamp {
+    # use ns in the timestamp
+    echo "$(date --utc +"${TS_FORMAT}.%N")"
+}
 
 function log {
     echo "[info][$(timestamp)] $*" >> $pbench_log
@@ -96,34 +90,21 @@ function debug_log {
     echo "[debug][${log_date}] $*" >> ${pbench_log}
 }
 
+# date may be set "accidentally" so add a var with an unlikely name
+# to check whether we need to set it.
+if [[ -z "$date" || -z "$_PBENCH_DATE_SET" ]]; then
+    # don't use ns in the date
+    export date=$(date --utc +"${TS_FORMAT}")
+    export _PBENCH_DATE_SET=1
+fi
+# don't use colons and dashes in the date suffix
+export date_suffix=$(date --date ${date} --utc +"%Y.%m.%dT%H.%M.%S")
 
-# Some standard global vars - try the config file first and fall back on hardwired defaults
-# which are valid today.
-if [[ -z "${_PBENCH_UNIT_TESTS}" ]]; then
-    # date may be set "accidentally" so add a var with an unlikely name
-    # to check whether we need to set it.
-    if [[ -z "$date" || -z "$_PBENCH_DATE_SET" ]]; then
-        # don't use ns in the date
-        export date=$(date --utc +"${TS_FORMAT}")
-        export _PBENCH_DATE_SET=1
-    fi
-    # don't use colons and dashes in the date suffix
-    export date_suffix=$(date --date ${date} --utc +"%Y.%m.%dT%H.%M.%S")
-    if [[ -z "${hostname}" ]]; then
-        export hostname=$(hostname -s)
-    fi
-    if [[ -z "${full_hostname}" ]]; then
-        export full_hostname=$(hostname)
-    fi
-else
-    export date="1900-01-01T00:00:00"
-    export date_suffix="1900.01.01T00.00.00"
-    if [[ -z "${hostname}" ]]; then
-        export hostname="testhost"
-    fi
-    if [[ -z "${full_hostname}" ]]; then
-        export full_hostname="testhost.example.com"
-    fi
+if [[ -z "${hostname}" ]]; then
+    export hostname=$(hostname -s)
+fi
+if [[ -z "${full_hostname}" ]]; then
+    export full_hostname=$(hostname)
 fi
 
 if [[ -z "$ssh_opts" ]]; then
@@ -156,33 +137,25 @@ function get_redhat_version() {
     cat /etc/redhat-release | awk '{ print $7 }'
 }
 
-if [[ -z "${_PBENCH_UNIT_TESTS}" ]]; then
-    function check_enable_copr {
-        local copr_user=$1
-        local copr_name=$2
+function check_enable_copr {
+    local copr_user=$1
+    local copr_name=$2
 
-        if is_fedora ; then
-            dnf copr enable ${copr_user}/${copr_name}
+    if is_fedora ; then
+        dnf copr enable ${copr_user}/${copr_name}
+    else
+        if is_redhat ; then
+            rhel_version=$(get_redhat_version)
+            rhel_major=${rhel_version%.*}
+            cd /etc/yum.repos.d/
+            local copr_url=https://copr.fedorainfracloud.org
+            local repo_file=${copr_user}-${copr_name}-epel-${rhel_major}.repo
+            [[ ! -f ${repo_file} ]] && wget -c ${copr_url}/coprs/${copr_user}/${copr_name}/repo/epel-${rhel_major}/${repo_file}
         else
-            if is_redhat ; then
-                rhel_version=$(get_redhat_version)
-                rhel_major=${rhel_version%.*}
-                cd /etc/yum.repos.d/
-                local copr_url=https://copr.fedorainfracloud.org
-                local repo_file=${copr_user}-${copr_name}-epel-${rhel_major}.repo
-                [[ ! -f ${repo_file} ]] && wget -c ${copr_url}/coprs/${copr_user}/${copr_name}/repo/epel-${rhel_major}/${repo_file}
-            else
-                echo "Unsupported distribution"
-            fi
+            echo "Unsupported distribution"
         fi
-    }
-else
-    function check_enable_copr {
-        echo $1
-        #$2 is the version which will vary
-        return 0
-    }
-fi
+    fi
+}
 
 function check_install_rpm {
     _n="${1}"
@@ -278,12 +251,12 @@ function generate_inventory {
     printf -- ${preamble} "${hostname}"
     for dirent in $(/bin/ls -1 ${tool_group_dir}); do
         if [[ "${dirent}" == "__trigger__" ]]; then
-		# Ignore trigger files
-		continue
-	elif [[ ! -d ${tool_group_dir}/${dirent} ]]; then
-		# Ignore spurious files
-		continue
-	fi
+            # Ignore trigger files
+            continue
+        elif [[ ! -d ${tool_group_dir}/${dirent} ]]; then
+            # Ignore spurious files
+            continue
+        fi
         printf -- "%s\n" "${dirent}"
     done
 }
@@ -304,9 +277,3 @@ function interrupt() {
     pbench-metadata-log --group=${tool_group} --dir=${benchmark_run_dir} int
     return 0
 }
-
-if [[ "${_PBENCH_UNIT_TESTS}" == 1 ]] ;then
-    # For unit tests, we use a mock kill:
-    # disable the built-in.
-    enable -n kill
-fi

--- a/agent/base
+++ b/agent/base
@@ -100,11 +100,11 @@ fi
 # don't use colons and dashes in the date suffix
 export date_suffix=$(date --date ${date} --utc +"%Y.%m.%dT%H.%M.%S")
 
-if [[ -z "${hostname}" ]]; then
-    export hostname=$(hostname -s)
+if [[ -z "${_pbench_hostname}" ]]; then
+    export _pbench_hostname=$(hostname -s)
 fi
-if [[ -z "${full_hostname}" ]]; then
-    export full_hostname=$(hostname -f)
+if [[ -z "${_pbench_full_hostname}" ]]; then
+    export _pbench_full_hostname=$(hostname -f)
 fi
 
 if [[ -z "$ssh_opts" ]]; then
@@ -239,7 +239,6 @@ function verify_common_bench_script_options {
 }
 
 # Generate inventory file with controller and remotes.
-# FIXME: need to make this work with new tools-v1 directory format.
 function generate_inventory {
     local component="${1}"
     local preamble=""

--- a/agent/base.ut.post
+++ b/agent/base.ut.post
@@ -1,0 +1,21 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; sh-indentation: 4; tab-width: 8 -*-
+
+# base.ut: contains the overrides of the base functions and environment
+#          variables needed for the unit test environments.
+
+function timestamp {
+    echo "1900-01-01T00:00:00.000000"
+}
+
+export date="1900-01-01T00:00:00"
+export date_suffix="1900.01.01T00.00.00"
+
+function check_enable_copr {
+    echo $1
+    #$2 is the version which will vary
+    return 0
+}
+
+# For unit tests, we use a mock kill: disable the bash built-in.
+enable -n kill

--- a/agent/base.ut.post
+++ b/agent/base.ut.post
@@ -12,8 +12,11 @@ export date="1900-01-01T00:00:00"
 export date_suffix="1900.01.01T00.00.00"
 
 function check_enable_copr {
-    echo $1
-    #$2 is the version which will vary
+    # For the unit test environment, we only echo the first argument passed to
+    # use, since that name doesn't change, but we don't echo the optional
+    # second argument, since that can contain data which will vary and cause
+    # gold-file-based test failures.
+    echo ${1}
     return 0
 }
 

--- a/agent/base.ut.pre
+++ b/agent/base.ut.pre
@@ -4,9 +4,9 @@
 # base.ut.pre: contains the overrides of the environment variables needed for
 #              the unit test environments.
 
-if [[ -z "${hostname}" ]]; then
-    export hostname="testhost"
+if [[ -z "${_pbench_hostname}" ]]; then
+    export _pbench_hostname="testhost"
 fi
-if [[ -z "${full_hostname}" ]]; then
-    export full_hostname="testhost.example.com"
+if [[ -z "${_pbench_full_hostname}" ]]; then
+    export _pbench_full_hostname="testhost.example.com"
 fi

--- a/agent/base.ut.pre
+++ b/agent/base.ut.pre
@@ -1,0 +1,12 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; sh-indentation: 4; tab-width: 8 -*-
+
+# base.ut.pre: contains the overrides of the environment variables needed for
+#              the unit test environments.
+
+if [[ -z "${hostname}" ]]; then
+    export hostname="testhost"
+fi
+if [[ -z "${full_hostname}" ]]; then
+    export full_hostname="testhost.example.com"
+fi

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -218,7 +218,7 @@ pbench-start-tools --group=$tool_group --dir=$benchmark_results_dir
 for file_size in $(echo $file_sizes | sed -e s/,/" "/g); do
 	for record_size in $(echo $record_sizes | sed -e s/,/" "/g); do
 		for run in $(seq 1 ${number_of_runs}); do
-			$benchmark_bin -i0 -i1 -i2 -i3 -i4 -i5 -i6 -i7 -i8 -i9 -i10 -i11 -i12  -c -e -f $targets -s ${file_size}g -r ${record_size}m >> $benchmark_results_dir/$(hostname)_$run.iozone
+			$benchmark_bin -i0 -i1 -i2 -i3 -i4 -i5 -i6 -i7 -i8 -i9 -i10 -i11 -i12  -c -e -f $targets -s ${file_size}g -r ${record_size}m >> $benchmark_results_dir/${_pbench_full_hostname}_$run.iozone
 		done
 	done
 done

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -29,7 +29,7 @@ export _testopt=${_testroot}/opt/pbench-agent
 res=0
 mkdir -p ${_testopt}/bench-scripts/postprocess ${_testopt}/bench-scripts/templates ${_testopt}/util-scripts ${_testopt}/lib ${_testopt}/unittest-scripts ${_testopt}/common/lib
 let res=res+${?}
-cp ${_tdir}/../base ${_testopt}/
+cat ${_tdir}/../base.ut.pre ${_tdir}/../base ${_tdir}/../base.ut.post > ${_testopt}/base
 let res=res+${?}
 cp -rH ${_tdir}/../lib/* ${_testopt}/lib/
 let res=res+${?}

--- a/agent/util-scripts/gold/pbench-copy-results/test-31.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-31.txt
@@ -54,7 +54,7 @@ user_script = sleep
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-39.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-39.txt
@@ -53,7 +53,7 @@ user_script = sleep
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-40.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-40.txt
@@ -53,7 +53,7 @@ user_script = sleep
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check && mv pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-41.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-41.txt
@@ -52,7 +52,7 @@ user_script = sleep
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-49.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-49.txt
@@ -54,7 +54,7 @@ user_script = sleep
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/pbench-collect-sysinfo
+++ b/agent/util-scripts/pbench-collect-sysinfo
@@ -217,7 +217,7 @@ for dirent in $(/bin/ls -1 ${tool_group_dir}); do
 	fi
 	hostdir="${dirent}"
 	label="$(cat ${tool_group_dir}/${hostdir}/__label__ 2> /dev/null)"
-	if [[ "${hostdir}" == "localhost" || "${hostdir}" == "${hostname}" || "${hostdir}" == "${full_hostname}" ]]; then
+	if [[ "${hostdir}" == "localhost" || "${hostdir}" == "${_pbench_hostname}" || "${hostdir}" == "${_pbench_full_hostname}" ]]; then
 		# We found local tools specified in the tools group directory,
 		# so we should collect sysinfo data locally.
 		pbench-sysinfo-dump "${sysinfo_path}" "${sysinfo}" "${label}" &

--- a/agent/util-scripts/pbench-metadata-log
+++ b/agent/util-scripts/pbench-metadata-log
@@ -89,14 +89,14 @@ if [[ -z "${date}" ]]; then
     error_log "Missing required \$date environment variable"
     exit 3
 fi
-if [[ -z "${full_hostname}" ]]; then
+if [[ -z "${_pbench_full_hostname}" ]]; then
     # Should be provided by ${pbench_bin}/base
-    error_log "Missing required \$full_hostname environment variable"
+    error_log "Missing required \$_pbench_full_hostname environment variable"
     exit 3
 fi
-if [[ -z "${hostname}" ]]; then
+if [[ -z "${_pbench_hostname}" ]]; then
     # Should be provided by ${pbench_bin}/base
-    error_log "Missing required \$hostname environment variable"
+    error_log "Missing required \$_pbench_hostname environment variable"
     exit 3
 fi
 
@@ -114,7 +114,7 @@ function metadata_log_tools {
 	elif [[ ! -d ${tool_group_dir}/${dirent} ]]; then
 	    # Skip spurious files of ${tool_group_dir}
 	    warn_log "[$script_name] \"${this_tool_file}\" is a file in \"${tool_group_dir}\"; that should not happen. Please consider deleting it."
-	elif [[ "${dirent}" == "${full_hostname}" ]]; then
+	elif [[ "${dirent}" == "${_pbench_full_hostname}" ]]; then
             local_tools=1
 	elif [[ -z "${remotes}" ]]; then
             remotes="${dirent}"
@@ -131,14 +131,14 @@ function metadata_log_tools {
         # first under the local host's hostname.
         cat >> ${log} <<EOF
 [tools]
-hosts = ${full_hostname} ${remotes}
+hosts = ${_pbench_full_hostname} ${remotes}
 group = ${group}
 trigger = "${trigger_val}"
 
-[tools/${full_hostname}]
-hostname-s = ${hostname}
+[tools/${_pbench_full_hostname}]
+hostname-s = ${_pbench_hostname}
 EOF
-        for toolent in $(/bin/ls -1 ${tool_group_dir}/${full_hostname} 2> /dev/null); do
+        for toolent in $(/bin/ls -1 ${tool_group_dir}/${_pbench_full_hostname} 2> /dev/null); do
             if [[ "${toolent}" == *.__noinstall__ ]]; then
                 continue
             fi
@@ -149,7 +149,7 @@ EOF
             fi
             # Add the options with a space in front, effectively making them continuation
             # lines as far the python config module is concerned.
-            printf -- "%s = %s\n" "${toolent_name}" "$(cat ${tool_group_dir}/${full_hostname}/${toolent} | sed 's/^/ /')"
+            printf -- "%s = %s\n" "${toolent_name}" "$(cat ${tool_group_dir}/${_pbench_full_hostname}/${toolent} | sed 's/^/ /')"
         done >> ${log}
     else
         if [[ ! -z "${remotes}" ]]; then
@@ -228,7 +228,7 @@ rpm-version = $(yum list installed pbench-agent 2>/dev/null | tail -n 1 | awk '{
 EOF
     cat >> ${TMPFILE} <<EOF
 [run]
-controller = ${full_hostname}
+controller = ${_pbench_full_hostname}
 start_run = ${ts}
 EOF
     metadata_log_tools "${TMPFILE}"

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -82,7 +82,7 @@ if [[ ! -f "${pbench_bin}/id_rsa" ]]; then
     exit 1
 fi
 
-controller=${full_hostname}
+controller=${_pbench_full_hostname}
 if [[ -z "${controller}" ]]; then
     error_log "Missing controller name (should be \"hostname -f\" value)"
     exit 1
@@ -105,7 +105,7 @@ if [[ -z "${rel}" ]]; then
     rel="unknown"
 fi
 # User-Agent HTTP header: <pbench-agent-ver-rel>:<FQDN>:<$USER>:<full path of this script>""
-user_agent="pbench-agent-${ver}-${rel}:$(hostname -f):${USER}:${script_name}"
+user_agent="pbench-agent-${ver}-${rel}:${controller}:${USER}:${script_name}"
 
 results_host_info_url=$(pbench-config host_info_url results)
 results_host_info=$(curl -s -A "${user_agent}" -L "${results_host_info_url}")

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -22,7 +22,7 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 #   * The next level of the hierarchy are directories named for each remote
 #     host name tools are register for
 #     * If the user registers the local host, we always use the full hostname,
-#       ${full_hostname}
+#       ${_pbench_full_hostname}
 #     * All other names are considered "remote" host names
 #   * Under each host name directory are tool and an optional "__label__" file
 #     * Each tool file is named after the tool for which each line of the file
@@ -34,8 +34,8 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 #     top-level directory of the tool group
 #
 # Examples:
-#   * A single local host, ${full_hostname} == "localhost", with four tools
-#     and a trigger:
+#   * A single local host, ${_pbench_full_hostname} == "localhost", with four
+#     tools and a trigger:
 #
 #     ${pbench_run}/
 #       tools-v1-default/
@@ -66,8 +66,9 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 #           perf
 #           perf.__noinstall__@
 #
-#   * Three hosts, one local (${full_hostname} == "localhost"), with two tools
-#     on all hosts, 1 additional tool on the local host, labels on all hosts:
+#   * Three hosts, one local (${_pbench_full_hostname} == "localhost"), with
+#     two tools on all hosts, 1 additional tool on the local host, labels on
+#     all hosts:
 #
 #     ${pbench_run}/
 #       tools-v1-my2tools/
@@ -304,7 +305,7 @@ debug_log "tool_opts: \"${tool_opts[@]}\""
 # Determine what our local hostname(s) and IP(s) are.
 # FIXME: this does not check for ipv6
 local_ips=$(ip a | grep "inet " | awk '{print $2}' | awk -F/ '{print $1}')
-local_interfaces="${local_ips} ${hostname} ${full_hostname} localhost"
+local_interfaces="${local_ips} ${_pbench_hostname} ${_pbench_full_hostname} localhost"
 
 # If for some reason the user specified a remote host, and that host is a
 # local interface, we work to make sure we only register one local host.
@@ -320,7 +321,7 @@ for (( i=0; ${i} < ${#remotes_A[@]}; i++ )); do
 				if [[ "${remotes_arg}" != "localhost" ]]; then
 					debug_log "The remote host you have provided, ${remote}, matches a local interface, so we will register this tool locally only"
 				fi
-				local_hostname="${full_hostname}"
+				local_hostname="${_pbench_full_hostname}"
 				local_label="${labels_A[${remote}]}"
 			else
 				if [[ "${remotes_arg}" != "localhost" ]]; then

--- a/agent/util-scripts/pbench-register-tool-set
+++ b/agent/util-scripts/pbench-register-tool-set
@@ -133,7 +133,7 @@ if [[ -n "${labels_arg}" ]]; then
 	pbench-register-tool --name=perf --test-labels ${remotes_arg}${labels_arg}
 	if [[ ${?} -ne 0 ]]; then
 		if [[ -z "${remotes_arg}" ]]; then
-			remotes_arg="(default) --remotes=${full_hostname}"
+			remotes_arg="(default) --remotes=${_pbench_full_hostname}"
 		fi
 		error_log "The number of labels given, \"${labels_arg}\", does not match the number of remotes given, \"${remotes_arg}\""
 		usage >&2

--- a/agent/util-scripts/pbench-sysinfo-dump
+++ b/agent/util-scripts/pbench-sysinfo-dump
@@ -21,9 +21,9 @@ fi
 
 label=$3
 if [[ -z "$label" ]]; then
-	dir="$dir/$hostname"
+	dir="${dir}/${_pbench_full_hostname}"
 else
-	dir="$dir/$label:$hostname"
+	dir="${dir}/${label}:${_pbench_full_hostname}"
 fi
 mkdir -p $dir
 if [[ ! -d "$dir" ]]; then
@@ -117,7 +117,7 @@ function collect_sos {
 		_modules="${_modules} tuned"
 	fi
 
-	_name="pbench-$(hostname -f)"
+	_name="pbench-${_pbench_full_hostname}"
 	_cmd="${dir}/sosreport-${_name}.cmd"
 	printf -- "sosreport" > ${_cmd}
 	for mod in ${_modules}; do

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -30,10 +30,12 @@ from pathlib import Path
 
 import redis
 
+import pbench.agent.toolmetadata as toolmetadata
+
 from pbench.agent.tool_data_sink import main as tds_main
 from pbench.agent.tool_meister import main as tm_main
 from pbench.agent import PbenchAgentConfig
-import pbench.agent.toolmetadata as toolmetadata
+from pbench.common.exceptions import BadConfig
 
 
 # Port number is "One Tool" in hex 0x17001
@@ -282,8 +284,8 @@ def main(argv):
 
     try:
         benchmark_run_dir = os.environ["benchmark_run_dir"]
-        hostname = os.environ["hostname"]
-        full_hostname = os.environ["full_hostname"]
+        hostname = os.environ["_pbench_hostname"]
+        full_hostname = os.environ["_pbench_full_hostname"]
     except Exception:
         logger.exception("failed to fetch parameters from the environment")
         return 1
@@ -297,8 +299,8 @@ def main(argv):
             return 1
     if not full_hostname or not hostname:
         logger.error(
-            "ERROR - hostname ('%s') and full_hostname ('%s') environment"
-            " variables are required",
+            "ERROR - _pbench_hostname ('%s') and _pbench_full_hostname ('%s')"
+            " environment variables are required",
             hostname,
             full_hostname,
         )
@@ -373,25 +375,33 @@ def main(argv):
 
     # 2.5. Add tool metadata json to redis
     try:
-        inst_dir = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"]).pbench_install_dir
+        inst_dir = PbenchAgentConfig(
+            os.environ["_PBENCH_AGENT_CONFIG"]
+        ).pbench_install_dir
     except BadConfig as exc:
         logger.error("%s", exc)
         return 1
     except Exception as exc:
-        logger.error("Unexpected error encountered logging pbench agent configuration: '%s'", exc)
+        logger.error(
+            "Unexpected error encountered logging pbench agent configuration: '%s'", exc
+        )
         return 1
 
     try:
         tm_start_path = Path(inst_dir).resolve(strict=True)
     except FileNotFoundError:
-        logger.error("Unable to determine proper installation directory, '%s' not found", inst_dir)
+        logger.error(
+            "Unable to determine proper installation directory, '%s' not found",
+            inst_dir,
+        )
         return 1
     except Exception as exc:
-        logger.exception("Unexpected error encountered resolving installation directory: '%s'", exc)
+        logger.exception(
+            "Unexpected error encountered resolving installation directory: '%s'", exc
+        )
         return 1
     tool_metadata = toolmetadata.ToolMetadata("json", tm_start_path, logger)
     tool_metadata.loadIntoRedis(redis_server)
-
 
     # 3. Start the tool-data-sink process
     #   - leave a PID file for the tool data sink process

--- a/agent/util-scripts/pbench-tool-meister-stop
+++ b/agent/util-scripts/pbench-tool-meister-stop
@@ -66,7 +66,7 @@ def main(argv):
     logger.addHandler(sh)
 
     try:
-        full_hostname = os.environ["full_hostname"]
+        full_hostname = os.environ["_pbench_full_hostname"]
         benchmark_run_dir = os.environ["benchmark_run_dir"]
     except Exception:
         logger.exception("failed to fetch parameters from the environment")

--- a/agent/util-scripts/test-bin/test-client-tool-meister
+++ b/agent/util-scripts/test-bin/test-client-tool-meister
@@ -6,17 +6,17 @@ pbench_bin="$(realpath -e ${_script_path}/..)"
 # source the base script
 . "${pbench_bin}"/base
 
-if [[ -z "${full_hostname}" ]]; then
-    printf -- "Missing 'full_hostname' environment variable" >&2
+if [[ -z "${_pbench_full_hostname}" ]]; then
+    printf -- "Missing '_pbench_full_hostname' environment variable" >&2
     exit 1
 fi
-export full_hostname
+export _pbench_full_hostname
 
-if [[ -z "${hostname}" ]]; then
-    printf -- "Missing 'hostname' environment variable" >&2
+if [[ -z "${_pbench_hostname}" ]]; then
+    printf -- "Missing '_pbench_hostname' environment variable" >&2
     exit 1
 fi
-export hostname
+export _pbench_hostname
 
 if [[ -z "${1}" ]]; then
      group="default"

--- a/agent/util-scripts/test-bin/test-start-stop-tool-meister
+++ b/agent/util-scripts/test-bin/test-start-stop-tool-meister
@@ -6,17 +6,17 @@ pbench_bin="$(realpath -e ${_script_path}/..)"
 # source the base script
 . "${pbench_bin}"/base
 
-if [[ -z "${full_hostname}" ]]; then
-    printf -- "Missing 'full_hostname' environment variable" >&2
+if [[ -z "${_pbench_full_hostname}" ]]; then
+    printf -- "Missing '_pbench_full_hostname' environment variable" >&2
     exit 1
 fi
-export full_hostname
+export _pbench_full_hostname
 
-if [[ -z "${hostname}" ]]; then
-    printf -- "Missing 'hostname' environment variable" >&2
+if [[ -z "${_pbench_hostname}" ]]; then
+    printf -- "Missing '_pbench_hostname' environment variable" >&2
     exit 1
 fi
-export hostname
+export _pbench_hostname
 
 if [[ -z "${1}" ]]; then
      group="default"

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -23,7 +23,7 @@ _testopt=${_testroot}/opt/pbench-agent
 res=0
 mkdir -p ${_testopt}/config ${_testopt}/util-scripts/tool-meister ${_testopt}/tool-scripts ${_testopt}/lib ${_testopt}/unittest-scripts ${_testopt}/common/lib
 let res=res+${?}
-cp -L ${_tdir}/../base ${_testopt}/
+cat ${_tdir}/../base.ut.pre ${_tdir}/../base ${_tdir}/../base.ut.post > ${_testopt}/base
 let res=res+${?}
 cp -rL ${_tdir}/../config/* ${_testopt}/config/
 # rename pbench-agent.cfg - we need to process it for each test but it gets cleaned up after each test.

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -295,7 +295,7 @@ class ToolDataSink(Bottle):
         self.tool_group = tool_group
         self.logger = logger
         # Initialize internal state
-        self._hostname = os.environ["full_hostname"]
+        self._hostname = os.environ["_pbench_full_hostname"]
         self.state = None
         self.tool_data_ctx = None
         self.directory = None

--- a/lib/pbench/cli/agent/commands/results/__init__.py
+++ b/lib/pbench/cli/agent/commands/results/__init__.py
@@ -12,7 +12,7 @@ def move_results(ctx, _user, _prefix, _show_server):
     config = PbenchAgentConfig(ctx["args"]["config"])
     logger = get_pbench_logger("pbench-move-results", config)
 
-    controller = os.environ.get("full_hostname")
+    controller = os.environ.get("_pbench_full_hostname")
     if not controller:
         logger.error("Missing controller name (should be 'hostname -f' value)")
         sys.exit(1)

--- a/lib/pbench/test/unit/agent/task/test_move_results.py
+++ b/lib/pbench/test/unit/agent/task/test_move_results.py
@@ -10,7 +10,7 @@ class TestMoveResults:
     @staticmethod
     @responses.activate
     def test_move_results(monkeypatch):
-        monkeypatch.setenv("full_hostname", "localhost")
+        monkeypatch.setenv("_pbench_full_hostname", "localhost")
         monkeypatch.setattr(datetime, "datetime", MockDatetime)
 
         responses.add(


### PR DESCRIPTION
Instead of accepting `hostname` and `full_hostname` as pre-defined environment variables, we rename them to be `_pbench_hostname` (contains `$(hostname -s)`) and `_pbench_full_hostname` (contains `$(hostname -f)`).  This prevents an inadvertent environment variables of the same name from changing the behavior of the agent.

We also consistently use those environment variables where possible to avoid disagreements on the host name used.

Some of the Python 3 code changed, and so `flake8` detected a problem.  Why it wasn't detected before is a mystery, but we fix it here as well.

We also take the opportunity, in separate commits, to stop embedding unit test logic in `agent/base`, and make sure we explicitly ask for the full hostname using `hostname -f`.