### PR TITLE
Exclude site-packages from coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 parallel = True
 data_file = /tmp/${USER}/cov/coverage.db
+omit = */site-packages/*


### PR DESCRIPTION
Our Python unit tests generate a coverage report, which currently includes all "non-system" packages, including the vast array of site-packages we reference.

Excluding these from the report raises our reported overall code coverage from 14% to 81%... pretty good improvement for
a one line change in a config file! ;-)