### PR TITLE
Remove the pbench user and group from the agent

### DIFF
--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/README.md
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/README.md
@@ -21,8 +21,6 @@ These are the variables that are defined by default and do not
 generally need to be modified:
 
 - pbench_agent_install_dir: the installation directory for the pbench agent (default: /opt/pbench-agent)
-- pbench_owner: the owner of all the files in the installation directory (default: pbench)
-- pbench_group: the group of all the files in the installation directory (default: pbench)
 - pbench_config_files: the list of config files to be installed (default '["pbench-agent.cfg"]')
 - pbench_config_dest: the location where the config file(s) are to be installed (default: {{ pbench_agent_install_dir }}/config)
 - pbench_key_dest: the location where the key file is to be installed (default: {{ pbench_agent_install_dir }})

--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/defaults/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/defaults/main.yml
@@ -1,7 +1,5 @@
 ---
 pbench_agent_install_dir: /opt/pbench-agent
-pbench_owner: pbench
-pbench_group: pbench
 pbench_config_files:
   - pbench-agent.cfg
 pbench_config_dest: "{{ pbench_agent_install_dir }}/config"

--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
@@ -1,26 +1,5 @@
 ---
 # pbench agent configuration
-- name: create pbench group
-  group:
-    name: "{{ pbench_group }}"
-    state: present
-
-- name: create pbench user
-  user:
-    name: "{{ pbench_owner }}"
-    comment: Pbench user
-    home: /home/{{ pbench_owner }}
-    group: "{{ pbench_group }}"
-    state: present
-
-- name: Change ownership of the installed tree
-  file:
-    path: "{{ pbench_agent_install_dir }}"
-    state: directory
-    recurse: yes
-    owner: "{{ pbench_owner }}"
-    group: "{{ pbench_group }}"
-
 - name: "pbench agent configuration - install config file(s)"
   include_role:
     name: pbench_agent_files_install
@@ -28,8 +7,6 @@
     source: "{{ pbench_config_url }}"
     dest: "{{ pbench_config_dest }}"
     mode: "0644"
-    owner: "{{ pbench_owner }}"
-    group: "{{ pbench_group }}"
     files: "{{ pbench_config_files }}"
 
 - name: "pbench agent configuration - install ssh key"
@@ -39,6 +16,4 @@
     source: "{{ pbench_key_url }}"
     dest: "{{ pbench_key_dest }}"
     mode: "0600"
-    owner: "{{ pbench_owner }}"
-    group: "{{ pbench_group }}"
     files: id_rsa

--- a/agent/ansible/pbench/agent/roles/pbench_agent_files_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_files_install/tasks/main.yml
@@ -28,8 +28,6 @@
     src:  "{{ tempdir_1.path }}/{{ item }}"
     dest: "{{ dest }}"
     mode: "{{ mode }}"
-    owner: "{{ pbench_owner }}"
-    group: "{{ pbench_group }}"
   with_items: "{{ files }}"
 
 - name: delete local temp dir


### PR DESCRIPTION
The pbench agent currently runs as root, and we don't really have the notion of
separate user for the agent ... yet.