### PR TITLE
Add API reverse proxy configuration to default Ansible Pbench deployment scripts

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -25,8 +25,8 @@ def main():
         print(e)
         sys.exit(1)
     try:
-        port = str(server_config.get("pbench-server", "rest_port"))
         host = str(server_config.get("pbench-server", "bind_host"))
+        port = str(server_config.get("pbench-server", "bind_port"))
         workers = str(server_config.get("pbench-server", "workers"))
     except (NoOptionError, NoSectionError) as e:
         print(f"{__name__}: ERROR: {e.__traceback__}")

--- a/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/main.yml
@@ -20,6 +20,23 @@
   notify:
     - restart apache
 
+- name: "Install the pbench server proxy config file"
+  template:
+    src: etc/httpd/conf.d/pbench.conf.j2
+    dest: /etc/httpd/conf.d/pbench.conf
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart apache
+
+- name: Allow application HTTP connections
+  # command: "setsebool -P httpd_can_network_connect on"
+  seboolean:
+    name: httpd_can_network_connect
+    persistent: yes
+    state: yes
+
 - name: "Make sure rsync is installed. Used below."
   package:
     name: rsync

--- a/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/templates/etc/httpd/conf.d/pbench.conf.j2
+++ b/server/ansible/roles/pbench-server-activate-httpd-setup-restart/tasks/templates/etc/httpd/conf.d/pbench.conf.j2
@@ -1,0 +1,6 @@
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass /api/ http://{{ pbench_host }}:{{ bind_port }}/api/
+    ProxyPassReverse /api/ http://{{ pbench_host }}:{{ bind_port }}/api/
+    ProxyPass / !
+</VirtualHost>

--- a/server/ansible/roles/pbench-server-vars/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-vars/tasks/main.yml
@@ -185,6 +185,22 @@
     msg: "{{ pbench_host }}"
     verbosity: 1
 
+# pbench server port
+- name: fetch the pbench server API port
+  shell: "pbench-config bind_port pbench-server"
+  register: cmd_output
+  environment:
+    _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"
+    PATH: "{{ pbench_server_install_dir }}/bin:/usr/bin"
+    PYTHONPATH: "{{ pbench_server_install_dir }}/lib"
+
+- set_fact:
+    bind_port: "{{ cmd_output.stdout_lines[0].strip() }}"
+
+- debug:
+    msg: "{{ bind_port }}"
+    verbosity: 1
+
 # pbench contact email address
 - name: fetch the contact email address
   shell: "pbench-config admin-email pbench-server"

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -62,7 +62,7 @@ pbench-receive-dir-prefix = %(pbench-local-dir)s/pbench-move-results-receive/fs-
 pbench-quarantine-dir = %(pbench-local-dir)s/quarantine
 
 # pbench-server rest api variables
-rest_port = 8001
+bind_port = 8001
 rest_version = 1
 # max allowed size for tarfile upload, acceptable format {X[unit] or X [unit]}
 rest_max_content_length = 1 gb

--- a/server/lib/config/pbench-server.cfg.example
+++ b/server/lib/config/pbench-server.cfg.example
@@ -14,7 +14,7 @@ pbench-backup-dir = /mnt/pbench.archive.backup
 # Add role for sync'ing with satellites
 roles = pbench-maintenance, pbench-prep, pbench-results, pbench-backup, pbench-sync-satellites
 # pbench-server rest api variables
-rest_port = 8001
+bind_port = 8001
 rest_version = 1
 rest_max_content_length = 100 * 1024 * 1024
 rest_uri = /api/v%(rest_version)s


### PR DESCRIPTION
The Pbench server API listens on port 8001; we want to be able to access the API externally through normal HTTP/HTTPS.

With an external reverse proxy gateway (e.g., NGINX) this can be accomplished by redirecting (e.g.) `pbench.example.com:/api/` to the actual server at port 8001 and opening the 8001/tcp port in the server firewall.

Our default Ansible deployment mechanism configures a local Apache which is directly accessed from outside. This PR adds an Apache reverse proxy to allow external API access on port 80.

With these changes, the Pbench gunicorn wsgi server will still listen on port 8001, but this port won't need to be opened externally as Apache will proxy `/api/` to port 8001. This means that all external accesses will go to port 80 (http) or (when we get there) 433 (https).

In the short term this affects the `pbench_server` configuration in the dashboard `endpoints.js`. Once #2024 (server-side endpoint configuration and metadata) is merged, I plan to change the dashboard to use that, simply `fetch`-ing that from `window.origin` and assigning it to `window.endpoints` within the launch html page, removing the need to manage a local static `endpoints.js` entirely.