### PR TITLE
Refactor server API implementation

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -1,14 +1,37 @@
 #!/bin/env python3
 
-from pbench.server.api import create_app
 import subprocess
+import sys
+
+from configparser import NoSectionError, NoOptionError
+
+from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
+from pbench.server.api import create_app, get_server_config
+
+
+def app():
+    try:
+        server_config = get_server_config()
+    except (ConfigFileNotSpecified, BadConfig) as e:
+        print(e)
+        sys.exit(1)
+    return create_app(server_config)
 
 
 def main():
-    app = create_app()
-    port = app.config["PORT"]
-    host = app.config["BIND_HOST"]
-    workers = app.config["WORKERS"]
+    try:
+        server_config = get_server_config()
+    except (ConfigFileNotSpecified, BadConfig) as e:
+        print(e)
+        sys.exit(1)
+    try:
+        port = server_config.get("pbench-server", "rest_port")
+        host = server_config.get("pbench-server", "bind_host")
+        workers = server_config.get("pbench-server", "workers")
+    except (NoOptionError, NoSectionError) as e:
+        print(f"{__name__}: ERROR: {e.__traceback__}")
+        sys.exit(1)
+
     subprocess.run(
         [
             "gunicorn",
@@ -18,6 +41,6 @@ def main():
             "/run/pbench-server/gunicorn.pid",
             "--bind",
             f"{str(host)}:{str(port)}",
-            "pbench.server.api:create_app()",
+            f"pbench.cli.server.shell:app())",
         ]
     )

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -5,442 +5,76 @@ Dashboard or any number of pbench agent users.
 """
 
 import os
-import sys
-import hashlib
-from pathlib import Path
-import requests
-import humanize
-import tempfile
 
-from flask import request, jsonify, Flask, make_response
-from flask_restful import Resource, abort, Api
-from werkzeug.utils import secure_filename
+from flask import Flask
+from flask_restful import Api
 
-from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.common.exceptions import BadConfig
-from pbench.server.utils import filesize_bytes
-
-from pbench.server.api.resources.query_controllers import QueryControllers
-
-ALLOWED_EXTENSIONS = {"xz"}
-
-
-def allowed_file(filename):
-    """Check if the file has the correct extension."""
-    try:
-        fn = filename.rsplit(".", 1)[1].lower()
-    except IndexError:
-        return False
-    allowed = "." in filename and fn in ALLOWED_EXTENSIONS
-    return allowed
+from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
+from pbench.server.api.resources.upload_api import Upload, HostInfo
+from pbench.server.api.resources.graphql_api import GraphQL
+from pbench.common.logger import get_pbench_logger
+from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
+from pbench.server.api.resources.query_apis.query_controllers import QueryControllers
 
 
-def register_endpoints(api, app):
+def register_endpoints(api, app, config):
     """Register flask endpoints with the corresponding resource classes
     to make the APIs active."""
 
-    base_uri = app.config["REST_URI"]
+    base_uri = config.rest_uri
     app.logger.info("Registering service endpoints with base URI {}", base_uri)
+
     api.add_resource(
         Upload,
         f"{base_uri}/upload/ctrl/<string:controller>",
-        resource_class_args=(app, api),
+        resource_class_args=(config, app.logger),
     )
+    api.add_resource(
+        HostInfo, f"{base_uri}/host_info", resource_class_args=(config, app.logger),
+    )
+    api.add_resource(
+        Elasticsearch,
+        f"{base_uri}/elasticsearch",
+        resource_class_args=(config, app.logger),
+    )
+    api.add_resource(
+        GraphQL, f"{base_uri}/graphql", resource_class_args=(config, app.logger),
+    )
+
     api.add_resource(
         QueryControllers,
         f"{base_uri}/controllers/list",
-        resource_class_args=(app, api),
+        resource_class_args=(config, app.logger),
     )
-    api.add_resource(HostInfo, f"{base_uri}/host_info", resource_class_args=(app, api))
-    api.add_resource(
-        Elasticsearch, f"{base_uri}/elasticsearch", resource_class_args=(app, api)
-    )
-    api.add_resource(GraphQL, f"{base_uri}/graphql", resource_class_args=(app, api))
 
 
-def create_app():
-    """Create Flask app with defined resource endpoints."""
-
+def get_server_config():
     cfg_name = os.environ.get("_PBENCH_SERVER_CONFIG")
     if not cfg_name:
-        print(
-            f"{__name__}: ERROR: No config file specified; set"
-            " _PBENCH_SERVER_CONFIG",
-            file=sys.stderr,
+        raise ConfigFileNotSpecified(
+            f"{__name__}: ERROR: No config file specified; set" " _PBENCH_SERVER_CONFIG"
         )
-        sys.exit(1)
 
     try:
-        config = PbenchServerConfig(cfg_name)
+        return PbenchServerConfig(cfg_name)
     except BadConfig as e:
-        print(f"{__name__}: {e} (config file {cfg_name})", file=sys.stderr)
-        sys.exit(1)
+        raise Exception(f"{__name__}: {e} (config file {cfg_name})").with_traceback(
+            e.__traceback__
+        )
 
-    app = Flask(__name__)
+
+def create_app(server_config):
+    """Create Flask app with defined resource endpoints."""
+
+    app = Flask("api-server")
     api = Api(app)
 
-    app.logger = get_pbench_logger(__name__, config)
-    app.config_server = config.conf["pbench-server"]
-    app.config_elasticsearch = config.conf["elasticsearch"]
-    app.config_graphql = config.conf["graphql"]
+    app.logger = get_pbench_logger(__name__, server_config)
 
-    prdp = app.config_server.get("pbench-receive-dir-prefix")
-    if not prdp:
-        app.logger.error("Missing config variable for pbench-receive-dir-prefix")
-        sys.exit(1)
-    try:
-        upload_directory = Path(f"{prdp}-002").resolve(strict=True)
-    except FileNotFoundError:
-        app.logger.exception("pbench-receive-dir-prefix does not exist on the host")
-        sys.exit(1)
-    except Exception:
-        app.logger.exception(
-            "Exception occurred during setting up the upload directory on the host"
-        )
-        sys.exit(1)
-    else:
-        app.upload_directory = upload_directory
+    app.config["DEBUG"] = False
+    app.config["TESTING"] = False
 
-    app.config["ES_URL"] = (
-        "http://"
-        + app.config_elasticsearch.get("host")
-        + ":"
-        + app.config_elasticsearch.get("port")
-    )
-    app.config["PORT"] = app.config_server.get("rest_port")
-    app.config["VERSION"] = app.config_server.get("rest_version")
-    app.config["MAX_CONTENT_LENGTH"] = filesize_bytes(
-        app.config_server.get("rest_max_content_length")
-    )
-    app.config["PREFIX"] = config.conf["Indexing"].get("index_prefix")
-    app.config["REST_URI"] = app.config_server.get("rest_uri")
-    app.config["BIND_HOST"] = app.config_server.get("bind_host")
-    app.config["WORKERS"] = app.config_server.get("workers")
-
-    register_endpoints(api, app)
+    register_endpoints(api, app, server_config)
 
     return app
-
-
-def _build_cors_preflight_response():
-    response = make_response()
-    response = _corsify_actual_response(response)
-    response.headers.add("Access-Control-Allow-Headers", "*")
-    response.headers.add("Access-Control-Allow-Methods", "*")
-    return response
-
-
-def _corsify_actual_response(response):
-    response.headers.add("Access-Control-Allow-Origin", "*")
-    return response
-
-
-class CorsOptionsRequest:
-    """
-    From the client side, an OPTIONS request is initiated before every POST to request CORS.
-    On the server side, the server must specify the response headers to grant CORS accordingly.
-    """
-
-    def __init__(self, app, options_exception_msg):
-        self.app = app
-        self.options_exception_msg = options_exception_msg
-
-    def options(self):
-        try:
-            response = _build_cors_preflight_response()
-        except Exception:
-            self.app.logger.exception(self.options_exception_msg)
-            abort(400, message=self.options_exception_msg)
-        response.status_code = 200
-        return response
-
-
-class GraphQL(Resource, CorsOptionsRequest):
-    """GraphQL API for post request via server."""
-
-    def __init__(self, app, api):
-        CorsOptionsRequest.__init__(
-            self, app, "Bad options request for the GraphQL query"
-        )
-        self.api = api
-
-    def post(self):
-        logger = self.app.logger
-        gql = self.app.config_graphql
-        graphQL = f"http://{gql.get('host')}:{gql.get('port')}"
-        json_data = request.get_json(silent=True)
-
-        if not json_data:
-            logger.warning("GraphQL: Invalid json object {}", request.url)
-            abort(400, message="GraphQL: Invalid json object in request")
-
-        try:
-            # query GraphQL
-            gql_response = requests.post(graphQL, json=json_data)
-            gql_response.raise_for_status()
-        except requests.exceptions.ConnectionError:
-            logger.exception("Connection refused during the GraphQL post request")
-            abort(502, message="Network problem, could not post to GraphQL Endpoint")
-        except requests.exceptions.Timeout:
-            logger.exception("Connection timed out during the GraphQL post request")
-            abort(
-                504, message="Connection timed out, could not post to GraphQL Endpoint"
-            )
-        except Exception:
-            logger.exception("Exception occurred during the GraphQL post request")
-            abort(500, message="INTERNAL ERROR")
-
-        try:
-            # construct response object
-            raw_response = make_response(gql_response.text)
-            response = _corsify_actual_response(raw_response)
-        except Exception:
-            logger.exception("Exception occurred in GraphQL response construction")
-            abort(
-                500, message="INTERNAL ERROR",
-            )
-
-        response.status_code = gql_response.status_code
-        return response
-
-
-class Elasticsearch(Resource, CorsOptionsRequest):
-    """Elasticsearch API for post request via server."""
-
-    def __init__(self, app, api):
-        CorsOptionsRequest.__init__(
-            self, app, "Bad options request for the Elasticsearch query"
-        )
-        self.api = api
-
-    def post(self):
-        logger = self.app.logger
-        es = self.app.config_elasticsearch
-        elasticsearch = f"http://{es.get('host')}:{es.get('port')}"
-        json_data = request.get_json(silent=True)
-        if not json_data:
-            logger.warning("Elasticsearch: Invalid json object. Query: {}", request.url)
-            abort(400, message="Elasticsearch: Invalid json object in request")
-
-        if not json_data["indices"]:
-            logger.warning("Elasticsearch: Missing indices path in the post request")
-            abort(400, message="Missing indices path in the Elasticsearch request")
-
-        try:
-            # query Elasticsearch
-            if "params" in json_data:
-                url = f"{elasticsearch}/{json_data['indices']}?{json_data['params']}"
-            else:
-                url = f"{elasticsearch}/{json_data['indices']}"
-
-            if "payload" in json_data:
-                es_response = requests.post(url, json=json_data["payload"])
-            else:
-                logger.debug("No payload found in Elasticsearch post request json data")
-                es_response = requests.get(url)
-            es_response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            logger.exception("HTTP error {} from Elasticsearch post request", e)
-            abort(es_response.status_code, message=f"HTTP error {e} from Elasticsearch")
-        except requests.exceptions.ConnectionError:
-            logger.exception("Connection refused during the Elasticsearch post request")
-            abort(
-                502, message="Network problem, could not post to Elasticsearch Endpoint"
-            )
-        except requests.exceptions.Timeout:
-            logger.exception(
-                "Connection timed out during the Elasticsearch post request"
-            )
-            abort(
-                504,
-                message="Connection timed out, could not post to Elasticsearch Endpoint",
-            )
-        except Exception:
-            logger.exception("Exception occurred during the Elasticsearch post request")
-            abort(
-                500, message="INTERNAL ERROR",
-            )
-
-        try:
-            # Construct our response object
-            raw_response = make_response(es_response.text)
-            response = _corsify_actual_response(raw_response)
-        except Exception:
-            logger.exception("Exception occurred Elasticsearch response construction")
-            abort(
-                500, message="INTERNAL ERROR",
-            )
-
-        response.status_code = es_response.status_code
-        return response
-
-
-class HostInfo(Resource):
-    def __init__(self, app, api):
-        self.app = app
-        self.api = api
-
-    def get(self):
-        try:
-            cfg = self.app.config_server
-            response = jsonify(
-                dict(
-                    message=f"{cfg.get('user')}@{cfg.get('host')}"
-                    f":{cfg.get('pbench-receive-dir-prefix')}-002"
-                )
-            )
-        except Exception as e:
-            self.app.logger.exception(
-                "There was something wrong constructing the host info: {}", e
-            )
-            abort(500, message="There was something wrong with your request")
-        response.status_code = 200
-        return response
-
-
-class Upload(Resource):
-    def __init__(self, app, api):
-        self.app = app
-        self.api = api
-
-    def put(self, controller):
-        logger = self.app.logger
-        if not request.headers.get("filename"):
-            logger.debug(
-                "Tarfile upload: Post operation failed due to missing filename header"
-            )
-            abort(
-                400,
-                message="Missing filename header, POST operation requires a filename header to name the uploaded file",
-            )
-        filename = secure_filename(request.headers.get("filename"))
-
-        if not request.headers.get("Content-MD5"):
-            logger.debug(
-                f"Tarfile upload: Post operation failed due to missing md5sum header for file {filename}"
-            )
-            abort(
-                400,
-                message="Missing md5sum header, POST operation requires md5sum of an uploaded file in header",
-            )
-        md5sum = request.headers.get("Content-MD5")
-
-        logger.debug("Receiving file: {}", filename)
-        if not allowed_file(filename):
-            logger.debug(
-                f"Tarfile upload: Bad file extension received for file {filename}"
-            )
-            abort(400, message="File extension not supported. Only .xz")
-
-        try:
-            content_length = int(request.headers.get("Content-Length"))
-        except ValueError:
-            logger.debug(
-                f"Tarfile upload: Invalid content-length header, not an integer for file {filename}"
-            )
-            abort(400, message="Invalid content-length header, not an integer")
-        except Exception:
-            logger.debug(
-                f"Tarfile upload: No Content-Length header value found for file {filename}"
-            )
-            abort(400, message="Missing required content-length header")
-        else:
-            max_len = self.app.config["MAX_CONTENT_LENGTH"]
-            if content_length > max_len:
-                logger.debug(
-                    f"Tarfile upload: Content-Length exceeded maximum upload size allowed. File: {filename}"
-                )
-                abort(
-                    400,
-                    message=f"Payload body too large, {content_length:d} bytes, maximum size should be less than "
-                    f"or equal to {humanize.naturalsize(max_len)}",
-                )
-            elif content_length == 0:
-                logger.debug(
-                    f"Tarfile upload: Content-Length header value is 0 for file {filename}"
-                )
-                abort(
-                    400,
-                    message="Upload failed, Content-Length received in header is 0",
-                )
-
-        path = Path(self.app.upload_directory, controller)
-        path.mkdir(exist_ok=True)
-        tar_full_path = Path(path, filename)
-        md5_full_path = Path(path, f"{filename}.md5")
-        bytes_received = 0
-
-        with tempfile.NamedTemporaryFile(mode="wb", dir=path) as ofp:
-            chunk_size = 4096
-            logger.debug("Writing chunks")
-            hash_md5 = hashlib.md5()
-
-            try:
-                while True:
-                    chunk = request.stream.read(chunk_size)
-                    bytes_received += len(chunk)
-                    if len(chunk) == 0 or bytes_received > content_length:
-                        break
-
-                    ofp.write(chunk)
-                    hash_md5.update(chunk)
-            except Exception:
-                logger.exception(
-                    "Tarfile upload: There was something wrong uploading {}", filename
-                )
-                abort(500, message=f"There was something wrong uploading {filename}")
-
-            if bytes_received != content_length:
-                logger.debug(
-                    f"Tarfile upload: Bytes received does not match with content length header value for file {filename}"
-                )
-                message = (
-                    f"Bytes received ({bytes_received}) does not match with content length header"
-                    f" ({content_length}), upload failed"
-                )
-                abort(400, message=message)
-
-            elif hash_md5.hexdigest() != md5sum:
-                logger.debug(f"Tarfile upload: md5sum check failed for file {filename}")
-                message = f"md5sum check failed for {filename}, upload failed"
-                abort(400, message=message)
-
-            # First write the .md5
-            try:
-                with md5_full_path.open("w") as md5fp:
-                    md5fp.write(f"{md5sum} {filename}\n")
-            except Exception:
-                try:
-                    os.remove(md5_full_path)
-                except FileNotFoundError:
-                    pass
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to remove .md5 {} when trying to clean up: {}}",
-                        md5_full_path,
-                        exc,
-                    )
-                logger.exception("Failed to write .md5 file, '{}'", md5_full_path)
-                raise
-
-            # Then create the final filename link to the temporary file.
-            try:
-                os.link(ofp.name, tar_full_path)
-            except Exception:
-                try:
-                    os.remove(md5_full_path)
-                except Exception as exc:
-                    logger.warning(
-                        "Failed to remove .md5 {} when trying to clean up: {}",
-                        md5_full_path,
-                        exc,
-                    )
-                logger.exception(
-                    "Failed to rename tar ball '{}' to '{}'", ofp.name, md5_full_path,
-                )
-                raise
-
-        response = jsonify(dict(message="File successfully uploaded"))
-        response.status_code = 201
-        return response

--- a/lib/pbench/server/api/resources/graphql_api.py
+++ b/lib/pbench/server/api/resources/graphql_api.py
@@ -1,0 +1,52 @@
+import requests
+from flask_restful import Resource, abort
+from flask import request, make_response
+from flask_cors import cross_origin
+
+
+class GraphQL(Resource):
+    """GraphQL API for post request via server."""
+
+    def __init__(self, config, logger):
+        self.logger = logger
+        self.graphql_host = config.get_conf(__name__, "graphql", "host", self.logger)
+        self.graphql_port = config.get_conf(__name__, "graphql", "port", self.logger)
+
+    @cross_origin()
+    def post(self):
+        self.graphql = f"http://{self.graphql_host}:{self.graphql_port}"
+
+        json_data = request.get_json(silent=True)
+
+        if not json_data:
+            message = "Invalid json object"
+            self.logger.warning(f"{message}: {request.url}")
+            abort(400, message=message)
+
+        try:
+            # query GraphQL
+            gql_response = requests.post(self.graphql, json=json_data)
+            gql_response.raise_for_status()
+        except requests.exceptions.ConnectionError:
+            self.logger.exception("Connection refused during the GraphQL post request")
+            abort(502, message="Network problem, could not post to GraphQL Endpoint")
+        except requests.exceptions.Timeout:
+            self.logger.exception(
+                "Connection timed out during the GraphQL post request"
+            )
+            abort(
+                504, message="Connection timed out, could not post to GraphQL Endpoint"
+            )
+        except Exception:
+            self.logger.exception("Exception occurred during the GraphQL post request")
+            abort(500, message="INTERNAL ERROR")
+
+        try:
+            # construct response object
+            response = make_response(gql_response.text)
+        except Exception:
+            self.logger.exception("Exception occurred GraphQL response construction")
+            abort(500, message="INTERNAL ERROR")
+
+        response.status_code = gql_response.status_code
+        return response

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -1,0 +1,33 @@
+"""
+Helper functions to get the elasticsearch specific configurations
+"""
+
+from configparser import NoSectionError, NoOptionError
+
+
+def get_es_host(config):
+    try:
+        return config.get("elasticsearch", "host")
+    except (NoOptionError, NoSectionError):
+        return ""
+
+
+def get_es_port(config):
+    try:
+        return config.get("elasticsearch", "port")
+    except (NoOptionError, NoSectionError):
+        return ""
+
+
+def get_es_url(config):
+    try:
+        return f"http://{get_es_host(config)}:{get_es_port(config)}"
+    except (NoOptionError, NoSectionError):
+        return ""
+
+
+def get_index_prefix(config):
+    try:
+        return config.get("Indexing", "index_prefix")
+    except (NoOptionError, NoSectionError):
+        return ""

--- a/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
+++ b/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
@@ -1,0 +1,85 @@
+import requests
+from flask_restful import Resource, abort
+from flask import request, make_response
+from flask_cors import cross_origin
+from pbench.server.api.resources.query_apis import get_es_url
+
+
+class Elasticsearch(Resource):
+    """Elasticsearch API for post request via server."""
+
+    def __init__(self, config, logger):
+        self.logger = logger
+        self.elasticsearch = get_es_url(config)
+
+    @cross_origin()
+    def post(self):
+        json_data = request.get_json(silent=True)
+        if not json_data:
+            message = "Invalid json object in the query"
+            self.logger.warning(f"{message}: {request.url}")
+            abort(400, message=message)
+
+        if not json_data["indices"]:
+            message = "Missing indices path in the post request"
+            self.logger.warning(f"{message}")
+            abort(400, message=f"{message}")
+
+        try:
+            # query Elasticsearch
+            if "params" in json_data:
+                url = (
+                    f"{self.elasticsearch}/{json_data['indices']}?{json_data['params']}"
+                )
+            else:
+                url = f"{self.elasticsearch}/{json_data['indices']}"
+
+            if "payload" in json_data:
+                es_response = requests.post(url, json=json_data["payload"])
+            else:
+                self.logger.debug(
+                    "No payload found in Elasticsearch post request json data"
+                )
+                es_response = requests.get(url)
+            es_response.raise_for_status()
+
+        except requests.exceptions.HTTPError as e:
+            self.logger.exception("HTTP error {} from Elasticsearch post request", e)
+            abort(es_response.status_code, message=f"HTTP error {e} from Elasticsearch")
+
+        except requests.exceptions.ConnectionError:
+            self.logger.exception(
+                "Connection refused during the Elasticsearch post request"
+            )
+            abort(
+                502, message="Network problem, could not post to Elasticsearch Endpoint"
+            )
+        except requests.exceptions.Timeout:
+            self.logger.exception(
+                "Connection timed out during the Elasticsearch post request"
+            )
+            abort(
+                504,
+                message="Connection timed out, could not post to Elasticsearch Endpoint",
+            )
+        except Exception:
+            self.logger.exception(
+                "Exception occurred during the Elasticsearch post request"
+            )
+            abort(
+                500, message="INTERNAL ERROR",
+            )
+
+        try:
+            # Construct our response object
+            response = make_response(es_response.text)
+        except Exception:
+            self.logger.exception(
+                "Exception occurred Elasticsearch response construction"
+            )
+            abort(
+                500, message="INTERNAL ERROR",
+            )
+
+        response.status_code = es_response.status_code
+        return response

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -1,0 +1,218 @@
+import os
+import humanize
+import tempfile
+import hashlib
+from pathlib import Path
+from flask_restful import Resource, abort
+from flask import request, jsonify
+from werkzeug.utils import secure_filename
+from pbench.server.utils import filesize_bytes
+
+ALLOWED_EXTENSIONS = {"xz"}
+
+
+class HostInfo(Resource):
+    def __init__(self, config, logger):
+        self.logger = logger
+        self.user = config.get_conf(__name__, "pbench-server", "user", self.logger)
+        self.host = config.get_conf(__name__, "pbench-server", "host", self.logger)
+        self.prdp = config.get_conf(
+            __name__, "pbench-server", "pbench-receive-dir-prefix", self.logger
+        )
+
+    def get(self):
+        try:
+            response = jsonify(
+                dict(message=f"{self.user}@{self.host}" f":{self.prdp}-002")
+            )
+        except Exception:
+            self.logger.exception(
+                "There was something wrong constructing the host info"
+            )
+            abort(500, message="INTERNAL ERROR")
+        response.status_code = 200
+        return response
+
+
+class Upload(Resource):
+    def __init__(self, config, logger):
+        self.config = config
+        self.logger = logger
+        self.max_content_length = filesize_bytes(
+            self.config.get_conf(
+                __name__, "pbench-server", "rest_max_content_length", self.logger
+            )
+        )
+
+    def put(self, controller):
+        if not request.headers.get("filename"):
+            self.logger.debug(
+                "Tarfile upload: Post operation failed due to missing filename header"
+            )
+            abort(
+                400,
+                message="Missing filename header, POST operation requires a filename header to name the uploaded file",
+            )
+        filename = secure_filename(request.headers.get("filename"))
+
+        if not request.headers.get("Content-MD5"):
+            self.logger.debug(
+                f"Tarfile upload: Post operation failed due to missing md5sum header for file {filename}"
+            )
+            abort(
+                400,
+                message="Missing md5sum header, POST operation requires md5sum of an uploaded file in header",
+            )
+        md5sum = request.headers.get("Content-MD5")
+
+        self.logger.debug("Receiving file: {}", filename)
+        if not self.allowed_file(filename):
+            self.logger.debug(
+                f"Tarfile upload: Bad file extension received for file {filename}"
+            )
+            abort(400, message="File extension not supported. Only .xz")
+
+        try:
+            content_length = int(request.headers.get("Content-Length"))
+        except ValueError:
+            self.logger.debug(
+                f"Tarfile upload: Invalid content-length header, not an integer for file {filename}"
+            )
+            abort(400, message="Invalid content-length header, not an integer")
+        except Exception:
+            self.logger.debug(
+                f"Tarfile upload: No Content-Length header value found for file {filename}"
+            )
+            abort(400, message="Missing required content-length header")
+        else:
+            if content_length > self.max_content_length:
+                self.logger.debug(
+                    f"Tarfile upload: Content-Length exceeded maximum upload size allowed. File: {filename}"
+                )
+                abort(
+                    400,
+                    message=f"Payload body too large, {content_length:d} bytes, maximum size should be less than "
+                    f"or equal to {humanize.naturalsize(self.max_content_length)}",
+                )
+            elif content_length == 0:
+                self.logger.debug(
+                    f"Tarfile upload: Content-Length header value is 0 for file {filename}"
+                )
+                abort(
+                    400,
+                    message="Upload failed, Content-Length received in header is 0",
+                )
+
+        path = self.upload_directory / controller
+        path.mkdir(exist_ok=True)
+        tar_full_path = Path(path, filename)
+        md5_full_path = Path(path, f"{filename}.md5")
+        bytes_received = 0
+
+        with tempfile.NamedTemporaryFile(mode="wb", dir=path) as ofp:
+            chunk_size = 4096
+            self.logger.debug("Writing chunks")
+            hash_md5 = hashlib.md5()
+
+            try:
+                while True:
+                    chunk = request.stream.read(chunk_size)
+                    bytes_received += len(chunk)
+                    if len(chunk) == 0 or bytes_received > content_length:
+                        break
+
+                    ofp.write(chunk)
+                    hash_md5.update(chunk)
+            except Exception:
+                self.logger.exception(
+                    "Tarfile upload: There was something wrong uploading {}", filename
+                )
+                abort(500, message=f"There was something wrong uploading {filename}")
+
+            if bytes_received != content_length:
+                self.logger.debug(
+                    f"Tarfile upload: Bytes received does not match with content length header value for file {filename}"
+                )
+                message = (
+                    f"Bytes received ({bytes_received}) does not match with content length header"
+                    f" ({content_length}), upload failed"
+                )
+                abort(400, message=message)
+
+            elif hash_md5.hexdigest() != md5sum:
+                self.logger.debug(
+                    f"Tarfile upload: md5sum check failed for file {filename}"
+                )
+                message = f"md5sum check failed for {filename}, upload failed"
+                abort(400, message=message)
+
+            # First write the .md5
+            try:
+                with md5_full_path.open("w") as md5fp:
+                    md5fp.write(f"{md5sum} {filename}\n")
+            except Exception:
+                try:
+                    os.remove(md5_full_path)
+                except FileNotFoundError:
+                    pass
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to remove .md5 %s when trying to clean up: %s",
+                        md5_full_path,
+                        exc,
+                    )
+                self.logger.exception("Failed to write .md5 file, '%s'", md5_full_path)
+                raise
+
+            # Then create the final filename link to the temporary file.
+            try:
+                os.link(ofp.name, tar_full_path)
+            except Exception:
+                try:
+                    os.remove(md5_full_path)
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to remove .md5 %s when trying to clean up: %s",
+                        md5_full_path,
+                        exc,
+                    )
+                self.logger.exception(
+                    "Failed to rename tar ball '%s' to '%s'", ofp.name, md5_full_path,
+                )
+                raise
+
+        response = jsonify(dict(message="File successfully uploaded"))
+        response.status_code = 201
+        return response
+
+    @staticmethod
+    def allowed_file(filename):
+        """Check if the file has the correct extension."""
+        try:
+            fn = filename.rsplit(".", 1)[1].lower()
+        except IndexError:
+            return False
+        allowed = "." in filename and fn in ALLOWED_EXTENSIONS
+        return allowed
+
+    @property
+    def upload_directory(self):
+        prdp = self.config.get_conf(
+            __name__, "pbench-server", "pbench-receive-dir-prefix", self.logger
+        )
+        try:
+            return Path(f"{prdp}-002").resolve(strict=True)
+        except FileNotFoundError:
+            self.logger.exception(
+                "pbench-receive-dir-prefix does not exist on the host"
+            )
+            raise FileNotFoundError(
+                "pbench-receive-dir-prefix does not exist on the host"
+            )
+        except Exception:
+            self.logger.exception(
+                "Exception occurred during setting up the upload directory on the host"
+            )
+            raise Exception(
+                "Some Exception occurred during setting up the upload directory on the host"
+            )

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -2,8 +2,7 @@ import shutil
 import tempfile
 import pytest
 from pathlib import Path
-
-from pbench.server.api import create_app
+from pbench.server.api import create_app, get_server_config
 
 
 server_cfg_tmpl = """[DEFAULT]
