### PR TITLE
Rework pass-thru API implementation a bit

### DIFF
--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -14,11 +14,14 @@ pbench-top-dir = {TMP}/srv/pbench
 
 [elasticsearch]
 host = elasticsearch.example.com
-port = 0000
+port = 7080
 
 [graphql]
 host = graphql.example.com
-port = 0000
+port = 7081
+
+[logging]
+logger_type = file
 
 ###########################################################################
 # The rest will come from the default config file.

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -1,14 +1,22 @@
 import os
+import socket
 
 import pytest
-import socket
-from werkzeug.utils import secure_filename
+import responses
+
 from pathlib import Path
+from werkzeug.utils import secure_filename
+
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
 
 
 class TestHostInfo:
     @staticmethod
-    def test_host_info(client, pytestconfig):
+    def test_host_info(client, pytestconfig, caplog):
         tmp_d = pytestconfig.cache.get("TMP", None)
         expected_message = (
             f"pbench@pbench.example.com:{tmp_d}/srv/pbench"
@@ -19,20 +27,24 @@ class TestHostInfo:
 
         assert response.status_code == 200
         assert response.json.get("message") == expected_message
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
 
 class TestElasticsearch:
     @staticmethod
-    def test_json_object(client):
+    def test_json_object(client, caplog):
         response = client.post(f"{client.config['REST_URI']}/elasticsearch")
         assert response.status_code == 400
         assert (
             response.json.get("message")
             == "Elasticsearch: Invalid json object in request"
         )
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
 
     @staticmethod
-    def test_empty_url_path(client):
+    def test_empty_url_path(client, caplog):
         response = client.post(
             f"{client.config['REST_URI']}/elasticsearch", json={"indices": ""}
         )
@@ -41,30 +53,38 @@ class TestElasticsearch:
             response.json.get("message")
             == "Missing indices path in the Elasticsearch request"
         )
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
 
     @staticmethod
-    def test_bad_request(client):
+    def test_bad_request(client, caplog, mocked_responses):
+        mocked_responses.add(
+            responses.POST,
+            "http://elasticsearch.example.com:7080/some_invalid_url",
+            status=400,
+        )
         response = client.post(
             f"{client.config['REST_URI']}/elasticsearch",
-            json={"indices": "some_invalid_url"},
+            json={"indices": "some_invalid_url", "payload": '{ "babble": "42" }'},
         )
-        assert response.status_code == 500
-        assert (
-            response.json.get("message") == "Could not post to Elasticsearch endpoint"
-        )
+        assert response.status_code == 400
+        assert response.json is None
+        assert len(caplog.records) == 0
 
 
 class TestGraphQL:
     @staticmethod
-    def test_json_object(client):
+    def test_json_object(client, caplog):
         response = client.post(f"{client.config['REST_URI']}/graphql")
         assert response.status_code == 400
         assert response.json.get("message") == "GraphQL: Invalid json object in request"
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "WARNING"
 
 
 class TestUpload:
     @staticmethod
-    def test_missing_filename_header_upload(client):
+    def test_missing_filename_header_upload(client, caplog):
         expected_message = (
             "Missing filename header, "
             "POST operation requires a filename header to name the uploaded file"
@@ -74,9 +94,11 @@ class TestUpload:
         )
         assert response.status_code == 400
         assert response.json.get("message") == expected_message
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_missing_md5sum_header_upload(client):
+    def test_missing_md5sum_header_upload(client, caplog):
         expected_message = "Missing md5sum header, POST operation requires md5sum of an uploaded file in header"
         response = client.put(
             f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
@@ -84,10 +106,12 @@ class TestUpload:
         )
         assert response.status_code == 400
         assert response.json.get("message") == expected_message
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
     @pytest.mark.parametrize("bad_extension", ("test.tar.bad", "test.tar", "test.tar."))
-    def test_bad_extension_upload(client, bad_extension):
+    def test_bad_extension_upload(client, bad_extension, caplog):
         expected_message = "File extension not supported. Only .xz"
         response = client.put(
             f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
@@ -95,9 +119,11 @@ class TestUpload:
         )
         assert response.status_code == 400
         assert response.json.get("message") == expected_message
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_empty_upload(client, pytestconfig):
+    def test_empty_upload(client, pytestconfig, caplog):
         expected_message = "Upload failed, Content-Length received in header is 0"
         filename = "tmp.tar.xz"
         tmp_d = pytestconfig.cache.get("TMP", None)
@@ -114,9 +140,11 @@ class TestUpload:
             )
         assert response.status_code == 400
         assert response.json.get("message") == expected_message
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_upload(client, pytestconfig):
+    def test_upload(client, pytestconfig, caplog):
         filename = "log.tar.xz"
         datafile = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
 
@@ -140,3 +168,5 @@ class TestUpload:
             f"receive_dir = '{receive_dir}', filename = '{filename}',"
             f" sfilename = '{sfilename}'"
         )
+        for record in caplog.records:
+            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -5,3 +5,4 @@ pytest-cov>=2.7.1
 pytest>=4.6.3, < 5
 pytest-helpers-namespace>=2019.1.8
 pytest-mock>=1.10.4
+responses


### PR DESCRIPTION
This all started because logging was not quite set up correctly for the server side API tests.  We use the `caplog` fixture to figure out what is being logged and then added `file` based logging by default so that logs would not leak through to the local system logs via the default `devlog` server configuration during a test run.

In getting the tests to work, we adjust how exceptions are handled so that emitted messages are not so broad.  We use 5xx status codes properly and quiet the logging where possible.

When an internal error is hit, we only report "INTERNAL ERROR" in the response, but log the details.