### PR TITLE
Harden against spaces in file names

### DIFF
--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -342,6 +342,9 @@ pbench-end-tools --group=${tool_group} --dir=${benchmark_run_dir}
 # Now that we have finished running all the iterations, create the
 # reference-result symlinks.
 while read -r rdir; do
+	if [[ -z "${rdir}" ]]; then
+		continue
+	fi
 	iteration_name="$(basename "$(dirname "${rdir}")")"
 	iteration="${iteration_name%%-*}"
 	if [ ${use_tool_triggers} -ne 0 ]; then

--- a/agent/bench-scripts/pbench-user-benchmark
+++ b/agent/bench-scripts/pbench-user-benchmark
@@ -341,8 +341,7 @@ pbench-end-tools --group=${tool_group} --dir=${benchmark_run_dir}
 
 # Now that we have finished running all the iterations, create the
 # reference-result symlinks.
-result_dirs="$(ls -1d ${benchmark_run_dir}/*/${sample_name} 2> /dev/null)"
-for rdir in ${result_dirs}; do
+while read -r rdir; do
 	iteration_name="$(basename "$(dirname "${rdir}")")"
 	iteration="${iteration_name%%-*}"
 	if [ ${use_tool_triggers} -ne 0 ]; then
@@ -353,7 +352,7 @@ for rdir in ${result_dirs}; do
 		record_iteration "${iteration}" "${iteration_name}" "${benchmark_bin}"
 	fi
 	ln -s "$(basename "${rdir}")" "$(dirname "${rdir}")/reference-result"
-done
+done <<< "$(ls -1d ${benchmark_run_dir}/*/${sample_name} 2> /dev/null)"
 
 ${script_path}/postprocess/user-benchmark-wrapper "${benchmark_run_dir}" "${total_duration}"
 

--- a/agent/profile
+++ b/agent/profile
@@ -24,11 +24,13 @@ function _pbench_setup() {
 	echo "                You will need to fix it before working with pbench." >&2
     else
 	local pdir
+	local NL=$'\n'
 	while read -r pdir; do
 	    if [[ ":${PYTHONPATH:-}:" != *":${pdir}:"* ]]; then
-		export PYTHONPATH=${pdir}${PYTHONPATH:+:${PYTHONPATH}}
+		PYTHONPATH=${pdir}${PYTHONPATH:+:${PYTHONPATH}}
 	    fi
-	done <<< "${prefix}/lib $(ls -1d ${prefix}/lib*/python3.*/site-packages)"
+	done <<< "${prefix}/lib${NL}$(ls -1d ${prefix}/lib*/python3.*/site-packages)"
+	export PYTHONPATH
 	export _PBENCH_AGENT_CONFIG=${prefix}/config/pbench-agent.cfg
 
 	_pbench_pathins "${prefix}/bench-scripts"

--- a/agent/profile
+++ b/agent/profile
@@ -24,11 +24,11 @@ function _pbench_setup() {
 	echo "                You will need to fix it before working with pbench." >&2
     else
 	local pdir
-	for pdir in ${prefix}/lib $(ls -1d ${prefix}/lib*/python3.*/site-packages); do
+	while read -r pdir; do
 	    if [[ ":${PYTHONPATH:-}:" != *":${pdir}:"* ]]; then
 		export PYTHONPATH=${pdir}${PYTHONPATH:+:${PYTHONPATH}}
 	    fi
-	done
+	done <<< "${prefix}/lib $(ls -1d ${prefix}/lib*/python3.*/site-packages)"
 	export _PBENCH_AGENT_CONFIG=${prefix}/config/pbench-agent.cfg
 
 	_pbench_pathins "${prefix}/bench-scripts"

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -7,8 +7,8 @@ if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
     export PATH=${_pdir}${PATH:+:${PATH}}
 fi
 
-for _pdir in $(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null) $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null); do
+while read -r _pdir; do
     if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
         export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
     fi
-done
+done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null) $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -7,8 +7,10 @@ if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
     export PATH=${_pdir}${PATH:+:${PATH}}
 fi
 
+NL=$'\n'
 while read -r _pdir; do
     if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
-        export PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
+        PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
     fi
-done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null) $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"
+done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null)${NL}$(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"
+export PYTHONPATH


### PR DESCRIPTION
When using the `bash` `for <var> in $(ls -1d ...); do` expressions, the shell will assign the variable values not only split by new-lines, but also by spaces.  So if a file name or directory in the path has a space in the name, the `ls -1d` output will not be interpreted correctly.

See also PR #1975.