### PR TITLE
Correct the `PYTHONPATH` for Jenkins jobs

### DIFF
--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -1,0 +1,14 @@
+_prefix="${1}"
+
+pip3 install --no-cache-dir --prefix="${_prefix}" -r ${progdir}/agent/requirements.txt -r ${progdir}/server/requirements.txt -r ${progdir}/agent/test-requirements.txt -r ${progdir}/server/test-requirements.txt
+
+_pdir=${_prefix}/bin
+if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
+    export PATH=${_pdir}${PATH:+:${PATH}}
+fi
+
+for _pdir in $(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null) $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null); do
+    if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
+        export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
+    fi
+done

--- a/jenkins/run-pytests
+++ b/jenkins/run-pytests
@@ -3,24 +3,7 @@
 prog="$(basename "${0}")"
 progdir="$(realpath -e $(dirname "${0}")/..)"
 
-_prefix="${1}"
-
-pip3 install --no-cache-dir --prefix="${_prefix}" -r ${progdir}/agent/requirements.txt -r ${progdir}/server/requirements.txt -r ${progdir}/agent/test-requirements.txt -r ${progdir}/server/test-requirements.txt
-
-_pdir=${_prefix}/bin
-if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
-    export PATH=${_pdir}${PATH:+:${PATH}}
-fi
-
-_pdir="$(ls -1d ${_prefix}/lib/python3.*/site-packages)"
-if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
-    export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
-fi
-
-_pdir="$(head -n 1 ${_prefix}/lib/python3.*/site-packages/pbench.egg-link)"
-if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
-    export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
-fi
+source $(dirname "${0}")/python-setup.sh
 
 printf -- "black --check ...\n"
 black --check .

--- a/jenkins/run-unittests
+++ b/jenkins/run-unittests
@@ -3,24 +3,7 @@
 prog="$(basename "${0}")"
 progdir="$(realpath -e $(dirname "${0}")/..)"
 
-_prefix="${1}"
-
-pip3 install --no-cache-dir --prefix="${_prefix}" -r ${progdir}/agent/requirements.txt -r ${progdir}/server/requirements.txt
-
-_pdir=${_prefix}/bin
-if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
-    export PATH=${_pdir}${PATH:+:${PATH}}
-fi
-
-_pdir="$(ls -1d ${_prefix}/lib/python3.*/site-packages)"
-if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
-    export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
-fi
-
-_pdir="$(head -n 1 ${_prefix}/lib/python3.*/site-packages/pbench.egg-link)"
-if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
-    export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
-fi
+source $(dirname "${0}")/python-setup.sh
 
 export PBENCH_UNITTEST_SERVER_MODE=parallel
 


### PR DESCRIPTION
We need to add the `lib/python3.*` and `lib64/python3.*` paths.