### PR TITLE
Add pbench create user CLI

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -1,0 +1,21 @@
+"""
+Create a click context object that holds the state of the server
+invocation. The CliContext will keep track of passed parameters,
+what command created it, which resources need to be cleaned up,
+and etc.
+
+We create an empty object at the beginning and populate the object
+with configuration, group names, at the beginning of the server
+execution.
+"""
+
+import click
+
+
+class CliContext:
+    """Initialize an empty click object"""
+
+    pass
+
+
+pass_cli_context = click.make_pass_decorator(CliContext, ensure=True)

--- a/lib/pbench/cli/server/options.py
+++ b/lib/pbench/cli/server/options.py
@@ -1,0 +1,39 @@
+import click
+from typing import Callable
+
+from pbench.cli.server import CliContext
+
+
+def common_options(in_f: Callable) -> Callable:
+    """
+    This function can be used as a decorator for multiple server side CLI utilities,
+    where it receives a click command decorated function as an argument and sets some
+    common configuration options on the CLI, in this case pbench server configuration
+    :param in_f: click command decorated function
+    :return: function with common click options set
+    """
+    out_f = _pbench_server_config(in_f)
+    return out_f
+
+
+def _pbench_server_config(f: Callable) -> Callable:
+    """Option for server configuration"""
+
+    def callback(ctx, param, value):
+        clictx = ctx.ensure_object(CliContext)
+        clictx.config = value
+        return value
+
+    return click.option(
+        "-C",
+        "--config",
+        required=True,
+        envvar="_PBENCH_SERVER_CONFIG",
+        type=click.Path(exists=True, readable=True),
+        callback=callback,
+        expose_value=False,
+        help=(
+            "Path to a pbench-server configuration file (defaults to the "
+            "'_PBENCH_SERVER_CONFIG' environment variable, if defined)"
+        ),
+    )(f)

--- a/lib/pbench/cli/server/user_create.py
+++ b/lib/pbench/cli/server/user_create.py
@@ -1,0 +1,84 @@
+import click
+from pbench import BadConfig
+from pbench.server import PbenchServerConfig
+from pbench.cli.server import pass_cli_context
+from pbench.cli.server.options import common_options
+from pbench.common.logger import get_pbench_logger
+from pbench.server.database.models.users import User
+from pbench.server.database.database import Database
+
+_NAME_ = "pbench-user-create"
+
+
+class UserCreate:
+    def __init__(self, context):
+        self.context = context
+
+    def execute(self):
+        config = PbenchServerConfig(self.context.config)
+
+        logger = get_pbench_logger(_NAME_, config)
+
+        # We're going to need the Postgres DB to track dataset state, so setup
+        # DB access.
+        Database.init_db(config, logger)
+
+        user = User(
+            username=self.context.username,
+            password=self.context.password,
+            first_name=self.context.first_name,
+            last_name=self.context.last_name,
+            email=self.context.email,
+        )
+        user.add()
+        click.echo(f"User {self.context.username} registered")
+
+
+@click.command()
+@common_options
+@click.option(
+    "--username",
+    prompt=True,
+    required=True,
+    help="pbench server account username (will prompt if unspecified)",
+)
+@click.option(
+    "--password",
+    prompt=True,
+    hide_input=True,
+    required=True,
+    help="pbench server account password (will prompt if unspecified)",
+)
+@click.option(
+    "--email",
+    prompt=True,
+    required=True,
+    help="pbench server account email (will prompt if unspecified)",
+)
+@click.option(
+    "--first-name",
+    prompt=True,
+    required=True,
+    help="pbench server account first name (will prompt if unspecified)",
+)
+@click.option(
+    "--last-name",
+    prompt=True,
+    required=True,
+    help="pbench server account last name (will prompt if unspecified)",
+)
+@pass_cli_context
+def main(context, username, password, email, first_name, last_name):
+    context.username = username
+    context.password = password
+    context.email = email
+    context.first_name = first_name
+    context.last_name = last_name
+
+    try:
+        rv = UserCreate(context).execute()
+    except Exception as exc:
+        click.echo(exc, err=True)
+        rv = 2 if isinstance(exc, BadConfig) else 1
+
+    click.get_current_context().exit(rv)

