### PR TITLE
CORS fixes and a new API

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -8,6 +8,7 @@ import os
 
 from flask import Flask
 from flask_restful import Api
+from flask_cors import CORS
 
 from pbench.server import PbenchServerConfig
 from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
@@ -16,6 +17,7 @@ from pbench.server.api.resources.graphql_api import GraphQL
 from pbench.common.logger import get_pbench_logger
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
 from pbench.server.api.resources.query_apis.query_controllers import QueryControllers
+from pbench.server.api.resources.query_apis.query_month_indices import QueryMonthIndices
 
 
 def register_endpoints(api, app, config):
@@ -41,10 +43,14 @@ def register_endpoints(api, app, config):
     api.add_resource(
         GraphQL, f"{base_uri}/graphql", resource_class_args=(config, app.logger),
     )
-
     api.add_resource(
         QueryControllers,
         f"{base_uri}/controllers/list",
+        resource_class_args=(config, app.logger),
+    )
+    api.add_resource(
+        QueryMonthIndices,
+        f"{base_uri}/controllers/months",
         resource_class_args=(config, app.logger),
     )
 
@@ -69,6 +75,7 @@ def create_app(server_config):
 
     app = Flask("api-server")
     api = Api(app)
+    CORS(app, resources={r"/api/*": {"origins": "*"}})
 
     app.logger = get_pbench_logger(__name__, server_config)
 

--- a/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
+++ b/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
@@ -1,7 +1,6 @@
 import requests
 from flask_restful import Resource, abort
 from flask import request, make_response
-from flask_cors import cross_origin
 from pbench.server.api.resources.query_apis import get_es_url
 
 
@@ -12,7 +11,6 @@ class Elasticsearch(Resource):
         self.logger = logger
         self.elasticsearch = get_es_url(config)
 
-    @cross_origin()
     def post(self):
         json_data = request.get_json(silent=True)
         if not json_data:

--- a/lib/pbench/server/api/resources/query_apis/query_month_indices.py
+++ b/lib/pbench/server/api/resources/query_apis/query_month_indices.py
@@ -1,0 +1,95 @@
+from flask import jsonify
+from flask_restful import Resource, abort
+import requests
+
+from pbench.server.api.resources.query_apis import get_es_url, get_index_prefix
+
+
+class QueryMonthIndices(Resource):
+    """
+    Abstracted Pbench API to get date-bounded controller data.
+    """
+
+    def __init__(self, config, logger):
+        self.logger = logger
+        self.es_url = get_es_url(config)
+        self.prefix = get_index_prefix(config)
+
+    def get(self):
+        """
+        GET to detect the month suffixes existing for run data indices.
+
+        Required headers include
+
+        Content-Type:   application/json
+        Accept:         application/json
+
+        The return payload is a list of "YYYY-mm" date strings corresponding
+        to the months in which tarballs were indexed into the appropriate
+        `run-data` index. (E.g., `drb.v6.run-data.2020-11`). Note that this
+        list is in DESCENDING order, so the earliest date is last.
+
+        NOTE: No authorization or input payload is required for this API.
+
+        NOTE: This is the format currently constructed by the Pbench
+        dashboard `src/model/datastore.js` fetchMonthIndices method, which
+        becomes part of the Redux state.
+
+        [
+            "2020-12",
+            "2020-11",
+            "2020-04"
+        ]
+        """
+        self.logger.info(
+            "QueryMonthIndices GET for prefix {}", self.prefix,
+        )
+
+        uri = f"{self.es_url}/_aliases"
+        try:
+            # query Elasticsearch
+            es_response = requests.get(uri, headers={"Accept": "application/json"})
+            es_response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.logger.exception("HTTP error {} from Elasticsearch post request", e)
+            abort(502, message="INTERNAL ERROR")
+        except requests.exceptions.ConnectionError:
+            self.logger.exception(
+                "Connection refused during the Elasticsearch post request"
+            )
+            abort(502, message="Network problem, could not post to Elasticsearch")
+        except requests.exceptions.Timeout:
+            self.logger.exception(
+                "Connection timed out during the Elasticsearch post request"
+            )
+            abort(504, message="Connection timed out, could not post to Elasticsearch")
+        except requests.exceptions.InvalidURL:
+            self.logger.exception(
+                "Invalid url {} during the Elasticsearch post request", uri
+            )
+            abort(500, message="INTERNAL ERROR")
+        except Exception as e:
+            self.logger.exception(
+                "Exception {!r} occurred during the Elasticsearch post request", e
+            )
+            abort(500, message="INTERNAL ERROR")
+        else:
+            months = []
+            target = f"{self.prefix}.v6.run-data."
+            try:
+                es_json = es_response.json()
+                self.logger.info("looking for {} in {}", target, es_json)
+                for index in es_json.keys():
+                    if target in index:
+                        months.append(index.split(".")[-1])
+                # The dashboard converts the strings to int (removing the '-')
+                # and does a numeric sort; however since we always have a full
+                # "YYYY-mm" date, this isn't necessary.
+                months.sort(reverse=True)
+                self.logger.info("found months {!r}", months)
+            except KeyError:
+                self.logger.exception("ES response not formatted as expected")
+                abort(500, message="INTERNAL ERROR")
+            else:
+                # construct response object
+                return jsonify(months)