@@ -83,12 +82,22 @@ def setup(request, pytestconfig):
 
 
 @pytest.fixture
-def client(pytestconfig, monkeypatch):
+def server_config(pytestconfig, monkeypatch):
     cfg_file = pytestconfig.cache.get("_PBENCH_SERVER_CONFIG", None)
     monkeypatch.setenv("_PBENCH_SERVER_CONFIG", cfg_file)
-    app = create_app()
-    app.testing = True
+
+    server_config = get_server_config()
+    return server_config
+
+
+@pytest.fixture
+def client(server_config):
+    app = create_app(server_config)
+
     """A test client for the app."""
     app_client = app.test_client()
+    app_client.logger = app.logger
     app_client.config = app.config
+    app_client.debug = True
+    app_client.testing = True
     return app_client

--- a/lib/pbench/test/unit/server/test_query_controller.py
+++ b/lib/pbench/test/unit/server/test_query_controller.py
@@ -1,0 +1,209 @@
+import pytest
+import re
+import requests
+
+from pbench.server.api.resources.query_apis import get_es_url, get_index_prefix
+
+
+@pytest.fixture
+def query_helper(client, server_config, requests_mock):
+    """
+    query_helper Help controller queries that want to interact with a mocked
+    Elasticsearch service.
+
+    This is a fixture which exposes a function of the same name that can be
+    used to set up and validate a mocked Elasticsearch query with a JSON
+    payload and an expected status.
+
+    Parameters to the mocked Elasticsearch POST are passed as keyword
+    parameters: these can be any of the parameters supported by the
+    request_mock post method. The most common are 'json' for the JSON
+    response payload, and 'exc' to throw an exception.
+
+    :return: the response object for further checking
+    """
+
+    def query_helper(payload, expected_index, expected_status, server_config, **kwargs):
+        es_url = get_es_url(server_config)
+        requests_mock.post(re.compile(f"{es_url}"), **kwargs)
+        response = client.post(
+            f"{server_config.rest_uri}/controllers/list", json=payload
+        )
+        assert requests_mock.last_request.url == (
+            es_url + expected_index + "/_search?ignore_unavailable=true"
+        )
+        assert response.status_code == expected_status
+        return response
+
+    return query_helper
+
+
+class TestQueryControllers:
+    """
+    Unit testing for resources/QueryControllers class.
+
+    In a web service context, we access class functions mostly via the
+    Flask test client rather than trying to directly invoke the class
+    constructor and `post` service.
+    """
+
+    def build_index(self, server_config, dates):
+        """
+        build_index Build the index list for query
+
+        Args:
+            dates (iterable): list of date strings
+        """
+        prefix = get_index_prefix(server_config)
+        idx = prefix + ".v6.run-data."
+        index = "/"
+        for d in dates:
+            index += f"{idx}{d},"
+        return index
+
+    def test_missing_json_object(self, client, server_config):
+        """
+        test_missing_json_object Test behavior when no JSON payload is given
+        """
+        response = client.post(f"{server_config.rest_uri}/controllers/list")
+        assert response.status_code == 400
+        assert (
+            response.json.get("message") == "QueryControllers: Missing request payload"
+        )
+
+    @pytest.mark.parametrize(
+        "keys",
+        (
+            {"user": "x"},
+            {"start": "2020"},
+            {"end": "2020"},
+            {"user": "x", "start": "2020"},
+            {"user": "x", "end": "2020"},
+            {"start": "2020", "end": "2020"},
+        ),
+    )
+    def test_missing_keys(self, client, server_config, keys):
+        """
+        test_missing_keys Test behavior when JSON payload does not contain
+        all required keys.
+
+        Note that "user", "prefix", "start", and "end" are all required;
+        however, Pbench will silently ignore any additional keys that are
+        specified.
+       """
+        response = client.post(f"{server_config.rest_uri}/controllers/list", json=keys)
+        assert response.status_code == 400
+        missing = [k for k in ("user", "start", "end") if k not in keys]
+        assert (
+            response.json.get("message")
+            == f"QueryControllers: Missing request data: {','.join(missing)}"
+        )
+
+    def test_bad_dates(self, client, server_config):
+        """
+        test_bad_dates Test behavior when a bad date string is given
+        """
+        response = client.post(
+            f"{server_config.rest_uri}/controllers/list",
+            json={
+                "user": "drb",
+                "prefix": "drb-",
+                "start": "2020-15",
+                "end": "2020-19",
+            },
+        )
+        assert response.status_code == 400
+        assert (
+            response.json.get("message")
+            == "QueryControllers: Invalid start or end time string"
+        )
+
+    def test_query(self, client, server_config, query_helper):
+        """
+        test_query Check the construction of Elasticsearch query URI
+        and filtering of the response body.
+        """
+        json = {
+            "user": "drb",
+            "start": "2020-08",
+            "end": "2020-10",
+        }
+        response_payload = {
+            "took": 1,
+            "timed_out": False,
+            "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+            "hits": {
+                "total": {"value": 2, "relation": "eq"},
+                "max_score": None,
+                "hits": [],
+            },
+            "aggregations": {
+                "controllers": {
+                    "doc_count_error_upper_bound": 0,
+                    "sum_other_doc_count": 0,
+                    "buckets": [
+                        {
+                            "key": "unittest-controller1",
+                            "doc_count": 2,
+                            "runs": {
+                                "value": 1.59847315581e12,
+                                "value_as_string": "2020-08-26T20:19:15.810Z",
+                            },
+                        },
+                        {
+                            "key": "unittest-controller2",
+                            "doc_count": 1,
+                            "runs": {
+                                "value": 1.6,
+                                "value_as_string": "2020-09-26T20:19:15.810Z",
+                            },
+                        },
+                    ],
+                }
+            },
+        }
+
+        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        response = query_helper(json, index, 200, server_config, json=response_payload)
+        res_json = response.json
+        assert isinstance(res_json, list)
+        assert len(res_json) == 2
+        assert res_json[0]["key"] == "unittest-controller1"
+        assert res_json[0]["controller"] == "unittest-controller1"
+        assert res_json[0]["results"] == 2
+        assert res_json[0]["last_modified_value"] == 1.59847315581e12
+        assert res_json[0]["last_modified_string"] == "2020-08-26T20:19:15.810Z"
+        assert res_json[1]["key"] == "unittest-controller2"
+        assert res_json[1]["controller"] == "unittest-controller2"
+        assert res_json[1]["results"] == 1
+        assert res_json[1]["last_modified_value"] == 1.6
+        assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
+
+    @pytest.mark.parametrize(
+        "exceptions",
+        (
+            {"exception": requests.exceptions.HTTPError, "status": 500},
+            {"exception": requests.exceptions.ConnectionError, "status": 502},
+            {"exception": requests.exceptions.Timeout, "status": 504},
+            {"exception": requests.exceptions.InvalidURL, "status": 500},
+            {"exception": Exception, "status": 500},
+        ),
+    )
+    def test_http_error(self, client, server_config, query_helper, exceptions):
+        """
+        test_http_error Check that an Elasticsearch error is reported
+        correctly.
+       """
+        json = {
+            "user": "drb",
+            "start": "2020-08",
+            "end": "2020-08",
+        }
+        index = self.build_index(server_config, ("2020-08",))
+        query_helper(
+            json,
+            index,
+            exceptions["status"],
+            server_config,
+            exc=exceptions["exception"],
+        )

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -1,9 +1,6 @@
 import os
 import socket
