### PR TITLE
Ensure pbench develop install occurs for tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
+parallel = True
 data_file = /tmp/${USER}/cov/coverage.db

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-panels

--- a/jenkins/branch.name
+++ b/jenkins/branch.name
@@ -1,1 +1,1 @@
-master
+main

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -67,6 +67,7 @@ RUN \
         python3-elasticsearch \
         python3-flake8 \
         python3-flask \
+        python3-flask-cors \
         python3-flask-restful \
         python3-gitdb \
         python3-gunicorn \
@@ -82,10 +83,12 @@ RUN \
         python3-pytest-mock \
         python3-redis \
         python3-requests \
+        python3-requests-mock \
         python3-responses \
         python3-s3transfer \
         python3-sh \
         python3-smmap \
+        python3-sphinx \
         python3-tox \
         python3-tox-current-env \
         python3-werkzeug \

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -1,6 +1,11 @@
 _prefix="${1}"
 
-pip3 install --no-cache-dir --progress-bar off --no-color --prefix="${_prefix}" -r ${progdir}/lint-requirements.txt -r ${progdir}/agent/requirements.txt -r ${progdir}/server/requirements.txt -r ${progdir}/agent/test-requirements.txt -r ${progdir}/server/test-requirements.txt
+if [[ -z "${_prefix}" ]]; then
+    printf -- "Missing prefix argument!" >&2
+    exit 1
+fi
+
+pip3 install --no-cache-dir --progress-bar off --no-color --prefix="${_prefix}" -r ${progdir}/lint-requirements.txt -r ${progdir}/docs/requirements.txt -r ${progdir}/agent/requirements.txt -r ${progdir}/server/requirements.txt -r ${progdir}/agent/test-requirements.txt -r ${progdir}/server/test-requirements.txt
 
 _pdir=${_prefix}/bin
 if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
@@ -14,3 +19,5 @@ while read -r _pdir; do
     fi
 done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null)${NL}$(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"
 export PYTHONPATH
+
+python3 setup.py develop --prefix="${_prefix}"

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,2 @@
 black==19.10b0
-flake8==3.8.3
-sphinx-panels
+flake8==3.7.7

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ envlist = lint
           bench-scripts
           py3-server
           server
-          coverage
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
In order for the Jenkins jobs to run correctly, we need to ensure that the `pbench` python3 module is installed, including the CLI binaries that need to be on the `PATH`.

We correct the version of `flake8` to be the one available in Fedora 32 (`3.7.7`), and add the missing RPMs to the development container to avoid unnecessary pip3 installs.  We also create a separate `docs/requirements.txt` file.

Finally, we update the branch name file to properly reference `main` so that we use the right image tag the development container.