### PR TITLE
Add missing `net-tools` req agent RPM

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -39,9 +39,9 @@ Requires:  python3-psutil
 Requires:  perl, perl-Data-UUID, perl-JSON, %{?prefixjsonxs}perl-JSON-XS
 Requires:  perl-Time-HiRes
 
-Requires:  ansible, bc, bzip2, hostname, iproute, iputils, openssh-clients
-Requires:  openssh-server, procps-ng, psmisc, redis, rsync, screen, sos, tar
-Requires:  xz
+Requires:  ansible, bc, bzip2, hostname, iproute, iputils, net-tools
+Requires:  openssh-clients, openssh-server, procps-ng, psmisc, redis, rsync
+Requires:  screen, sos, tar, xz
 
 Obsoletes: pbench <= 0.34
 Conflicts: pbench <= 0.34

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -46,6 +46,7 @@ RUN \
         iproute \
         iputils \
         less \
+        net-tools \
         openssh-clients \
         openssh-server \
         perl \


### PR DESCRIPTION
The `pbench-uperf` bench-script invokes `netstat`, so we need to provide a requirement on the `net-tools` RPM in order to be sure that command is available.

While we are at it, we also add it to the development image used by the Jenkins CI, just in case.