### PR TITLE
Return same status code for bad username and bad password

### DIFF
--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -191,7 +191,7 @@ class Login(Resource):
             self.logger.warning(
                 "No user found in the db for Username: {} while login", username
             )
-            abort(403, message="Bad login")
+            abort(401, message="Bad login")
 
         # Validate the password
         if not check_password_hash(user.password, password):

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -211,7 +211,7 @@ class TestUserAuthentication:
             response = login_user(client, server_config, "username", "12345")
             data = response.json
             assert data["message"] == "Bad login"
-            assert response.status_code == 403
+            assert response.status_code == 401
 
     @staticmethod
     def test_get_user(client, server_config):


### PR DESCRIPTION
Fixes issue https://github.com/distributed-system-analysis/pbench/issues/2148
We should return 401, whether it is bad username or password in the user login.