### PR TITLE
Use `ssh_opts` when starting remote tool meisters

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -371,7 +371,7 @@ INFO pbench-tool-meister main -- Remove pid file ... (tm-lite-testhost.example.c
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -371,7 +371,7 @@ INFO pbench-tool-meister main -- Remove pid file ... (tm-lite-testhost.example.c
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -21,6 +21,7 @@ import errno
 import json
 import logging
 import os
+import shlex
 import signal
 import socket
 import sys
@@ -283,6 +284,9 @@ def main(argv):
         logger.exception("failed to load tool group data")
         return 1
 
+    # See if anybody told us to use certain options with SSH commands.
+    ssh_opts = os.environ.get("ssh_opts", "")
+
     try:
         benchmark_run_dir = os.environ["benchmark_run_dir"]
         hostname = os.environ["_pbench_hostname"]
@@ -501,8 +505,11 @@ def main(argv):
     # is the same on the local host as it is on any remote host.
     ssh_cmd = "ssh"
     ssh_path = find_executable(ssh_cmd)
-    args = [
+    base_args = [
         ssh_cmd,
+    ]
+    base_args.extend(shlex.split(ssh_opts))
+    args = [
         "<host replace me>",
         f"{tool_meister_cmd}-remote",
         tm_bind_hostname,
@@ -567,13 +574,16 @@ def main(argv):
             else:
                 successes += 1
             continue
-        args[1] = host
-        args[5] = tm_param_key
+        args[0] = host
+        args[4] = tm_param_key
+        ssh_args = base_args + args
         logger.debug(
-            "d. starting remote tool meister, ssh_path=%r args=%r", ssh_path, args
+            "d. starting remote tool meister, ssh_path=%r ssh_args=%r",
+            ssh_path,
+            ssh_args,
         )
         try:
-            pid = os.spawnv(os.P_NOWAIT, ssh_path, args)
+            pid = os.spawnv(os.P_NOWAIT, ssh_path, ssh_args)
         except Exception:
             logger.exception(
                 "failed to create a tool meister instance for host %s", host


### PR DESCRIPTION
We have been using `ssh_opts` everywhere except when using `ssh` to start the Tool Meisters remotely.