--- a/lib/pbench/test/unit/server/test_user_create.py
+++ b/lib/pbench/test/unit/server/test_user_create.py
@@ -1,0 +1,77 @@
+from click.testing import CliRunner
+import responses
+
+from pbench.cli.server import user_create
+
+
+class TestCreateUser:
+    USER_SWITCH = "--username"
+    PSWD_SWITCH = "--password"
+    PSWD_PROMPT = "Password: "
+    EMAIL_SWITCH = "--email"
+    FIRST_NAME_SWITCH = "--first-name"
+    LAST_NAME_SWITCH = "--last-name"
+    USER_TEXT = "test_user"
+    PSWD_TEXT = "password"
+    EMAIL_TEXT = "test@domain.com"
+    FIRST_NAME_TEXT = "First"
+    LAST_NAME_TEXT = "Last"
+    URL = "http://pbench.example.com/api/v1"
+    ENDPOINT = "/register"
+
+    @staticmethod
+    @responses.activate
+    def test_help(pytestconfig):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(user_create.main, ["--help"])
+        assert result.exit_code == 0
+        assert str(result.stdout).startswith("Usage:")
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_args(server_config, pytestconfig):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            user_create.main,
+            args=[
+                TestCreateUser.USER_SWITCH,
+                TestCreateUser.USER_TEXT,
+                TestCreateUser.PSWD_SWITCH,
+                TestCreateUser.PSWD_TEXT,
+                TestCreateUser.EMAIL_SWITCH,
+                TestCreateUser.EMAIL_TEXT,
+                TestCreateUser.FIRST_NAME_SWITCH,
+                TestCreateUser.FIRST_NAME_TEXT,
+                TestCreateUser.LAST_NAME_SWITCH,
+                TestCreateUser.LAST_NAME_TEXT,
+            ],
+        )
+        assert result.stdout_bytes == b"User test_user registered\n"
+        assert result.exit_code == 0
+        assert not result.stderr_bytes
+
+    @staticmethod
+    @responses.activate
+    def test_valid_user_registration(server_config, pytestconfig):
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            user_create.main,
+            args=[
+                TestCreateUser.USER_SWITCH,
+                TestCreateUser.USER_TEXT,
+                TestCreateUser.EMAIL_SWITCH,
+                TestCreateUser.EMAIL_TEXT,
+                TestCreateUser.FIRST_NAME_SWITCH,
+                TestCreateUser.FIRST_NAME_TEXT,
+                TestCreateUser.LAST_NAME_SWITCH,
+                TestCreateUser.LAST_NAME_TEXT,
+            ],
+            input=f"{TestCreateUser.PSWD_TEXT}\n",
+        )
+        assert result.exit_code == 0
+        assert (
+            result.stdout
+            == f"{TestCreateUser.PSWD_PROMPT}\n" + "User test_user registered\n"
+        )
+        assert not result.stderr_bytes

--- a/server/Makefile
+++ b/server/Makefile
@@ -19,6 +19,9 @@ INSTALL = install
 #INSTALLOPTS = --mode 755 --directory --owner=${OWNER} --group=${GROUP}
 INSTALLOPTS = --directory
 
+click-scripts = \
+	pbench-user-create
+
 # targets
 .PHONY: install \
 	install-dirs \
@@ -41,7 +44,7 @@ install-python3-setup: install-bin install-lib
 	mkdir -p ${DESTDIR}/python3
 	${COPY} requirements.txt ${DESTDIR}
 	(cd ..; SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py install --prefix=${DESTDIR}/python3)
-	${COPY} ${DESTDIR}/python3/bin/pbench-config ${DESTDIR}/python3/bin/pbench-server ${BINDIR}/
+	${COPY} $(addprefix ${DESTDIR}/python3/bin/, pbench-config pbench-server ${click-scripts}) ${BINDIR}/
 	${RM} -r ${DESTDIR}/python3
 	${COPY} ../lib/pbench ${LIBDIR}/
 	${RM} -r $$(find ${LIBDIR} -name __pycache__) ${LIBDIR}/pbench/test ${LIBDIR}/pbench/agent ${LIBDIR}/pbench/cli/agent

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ console_scripts =
    pbench-list-triggers = pbench.cli.agent.commands.triggers.list:main
    pbench-register-tool-trigger = pbench.cli.agent.commands.triggers.register:main
    pbench-server = pbench.cli.server.shell:main
+   pbench-user-create = pbench.cli.server.user_create:main
 
 [tools:pytest]
 testpaths = lib/pbench/test


### PR DESCRIPTION
Addresses `create_user` from issue https://github.com/distributed-system-analysis/pbench/issues/2183

This PR lets us create pbench user from command line. 

The `pbench_create_user` tool accepts a username, password, email, first_name, last_name as a required parameters. These can be specified on the command line. However, if any of the parameter is not specified on the command line, the tool will prompt for them. The response to the password prompt is not echoed. The tool also optionally accept `--exist-ok` option, and if specified it will ignore the error if the user already exists and return success.