### PR TITLE
Fix logout response workflow

### DIFF
--- a/lib/pbench/server/api/auth.py
+++ b/lib/pbench/server/api/auth.py
@@ -79,7 +79,7 @@ class Auth:
                 )
                 abort(
                     401,
-                    message="Malformed Authorization header, request auth needs bearer token: Bearer <session_token>",
+                    message="Malformed Authorization header, request needs bearer token: Bearer <session_token>",
                 )
             return auth_token
 

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -398,13 +398,13 @@ class TestUserAuthentication:
             )
             assert logout_response.status_code == 200
 
-            # invalid token logout
+            # Logout using invalid token
+            # Expect 200 on response, since the invalid token can not be used anymore
             response = client.post(
                 f"{server_config.rest_uri}/logout",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
-            data = response.json
-            assert data is None
+            assert response.status_code == 200
 
     @staticmethod
     def test_delete_user(client, server_config):


### PR DESCRIPTION
Fixes logout workflow as mentioned in the issue https://github.com/distributed-system-analysis/pbench/issues/2130

Right now the logout workflow returns `401` if an invalid `Authorization` token is presented in a request, however, in order to make logout smooth for the user and not being picky about logging out is less prone to security issues. We almost always want to return success on logout if the token is expired or is already removed from our database and no longer tracked. 