### PR TITLE
When installing the server, set the host-info state to maintenance

### DIFF
--- a/server/ansible/pbench-repo-install.yml
+++ b/server/ansible/pbench-repo-install.yml
@@ -3,8 +3,6 @@
 - name: install pbench.repo
   hosts: servers
   remote_user: root
-  become: yes
-  become_user: root
 
   roles:
     - pbench-repo-install

--- a/server/ansible/pbench-server-disable.yml
+++ b/server/ansible/pbench-server-disable.yml
@@ -1,0 +1,12 @@
+---
+- name: disable pbench-server
+  hosts: servers
+  remote_user: pbench
+
+  vars:
+    pbench_configuration_environment: "{{ cenv | default('production') }}"
+
+  roles:
+    - pbench-server-vars
+    - { role: pbench-server-set-state, pbench_server_state: off}
+    - pbench-server-crontab-disable

--- a/server/ansible/pbench-server-enable.yml
+++ b/server/ansible/pbench-server-enable.yml
@@ -1,0 +1,12 @@
+---
+- name: enable pbench-server
+  hosts: servers
+  remote_user: pbench
+
+  vars:
+    pbench_configuration_environment: "{{ cenv | default('production') }}"
+
+  roles:
+    - pbench-server-vars
+    - { role: pbench-server-set-state, pbench_server_state: on}
+    - pbench-server-crontab-enable

--- a/server/ansible/pbench-server-install.yml
+++ b/server/ansible/pbench-server-install.yml
@@ -2,8 +2,6 @@
 - name: install pbench-server
   hosts: servers
   remote_user: root
-  become: yes
-  become_user: root
 
   vars:
     pbench_configuration_environment: "{{ cenv | default('production') }}"

--- a/server/ansible/roles/pbench-repo-install/defaults/main.yml
+++ b/server/ansible/roles/pbench-repo-install/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
-test_repo_enabled: 0
+fedoraproject_username: ndokos
+pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
 
 repos:
   - tag: pbench
+    user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/pbench/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/pbench/pubkey.gpg"
     gpgcheck: 1

--- a/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-setup-results-host-info/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+# Example: /var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+#          ^-----------^ ^-------------------pbench_host_info_prefix-------------------^
+#                ^
+#     httpd_document_root_dir
 - name: "make sure the directory exists"
   file:
     path: "{{ httpd_document_root_dir }}/{{ pbench_host_info_prefix | dirname }}"
@@ -27,10 +31,11 @@
   with_items:
     - "002"
 
-- name: "set up links to the active files"
+- name: "set up links to the maintenance files"
   file:
     path: "{{ httpd_document_root_dir }}/{{ pbench_host_info_prefix }}{{ item }}"
-    src:  "{{ pbench_host_info_prefix | basename }}{{ item }}.active"
+    src:  "{{ pbench_host_info_prefix | basename }}{{ item }}.maint"
     state: link
+    force: yes
   with_items:
     - "002"

--- a/server/ansible/roles/pbench-server-crontab-disable/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-crontab-disable/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: "save the current crontab before disabling"
+  shell:
+    cmd: "crontab -l > {{ pbench_server_install_dir }}/lib/crontab/crontab.back.{{ ansible_date_time.iso8601 }}"
+  when: ansible_user_id == pbench_user
+
+- name: "disable crontab"
+  command:
+    cmd: crontab -r
+  when: ansible_user_id == pbench_user

--- a/server/ansible/roles/pbench-server-crontab-enable/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-crontab-enable/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- name: "enable crontab for user 'pbench' - this role is supposed to be run as that user, *not* as root"
+  command:
+    cmd: crontab {{ pbench_server_install_dir }}/lib/crontab/crontab
+  when: ansible_user_id == pbench_user

--- a/server/ansible/roles/pbench-server-set-state/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-set-state/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Example: /var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+#          ^-----------^ ^-------------------pbench_host_info_prefix-------------------^
+#                ^
+#     httpd_document_root_dir
+- name: "debug"
+  debug:
+    msg: State is {{ pbench_server_state }}
+    verbosity: 1
+
+- name: "set up links to the appropriate file(s), depending on desired state (on or off)"
+  file:
+    path: "{{ httpd_document_root_dir }}/{{ pbench_host_info_prefix }}{{ item }}"
+    src:  "{{ pbench_host_info_prefix | basename }}{{ item }}.{{'active' if pbench_server_state else 'maint' }}"
+    state: link
+    force: yes
+  with_items:
+    - "002"


### PR DESCRIPTION
Currently, when installing the server, we set the `host-info` state to `active`, which allows `pbench-move`/`copy-results` to start sending tar balls to the server.

This PR sets the `host-info` state to `maintenance`.

It also adds playbooks and roles to explicitly enable and disable the server. The workflow now becomes

```
ansible-playbook ... pbench-server-disable.yml

ansible-playbook ... pbench-server-install.yml
# check crontab
ansible-playbook ... pbench-server-enable.yml
```

Unfortunately, the disable role has no easy way to make sure that the queue is drained: it can check the reception area to make sure it's empty, but various cron jobs may still be running processing tar balls (or might run in the next few minutes): it could check all the state directories to make sure they don't contain any tar ball symbolic links, but that seems a bit fragile (and perhaps expensive). So, for now at least, we punt and leave it up to the administrator to check and make sure that, after the disablement, all the tar balls have been processed before shutting off the `crontab` manually with

```
crontab -u pbench -r
```

Another possibility is to shut off the crontab anyway, and wait until all currently running `cron` jobs are done before proceeding. There might still be some tar balls in a "to-process" state, but they will be processed after the server is enabled again.

This is what's implemented here: enabling the server turns the `crontab` on and disabling the server turns the `crontab` off. The administrator still has to wait, checking that the various pbench processes that might be running have actually finished, before proceeding.

The crontab enablement/disablement is performed by separate roles: it's only the playbooks that impose the unitarity of enablement or disablement. After review, the roles are now protected, so that they only trigger when the roles are run as the "pbench" user: they are no-ops otherwise.

Privilege escalation in all the playbooks is now done through the `remote_user` variable. It is `root` for the installation playbook, but it is `pbench` for the enablement and disablement playbooks.
