### PR TITLE
Modifications to template data types for dashboard

### DIFF
--- a/server/bin/gold/test-7.0.1.txt
+++ b/server/bin/gold/test-7.0.1.txt
@@ -2335,7 +2335,8 @@ Template: pbench-unittests.v5.result-data
                 "type": "date"
             },
             "@timestamp_original": {
-                "type": "text"
+                "index": false,
+                "type": "keyword"
             },
             "iteration": {
                 "properties": {
@@ -2445,7 +2446,8 @@ Template: pbench-unittests.v5.result-data-sample
                 "type": "date"
             },
             "@timestamp_original": {
-                "type": "text"
+                "index": false,
+                "type": "keyword"
             },
             "benchmark": {
                 "properties": {
@@ -3072,6 +3074,11 @@ Template: pbench-unittests.v5.result-data-sample
                         "type": "long"
                     },
                     "measurement_title": {
+                        "fields": {
+                            "raw": {
+                                "type": "keyword"
+                            }
+                        },
                         "type": "text"
                     },
                     "measurement_type": {

--- a/server/lib/mappings/result-data-sample.json
+++ b/server/lib/mappings/result-data-sample.json
@@ -9,7 +9,8 @@
             "format": "dateOptionalTime"
         },
         "@timestamp_original": {
-            "type": "text"
+            "type": "keyword",
+            "index": false
         },
         "@generated-by": {
             "type": "keyword"
@@ -73,7 +74,12 @@
                     "type": "long"
                 },
                 "measurement_title": {
-                    "type": "text"
+                    "type": "text",
+                    "fields": {
+                        "raw": {
+                            "type": "keyword"
+                        }
+                    }
                 },
                 "category": {
                     "type": "keyword"

--- a/server/lib/mappings/result-data.json
+++ b/server/lib/mappings/result-data.json
@@ -9,7 +9,8 @@
             "format": "dateOptionalTime"
         },
         "@timestamp_original": {
-            "type": "text"
+            "type": "keyword",
+            "index": false
         },
         "result_data_sample_parent": {
             "type": "keyword"


### PR DESCRIPTION
These changes to the document templates allow dashboard queries to sort or aggregate on these fields. One field changes from `"text"` to `"keyword"` (because there seems to be unlikely to be any value to `@timestamp_original` in full text search), whereas another uses the Elasticsearch ability to double-map a field as both `"text"` and `"keyword"` so that the description string could be hit by a full text search and can also be used for sorting.

I've re-indexed my test tarballs with these changes and verified that my modified dashboard code works now.