### PR TITLE
Fix turbostat for real this time

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -512,7 +512,6 @@ else
 fi
 
 tool_output_dir="${tool_dir}/${tool_name}" # all tools keep data in their tool specific dir
-tool_pid_file="${tool_output_dir}/${tool_name}.pid"
 
 function safe_kill() {
 	# safe kill: check for strange situations and deal with them.  If
@@ -711,19 +710,21 @@ start)
 
 	if [[ ! -z "${options}" ]]; then
 		# Record any options for later post-processing use.
-		echo "${options}" > ${tool_output_dir}/${tool_name}.options
+		echo "${options}" > ./${tool_name}.options
 	fi
 
-	tool_cmd_file="${tool_output_dir}/${tool_name}.cmd"
+	tool_cmd_file="./${tool_name}.cmd"
 	if [[ -z "${gopath}" ]]; then
 		if [[ "${tool_package_name}" == "golang" ]]; then
 			printf -- "%s: golang based tools require the --gopath option\n" "${tool_name}" >&2
+			popd > /dev/null
 			exit 1
 		fi
 		_gopath=""
 	else
 		if [[ ! -d "${gopath}/bin" ]]; then
 			printf -- "%s: invalid GOPATH directory specified, '%s'\n" "${tool_name}" "${gopath}" >&2
+			popd > /dev/null
 			exit 1
 		fi
 		# The leading space in the following two variables is REQUIRED!
@@ -734,6 +735,7 @@ start)
 	else
 		if [[ ! -x "${goroot}/bin/go" ]]; then
 			printf -- "%s: invalid GOROOT directory specified, '%s'\n" "${tool_name}" "${goroot}" >&2
+			popd > /dev/null
 			exit 1
 		fi
 		# The leading space in the following variable is REQUIRED!
@@ -754,9 +756,9 @@ start)
 	printf -- "#!/bin/bash\n# base-tool generated command file\n\nLANG=C PYTHONUNBUFFERED=True%s%s%s exec %s\n" "${_goroot}" "${_gopath}" "${_newpath}" "${tool_cmd}" > "${tool_cmd_file}"
 	chmod +x "${tool_cmd_file}"
 	printf -- "%s: running \"%s\"\n" "${tool_name}" "${tool_cmd}"
-	tool_stdout_file="${tool_output_dir}/${tool_name}-stdout.txt"
-	tool_stderr_file="${tool_output_dir}/${tool_name}-stderr.txt"
-	${tool_cmd_file} > "${tool_stdout_file}" 2> "${tool_stderr_file}" & echo ${!} > "${tool_pid_file}"
+	tool_stdout_file="./${tool_name}-stdout.txt"
+	tool_stderr_file="./${tool_name}-stderr.txt"
+	${tool_cmd_file} > "${tool_stdout_file}" 2> "${tool_stderr_file}" & echo ${!} > "./${tool_name}.pid"
 	wait
 	rc=0
 	popd > /dev/null
@@ -768,6 +770,7 @@ stop)
 	fi
 	enable -n kill
 	printf -- "%s: stopping\n" "${tool_name}"
+	tool_pid_file="${tool_output_dir}/${tool_name}.pid"
 	if [[ -s "${tool_pid_file}" ]]; then
 		pid="$(cat ${tool_pid_file})"
 		if [[ ! -z "${pid}" ]] ;then
@@ -808,7 +811,7 @@ stop)
 				fi
 				rc=${?}
 				;;
-			blktrace|bpftrace|iostat|mpstat|sar|systemtap|tcpdump|vmstat)
+			blktrace|bpftrace|iostat|mpstat|sar|systemtap|tcpdump|turbostat|vmstat)
 				safe_kill "${tool_name}" "${pid}"
 				rc=${?}
 				;;
@@ -857,9 +860,9 @@ stop)
 				args=""
 			fi
 			pushd ${tool_output_dir} >/dev/null
