### PR TITLE
Address some undesirable tox behaviors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ fio-histo-log-pctiles.py
 | binary-search.py
 | profile-builder.py
 | agent/stockpile
+| .git
 )
 '''

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ minversion = 3.5.0
 skipdist = True
 skip_missing_interpreters = True
 isolated_build = True
+toxworkdir = {env:TOXWORKDIR:/tmp/{env:USER}/tox}
 envlist = lint
           py3-agent
           datalog
@@ -16,14 +17,17 @@ envlist = lint
 [testenv]
 usedevelop = True
 install_command = pip install -U {opts} {packages}
+passenv =
+    PY_COLORS
+    NO_COLORS
+    TERM
 setenv =
     VIRTUAL_ENV = {envdir}
-commands_pre =
-    {toxinidir}/utils/detox {envdir}
-envars =
-    PATH = {env:PATH}:{toxinidir}/bin
+    XDG_CACHE_HOME = {envdir}
     SKIP_GENERATE_AUTHORS = 1
     SKIP_WRITE_GIT_CHANGELOG = 1
+commands_pre =
+    {toxinidir}/utils/detox {envdir}
 whitelist_externals =
     bash
     rm

--- a/tox.ini
+++ b/tox.ini
@@ -34,54 +34,54 @@ whitelist_externals =
 description = Runs all non-Python3-based server unit/functional tests
 passenv = PBENCH_UNITTEST_SERVER_MODE
 deps =
-   -r{toxinidir}/server/requirements.txt
-   -r{toxinidir}/server/test-requirements.txt
+    -r{toxinidir}/server/requirements.txt
+    -r{toxinidir}/server/test-requirements.txt
 commands =
     bash -c "./server/bin/unittests {posargs}"
 
 [testenv:datalog]
 description = Runs all non-Python3-based agent tool-scripts/datalog unit/functional tests
 deps =
-   -r{toxinidir}/agent/requirements.txt
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/tool-scripts/datalog/unittests {posargs}"
 
 [testenv:postprocess]
 description = Runs all non-Python3-based agent tool-scripts/postprocess unit/functional tests
 deps =
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/tool-scripts/postprocess/unittests {posargs}"
 
 [testenv:tool-scripts]
 description = Runs all non-Python3-based agent tool-scripts unit/functional tests
 deps =
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/tool-scripts/unittests {posargs}"
 
 [testenv:util-scripts]
 description = Runs all non-Python3-based agent util-scripts unit/functional tests
 deps =
-   -r{toxinidir}/agent/requirements.txt
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/util-scripts/unittests {posargs}"
 
 [testenv:bench-scripts]
 description = Runs all non-Python3-based agent bench-scripts unit/functional tests
 deps =
-   -r{toxinidir}/agent/requirements.txt
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/bench-scripts/unittests {posargs}"
 
 [testenv:py3-server]
 description = Runs all Python3-based server unit and functional tests
 deps =
-   -r{toxinidir}/server/requirements.txt
-   -r{toxinidir}/server/test-requirements.txt
+    -r{toxinidir}/server/requirements.txt
+    -r{toxinidir}/server/test-requirements.txt
 commands =
     pytest ./lib/pbench/test/unit/common
     pytest ./lib/pbench/test/unit/server 
@@ -90,8 +90,8 @@ commands =
 [testenv:py3-agent]
 description = Runs all Python3-based agent unit and functional tests
 deps =
-   -r{toxinidir}/agent/requirements.txt
-   -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/agent/requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt
 commands =
     pytest ./lib/pbench/test/unit/common
     pytest ./lib/pbench/test/unit/agent


### PR DESCRIPTION
The first item is we now use `/tmp/${USER}/tox` as the working directory (`{toxworkdir}`) to avoid touching the local source tree.  Along with this change, we also tell `black` to store its cache in the `lint` environment via the `XDG_CACHE_HOME` environment variable.

Further, we pass along the `PY_COLORS`, `NO_COLORS`, and `TERM` environment variables so that `tox` runs are well behaved in non-interactive terminal environments.

Still further, we remove the `envars` section, moving those into the proper `setenv` section.

Finally, we address some indentation issues in `tox.ini` itself in a separate commit.