-
 import pytest
-import re
-import requests
 
 from pathlib import Path
 from werkzeug.utils import secure_filename
@@ -11,14 +8,14 @@ from werkzeug.utils import secure_filename
 
 class TestHostInfo:
     @staticmethod
-    def test_host_info(client, pytestconfig, caplog):
+    def test_host_info(client, pytestconfig, caplog, server_config):
         tmp_d = pytestconfig.cache.get("TMP", None)
         expected_message = (
             f"pbench@pbench.example.com:{tmp_d}/srv/pbench"
             "/pbench-move-results-receive"
             "/fs-version-002"
         )
-        response = client.get(f"{client.config['REST_URI']}/host_info")
+        response = client.get(f"{server_config.rest_uri}/host_info")
 
         assert response.status_code == 200
         assert response.json.get("message") == expected_message
@@ -28,36 +25,32 @@ class TestHostInfo:
 
 class TestElasticsearch:
     @staticmethod
-    def test_json_object(client, caplog):
-        response = client.post(f"{client.config['REST_URI']}/elasticsearch")
+    def test_json_object(client, caplog, server_config):
+        response = client.post(f"{server_config.rest_uri}/elasticsearch")
         assert response.status_code == 400
-        assert (
-            response.json.get("message")
-            == "Elasticsearch: Invalid json object in request"
-        )
+        assert response.json.get("message") == "Invalid json object in the query"
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
 
     @staticmethod