-			${_script_path} "${tool_output_dir}" ${args} \
-					>  ${tool_output_dir}/${tool_name}-stop-postprocess.out \
-					2> ${tool_output_dir}/${tool_name}-stop-postprocess.err
+			${_script_path} "." ${args} \
+					>  ./${tool_name}-stop-postprocess.out \
+					2> ./${tool_name}-stop-postprocess.err
 			rc=${?}
 			popd >/dev/null
 		else
@@ -884,9 +887,9 @@ postprocess)
 	if [[ -x "${_script_path}" ]]; then
 		printf -- "%s: post-processing data\n" "${tool_name}"
 		pushd ${tool_output_dir} >/dev/null
-		${_script_path} "${tool_output_dir}" \
-				>  ${tool_output_dir}/${tool_name}-postprocess.out \
-				2> ${tool_output_dir}/${tool_name}-postprocess.err
+		${_script_path} "." \
+				>  ./${tool_name}-postprocess.out \
+				2> ./${tool_name}-postprocess.err
 		rc=${?}
 		popd >/dev/null
 	else

--- a/agent/tool-scripts/tests/blktrace/gold/test-execution.log
+++ b/agent/tool-scripts/tests/blktrace/gold/test-execution.log
@@ -1,2 +1,2 @@
 blktrace-datalog /dev/sda42 /dev/sdb42 /dev/sdc42
-blktrace-stop-postprocess /var/tmp/pbench-test-tool-scripts/blktrace/tools-group/blktrace
+blktrace-stop-postprocess .

--- a/agent/tool-scripts/tests/cpuacct/gold/test-execution.log
+++ b/agent/tool-scripts/tests/cpuacct/gold/test-execution.log
@@ -1,3 +1,3 @@
 cpuacct-datalog 10
-cpuacct-stop-postprocess /var/tmp/pbench-test-tool-scripts/cpuacct/tools-group/cpuacct
-cpuacct-postprocess /var/tmp/pbench-test-tool-scripts/cpuacct/tools-group/cpuacct
+cpuacct-stop-postprocess .
+cpuacct-postprocess .

--- a/agent/tool-scripts/tests/disk/gold/test-execution.log
+++ b/agent/tool-scripts/tests/disk/gold/test-execution.log
@@ -1,2 +1,2 @@
 disk-datalog 10
-disk-postprocess /var/tmp/pbench-test-tool-scripts/disk/tools-group/disk
+disk-postprocess .

--- a/agent/tool-scripts/tests/docker/gold/test-execution.log
+++ b/agent/tool-scripts/tests/docker/gold/test-execution.log
@@ -1,2 +1,2 @@
 docker-datalog 10
-docker-postprocess /var/tmp/pbench-test-tool-scripts/docker/tools-group/docker
+docker-postprocess .

--- a/agent/tool-scripts/tests/haproxy-ocp/gold/test-execution.log
+++ b/agent/tool-scripts/tests/haproxy-ocp/gold/test-execution.log
@@ -1,2 +1,2 @@
 haproxy-ocp-datalog /var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp 10 false
-haproxy-ocp-postprocess /var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp
+haproxy-ocp-postprocess .

--- a/agent/tool-scripts/tests/iostat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/iostat/gold/test-execution.log
@@ -1,2 +1,2 @@
 iostat-datalog 10
-iostat-postprocess /var/tmp/pbench-test-tool-scripts/iostat/tools-group/iostat
+iostat-postprocess .

--- a/agent/tool-scripts/tests/jmap/gold/test-execution.log
+++ b/agent/tool-scripts/tests/jmap/gold/test-execution.log
@@ -1,2 +1,2 @@
 jmap-datalog /var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap 10 42 jmap-pat-42
-jmap-postprocess /var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap
+jmap-postprocess .

--- a/agent/tool-scripts/tests/jstack/gold/test-execution.log
+++ b/agent/tool-scripts/tests/jstack/gold/test-execution.log
@@ -1,2 +1,2 @@
 jstack-datalog /var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack 10 42 jstack-pat-42
-jstack-postprocess /var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack
+jstack-postprocess .

