### PR TITLE
Backport f33 centos8 cont fixes

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -11,6 +11,9 @@ RUN \
 {% if distro_image.startswith('centos') %}
     {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm{% if distro_image == 'centos:7' %} centos-release-scl-rh centos-release-scl{% endif %} && \
 {% endif %}
-    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}{% if distro_image == 'centos:7' %}--enablerepo=centos-sclo-rh {% endif %} pbench-agent && \
+    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo powertools glibc-locale-source {% endif %}{% if distro_image == 'centos:7' %}--enablerepo=centos-sclo-rh {% endif %} pbench-agent && \
+{% if distro_image == 'centos:8' %}
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+{% endif %}
     {{ pkgmgr }} -y clean all && \
     rm -rf /var/cache/{{ pkgmgr }}

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -5,6 +5,6 @@ FROM pbench-agent-base-{{ distro }}:{{ tag }}
 #
 # FIXME: this is not exhaustive, it does not include RPMs to support
 #        Kubernetes or RHV environments.
-RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench {{ rpms }} && \
+RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo powertools {% endif %}--enablerepo copr-pbench {{ rpms }} && \
     {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} -y clean all && \
     rm -rf /var/cache/{% if distro == 'centos-7' %}yum{% else %}dnf{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -39,9 +39,9 @@ _WORKLOAD_RPMS = fio uperf
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 
 # By default we only build images for the following distributions:
-_DISTROS = centos-8 centos-7 fedora-32 fedora-31
+_DISTROS = centos-8 centos-7 fedora-33 fedora-32
 
-all: $(foreach distro, ${_DISTROS}, ${distro}-all-tagged)
+all: all-tags $(foreach distro, ${_DISTROS}, ${distro}-all-tagged)
 
 #+
 # Tagging targets
@@ -49,6 +49,12 @@ all: $(foreach distro, ${_DISTROS}, ${distro}-all-tagged)
 
 # Add the "latest" tag to the local images.
 tag-latest: $(foreach distro, ${_DISTROS}, ${distro}-tag-latest)
+
+# Add the "beta" tag to the local images.
+tag-beta: $(foreach distro, ${_DISTROS}, ${distro}-tag-beta)
+
+# Add the "alpha" tag to the local images.
+tag-alpha: $(foreach distro, ${_DISTROS}, ${distro}-tag-alpha)
 
 # Add the "v<Major>-latest" tag to the local images.
 tag-major: $(foreach distro, ${_DISTROS}, ${distro}-tag-major)
@@ -65,6 +71,12 @@ push: $(foreach distro, ${_DISTROS}, ${distro}-push)
 
 # Push images with the "latest" tag.
 push-latest: $(foreach distro, ${_DISTROS}, ${distro}-push-latest)
+
+# Push images with the "beta" tag.
+push-beta: $(foreach distro, ${_DISTROS}, ${distro}-push-beta)
+
+# Push images with the "alpha" tag.
+push-alpha: $(foreach distro, ${_DISTROS}, ${distro}-push-alpha)
 
 # Push images with the "v<Major>-latest" tag.
 push-major: $(foreach distro, ${_DISTROS}, ${distro}-push-major)
@@ -125,6 +137,12 @@ push-major-minor: $(foreach distro, ${_DISTROS}, ${distro}-push-major-minor)
 %-push-latest: %-tags.lis
 	./push ${IMAGE_REPO} $* latest
 
+%-push-beta: %-tags.lis
+	./push ${IMAGE_REPO} $* beta
+
+%-push-alpha: %-tags.lis
+	./push ${IMAGE_REPO} $* alpha
+
 %-push-major: %-tags.lis
 	./push ${IMAGE_REPO} $* _major
 
@@ -138,6 +156,12 @@ push-major-minor: $(foreach distro, ${_DISTROS}, ${distro}-push-major-minor)
 %-tag-latest: %-tags.lis
 	./tagit $* latest
 
+%-tag-beta: %-tags.lis
+	./tagit $* beta
+
+%-tag-alpha: %-tags.lis
+	./tagit $* alpha
+
 %-tag-major: %-tags.lis
 	./tagit $* major-latest
 
@@ -147,6 +171,15 @@ push-major-minor: $(foreach distro, ${_DISTROS}, ${distro}-push-major-minor)
 # Build the tags file for the given distribution.
 %-tags.lis:
 	./gen-tags-from-rpm "${URL_PREFIX}" "$*" "${_ARCH}" "${_TEST_SUFFIX}" > ${@}
+
+# Helper target to build each distro's "-tags.lis" file and verify they
+# are consistent.
+all-tags: pkgmgr-clean $(foreach distro, ${_DISTROS}, ${distro}-tags.lis)
+	./verify-tags *-tags.lis
+
+# Helper target to ensure local cache consistent by "cleaning"
+pkgmgr-clean:
+	dnf clean all
 
 #+
 # For the following rules, the various CentOS "base" images need a mapping
@@ -162,11 +195,14 @@ centos-8-base.Dockerfile: Dockerfile.base.j2 epel-8-pbench.repo
 centos-7-base.Dockerfile: Dockerfile.base.j2 epel-7-pbench.repo
 	jinja2 Dockerfile.base.j2 -D pbench_repo_file=epel-7-pbench.repo -D pkgmgr=yum -D distro_image=centos:7 -D distro_image_name="CentOS 7" -o $@
 
+fedora-33-base.Dockerfile: Dockerfile.base.j2 fedora-33-pbench.repo
+	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-33-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:33 -D distro_image_name="Fedora 33" -o $@
+
 fedora-32-base.Dockerfile: Dockerfile.base.j2 fedora-32-pbench.repo
 	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-32-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:32 -D distro_image_name="Fedora 32" -o $@
 
-fedora-31-base.Dockerfile: Dockerfile.base.j2 fedora-31-pbench.repo
-	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-31-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:31 -D distro_image_name="Fedora 31" -o $@
+# Helper target to build each distro's ".repo" and ".Dockerfile"
+all-dockerfiles: $(foreach distro, ${_DISTROS}, ${distro}-base.Dockerfile ${distro}-tools.Dockerfile ${distro}-workloads.Dockerfile ${distro}-all.Dockerfile)
 
 # Rule pattern dependencies on non-patterned targets have to be set up
 # separately for some reason.

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -3,7 +3,7 @@
 Container image building requires both the `buildah` and `jinja2` CLI
 commands to be present.
 
-On Fedora 31 and later systems, use the following command to install the
+On Fedora 32 and later systems, use the following command to install the
 required CLI interface RPMs:
 
     sudo dnf install buildah python3-jinja2-cli
@@ -24,7 +24,7 @@ and place them in a single yum/dnf repository accessible via HTTPS.  By
 default, we use Fedora COPR repos under the `ndokos` user (one can
 override the yum/dnf repos and user via the `URL_PREFIX` and `USER`
 environment variables, and use `pbench-test` repos by setting the `TEST`
-environment variable to `test`). 
+environment variable to `test`).
 
 Once the proper RPMs are available in the target repo, the default
 `Makefile` target, `all`, will build all the default images, and tag
