### PR TITLE
Add unit tests for pbench-clear-tools

### DIFF
--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-def test_clear_tools_help():
+def test_pbench_clear_tools_help():
     command = ["pbench-clear-tools", "--help"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"Usage: pbench-clear-tools [OPTIONS]" in out


### PR DESCRIPTION
Signed-off-by: Charles Short <chucks@redhat.com>
Convert pbench-clear-tools to python3 unit tests.