--- a/agent/tool-scripts/tests/kvm-spinlock/gold/test-execution.log
+++ b/agent/tool-scripts/tests/kvm-spinlock/gold/test-execution.log
@@ -1,2 +1,2 @@
 kvm-spinlock-datalog 10
-kvm-spinlock-postprocess /var/tmp/pbench-test-tool-scripts/kvm-spinlock/tools-group/kvm-spinlock
+kvm-spinlock-postprocess .

--- a/agent/tool-scripts/tests/kvmstat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/kvmstat/gold/test-execution.log
@@ -1,2 +1,2 @@
 kvmstat-datalog 10
-kvmstat-postprocess /var/tmp/pbench-test-tool-scripts/kvmstat/tools-group/kvmstat
+kvmstat-postprocess .

--- a/agent/tool-scripts/tests/kvmtrace/gold/test-execution.log
+++ b/agent/tool-scripts/tests/kvmtrace/gold/test-execution.log
@@ -1,2 +1,2 @@
 kvmtrace-datalog 42 43
-kvmtrace-stop-postprocess /var/tmp/pbench-test-tool-scripts/kvmtrace/tools-group/kvmtrace forty-two
+kvmtrace-stop-postprocess . forty-two

--- a/agent/tool-scripts/tests/mpstat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/mpstat/gold/test-execution.log
@@ -1,3 +1,3 @@
 mpstat-datalog 10
-mpstat-stop-postprocess /var/tmp/pbench-test-tool-scripts/mpstat/tools-group/mpstat
-mpstat-postprocess /var/tmp/pbench-test-tool-scripts/mpstat/tools-group/mpstat
+mpstat-stop-postprocess .
+mpstat-postprocess .

--- a/agent/tool-scripts/tests/numastat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/numastat/gold/test-execution.log
@@ -1,2 +1,2 @@
 numastat-datalog 10 pig42
-numastat-postprocess /var/tmp/pbench-test-tool-scripts/numastat/tools-group/numastat
+numastat-postprocess .

--- a/agent/tool-scripts/tests/openvswitch/gold/test-execution.log
+++ b/agent/tool-scripts/tests/openvswitch/gold/test-execution.log
@@ -1,2 +1,2 @@
 openvswitch-datalog /var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch 10
-openvswitch-postprocess /var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch
+openvswitch-postprocess .

--- a/agent/tool-scripts/tests/perf/gold/test-execution.log
+++ b/agent/tool-scripts/tests/perf/gold/test-execution.log
@@ -1,2 +1,2 @@
 perf-datalog /var/tmp/pbench-test-tool-scripts/perf/tools-group/perf --a42 -g
-perf-stop-postprocess /var/tmp/pbench-test-tool-scripts/perf/tools-group/perf '--b43' -g
+perf-stop-postprocess . '--b43' -g

--- a/agent/tool-scripts/tests/pidstat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/pidstat/gold/test-execution.log
@@ -1,2 +1,2 @@
 pidstat-datalog /var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat 10 true p=one42,two43,three44 -other-opt
-pidstat-postprocess /var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat
+pidstat-postprocess .

--- a/agent/tool-scripts/tests/proc-interrupts/gold/test-execution.log
+++ b/agent/tool-scripts/tests/proc-interrupts/gold/test-execution.log
@@ -1,2 +1,2 @@
 File-Capture-datalog 10 /proc/interrupts
-proc-interrupts-postprocess /var/tmp/pbench-test-tool-scripts/proc-interrupts/tools-group/proc-interrupts
+proc-interrupts-postprocess .

--- a/agent/tool-scripts/tests/proc-sched_debug/gold/test-execution.log
+++ b/agent/tool-scripts/tests/proc-sched_debug/gold/test-execution.log
@@ -1,2 +1,2 @@
 File-Capture-datalog 10 /proc/sched_debug
-proc-sched_debug-postprocess /var/tmp/pbench-test-tool-scripts/proc-sched_debug/tools-group/proc-sched_debug
+proc-sched_debug-postprocess .

--- a/agent/tool-scripts/tests/proc-vmstat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/proc-vmstat/gold/test-execution.log
@@ -1,2 +1,2 @@
 File-Capture-datalog 10 /proc/vmstat
