### PR TITLE
Fix pytest-helpers-namespace at 2019.1.8

### DIFF
--- a/agent/test-requirements.txt
+++ b/agent/test-requirements.txt
@@ -3,6 +3,6 @@ gitpython
 mock>=3.0.5
 pytest-cov>=2.7.1
 pytest>=4.6.3, < 5
-pytest-helpers-namespace>=2019.1.8
+pytest-helpers-namespace==2019.1.8
 pytest-mock>=1.10.4
 responses

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -3,6 +3,6 @@ gitpython
 mock>=3.0.5
 pytest-cov>=2.7.1
 pytest>=4.6.3, < 5
-pytest-helpers-namespace>=2019.1.8
+pytest-helpers-namespace==2019.1.8
 pytest-mock>=1.10.4
 requests_mock


### PR DESCRIPTION
Looks like there are problems with the recently released version `2021.3.24`.