### PR TITLE
Fix move results ssh loop (b0.69)

### DIFF
--- a/agent/util-scripts/gold/pbench-copy-results/test-31.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-31.txt
@@ -55,7 +55,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-copy-results/test-39.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-39.txt
@@ -54,7 +54,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-copy-results/test-40.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-40.txt
@@ -54,7 +54,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check && mv pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check && mv pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-copy-results/test-41.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-41.txt
@@ -53,7 +53,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-copy-results/test-49.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-49.txt
@@ -55,7 +55,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/pbench-move-results/test-33.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-33.txt
@@ -59,7 +59,7 @@ user_script = sleep
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:agent.example.com:nobody:pbench-move-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -q -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-move-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-copy-result-tb
+++ b/agent/util-scripts/pbench-copy-result-tb
@@ -74,7 +74,7 @@ fi
 # Verify the remotely copied bits are good
 md5name=$(basename ${tarball}).md5
 controller=$(basename ${controller_dir})
-ssh -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} "cd ${results_path_prefix}/${controller}; md5sum --check ${md5name}.check && mv ${md5name}.check ${md5name}"
+ssh -n -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} "cd ${results_path_prefix}/${controller}; md5sum --check ${md5name}.check && mv ${md5name}.check ${md5name}"
 chk_res=${?}
 if [[ ${chk_res} -ne 0 ]]; then
     error_log "ERROR: remote copy failed, remote tarball MD5 does not match original"

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -156,10 +156,10 @@ if [[ ! -z "${show_server}" ]] ;then
 fi
 
 # ssh probe test
-ssh -q -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} exit
+ssh -n -q -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} exit
 if [[ $? -ne 0 ]]; then
     error_log "ERROR: results host unreachable: ${results_repo}"
-    debug_log "the following ssh command failed: \"ssh -q -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} exit\""
+    debug_log "the following ssh command failed: \"ssh -n -q -i ${pbench_bin}/id_rsa ${ssh_opts} ${results_repo} exit\""
     exit 1
 fi
 


### PR DESCRIPTION
See https://www.vidarholen.net/contents/blog/?p=632 for a great write-up on the gory details.  Basically, you can't issue an `ssh` in a while loop that reads from `stdin`, one must instruct `ssh` to use `/dev/null`.

Backported from PR #2046.