-proc-vmstat-postprocess /var/tmp/pbench-test-tool-scripts/proc-vmstat/tools-group/proc-vmstat
+proc-vmstat-postprocess .

--- a/agent/tool-scripts/tests/prometheus-metrics/gold/test-execution.log
+++ b/agent/tool-scripts/tests/prometheus-metrics/gold/test-execution.log
@@ -1,2 +1,2 @@
 prometheus-metrics-datalog /var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics 42 tests/prometheus-metrics/inventory-hosts.lis
-prometheus-metrics-postprocess /var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics
+prometheus-metrics-postprocess .

--- a/agent/tool-scripts/tests/qemu-migrate/gold/test-execution.log
+++ b/agent/tool-scripts/tests/qemu-migrate/gold/test-execution.log
@@ -1,2 +1,2 @@
 qemu-migrate-datalog 10 qemu-vm-42
-qemu-migrate-postprocess /var/tmp/pbench-test-tool-scripts/qemu-migrate/tools-group/qemu-migrate
+qemu-migrate-postprocess .

--- a/agent/tool-scripts/tests/rabbit/gold/test-execution.log
+++ b/agent/tool-scripts/tests/rabbit/gold/test-execution.log
@@ -1,2 +1,2 @@
 rabbit-datalog 10 guest guest
-rabbit-postprocess /var/tmp/pbench-test-tool-scripts/rabbit/tools-group/rabbit
+rabbit-postprocess .

--- a/agent/tool-scripts/tests/sar/gold/test-execution.log
+++ b/agent/tool-scripts/tests/sar/gold/test-execution.log
@@ -1,2 +1,2 @@
 sar-datalog /var/tmp/pbench-test-tool-scripts/sar/tools-group/sar 10
-sar-postprocess /var/tmp/pbench-test-tool-scripts/sar/tools-group/sar
+sar-postprocess .

--- a/agent/tool-scripts/tests/sysfs/gold/test-execution.log
+++ b/agent/tool-scripts/tests/sysfs/gold/test-execution.log
@@ -1,2 +1,2 @@
 sysfs-datalog 10 kernel 4 *
-sysfs-postprocess /var/tmp/pbench-test-tool-scripts/sysfs/tools-group/sysfs
+sysfs-postprocess .

--- a/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42-postprocess.out
+++ b/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42-postprocess.out
@@ -1,1 +1,1 @@
-/var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.post /var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42
+/var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.post .

--- a/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42-stop-postprocess.out
+++ b/agent/tool-scripts/tests/user-tool/gold/tools-group/user-tool-foo42/user-tool-foo42-stop-postprocess.out
@@ -1,1 +1,1 @@
-/var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.stop /var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42
+/var/tmp/pbench-test-tool-scripts/user-tool/tmp/foo42.stop .

--- a/agent/tool-scripts/tests/virsh-migrate/gold/test-execution.log
+++ b/agent/tool-scripts/tests/virsh-migrate/gold/test-execution.log
@@ -1,2 +1,2 @@
 virsh-migrate-datalog 42 vm42
-virsh-migrate-postprocess /var/tmp/pbench-test-tool-scripts/virsh-migrate/tools-group/virsh-migrate
+virsh-migrate-postprocess .

--- a/agent/tool-scripts/tests/vmstat/gold/test-execution.log
+++ b/agent/tool-scripts/tests/vmstat/gold/test-execution.log
@@ -1,2 +1,2 @@
 vmstat-datalog 10
-vmstat-postprocess /var/tmp/pbench-test-tool-scripts/vmstat/tools-group/vmstat
+vmstat-postprocess .


### PR DESCRIPTION
Okay, commit f74a4c3b6 tried to fix the termination of the `turbostat` command but failed to miss one critical change: the `safe_kill` call needs the name of the process to be killed.  That previous commit changed the behavior such that the process name is now "turbostat", but we were still looking for "turbostat-datalog".

Along the way, fix `base-tool` to properly handle relative path arguments which facilitate easier manual testing.

See also PR #2041.