### PR TITLE
Fix bug when reading a file in chunks

### DIFF
--- a/lib/pbench/server/s3backup/__init__.py
+++ b/lib/pbench/server/s3backup/__init__.py
@@ -306,7 +306,7 @@ class S3Connector(Connector):
         md5s = []
 
         with open(tb, "rb") as fp:
-            for data in fp.read(chunk_size):
+            for data in iter(lambda: fp.read(chunk_size), b""):
                 md5s.append(hashlib.md5(data))
 
         if len(md5s) > 1:


### PR DESCRIPTION
Fix #2034

Commit 8a4417838959ec17d234eff887540dc461386cb2 broke the function
calculate_multipart_etag(): it replaced a (working) while-loop that
was reading the tarball in chunks with a broken for-loop which read
one chunk of the file and then iterated over the bytes of that chunk.

We retain the for-loop but fix the iterator to give us back the next
chunk each time.