@@ -50,10 +50,10 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 ```
 
 There are make targets for each of the four supported distributions,
-CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 32 (`fedora-32`),
-and Fedora 31 (`fedora-31`).  There are also make targets for each
+CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 33 (`fedora-33`),
+and Fedora 32 (`fedora-32`).  There are also make targets for each
 subset of the four images (all, base, tools, workloads) built for
-each distribution, e.g. `centos-8-tools`, `fedora-31-base`, etc.
+each distribution, e.g. `centos-8-tools`, `fedora-32-base`, etc.
 
 Two tags are always applied to an image that is built, the `<git
 commit ID>` derived from the RPM version, and the version string of
@@ -71,6 +71,10 @@ appropriate (these tags are not automatically applied at build time):
 
  * `tag-major-minor` -adds the `v<Major>.<Minor>-latest` label to
    the images ...
+
+ * `tag-alpha` - adds the `alpha` label to the images ...
+
+ * `tag-beta` - adds the `beta` label to the images ...
 
 Finally, there are "push" targets to copy the locally built and
 tagged images to a non-local container image repository.  By default
@@ -90,6 +94,10 @@ published already.  The push targets are:
 
  * `push-major-minor` - pushes all the images by their
    `v<Major>.<Minor>-latest` tag
+
+ * `push-alpha` - pushes all the images by their `alpha` tag
+
+ * `push-beta` - pushes all the images by their `beta` tag
 
 NOTE WELL: Each separate tag for each image needs to be pushed to
 the non-local container image repository.  This does NOT result in

--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -1,6 +1,6 @@
 ---
 repos:
-  - tag: pbench
+  - tag: pbench{{ test_suffix }}
     user: {{ user }}
     baseurl: "{{ url_prefix }}/pbench{{ test_suffix }}/{{ distro }}-$basearch"
     gpgkey: "{{ url_prefix }}/pbench{{ test_suffix }}/pubkey.gpg"

--- a/agent/containers/images/verify-tags
+++ b/agent/containers/images/verify-tags
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [[ -z "${1}" ]]; then
+    printf -- "No tags files given to process!\n" >&2
+    exit 1
+fi
+
+# Use the first argument as the check-sum to verify against.
+cksum="$(cksum ${1} | awk '{print $1}')"
+shift
+
+ret_val=0
+while [[ ! -z "${1}" ]]; do
+    new_cksum="$(cksum ${1} | awk '{print $1}')"
+    shift
+    if [[ "${cksum}" != "${new_cksum}" ]]; then
+        ret_val=1
+        printf -- "Checksums don't match!\n" >&2
+        break
+    fi
+done
+
+exit ${ret_val}


### PR DESCRIPTION
This is a back port of commits that are in PR #2059 for the `b0.69` branch.

We enable support for Fedora 33 container builds, and fixes for `locale` issues on CentOS 8, along with the apparent rename of the `powertools` repo (used to be `PowerTools`).