### PR TITLE
Fix py move-results to use `ConfigParser`

### DIFF
--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 def base_setup(request, pytestconfig):
     """Test package setup for pbench-agent"""
-    print("Test SETUP for pbench-agent")
 
     # Create a single temporary directory for the "/opt/pbench-agent" and
     # "/var/lib/pbench-agent" directories.
@@ -32,7 +31,6 @@ def base_setup(request, pytestconfig):
 
     def teardown():
         """Test package teardown for pbench-agent"""
-        print("Test TEARDOWN for pbench-agent")
         TMP.cleanup()
 
     request.addfinalizer(teardown)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -37,7 +37,6 @@ files = pbench-server-default.cfg
 @pytest.fixture(scope="session", autouse=True)
 def setup(request, pytestconfig):
     """Test package setup for pbench-server"""
-    print("\nTest SETUP for pbench-server")
 
     # Create a single temporary directory for the "/srv/pbench" and
     # "/opt/pbench-server" directories.
@@ -75,7 +74,6 @@ def setup(request, pytestconfig):
 
     def teardown():
         """Test package teardown for pbench-server"""
-        print("\nTest TEARDOWN for pbench-server")
         TMP.cleanup()
 
     request.addfinalizer(teardown)


### PR DESCRIPTION
The Python 3 based "move-results" code was using the old `configtools` module instead of just using `ConfigParser` directly.  This would end up causing failures in the unit tests because it was calling the `parse_args` method of `configtools` to first parse the command line arguments.  But in principle, we never want to access the command line arguments while running unit tests.  The unit test should provide them for the method under test to properly ensure the correct behavior is tested.

We simply replace the use of `configtools` with `ConfigParser` directly, which ends up simplifying the code as well.

Further, using configtools just for the result directory `metadata.log` is over kill, because `configtools` was there to support multiple configuration files, and there is only one `metadata.log` file.

We remove the `SETUP` and `TEARDOWN` messages since they are really debugging statements and have no business being there for normal test operation.