### PR TITLE
Rejig functional unit tests

### DIFF
--- a/agent/test-requirements.txt
+++ b/agent/test-requirements.txt
@@ -1,3 +1,7 @@
 gitpython
+mock>=3.0.5
+pytest-cov>=2.7.1
 pytest>=4.6.3, < 5
+pytest-helpers-namespace>=2019.1.8
+pytest-mock>=1.10.4
 responses

--- a/lib/pbench/test/functional/conftest.py
+++ b/lib/pbench/test/functional/conftest.py
@@ -1,7 +1,25 @@
+import os
+import subprocess
+
 import pytest
+
 from pbench.test.unit.agent.conftest import base_setup
 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup(request, pytestconfig):
     return base_setup(request, pytestconfig)
+
+
+@pytest.helpers.register
+def capture(command):
+    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = proc.communicate()
+    return out, err, proc.returncode
+
+
+@pytest.fixture
+def pbench_run(tmpdir):
+    pbench_run = tmpdir / "test/var/lib/pbench-agent"
+    os.makedirs(pbench_run)
+    yield pbench_run

--- a/lib/pbench/test/functional/test_pbench_config.py
+++ b/lib/pbench/test/functional/test_pbench_config.py
@@ -1,23 +1,17 @@
-import subprocess
+import pytest
 
 from pbench.test.unit.agent.conftest import valid_config, agent_config_env  # noqa F401
 
 
-def capture(command):
-    proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = proc.communicate()
-    return out, err, proc.returncode
-
-
 def test_pbench_config():
     command = ["pbench-config"]
-    out, err, exitcode = capture(command)
+    out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 1
 
 
 def test_pbench_config_help():
     command = ["pbench-config", "--help"]
-    out, err, exitcode = capture(command)
+    out, err, exitcode = pytest.helpers.capture(command)
     assert out.decode("UTF-8").startswith("Usage: pbench-config ")
     assert exitcode == 0
 
@@ -25,7 +19,7 @@ def test_pbench_config_help():
 def test_pbench_agent_config(valid_config, agent_config_env, pytestconfig):  # noqa F811
     TMP = pytestconfig.cache.get("TMP", None)
     command = ["pbench-config", "pbench_run", "pbench-agent"]
-    out, err, exitcode = capture(command)
+    out, err, exitcode = pytest.helpers.capture(command)
     assert f"{TMP}/var/lib/pbench-agent".encode("UTF-8") in out
     assert (
         exitcode == 0

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -1,2 +1,6 @@
 gitpython
+mock>=3.0.5
+pytest-cov>=2.7.1
 pytest>=4.6.3, < 5
+pytest-helpers-namespace>=2019.1.8
+pytest-mock>=1.10.4


### PR DESCRIPTION
Use pytest helpers to create a reproducable envrionment
that we do with the shell scripts. Eventually, this
will replace the shell scripts and the gold files
that we *shudder* use.

Signed-off-by: Charles Short <chucks@redhat.com>