### PR TITLE
Finish to remove agent user/group

### DIFF
--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -4,8 +4,6 @@ pbench_web_server = pbench.example.com
 
 [pbench-agent]
 install-dir = %(pbench_install_dir)s
-pbench_user = pbench
-pbench_group = pbench
 pbench_run = /var/lib/pbench-agent
 pbench_log = %(pbench_run)s/pbench.log
 

--- a/agent/util-scripts/gold/pbench-agent-config-activate/test-14.txt
+++ b/agent/util-scripts/gold/pbench-agent-config-activate/test-14.txt
@@ -10,8 +10,6 @@ pbench_install_dir = /var/tmp/pbench-test-utils/opt/pbench-agent
 
 [pbench-agent]
 install-dir = %(pbench_install_dir)s
-pbench_user = upbench
-pbench_group = gpbench
 
 [config]
 path = %(pbench_install_dir)s/config

--- a/agent/util-scripts/pbench-agent-config-ssh-key
+++ b/agent/util-scripts/pbench-agent-config-ssh-key
@@ -14,22 +14,11 @@
 
 configfile=$1
 keyfile=$2
-user=$(pbench-config -C $configfile pbench_user pbench-agent)
-group=$(pbench-config -C $configfile pbench_group pbench-agent)
-
-# fallbacks assume the existence of user/group pbench
-if [ -z "$user" ] ;then
-    user=pbench
-fi
-if [ -z "$group" ] ;then
-    group=pbench
-fi
 
 pbenchdir=$(pbench-config -C $configfile install-dir pbench-agent)
 # copy the key file and adjust perms
 if [ -f $keyfile ] ;then
     cp $keyfile $pbenchdir/id_rsa
-    chown $user.$group $pbenchdir/id_rsa
     chmod 600 $pbenchdir/id_rsa
 else
     exit 3

--- a/agent/util-scripts/samples/pbench-agent-config-activate/test-14/pbench/tmp/pbench-agent.cfg
+++ b/agent/util-scripts/samples/pbench-agent-config-activate/test-14/pbench/tmp/pbench-agent.cfg
@@ -3,8 +3,6 @@ pbench_install_dir = _REPLACE_ME_
 
 [pbench-agent]
 install-dir = %(pbench_install_dir)s
-pbench_user = upbench
-pbench_group = gpbench
 
 [config]
 path = %(pbench_install_dir)s/config

--- a/lib/pbench/cli/agent/commands/results/__init__.py
+++ b/lib/pbench/cli/agent/commands/results/__init__.py
@@ -25,9 +25,6 @@ def move_results(ctx, _user, _prefix, _show_server):
         )
         logger.debug("'webserver' variable in 'results' section not set")
 
-    if not _user:
-        _user = config.agent.get("pbench_user")
-
     server_rest_url = config.results.get("server_rest_url")
     response = requests.get(f"{server_rest_url}/host_info")
     if response.status_code not in [200, 201]:


### PR DESCRIPTION
The pbench-agent does not really use a user and group. As described in PR #1997, the agent is really only runnable as `root` today.