### PR TITLE
Remove colorlog; add Makefile for pbench-devel

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -26,9 +26,9 @@ Requires:  python3-docutils, python3-psutil
 %if 0%{?fedora} != 0
 Requires:  python3, python3-pip
 # RPMs for modules in requirements.txt
-Requires:  python3-bottle, python3-cffi, python3-click, python3-colorlog
-Requires:  python3-daemon, python3-jinja2, python3-redis, python3-requests
-Requires:  python3-werkzeug, python3-sh
+Requires:  python3-bottle, python3-cffi, python3-click, python3-daemon
+Requires:  python3-jinja2, python3-redis, python3-requests, python3-werkzeug
+Requires:  python3-sh
 # RPMs for module dependencies
 Requires:  python3-psutil
 %endif

--- a/agent/rpm/python-module-mapping.table
+++ b/agent/rpm/python-module-mapping.table
@@ -4,7 +4,6 @@ ansible          n/a                -         -                  The "ansible" p
 bottle           python3-bottle     -         -
 cffi             python3-cffi       -         python3-cffi
 click            python3-click      -         python3-click
-colorlog         python3-colorlog   -         -
 python-daemon    python3-daemon     -         -                  Typically needs the "lockfile" and "docutils" packages installed as well
 python-pidfile   -                  -         -                  Neither Fedora nor RHEL package the pidfile module, needs "psutil" which is typicaly packaged
 redis            python3-redis      -         -

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -1,0 +1,12 @@
+# A simple Makefile for building and pushing the pbench-devel
+# container image.
+
+BRANCH := $(shell cat ./branch.name)
+
+all: image
+
+push:
+	buildah push localhost/pbench-devel:${BRANCH} quay.io/pbench/pbench-devel:${BRANCH}
+
+image:
+	buildah bud -f development.Dockerfile -t localhost/pbench-devel:${BRANCH}

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -61,7 +61,6 @@ RUN \
         python3-bottle \
         python3-cffi \
         python3-click \
-        python3-colorlog \
         python3-coverage \
         python3-daemon \
         python3-elasticsearch \


### PR DESCRIPTION
The Python 3 `colorlog` module was removed with commit 3a851f84, but we failed to remove it from the `pbench-agent` RPM requires list, or from the recently added `pbench-devel` container image.

While we are at it, we added a simple Makefile for building the `pbench-devel` container image and pushing it to Quay.io.