### PR TITLE
Fix es url formation when params exist in json data

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
+++ b/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
@@ -25,12 +25,10 @@ class Elasticsearch(Resource):
 
         try:
             # query Elasticsearch
+            url = f"{self.elasticsearch}/{json_data['indices']}"
             if "params" in json_data:
-                url = (
-                    f"{self.elasticsearch}/{json_data['indices']}?{json_data['params']}"
-                )
-            else:
-                url = f"{self.elasticsearch}/{json_data['indices']}"
+                if "ignore_unavailable" in json_data["params"]:
+                    url = f"{url}?ignore_unavailable={json_data['params']['ignore_unavailable']}"
 
             if "payload" in json_data:
                 es_response = requests.post(url, json=json_data["payload"])


### PR DESCRIPTION
During the discussion with @gurbirkalsi on es queries from dashboard we found a bug in server elasticsearch api endpoint about how we format search url when `ignore_unavailable` key is present in the params of the json data.

If params present in the json data we were formatting it like this 
`"{self.elasticsearch}/{json_data['indices']}?{json_data['params']}"` 
instead it should be
`"{self.elasticsearch}/{json_data['indices']}?ignore_unavailable={json_data['params']['ignore_unavailable']}"`
