### PR TITLE
Fix extra trailing parenthesis when gunicorn app starts

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -41,6 +41,6 @@ def main():
             "/run/pbench-server/gunicorn.pid",
             "--bind",
             f"{host}:{port}",
-            "pbench.cli.server.shell:app())",
+            "pbench.cli.server.shell:app()",
         ]
     )


### PR DESCRIPTION
There was bug introduced with an extra parenthesis in shell script when starting the gunicorn app which @dbutenhof noticed when testing 