### PR TITLE
Add missing "g" to commit id field in the server config file

### DIFF
--- a/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-add-commit-id/tasks/main.yml
@@ -4,6 +4,6 @@
     path: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
     section: pbench-server
     option: commit_id
-    value: "{{ pbench_version }}-{{ pbench_seqno }}{{ pbench_sha1 }}"
+    value: "{{ pbench_version }}-{{ pbench_seqno }}g{{ pbench_sha1 }}"
     backup: yes
 


### PR DESCRIPTION
Fixes #2043

The "commit_id" field is supposed to have the form:
```
  <version>-<seqno>g<sha1>
```
but was missing the "g".