### PR TITLE
Pythonize pbench-log-timestamp

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -35,7 +35,6 @@ util-scripts = \
 	pbench-import-cdm \
 	pbench-init-tools \
 	pbench-kill-tools \
-	pbench-log-timestamp \
 	pbench-make-result-tb \
 	pbench-metadata-log \
 	pbench-move-results \
@@ -253,6 +252,7 @@ install-python3-setup: install-util-scripts install-lib
 	${COPY} ${DESTDIR}/python3/bin/pbench-cleanup ${UTILDIR}/
 	${COPY} ${DESTDIR}/python3/bin/pbench-list-tools ${UTILDIR}/
 	${COPY} ${DESTDIR}/python3/bin/pbench-register-tool-trigger ${UTILDIR}/
+	${COPY} ${DESTDIR}/python3/bin/pbench-log-timestamp ${UTILDIR}/
 	rm -rf ${DESTDIR}/python3
 	${COPY} ../lib/pbench ${LIBDIR}/
 	rm -r $$(find ${LIBDIR} -name __pycache__) ${LIBDIR}/pbench/test ${LIBDIR}/pbench/server ${LIBDIR}/pbench/cli/server

--- a/agent/util-scripts/pbench-log-timestamp
+++ b/agent/util-scripts/pbench-log-timestamp
@@ -1,8 +1,0 @@
-#!/usr/bin/perl
-use Time::HiRes qw(gettimeofday);
-
-# turn on autoflushing
-$| = 1;
-while (<STDIN>) {
-	printf "%d: %s", int (gettimeofday * 1000), $_;
-}

--- a/lib/pbench/cli/agent/commands/timestamp.py
+++ b/lib/pbench/cli/agent/commands/timestamp.py
@@ -1,0 +1,13 @@
+"""pbench-log-timestamp"""
+
+import time
+
+import click
+
+
+@click.command()
+def main():
+    """ Add timestamp to user input"""
+    stdin = click.get_text_stream("stdin").read()
+    for line in stdin.splitlines():
+        print(f"{time.time_ns()}:{line}")

--- a/lib/pbench/test/functional/agent/cli/commands/test_log_timestamp.py
+++ b/lib/pbench/test/functional/agent/cli/commands/test_log_timestamp.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def test_pbench_log_timestamp():
+    command = ["pbench-log-timestamp", "--help"]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert b"Usage: pbench-log-timestamp [OPTIONS]" in out
+    assert exitcode == 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
    pbench-cleanup = pbench.cli.agent.commands.cleanup:main
    pbench-list-tools = pbench.cli.agent.commands.tools.list:main
    pbench-register-tool-trigger = pbench.cli.agent.commands.triggers.register:main
+   pbench-log-timestamp = pbench.cli.agent.commands.timestamp:main
 
 [tools:pytest]
 testpaths = lib/pbench/test


### PR DESCRIPTION
Replace shell script with python script and add unit test.

Signed-off-by: Charles Short <chucks@redhat.com>