-    def test_empty_url_path(client, caplog):
+    def test_empty_url_path(client, caplog, server_config):
         response = client.post(
-            f"{client.config['REST_URI']}/elasticsearch", json={"indices": ""}
+            f"{server_config.rest_uri}/elasticsearch", json={"indices": ""}
         )
         assert response.status_code == 400
         assert (
-            response.json.get("message")
-            == "Missing indices path in the Elasticsearch request"
+            response.json.get("message") == "Missing indices path in the post request"
         )
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
 
     @staticmethod
-    def test_bad_request(client, caplog, requests_mock):
+    def test_bad_request(client, caplog, server_config, requests_mock):
         requests_mock.post(
             "http://elasticsearch.example.com:7080/some_invalid_url", status_code=400
         )
         response = client.post(
-            f"{client.config['REST_URI']}/elasticsearch",
+            f"{server_config.rest_uri}/elasticsearch",
             json={"indices": "some_invalid_url", "payload": '{ "babble": "42" }'},
         )
         assert response.status_code == 400
@@ -73,23 +66,23 @@ class TestElasticsearch:
 
 class TestGraphQL:
     @staticmethod
-    def test_json_object(client, caplog):
-        response = client.post(f"{client.config['REST_URI']}/graphql")
+    def test_json_object(client, caplog, server_config):
+        response = client.post(f"{server_config.rest_uri}/graphql")
         assert response.status_code == 400
