### PR TITLE
Improve diagnostic for connection error in pbench-generate-token

### DIFF
--- a/lib/pbench/cli/agent/commands/generate_token.py
+++ b/lib/pbench/cli/agent/commands/generate_token.py
@@ -24,12 +24,11 @@ class GenerateToken(BaseCommand):
             "password": self.context.password,
             "token_duration": self.context.token_duration,
         }
+        uri = f"{server}/login"
         try:
-            response = requests.post(f"{server}/login", headers=headers, json=payload)
+            response = requests.post(uri, headers=headers, json=payload)
         except requests.exceptions.ConnectionError as exc:
-            if hasattr(exc.args[0], "reason"):
-                raise exc.args[0].reason
-            raise
+            raise RuntimeError(f"Cannot connect to '{uri}'") from exc
 
         payload = response.json()
         if response.ok:

--- a/lib/pbench/test/unit/agent/task/test_generate_token.py
+++ b/lib/pbench/test/unit/agent/task/test_generate_token.py
@@ -164,4 +164,6 @@ class TestGenerateToken:
         )
         assert result.exit_code == 1
         assert not result.stdout
-        assert str(result.stderr).find("Failed to establish a new connection") != -1
+        assert -1 != str(result.stderr).find(
+            "Cannot connect to 'http://pbench.example.com/api/v1/login'"
+        )


### PR DESCRIPTION
This pull request consists of a small commit which tries to produce a better diagnostic when the `pbench-generate-token` tool is unable to connect to the pbench server.

The `requests` package `ConnectionError` exception text is not very friendly, so we catch that exception and raise our own exception which provides a nicer message (not quite as nice as I would like, but better than what was there).

Old message:
```
<urllib3.connection.HTTPConnection object at 0x10a661100>: Failed to establish a new connection: [Errno 8] nodename nor servname provided, or not known
```

New message:
```
Cannot connect to 'http://pbench.example.com/api/v1/login'
```

Resolves #2150.