### PR TITLE
Fix use of date parsing in query API

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/query_controllers.py
+++ b/lib/pbench/server/api/resources/query_apis/query_controllers.py
@@ -160,8 +160,8 @@ class QueryControllers(Resource):
                 abort(401, message="invalid user authorization")
 
         try:
-            start = parser.parse(start_arg)
-            end = parser.parse(end_arg)
+            start = parser.parse(start_arg).replace(day=1)
+            end = parser.parse(end_arg).replace(day=1)
         except Exception as e:
             self.logger.info(
                 "Invalid start or end time string: {}, {}: {}", start_arg, end_arg, e


### PR DESCRIPTION
The `parser.parse()` function will return a `datetime` object, filling in any missing date components missing from the input string. This means that when you call `parser.parse()` on the 29th, 30th, or 31st of a month, and you range spans months which do not have those dates, then those months are omitted.

The simple fix is to force the day to be the 1st, avoiding this problem.

Fixes #2084.