### PR TITLE
Setting SELinux Labels correctly in prep-shim

### DIFF
--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -74,6 +74,7 @@ RUN \
         python3-humanize \
         python3-itsdangerous \
         python3-jinja2 \
+        python3-libselinux \
         python3-mock \
         python3-pip \
         python3-psutil \

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -1093,6 +1093,14 @@ run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 3 tarballs cle
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ test-execution.log file contents
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz.md5', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz.md5', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz.md5', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz', recursive=False, verbose=False, force=False)
+selinux.restorecon('/var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz.md5', recursive=False, verbose=False, force=False)
 ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-sync-package-tarballs
 ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-satellite-state-change /var/tmp/pbench-test-server/test-5.2/pbench-satellite/archive/fs-version-001
 --- test-execution.log file contents

--- a/server/bin/test-lib/selinux.py
+++ b/server/bin/test-lib/selinux.py
@@ -1,0 +1,23 @@
+# This is a mock file for selinux.restorecon test cases
+import os
+
+
+def restorecon(path, recursive=False, verbose=False, force=False):
+    """ Restore SELinux context on a given path
+
+    Arguments:
+    path -- The pathname for the file or directory to be relabeled.
+
+    Keyword arguments:
+    recursive -- Change files and directories file labels recursively (default False)
+    verbose -- Show changes in file labels (default False)
+    force -- Force reset of context to match file_context for customizable files,
+    and the default file context, changing the user, role, range portion  as well
+    as the type (default False)
+    """
+    with open(os.environ["_testlog"], "a") as ofp:
+        ofp.write(
+            f"selinux.restorecon({str(path)!r}, recursive={recursive!r}, verbose={verbose!r}, force={force!r})\n"
+        )
+
+    return 0

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -108,7 +108,10 @@ function _run_allscripts {
     _run pbench-backup-tarballs
     _run pbench-verify-backup-tarballs
     # Invoke pbench-satellite-cleanup in the context of the satellite
-    PATH=${_testopt_sat}/unittest-scripts:${_testopt_sat}/bin:${_orig_PATH} _PBENCH_SERVER_CONFIG=${SATCONFIG} _run pbench-satellite-cleanup
+    PATH=${_testopt_sat}/unittest-scripts:${_testopt_sat}/bin:${_orig_PATH} \
+        PYTHONPATH=${_testopt_sat}/unittest-lib:${_orig_PYTHONPATH} \
+        _PBENCH_SERVER_CONFIG=${SATCONFIG} \
+        _run pbench-satellite-cleanup
 }
 
 function _local_find {
@@ -248,7 +251,15 @@ function _setup_state {
     let res=res+$?
     cp -a $_tdir/test-bin/* $_testopt/unittest-scripts/
     let res=res+$?
-    cp $_tdir/test-bin/* $_testopt_sat/unittest-scripts/
+    cp -a $_tdir/test-bin/* $_testopt_sat/unittest-scripts/
+    let res=res+$?
+    mkdir -p ${_testopt}/unittest-lib/
+    let res=res+$?
+    mkdir -p ${_testopt_sat}/unittest-lib/
+    let res=res+$?
+    cp -a ${_tdir}/test-lib/* ${_testopt}/unittest-lib/
+    let res=res+$?
+    cp -a ${_tdir}/test-lib/* ${_testopt_sat}/unittest-lib/
     let res=res+$?
     mkdir -p $_testopt/bin
     let res=res+$?
@@ -314,7 +325,9 @@ function _setup_state {
     # All the "real" scripts are found at $_testopt/bin, the mock scripts
     # are found in $_testopt/unittest-scripts.
     _orig_PATH=$PATH
+    _orig_PYTHONPATH=$PYTHONPATH
     export PATH=$_testopt/unittest-scripts:$_testopt/bin:$PATH
+    export PYTHONPATH=$_testopt/unittest-lib:$PYTHONPATH
 
     # Expected location of the final configuration files
     export _PBENCH_SERVER_CONFIG=$_testopt/lib/config/pbench-server.cfg
@@ -489,6 +502,7 @@ function _reset_state {
     fi
 
     export PATH=${_orig_PATH}
+    export PYTHONPATH=${_orig_PYTHONPATH}
     unset _PBENCH_SERVER_CONFIG
     unset SATCONFIG
 

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -15,8 +15,10 @@ Requires: python3 python3-devel gcc
 Requires:       policycoreutils
 %if 0%{?rhel} != 7
 Requires: policycoreutils-python-utils
+Requires: libselinux-python3
 %else
 Requires: policycoreutils-python
+Requires: python3-libselinux
 %endif
 
 Requires: npm


### PR DESCRIPTION
Fixes #1928 

We not only need to preserve the labels but also all the metadata of the tarball.

- [x] restorecon - help to preserve all metadata