### PR TITLE
Restore the SELinux context of the tarball after the move

### DIFF
--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -1103,6 +1103,10 @@ run-1970-01-01T00:00:42-UTC: pbench-satellite-cleanup ends: Total 3 tarballs cle
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ test-execution.log file contents
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes//var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-0_1970.01.01T00.42.00.tar.xz
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes//var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-dot-prefix_1970.01.01T00.42.00.tar.xz
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-b-with-prefixes//var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-b-with-prefixes/tarball-w-prefix-dot_1970.01.01T00.42.00.tar.xz
+restorecon /var/tmp/pbench-test-server/test-5.2/pbench/archive/fs-version-001/controller-g-normal//var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-g-normal/tarball-normal_1970.01.01T00.42.00.tar.xz
 ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-sync-package-tarballs
 ssh pbench-satellite.example.com /var/tmp/pbench-test-server/test-5.2/opt/pbench-server-satellite/bin/pbench-satellite-state-change /var/tmp/pbench-test-server/test-5.2/pbench-satellite/archive/fs-version-001
 --- test-execution.log file contents

--- a/server/bin/pbench-server-prep-shim-002.sh
+++ b/server/bin/pbench-server-prep-shim-002.sh
@@ -187,6 +187,13 @@ while read tbmd5 ;do
         (( nerrs++ ))
         continue
     fi
+    # mv does not restore the SELinux context properly, so we do it by hand
+    restorecon ${dest}/${tb}
+    sts=${?}
+    if [[ ${sts} -ne 0 ]]; then
+        # log it but do not abort
+        log_error "${TS}: Error: \"restorecon ${dest}/${tb}\", status ${sts}" "${status}"
+    fi
 
     # Now that we have successfully moved the tar ball and its .md5 to the
     # destination, we can remove the original .md5 file.


### PR DESCRIPTION
Commit c3ad67c101e394784924f14c5bfceb8d239b636f changed the way we get the tarball from the reception area to the archive, from `cp` to `mv` in order to avoid a data copy. But `cp` set the SELinux context from the parent directory, which made the tar ball accessible through HTTP; `mv` does not do that.

Add an explicit `restorecon` to remedy that and fix test-5.2 for the new output.