--- a/lib/pbench/test/unit/server/test_query_controller.py
+++ b/lib/pbench/test/unit/server/test_query_controller.py
@@ -67,9 +67,7 @@ class TestQueryControllers:
         """
         response = client.post(f"{server_config.rest_uri}/controllers/list")
         assert response.status_code == 400
-        assert (
-            response.json.get("message") == "QueryControllers: Missing request payload"
-        )
+        assert response.json.get("message") == "Missing request payload"
 
     @pytest.mark.parametrize(
         "keys",
@@ -95,8 +93,7 @@ class TestQueryControllers:
         assert response.status_code == 400
         missing = [k for k in ("user", "start", "end") if k not in keys]
         assert (
-            response.json.get("message")
-            == f"QueryControllers: Missing request data: {','.join(missing)}"
+            response.json.get("message") == f"Missing request data: {','.join(missing)}"
         )
 
     def test_bad_dates(self, client, server_config):
@@ -113,10 +110,7 @@ class TestQueryControllers:
             },
         )
         assert response.status_code == 400
-        assert (
-            response.json.get("message")
-            == "QueryControllers: Invalid start or end time string"
-        )
+        assert response.json.get("message") == "Invalid start or end time string"
 
     def test_query(self, client, server_config, query_helper):
         """
@@ -182,7 +176,7 @@ class TestQueryControllers:
     @pytest.mark.parametrize(
         "exceptions",
         (
-            {"exception": requests.exceptions.HTTPError, "status": 500},
+            {"exception": requests.exceptions.HTTPError, "status": 502},
             {"exception": requests.exceptions.ConnectionError, "status": 502},
             {"exception": requests.exceptions.Timeout, "status": 504},
             {"exception": requests.exceptions.InvalidURL, "status": 500},

--- a/lib/pbench/test/unit/server/test_query_month_indices.py
+++ b/lib/pbench/test/unit/server/test_query_month_indices.py
@@ -1,0 +1,123 @@
+import pytest
+import re
+import requests
+
+from pbench.server.api.resources.query_apis import get_es_url
+
+
+@pytest.fixture
+def get_helper(client, server_config, requests_mock):
+    """
+    query_helper Help controller queries that want to interact with a mocked
+    Elasticsearch service.
+
+    This is a fixture which exposes a function of the same name that can be
+    used to set up and validate a mocked Elasticsearch query with a JSON
+    payload and an expected status.
+
+    Parameters to the mocked Elasticsearch POST are passed as keyword
+    parameters: these can be any of the parameters supported by the
+    request_mock post method. The most common are 'json' for the JSON
+    response payload, and 'exc' to throw an exception.
+
+    :return: the response object for further checking
+    """
+
+    def get_helper(expected_status, server_config, **kwargs):
+        es_url = get_es_url(server_config)
+        requests_mock.get(re.compile(f"{es_url}"), **kwargs)
+        response = client.get(f"{server_config.rest_uri}/controllers/months")
+        assert requests_mock.last_request.url == (es_url + "/_aliases")
+        assert response.status_code == expected_status
+        return response
+
+    return get_helper
+
+
+class TestQueryMonthIndices:
+    """
+    Unit testing for resources/QueryMonthIndices class.
+
+    In a web service context, we access class functions mostly via the
+    Flask test client rather than trying to directly invoke the class
+    constructor and `post` service.
+    """
+
+    def test_query(self, client, server_config, get_helper):
+        """
+        test_query Check the construction of Elasticsearch query URI
+        and filtering of the response body.
+        """
+        response_payload = {
+            ".opendistro-alerting-alert-history-2020.12.05-000177": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.11-000153": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.12-000154": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.22-000164": {"aliases": {}},
+            "unit-test.v5.result-data-sample.2020-04-29": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.02-000174": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.03-000175": {"aliases": {}},
+            "unit-test.v6.run-toc.2020-11": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.13-000155": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.18-000160": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.30-000172": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.29-000171": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.28-000170": {"aliases": {}},
+            "unit-test.v6.run-toc.2020-12": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.21-000163": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.06-000178": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.01-000173": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.24-000166": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.26-000168": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.14-000156": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.15-000157": {"aliases": {}},
+            "unit-test.v5.result-data.2020-04-29": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.19-000161": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.10-000182": {
+                "aliases": {".opendistro-alerting-alert-history-write": {}}
+            },
+            ".opendistro-alerting-alert-history-2020.11.27-000169": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.08-000180": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.17-000159": {"aliases": {}},
+            "unit-test.v6.run-data.2020-12": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.04-000176": {"aliases": {}},
+            "unit-test.v6.run-data.2020-04": {"aliases": {}},
+            ".kibana_2": {"aliases": {".kibana": {}}},
+            ".opendistro-alerting-alert-history-2020.11.23-000165": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.07-000179": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.12.09-000181": {"aliases": {}},
+            ".opendistro-alerting-alerts": {"aliases": {}},
+            ".kibana_1": {"aliases": {}},
+            "unit-test.v6.run-toc.2020-04": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.25-000167": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.16-000158": {"aliases": {}},
+            ".opendistro-alerting-alert-history-2020.11.20-000162": {"aliases": {}},
+            "unit-test.v4.server-reports.2020-12": {"aliases": {}},
+            "unit-test.v6.run-data.2020-11": {"aliases": {}},
+        }
+
+        response = get_helper(200, server_config, json=response_payload)
+        res_json = response.json
+        assert isinstance(res_json, list)
+        assert len(res_json) == 3
+        assert res_json[0] == "2020-12"
+        assert res_json[1] == "2020-11"
+        assert res_json[2] == "2020-04"
+
+    @pytest.mark.parametrize(
+        "exceptions",
+        (
+            {"exception": requests.exceptions.HTTPError, "status": 502},
+            {"exception": requests.exceptions.ConnectionError, "status": 502},
+            {"exception": requests.exceptions.Timeout, "status": 504},
+            {"exception": requests.exceptions.InvalidURL, "status": 500},
+            {"exception": Exception, "status": 500},
+        ),
+    )
+    def test_http_error(self, client, server_config, get_helper, exceptions):
+        """
+        test_http_error Check that an Elasticsearch error is reported
+        correctly.
+        """
+        get_helper(
+            exceptions["status"], server_config, exc=exceptions["exception"],
+        )


### PR DESCRIPTION
In experimentation with a dashboard on my live server, I found that the current use of `@cross_origin` isn't actually working; I suspect this is because documentation suggests it needs to follow `@app.route(...)`, which we don't use.

Instead, change to a global CORS configuration triggered by wrapping the `app` object in a `CORS` object. This demonstrably works, and should keep us out of trouble for a while. (Note that, ideally, we want to set up Apache `mod_wsgi` to allow redirecting the default http and eventually https port to our app for `/api...` paths, which would mean our dashboard wouldn't need CORS -- very good from a security point of view -- though we may still want some sort of CORS support to allow integration of our server with other browser apps that might not be able to load their code from our server.)

In the process of my experimentation to get the dashboard started on 0.71 with Elasticsearch V7, I also wrote a second native server API to replace `fetchMonthIndices` ... because that and the existing `queryControllers` are required to get the dashboard up to the initial controller display. (I can't get further without Elasticsearch CORS, on which I'm still waiting.)

Rather than pursuing additional native APIs in the short term, I plan to rely on getting the RDU2 Elasticsearch V7 server configured for CORS and work directly on updating necessary dashboard queries. However I currently have dashboard code that uses my `queryMonthIndices` and `queryControllers` APIs, and when I get to the point of posting a dashboard PR I'll probably leave it that way as a milestone.