### PR TITLE
Drop Fedora 31 RPMs/containers, add support for Fedora 33 RPMs/containers

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -15,6 +15,9 @@ RUN \
 {% if distro_image.startswith('centos') %}
     {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm && \
 {% endif %}
-    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %} pbench-agent && \
+    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo powertools glibc-locale-source {% endif %} pbench-agent && \
+{% if distro_image == 'centos:8' %}
+    localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+{% endif %}
     {{ pkgmgr }} -y clean all && \
     rm -rf /var/cache/{{ pkgmgr }}

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -5,6 +5,6 @@ FROM pbench-agent-base-{{ distro }}:{{ tag }}
 #
 # FIXME: this is not exhaustive, it does not include RPMs to support
 #        Kubernetes or RHV environments.
-RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo PowerTools {% endif %}{{ rpms }} && \
+RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y {% if distro == 'centos-8' %}--enablerepo powertools {% endif %}{{ rpms }} && \
     {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} -y clean all && \
     rm -rf /var/cache/{% if distro == 'centos-7' %}yum{% else %}dnf{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -39,7 +39,7 @@ _WORKLOAD_RPMS = fio uperf
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 
 # By default we only build images for the following distributions:
-_DISTROS = centos-8 centos-7 fedora-32 fedora-31
+_DISTROS = centos-8 centos-7 fedora-33 fedora-32
 
 all: all-tags $(foreach distro, ${_DISTROS}, ${distro}-all-tagged)
 
@@ -195,11 +195,11 @@ centos-8-base.Dockerfile: Dockerfile.base.j2 epel-8-pbench.repo
 centos-7-base.Dockerfile: Dockerfile.base.j2 epel-7-pbench.repo
 	jinja2 Dockerfile.base.j2 -D pbench_repo_file=epel-7-pbench.repo -D pkgmgr=yum -D distro_image=centos:7 -D distro_image_name="CentOS 7" -o $@
 
+fedora-33-base.Dockerfile: Dockerfile.base.j2 fedora-33-pbench.repo
+	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-33-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:33 -D distro_image_name="Fedora 33" -o $@
+
 fedora-32-base.Dockerfile: Dockerfile.base.j2 fedora-32-pbench.repo
 	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-32-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:32 -D distro_image_name="Fedora 32" -o $@
-
-fedora-31-base.Dockerfile: Dockerfile.base.j2 fedora-31-pbench.repo
-	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-31-pbench.repo -D pkgmgr=dnf -D distro_image=fedora:31 -D distro_image_name="Fedora 31" -o $@
 
 # Helper target to build each distro's ".repo" and ".Dockerfile"
 all-dockerfiles: $(foreach distro, ${_DISTROS}, ${distro}-base.Dockerfile ${distro}-tools.Dockerfile ${distro}-workloads.Dockerfile ${distro}-all.Dockerfile)

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -3,7 +3,7 @@
 Container image building requires both the `buildah` and `jinja2` CLI
 commands to be present.
 
-On Fedora 31 and later systems, use the following command to install the
+On Fedora 32 and later systems, use the following command to install the
 required CLI interface RPMs:
 
     sudo dnf install buildah python3-jinja2-cli
@@ -50,10 +50,10 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 ```
 
 There are make targets for each of the four supported distributions,
-CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 32 (`fedora-32`),
-and Fedora 31 (`fedora-31`).  There are also make targets for each
+CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 33 (`fedora-33`),
+and Fedora 32 (`fedora-32`).  There are also make targets for each
 subset of the four images (all, base, tools, workloads) built for
-each distribution, e.g. `centos-8-tools`, `fedora-31-base`, etc.
+each distribution, e.g. `centos-8-tools`, `fedora-32-base`, etc.
 
 Two tags are always applied to an image that is built, the `<git
 commit ID>` derived from the RPM version, and the version string of


### PR DESCRIPTION
We also address the locale issues in CentOS 8 containers.