### PR TITLE
Add pbench-generate-token tool

### DIFF
--- a/lib/pbench/cli/agent/__init__.py
+++ b/lib/pbench/cli/agent/__init__.py
@@ -4,7 +4,7 @@ invocation. The CliContext will keep track of passed parameters,
 what command created it, which resources need to be cleaned up,
 and etc.
 
-We create an empty object at the begining and populate the object
+We create an empty object at the beginning and populate the object
 with configuration, group names, at the beginning of the agent
 execution.
 """
@@ -13,7 +13,7 @@ import click
 
 
 class CliContext:
-    """Inialize an empty click object"""
+    """Initialize an empty click object"""
 
     pass
 

--- a/lib/pbench/cli/agent/commands/generate_token.py
+++ b/lib/pbench/cli/agent/commands/generate_token.py
@@ -1,0 +1,80 @@
+"""pbench-generate-token"""
+
+import click
+import requests
+
+from pbench.agent.base import BaseCommand
+from pbench.cli.agent import pass_cli_context
+from pbench.cli.agent.options import common_options
+
+
+class GenerateToken(BaseCommand):
+    def __init__(self, context):
+        super().__init__(context)
+
+    def execute(self):
+        """Generate a token used to access the pbench server RESTful API"""
+
+        server = self.config.agent.parser.get("results", "server_rest_url")
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        # TODO:  The server does not currently accept the 'token_duration' key,
+        #  so it just gets ignored, for now.
+        payload = {
+            "username": self.context.username,
+            "password": self.context.password,
+            "token_duration": self.context.token_duration,
+        }
+        try:
+            response = requests.post(f"{server}/login", headers=headers, json=payload)
+        except requests.exceptions.ConnectionError as exc:
+            if hasattr(exc.args[0], "reason"):
+                raise exc.args[0].reason
+            raise
+
+        payload = response.json()
+        if response.ok:
+            click.echo(payload["auth_token"])
+            return 0
+
+        click.echo(
+            payload["message"] if "message" in payload else response.reason, err=True
+        )
+        return 1
+
+
+@click.command()
+@common_options
+@click.option(
+    "--username",
+    prompt=True,
+    required=True,
+    help="pbench server account username (will prompt if unspecified)",
+)
+@click.option(
+    "--password",
+    prompt=True,
+    hide_input=True,
+    required=True,
+    help="pbench server account password (will prompt if unspecified)",
+)
+@click.option(
+    "--token-duration",
+    type=int,
+    required=False,
+    default=3600,
+    show_default=True,
+    help="number of seconds",
+)
+@pass_cli_context
+def main(context, username, password, token_duration):
+    context.username = username
+    context.password = password
+    context.token_duration = token_duration
+
+    try:
+        rv = GenerateToken(context).execute()
+    except Exception as exc:
+        click.echo(exc, err=True)
+        rv = 1
+
+    click.get_current_context().exit(rv)

--- a/lib/pbench/cli/agent/options.py
+++ b/lib/pbench/cli/agent/options.py
@@ -19,13 +19,13 @@ def _pbench_agent_config(f):
     return click.option(
         "-C",
         "--config",
+        required=True,
         envvar="_PBENCH_AGENT_CONFIG",
-        type=click.Path(exists=True),
+        type=click.Path(exists=True, readable=True),
         callback=callback,
         expose_value=False,
         help=(
-            "Path to a pbench-agent config. If provided pbench will load "
-            "this config file first. By default is looking for config in "
-            "'_PBENCH_AGENT_CONFIG' envrionment variable."
+            "Path to a pbench-agent configuration file (defaults to the "
+            "'_PBENCH_AGENT_CONFIG' environment variable, if defined)"
         ),
     )(f)

--- a/lib/pbench/test/unit/agent/task/test_generate_token.py
+++ b/lib/pbench/test/unit/agent/task/test_generate_token.py
@@ -1,0 +1,167 @@
+from click.testing import CliRunner
+import requests
+import responses
+
+from pbench.cli.agent.commands import generate_token
+
+
+class TestGenerateToken:
+
+    USER_SWITCH = "--username"
+    PSWD_SWITCH = "--password"
+    USER_PROMPT = "Username: "
+    PSWD_PROMPT = "Password: "
+    USER_TEXT = "test_user"
+    PSWD_TEXT = "password"
+    TOKEN_TEXT = "what is a token but 139 characters of gibberish"
+    URL = "http://pbench.example.com/api/v1"
+    ENDPOINT = "/login"
+
+    @staticmethod
+    def add_success_mock_response():
+        responses.add(
+            responses.POST,
+            TestGenerateToken.URL + TestGenerateToken.ENDPOINT,
+            status=200,
+            json={"auth_token": TestGenerateToken.TOKEN_TEXT},
+        )
+
+    @staticmethod
+    def add_badlogin_mock_response():
+        responses.add(
+            responses.POST,
+            TestGenerateToken.URL + TestGenerateToken.ENDPOINT,
+            status=403,
+            json={"message": "Bad login"},
+        )
+
+    @staticmethod
+    def add_connectionerr_mock_response():
+        responses.add(
+            responses.POST,
+            TestGenerateToken.URL + TestGenerateToken.ENDPOINT,
+            body=requests.exceptions.ConnectionError(
+                "<urllib3.connection.HTTPConnection object at 0x1080854c0>: "
+                "Failed to establish a new connection: [Errno 8] "
+                "nodename nor servname provided, or not known"
+            ),
+        )
+
+    @staticmethod
+    @responses.activate
+    def test_help(pytestconfig):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(generate_token.main, ["--help"])
+        assert result.exit_code == 0
+        assert str(result.stdout).startswith("Usage:")
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_args_both(valid_config, pytestconfig):
+        TestGenerateToken.add_success_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[
+                TestGenerateToken.USER_SWITCH,
+                TestGenerateToken.USER_TEXT,
+                TestGenerateToken.PSWD_SWITCH,
+                TestGenerateToken.PSWD_TEXT,
+            ],
+        )
+        assert result.exit_code == 0
+        assert result.stdout == f"{TestGenerateToken.TOKEN_TEXT}\n"
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_args_username(valid_config, pytestconfig):
+        TestGenerateToken.add_success_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[TestGenerateToken.USER_SWITCH, TestGenerateToken.USER_TEXT],
+            input=f"{TestGenerateToken.PSWD_TEXT}\n",
+        )
+        assert result.exit_code == 0
+        assert (
+            result.stdout
+            == f"{TestGenerateToken.PSWD_PROMPT}\n"
+            + f"{TestGenerateToken.TOKEN_TEXT}\n"
+        )
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_args_password(valid_config, pytestconfig):
+        TestGenerateToken.add_success_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[TestGenerateToken.PSWD_SWITCH, TestGenerateToken.PSWD_TEXT],
+            input=f"{TestGenerateToken.USER_TEXT}\n",
+        )
+        assert result.exit_code == 0
+        assert (
+            result.stdout
+            == f"{TestGenerateToken.USER_PROMPT}{TestGenerateToken.USER_TEXT}\n"
+            + f"{TestGenerateToken.TOKEN_TEXT}\n"
+        )
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_args_none(valid_config, pytestconfig):
+        TestGenerateToken.add_success_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[],
+            input=f"{TestGenerateToken.USER_TEXT}\n{TestGenerateToken.PSWD_TEXT}\n",
+        )
+        assert result.exit_code == 0
+        assert (
+            result.stdout
+            == f"{TestGenerateToken.USER_PROMPT}{TestGenerateToken.USER_TEXT}\n"
+            + f"{TestGenerateToken.PSWD_PROMPT}\n"
+            + f"{TestGenerateToken.TOKEN_TEXT}\n"
+        )
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_bad_login(valid_config, pytestconfig):
+        TestGenerateToken.add_badlogin_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[
+                TestGenerateToken.USER_SWITCH,
+                TestGenerateToken.USER_TEXT,
+                TestGenerateToken.PSWD_SWITCH,
+                TestGenerateToken.PSWD_TEXT,
+            ],
+        )
+        assert result.exit_code == 1
+        assert not result.stdout
+        assert result.stderr == "Bad login\n"
+
+    @staticmethod
+    @responses.activate
+    def test_connection_failed(valid_config, pytestconfig):
+
+        TestGenerateToken.add_connectionerr_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            generate_token.main,
+            args=[
+                TestGenerateToken.USER_SWITCH,
+                TestGenerateToken.USER_TEXT,
+                TestGenerateToken.PSWD_SWITCH,
+                TestGenerateToken.PSWD_TEXT,
+            ],
+        )
+        assert result.exit_code == 1
+        assert not result.stdout
+        assert str(result.stderr).find("Failed to establish a new connection") != -1

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ console_scripts =
    pbench-cleanup = pbench.cli.agent.commands.cleanup:main
    pbench-list-tools = pbench.cli.agent.commands.tools.list:main
    pbench-register-tool-trigger = pbench.cli.agent.commands.triggers.register:main
+   pbench-generate-token = pbench.cli.agent.commands.generate_token:main
 
 [tools:pytest]
 testpaths = lib/pbench/test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = pbench
 summary = A benchmarking and performance analysis framework
-description-file =
+description_file =
     README.md
 author = Pbench by Red Hat
 maintainer = Pbench by Red Hat
-home-page = https://github.com/distributed-system-analysis/pbench
+home_page = https://github.com/distributed-system-analysis/pbench
 classifier =
    Programming Language :: Python :: 3.6,
    License :: OSI Approved :: GNU General Public License v3 (GPLv3),


### PR DESCRIPTION
This pull request is a series of commits culminating in the addition of a simple tool which takes a username/password pair and generates a token for use with the pbench server's REST interface.  The targeted use case for the token is to allow Riya's overhaul of the `pbench-move-results` tool to make an authenticated access to the server.

Most of the commits in this pull request are small, point changes to things which I encountered in the process of implementing the new tool:

- Fix docstring typos in `cli/agent/__init__.py` (no functional changes).
- Tweak Click options for agent config command line option, to make it behave more gracefully.
- Tweak the setup option names to replace hyphens with underscores, since my installation was generating warnings.

The new tool accepts a username and password.  These can be specified on the command line for convenience, but, of course, putting the password on the command line in clear text will likely allow it to "leak" to log files or to other users on the system.  If the username and/or password is not specified on the command line, the tool will prompt for them.  The response to the password prompt is not echoed, for security reasons.

The tool makes a `PUT` request to the pbench server creating a "login" and receiving a token from the response.  If the request is successful, the token is printed to `stdout` and the tool exits with a success (zero) status.  The output can be captured either by redirecting `stdout` to a file or by copying-and-pasting the terminal output.  If the request is unsuccessful, the tool exits with an error status with a diagnostic sent to `stderr`.

The token value can then be stored in a "secret" which is made available to other tools such as `pbench-move-results` in their respective execution environments, or it can be specified in clear-text, because it is an ephemeral value.

This implementation of `pbench-generate-token` provides latent support for allowing the user to specify the duration for which the token is valid.  The current server implementation provides a fixed duration, so in effect any value specified to this tool is ignored.  However, in the future, once we have support for role-based authorization in the server, it will be practical to provide variable duration tokens, at which point the option in this tool will become useful.

[This PR now includes unit tests and is ready for formal review; comments provided during the draft phase have been incorporated into their respective commits, and the branch has been rebased on the end of `main`.]