### PR TITLE
Add dependencies to pbench-devel required to build RPMs

### DIFF
--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -74,6 +74,7 @@ RUN \
         python3-humanize \
         python3-itsdangerous \
         python3-jinja2 \
+        python3-jinja2-cli \
         python3-libselinux \
         python3-mock \
         python3-pip \
@@ -94,6 +95,8 @@ RUN \
         python3-tox-current-env \
         python3-werkzeug \
         redis \
+        rpmlint \
+        rpm-build \
         rsync \
         screen \
         sos \


### PR DESCRIPTION
This PR modifies the Dockerfile for the `pbench-devel` container to add a couple of missing dependencies required to build RPMs for the agent and server.