### PR TITLE
Fix warning while running unit tests

### DIFF
--- a/agent/tool-scripts/datalog/prometheus-metrics-datalog
+++ b/agent/tool-scripts/datalog/prometheus-metrics-datalog
@@ -105,7 +105,7 @@ for host, port, cert, key, selfsigned, linenum in host_n_port(inv_file):
                 PROG, host, linenum)
         sys.exit(1)
     else:
-        if pid is 0:
+        if pid == 0:
             # Child continue below
             parent = False
             break


### PR DESCRIPTION
+ ./prometheus-metrics-datalog:108: SyntaxWarning: "is" with a literal. Did you mean "=="?
+   if pid is 0:

Signed-off-by: Charles Short <chucks@redhat.com>