-        assert response.json.get("message") == "GraphQL: Invalid json object in request"
+        assert response.json.get("message") == "Invalid json object"
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
 
 
 class TestUpload:
     @staticmethod
-    def test_missing_filename_header_upload(client, caplog):
+    def test_missing_filename_header_upload(client, caplog, server_config):
         expected_message = (
             "Missing filename header, "
             "POST operation requires a filename header to name the uploaded file"
         )
         response = client.put(
-            f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}"
+            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}"
         )
         assert response.status_code == 400
         assert response.json.get("message") == expected_message
@@ -97,10 +90,10 @@ class TestUpload:
             assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_missing_md5sum_header_upload(client, caplog):
+    def test_missing_md5sum_header_upload(client, caplog, server_config):
         expected_message = "Missing md5sum header, POST operation requires md5sum of an uploaded file in header"
         response = client.put(
-            f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
+            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
             headers={"filename": "f.tar.xz"},
         )
         assert response.status_code == 400
@@ -110,10 +103,10 @@ class TestUpload:
 
     @staticmethod
     @pytest.mark.parametrize("bad_extension", ("test.tar.bad", "test.tar", "test.tar."))
-    def test_bad_extension_upload(client, bad_extension, caplog):
+    def test_bad_extension_upload(client, bad_extension, caplog, server_config):
         expected_message = "File extension not supported. Only .xz"
         response = client.put(
-            f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
+            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
             headers={"filename": bad_extension, "Content-MD5": "md5sum"},
         )
         assert response.status_code == 400
