### PR TITLE
Fix spec file and ansible roles

### DIFF
--- a/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/main.yml
@@ -12,6 +12,14 @@
   notify:
     - restart apache
 
+- name: "Create pbench-tarballs link in doc root"
+  file:
+    src: "{{ pbench_dir }}/archive/fs-version-001"
+    path: "{{ httpd_document_root_dir }}/pbench-tarballs"
+    state: link
+  notify:
+    - restart apache
+
 - name: "Make sure rsync is installed. Used below."
   package:
     name: rsync

--- a/server/ansible/roles/pbench-server-firewall/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-firewall/tasks/main.yml
@@ -3,6 +3,7 @@
   firewalld:
     service: "{{ item }}"
     permanent: yes
+    immediate: yes
     state: enabled
   with_items:
     - http

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -49,11 +49,11 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}/%{installdir}
 cp -a ./server/* %{buildroot}/%{installdir}
 
-mkdir -p %{buildroot}/%{installdir}/html/static
-cp -a ./web-server/* %{buildroot}/%{installdir}/html/static
+mkdir -p %{buildroot}/%{installdir}/%{static}
+cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 
 # for the npm install below
-mv %{buildroot}/%{installdir}/html/static/package.json %{buildroot}/%{installdir}
+mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
 %post
 # Install python dependencies
@@ -64,6 +64,21 @@ pip3 install -r /%{installdir}/requirements.txt
 cd /%{installdir}
 rm -rf node_modules
 npm install
+
+# this only handles v0.3
+# AFAIK, we don't need all the other modules that package.json includes.
+jslist="node_modules/d3/d3.min.js
+        node_modules/d3-queue/build/d3-queue.min.js
+        node_modules/save-svg-as-png/lib/saveSvgAsPng.js"
+
+# Copy them to the appropriate directory for v0.3. That
+# directory should exist already because of the `cp -a'
+# of the web-server stuff above, but add an explicit
+# mkdir just in case, although it should be a no-op.
+mkdir -p /%{installdir}/%{static}/js/v0.3
+for x in ${jslist} ;do
+    cp $x /%{installdir}/%{static}/js/v0.3
+done
 
 # Finally, make sure the installation directory is entirely owned
 # by the pbench user.


### PR DESCRIPTION
This is a forward port of PR #1988 (which was against the b0.69 branch) to master branch.

When I simplified the spec file back in June, I went a bit too far
and lost the js files that we need for visualization. Some of these have
been added back: the rest are needed for the (very) old web-server version
only.

The firewall role added http and https services to the "permanent" setup
but neglected to reload the rules, so they were not valid for the current
boot (although they would work fine after a reboot :-) ).

The pbench-tarballs link from /var/www/html to the archive was not created
by the playbook (it was added manually to the production server). It is
now added by the playbook.