### PR TITLE
Fix server spec file

### DIFF
--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -129,7 +129,11 @@ fi
 /%{installdir}/lib/pbench/server/mock.py
 /%{installdir}/lib/pbench/server/utils.py
 /%{installdir}/lib/pbench/server/api/__init__.py
-/%{installdir}/lib/pbench/server/api/resources/query_controllers.py
+/%{installdir}/lib/pbench/server/api/resources/graphql_api.py
+/%{installdir}/lib/pbench/server/api/resources/upload_api.py
+/%{installdir}/lib/pbench/server/api/resources/query_apis/__init__.py
+/%{installdir}/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
+/%{installdir}/lib/pbench/server/api/resources/query_apis/query_controllers.py
 /%{installdir}/lib/pbench/server/s3backup/__init__.py
 /%{installdir}/lib/pbench/cli/__init__.py
 /%{installdir}/lib/pbench/cli/getconf.py


### PR DESCRIPTION
The reorganized API resource files need to be represented properly in the RPM spec file.

There are several flake8/black violations elsewhere that somehow got past presubmit checks that I needed to fix to get this in; I know Pete has already fixed at least one of them.