@@ -122,7 +115,7 @@ class TestUpload:
             assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_empty_upload(client, pytestconfig, caplog):
+    def test_empty_upload(client, pytestconfig, caplog, server_config):
         expected_message = "Upload failed, Content-Length received in header is 0"
         filename = "tmp.tar.xz"
         tmp_d = pytestconfig.cache.get("TMP", None)
@@ -130,7 +123,7 @@ class TestUpload:
 
         with open(Path(tmp_d, filename), "rb") as data_fp:
             response = client.put(
-                f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
                 data=data_fp,
                 headers={
                     "filename": "log.tar.xz",
@@ -143,7 +136,7 @@ class TestUpload:
             assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
-    def test_upload(client, pytestconfig, caplog):
+    def test_upload(client, pytestconfig, caplog, server_config):
         filename = "log.tar.xz"
         datafile = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
 
@@ -152,7 +145,7 @@ class TestUpload:
 
         with open(datafile, "rb") as data_fp:
             response = client.put(
-                f"{client.config['REST_URI']}/upload/ctrl/{socket.gethostname()}",
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
                 data=data_fp,
                 headers={"filename": filename, "Content-MD5": md5sum},
             )
@@ -169,204 +162,3 @@ class TestUpload:
         )
         for record in caplog.records:
             assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
-
-
-@pytest.fixture
-def query_helper(client, requests_mock):
-    """
-    query_helper Help controller queries that want to interact with a mocked
-    Elasticsearch service.
-
-    This is a fixture which exposes a function of the same name that can be
-    used to set up and validate a mocked Elasticsearch query with a JSON
-    payload and an expected status.
-
-    Parameters to the mocked Elasticsearch POST are passed as keyword
-    parameters: these can be any of the parameters supported by the
-    request_mock post method. The most common are 'json' for the JSON
-    response payload, and 'exc' to throw an exception.
-
-    :return: the response object for further checking
-    """
-
-    def query_helper(payload, expected_index, expected_status, **kwargs):
-        requests_mock.post(re.compile(f'{client.config["ES_URL"]}'), **kwargs)
-        response = client.post(
-            f"{client.config['REST_URI']}/controllers/list", json=payload
-        )
-        assert requests_mock.last_request.url == (
-            client.config["ES_URL"]
-            + expected_index
-            + "/_search?ignore_unavailable=true"
-        )
-        assert response.status_code == expected_status
-        return response
-
-    return query_helper
-
-
-class TestQueryControllers:
-    """
-    Unit testing for resources/QueryControllers class.
-
-    In a web service context, we access class functions mostly via the
-    Flask test client rather than trying to directly invoke the class
-    constructor and `post` service.
-    """
-
-    def build_index(self, client, dates):
-        """
-        build_index Build the index list for query
-
-        Args:
-            dates (iterable): list of date strings
-        """
-        prefix = client.config["PREFIX"]
-        idx = prefix + ".v6.run-data."
-        index = "/"
-        for d in dates:
-            index += f"{idx}{d},"
-        return index
-
-    def test_missing_json_object(self, client):
-        """
-        test_missing_json_object Test behavior when no JSON payload is given
-        """
-        response = client.post(f"{client.config['REST_URI']}/controllers/list")
-        assert response.status_code == 400
-        assert (
-            response.json.get("message") == "QueryControllers: Missing request payload"
-        )
-
-    @pytest.mark.parametrize(
-        "keys",
-        (
-            {"user": "x"},
-            {"start": "2020"},
-            {"end": "2020"},
-            {"user": "x", "start": "2020"},
-            {"user": "x", "end": "2020"},
-            {"start": "2020", "end": "2020"},
-        ),
-    )
-    def test_missing_keys(self, client, keys):
-        """
-        test_missing_keys Test behavior when JSON payload does not contain
-        all required keys.
-
-        Note that "user", "prefix", "start", and "end" are all required;
-        however, Pbench will silently ignore any additional keys that are
-        specified.
-       """
-        response = client.post(
-            f"{client.config['REST_URI']}/controllers/list", json=keys
-        )
-        assert response.status_code == 400
-        missing = [k for k in ("user", "start", "end") if k not in keys]
-        assert (
-            response.json.get("message")
-            == f"QueryControllers: Missing request data: {','.join(missing)}"
-        )
-
-    def test_bad_dates(self, client):
-        """
-        test_bad_dates Test behavior when a bad date string is given
-        """
-        response = client.post(
-            f"{client.config['REST_URI']}/controllers/list",
-            json={
-                "user": "drb",
-                "prefix": "drb-",
-                "start": "2020-15",
-                "end": "2020-19",
-            },
-        )
-        assert response.status_code == 400
-        assert (
-            response.json.get("message")
-            == "QueryControllers: Invalid start or end time string"
-        )
-
-    def test_query(self, client, query_helper):
-        """
-        test_query Check the construction of Elasticsearch query URI
-        and filtering of the response body.
-        """
-        json = {
-            "user": "drb",
-            "start": "2020-08",
-            "end": "2020-10",
-        }
-        response_payload = {
-            "took": 1,
-            "timed_out": False,
-            "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
-            "hits": {
-                "total": {"value": 2, "relation": "eq"},
-                "max_score": None,
-                "hits": [],
-            },
-            "aggregations": {
-                "controllers": {
-                    "doc_count_error_upper_bound": 0,
-                    "sum_other_doc_count": 0,
-                    "buckets": [
-                        {
-                            "key": "unittest-controller1",
-                            "doc_count": 2,
-                            "runs": {
-                                "value": 1.59847315581e12,
-                                "value_as_string": "2020-08-26T20:19:15.810Z",
-                            },
-                        },
-                        {
-                            "key": "unittest-controller2",
-                            "doc_count": 1,
-                            "runs": {
-                                "value": 1.6,
-                                "value_as_string": "2020-09-26T20:19:15.810Z",
-                            },
-                        },
-                    ],
-                }
-            },
-        }
-
-        index = self.build_index(client, ("2020-08", "2020-09", "2020-10"))
-        response = query_helper(json, index, 200, json=response_payload)
-        res_json = response.json
-        assert isinstance(res_json, list)
-        assert len(res_json) == 2
-        assert res_json[0]["key"] == "unittest-controller1"
-        assert res_json[0]["controller"] == "unittest-controller1"
-        assert res_json[0]["results"] == 2
-        assert res_json[0]["last_modified_value"] == 1.59847315581e12
-        assert res_json[0]["last_modified_string"] == "2020-08-26T20:19:15.810Z"
-        assert res_json[1]["key"] == "unittest-controller2"
-        assert res_json[1]["controller"] == "unittest-controller2"
-        assert res_json[1]["results"] == 1
-        assert res_json[1]["last_modified_value"] == 1.6
-        assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
-
-    @pytest.mark.parametrize(
-        "exceptions",
-        (
-            {"exception": requests.exceptions.HTTPError, "status": 500},
-            {"exception": requests.exceptions.ConnectionError, "status": 502},
-            {"exception": requests.exceptions.Timeout, "status": 504},
-            {"exception": requests.exceptions.InvalidURL, "status": 500},
-            {"exception": Exception, "status": 500},
-        ),
-    )
-    def test_http_error(self, client, query_helper, exceptions):
-        """
-        test_http_error Check that an Elasticsearch error is reported
-        correctly.
-       """
-        json = {
-            "user": "drb",
-            "start": "2020-08",
-            "end": "2020-08",
-        }
-        index = self.build_index(client, ("2020-08",))
-        query_helper(json, index, exceptions["status"], exc=exceptions["exception"])

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,6 +3,7 @@ python-dateutil
 elasticsearch
 flask
 flask-restful
+flask_cors
 gunicorn
 humanize
 pyesbulk>=2.0.1


### PR DESCRIPTION
This PR attempts to refactor some of the server API implementations

- Remove global variable `app` 
- Keep `create_app` functionality clean and high level.
- Modularize the API implementations
  - Create Separate api module for upload, elasticsearch and graphql
- Remove custom implementation of CORS 
  - Use `flask_cors` module to add  CORS decorator
- Use the loaded PbenchServerConfig object instead of reassigning them to app.config 

