### PR TITLE
Add hostname and IP address validation for env

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -100,14 +100,29 @@ fi
 # don't use colons and dashes in the date suffix
 export date_suffix=$(date --date ${date} --utc +"%Y.%m.%dT%H.%M.%S")
 
+function validate_hostname {
+    validate-hostname "${1}"
+    if [[ ${?} -ne 0 ]]; then
+        error_log "Invalid ${2}: '${1}'"
+        exit 1
+    fi
+}
+
 if [[ -z "${_pbench_hostname}" ]]; then
     export _pbench_hostname=$(hostname -s)
 fi
+validate_hostname "${_pbench_hostname}" "_pbench_hostname"
 if [[ -z "${_pbench_full_hostname}" ]]; then
     export _pbench_full_hostname=$(hostname -f)
 fi
+validate_hostname "${_pbench_full_hostname}" "_pbench_full_hostname"
 if [[ -z "${_pbench_hostname_ip}" ]]; then
     export _pbench_hostname_ip=$(hostname -i)
+fi
+validate-ipaddress "${_pbench_hostname_ip}"
+if [[ ${?} -ne 0 ]]; then
+    error_log "Invalid IP address: '${_pbench_hostname_ip}'"
+    exit 1
 fi
 
 if [[ -z "$ssh_opts" ]]; then

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -43,7 +43,7 @@ cp ${_tdir}/postprocess/* ${_testopt}/bench-scripts/postprocess
 let res=res+${?}
 cp ${_tdir}/templates/* ${_testopt}/bench-scripts/templates
 let res=res+${?}
-cp -a $_tdir/../util-scripts/{require-rpm,pbench-*} $_testopt/util-scripts/
+cp -a $_tdir/../util-scripts/{require-rpm,validate-*,pbench-*} $_testopt/util-scripts/
 let res=res+$?
 cp -rH ${_tdir}/test-bin/* ${_testopt}/unittest-scripts/
 let res=res+${?}

--- a/agent/util-scripts/gold/pbench-move-results/test-22.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-22.txt
@@ -1,0 +1,11 @@
++++ Running test-22 pbench-move-results --controller=bad_host_name.example.com
+[error][1900-01-01T00:00:00.000000] Invalid controller: 'bad_host_name.example.com'
+--- Finished test-22 pbench-move-results (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state
++++ pbench.log file contents
+[error][1900-01-01T00:00:00.000000] Invalid controller: 'bad_host_name.example.com'
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-01.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-01.txt
@@ -1,0 +1,13 @@
++++ Running test-01 pbench-register-tool --name=mpstat --group=default --remote=invalid_remote.example.com,good.example.com,bad_remote.example.com
+[error][1900-01-01T00:00:00.000000] Invalid remote specified: 'invalid_remote.example.com'
+[error][1900-01-01T00:00:00.000000] Invalid remote specified: 'bad_remote.example.com'
+--- Finished test-01 pbench-register-tool (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state
++++ pbench.log file contents
+[error][1900-01-01T00:00:00.000000] Invalid remote specified: 'invalid_remote.example.com'
+[error][1900-01-01T00:00:00.000000] Invalid remote specified: 'bad_remote.example.com'
+--- pbench.log file contents

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -1,11 +1,11 @@
 +++ Running test-56 test-client-tool-meister lite with-remotes
 "mpstat" tool is now registered for host "testhost.example.com" in group "lite"
 "dcgm" tool is now registered for host "testhost.example.com" in group "lite"
-"mpstat" tool is now registered for host "remote_a.example.com" in group "lite"
-"mpstat" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
-"node-exporter" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
-"dcgm" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
-"pcp" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+"mpstat" tool is now registered for host "remote-a.example.com" in group "lite"
+"mpstat" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
+"node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
+"dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
+"pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 pbench-tool-data-sink: connected to redis server localhost:17001
 pbench-tool-meister: connected to redis server localhost:17001
 pbench-tool-meister: connected to redis server localhost:17001
@@ -20,32 +20,32 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.out
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com/mpstat/mpstat-stderr.txt
@@ -61,32 +61,32 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.out
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com/mpstat/mpstat-stderr.txt
@@ -104,42 +104,42 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/ssh_config.d
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/tm-sysinfo.out
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/contents.lis
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/pbench-sysinfo-dump.file
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/tm-sysinfo.err
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/tm-sysinfo.out
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote_b.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote_b.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote_b.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote_b.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote_c.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote_c.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote_c.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote_c.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote_a.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote_a.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote_a.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote_a.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote-b.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote-b.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote-b.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/blue:remote-b.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote-c.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote-c.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote-c.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/red:remote-c.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote-a.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote-a.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote-a.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/remote-a.example.com/tm-sysinfo.out
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/testhost.example.com/contents.lis
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/testhost.example.com/pbench-sysinfo-dump.file
@@ -163,125 +163,125 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/testhost.example.com/dcgm/tm-dcgm-start.out
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.out
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/node_exporter.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/dcgm.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/pmcd.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/node_exporter.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/dcgm.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/pmcd.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/__label__
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/node-exporter
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/__label__
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/dcgm
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/pcp
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/dcgm
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/mpstat
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister __exit__ -- remote_a.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister __exit__ -- remote-a.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-INFO pbench-tool-meister __exit__ -- remote_b.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+INFO pbench-tool-meister __exit__ -- remote-b.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-INFO pbench-tool-meister __exit__ -- remote_c.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/node_exporter.file:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/node_exporter.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/dcgm.file:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/dcgm.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/pmcd.file:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/pmcd.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd --foreground --socket=./pmcd.socket --port=55677 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com/mpstat:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com/mpstat:
 --interval=42
 --options=forty-two
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/__label__:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/__label__:
 blue
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/mpstat:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/mpstat:
 --interval=42
 --options=forty-two
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/node-exporter:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/node-exporter:
 --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/__label__:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/__label__:
 red
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/dcgm:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/dcgm:
 --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/pcp:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/pcp:
 --interval=42
 --options=forty-two
 === /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/dcgm:
@@ -296,15 +296,15 @@ red
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
 [info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "testhost.example.com" in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_a.example.com" in group "lite"
+[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote-a.example.com" in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
+[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
-[info][1900-01-01T00:00:00.000000] "node-exporter" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
+[info][1900-01-01T00:00:00.000000] "node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
-[info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+[info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "pcp" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+[info][1900-01-01T00:00:00.000000] "pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 [info][1900-01-01T00:00:00.000000] Collecting system information
 [info][1900-01-01T00:00:00.000000] Collecting system information
 --- pbench.log file contents
@@ -331,11 +331,11 @@ start_run = 1900-01-01T00:00:00.000042
 end_run = 1900-01-01T00:00:00.000043
 
 [tools]
-hosts = remote_a.example.com remote_b.example.com remote_c.example.com testhost.example.com
+hosts = remote-a.example.com remote-b.example.com remote-c.example.com testhost.example.com
 group = lite
 trigger = None
 
-[tools/remote_a.example.com]
+[tools/remote-a.example.com]
 label = 
 tools = mpstat
 hostname-s = agent.example.com
@@ -345,12 +345,12 @@ hostname-a = agent.example.com
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 
-[tools/remote_a.example.com/mpstat]
+[tools/remote-a.example.com/mpstat]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 
-[tools/remote_b.example.com]
+[tools/remote-b.example.com]
 label = blue
 tools = mpstat,node-exporter
 hostname-s = agent.example.com
@@ -361,17 +361,17 @@ rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 node-exporter = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 
-[tools/remote_b.example.com/mpstat]
+[tools/remote-b.example.com/mpstat]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 
-[tools/remote_b.example.com/node-exporter]
+[tools/remote-b.example.com/node-exporter]
 options = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 install_check_status_code = 0
 install_check_output = node_exporter tool properly installed
 
-[tools/remote_c.example.com]
+[tools/remote-c.example.com]
 label = red
 tools = dcgm,pcp
 hostname-s = agent.example.com
@@ -382,12 +382,12 @@ rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 pcp = --interval=42 --options=forty-two
 
-[tools/remote_c.example.com/dcgm]
+[tools/remote-c.example.com/dcgm]
 options = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 install_check_status_code = 0
 install_check_output = dcgm tool properly installed
 
-[tools/remote_c.example.com/pcp]
+[tools/remote-c.example.com/pcp]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = pcp tool (pmcd) properly installed
@@ -419,16 +419,16 @@ install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Hit Ctrl-C to quit.
 INFO pbench-tool-data-sink execute -- Tool Data Sink terminating
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_b.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_c.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote_b.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote_c.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote_b.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote_b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-c.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote-b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/9df83db2144bfc399f1f1343b788a63c/remote-c.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote-b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote-b.example.com HTTP/1.1" 200 0
 INFO pbench-tool-data-sink tm_log_capture -- Running Tool Meister log capture ...
 INFO pbench-tool-data-sink web_server_run -- Bottle web server exited
 INFO pbench-tool-data-sink web_server_run -- Running Bottle web server ...
@@ -478,50 +478,50 @@ INFO pbench-tool-meister __exit__ -- testhost.example.com: terminating
 --- mock-run/tm/tm-lite-testhost.example.com.out file contents
 +++ mock-run/tm/tm.logs file contents
 pbench-tool-meister-start - verify logging channel up
-remote_a.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-remote_a.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0002 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0003 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0004 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_a.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_a.example.com 0006 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0007 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0008 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_a.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_a.example.com 0011 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0012 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-remote_a.example.com 0013 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0014 INFO pbench-tool-meister __exit__ -- remote_a.example.com: terminating
-remote_b.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-remote_b.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
-remote_b.example.com 0003 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0004 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_b.example.com 0006 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_b.example.com 0007 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0008 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0009 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_b.example.com 0011 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_b.example.com 0012 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0013 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
-remote_b.example.com 0014 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
-remote_b.example.com 0015 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-remote_b.example.com 0016 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0017 INFO pbench-tool-meister __exit__ -- remote_b.example.com: terminating
-remote_c.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-remote_c.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-remote_c.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
-remote_c.example.com 0003 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
-remote_c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
-remote_c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
-remote_c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
-remote_c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-remote_c.example.com 0008 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-remote_c.example.com 0009 INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-remote_c.example.com 0010 INFO pbench-tool-meister __exit__ -- remote_c.example.com: terminating
+remote-a.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+remote-a.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0002 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0003 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0004 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-a.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-a.example.com 0006 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0007 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0008 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-a.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-a.example.com 0011 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0012 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+remote-a.example.com 0013 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0014 INFO pbench-tool-meister __exit__ -- remote-a.example.com: terminating
+remote-b.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+remote-b.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
+remote-b.example.com 0003 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0004 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-b.example.com 0006 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-b.example.com 0007 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0008 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0009 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-b.example.com 0011 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-b.example.com 0012 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0013 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
+remote-b.example.com 0014 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
+remote-b.example.com 0015 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+remote-b.example.com 0016 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0017 INFO pbench-tool-meister __exit__ -- remote-b.example.com: terminating
+remote-c.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+remote-c.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+remote-c.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
+remote-c.example.com 0003 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
+remote-c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
+remote-c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
+remote-c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
+remote-c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
+remote-c.example.com 0008 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+remote-c.example.com 0009 INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+remote-c.example.com 0010 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
 testhost.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com block,security_mitigations,sos parallel
 testhost.example.com 0001 INFO pbench-tool-meister sysinfo -- testhost.example.com: sysinfo send (no-op) lite /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com
 testhost.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
@@ -546,14 +546,14 @@ testhost.example.com 0017 INFO pbench-tool-meister __exit__ -- testhost.example.
 +++ tools-lite/pcp/pmproxy.file file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmproxy --log=- --foreground --timeseries --port=44566 --redishost=localhost --redisport=17001 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmproxy.conf
 --- tools-lite/pcp/pmproxy.file file contents
-+++ tools-lite/pcp/remote_c.example.com/pmcd_wait.file file contents
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote_c.example.com:55677 -t 30
---- tools-lite/pcp/remote_c.example.com/pmcd_wait.file file contents
-+++ tools-lite/pcp/remote_c.example.com/pmlogger-proc.log file contents
---- tools-lite/pcp/remote_c.example.com/pmlogger-proc.log file contents
-+++ tools-lite/pcp/remote_c.example.com/pmlogger.file file contents
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote_c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote_c.example.com/%Y%m%d.%H.%M
---- tools-lite/pcp/remote_c.example.com/pmlogger.file file contents
++++ tools-lite/pcp/remote-c.example.com/pmcd_wait.file file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote-c.example.com:55677 -t 30
+--- tools-lite/pcp/remote-c.example.com/pmcd_wait.file file contents
++++ tools-lite/pcp/remote-c.example.com/pmlogger-proc.log file contents
+--- tools-lite/pcp/remote-c.example.com/pmlogger-proc.log file contents
++++ tools-lite/pcp/remote-c.example.com/pmlogger.file file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote-c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote-c.example.com/%Y%m%d.%H.%M
+--- tools-lite/pcp/remote-c.example.com/pmlogger.file file contents
 +++ tools-lite/prometheus/prom.log file contents
 --- tools-lite/prometheus/prom.log file contents
 +++ tools-lite/prometheus/prometheus.file file contents
@@ -570,14 +570,14 @@ scrape_configs:
     - targets: ['localhost:9090']
 
 
-  - job_name: 'remote_b.example.com_node-exporter'
+  - job_name: 'remote-b.example.com_node-exporter'
     static_configs:
-    - targets: ['remote_b.example.com:9100']
+    - targets: ['remote-b.example.com:9100']
 
 
-  - job_name: 'remote_c.example.com_dcgm'
+  - job_name: 'remote-c.example.com_dcgm'
     static_configs:
-    - targets: ['remote_c.example.com:9400']
+    - targets: ['remote-c.example.com:9400']
 
 
   - job_name: 'testhost.example.com_dcgm'
@@ -602,12 +602,12 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com block,security_mitigations,sos parallel
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/end/testhost.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
@@ -615,11 +615,11 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd --foreground --socket=./pmcd.socket --port=55677 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote_c.example.com:55677 -t 30
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote_c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote_c.example.com/%Y%m%d.%H.%M
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote-c.example.com:55677 -t 30
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote-c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote-c.example.com/%Y%m%d.%H.%M
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmproxy --log=- --foreground --timeseries --port=44566 --redishost=localhost --redisport=17001 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmproxy.conf
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/prometheus --config.file=/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus/prometheus.yml --storage.tsdb.path=/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com yes
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com yes
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-a.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-b.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-c.example.com yes
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -1,11 +1,11 @@
 +++ Running test-57 test-client-tool-meister lite with-remotes delayed-send interrupt
 "mpstat" tool is now registered for host "testhost.example.com" in group "lite"
 "dcgm" tool is now registered for host "testhost.example.com" in group "lite"
-"mpstat" tool is now registered for host "remote_a.example.com" in group "lite"
-"mpstat" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
-"node-exporter" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
-"dcgm" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
-"pcp" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+"mpstat" tool is now registered for host "remote-a.example.com" in group "lite"
+"mpstat" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
+"node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
+"dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
+"pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 pbench-tool-data-sink: connected to redis server localhost:17001
 pbench-tool-meister: connected to redis server localhost:17001
 pbench-tool-meister: connected to redis server localhost:17001
@@ -20,32 +20,32 @@ system information not collected when --interrupt specified
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.out
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/mock-run/0-iter-zero/sample42/tools-lite/testhost.example.com/mpstat/mpstat-stderr.txt
@@ -61,32 +61,32 @@ system information not collected when --interrupt specified
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote_b.example.com/tm-mpstat-stop.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stderr.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stdout.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat-stop-postprocess.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.cmd
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/mpstat.file
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/mpstat/online-cpus.txt
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-start.out
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.err
-/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote_a.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/blue:remote-b.example.com/tm-mpstat-stop.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stderr.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stdout.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat-stop-postprocess.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.cmd
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/mpstat.file
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/mpstat/online-cpus.txt
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-start.out
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.err
+/var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/remote-a.example.com/tm-mpstat-stop.out
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/mock-run/1-iter-one/sample42/tools-lite/testhost.example.com/mpstat/mpstat-stderr.txt
@@ -104,21 +104,21 @@ system information not collected when --interrupt specified
 /var/tmp/pbench-test-utils/pbench/mock-run/ssh_config.d
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote_b.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote_c.example.com/tm-sysinfo.out
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/contents.lis
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/pbench-sysinfo-dump.file
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/tm-sysinfo.err
-/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote_a.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/blue:remote-b.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/red:remote-c.example.com/tm-sysinfo.out
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/contents.lis
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/pbench-sysinfo-dump.file
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/tm-sysinfo.err
+/var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/remote-a.example.com/tm-sysinfo.out
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/contents.lis
 /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com/pbench-sysinfo-dump.file
@@ -142,119 +142,119 @@ system information not collected when --interrupt specified
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/testhost.example.com/dcgm/tm-dcgm-start.out
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.out
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
 /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/node_exporter.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/dcgm.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/pmcd.file
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.err
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.out
-/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/node_exporter.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/dcgm.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/pmcd.file
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.err
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.out
+/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/__label__
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/mpstat
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/node-exporter
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/__label__
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/dcgm
-/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/pcp
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/dcgm
 /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/mpstat
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-INFO pbench-tool-meister __exit__ -- remote_a.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_a.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+INFO pbench-tool-meister __exit__ -- remote-a.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-a.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
-INFO pbench-tool-meister __exit__ -- remote_b.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_b.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.err:
-INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
+INFO pbench-tool-meister __exit__ -- remote-b.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-b.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.err:
+INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-INFO pbench-tool-meister __exit__ -- remote_c.example.com: terminating
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote_c.example.com.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/node_exporter.file:
+INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/node_exporter.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com/node-exporter/tm-node-exporter-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/dcgm.file:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com/node-exporter/tm-node-exporter-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/dcgm.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/dcgm/tm-dcgm-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/pmcd.file:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/dcgm/tm-dcgm-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/pmcd.file:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd --foreground --socket=./pmcd.socket --port=55677 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.err:
-=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com/pcp/tm-pcp-start.out:
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_a.example.com/mpstat:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.err:
+=== /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com/pcp/tm-pcp-start.out:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com/mpstat:
 --interval=42
 --options=forty-two
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/__label__:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/__label__:
 blue
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/mpstat:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/mpstat:
 --interval=42
 --options=forty-two
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_b.example.com/node-exporter:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-b.example.com/node-exporter:
 --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/__label__:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/__label__:
 red
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/dcgm:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/dcgm:
 --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
-=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote_c.example.com/pcp:
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-c.example.com/pcp:
 --interval=42
 --options=forty-two
 === /var/tmp/pbench-test-utils/pbench/tools-v1-lite/testhost.example.com/dcgm:
@@ -269,15 +269,15 @@ red
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
 [info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "testhost.example.com" in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_a.example.com" in group "lite"
+[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote-a.example.com" in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
+[info][1900-01-01T00:00:00.000000] "mpstat" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
-[info][1900-01-01T00:00:00.000000] "node-exporter" tool is now registered for host "remote_b.example.com", with label "blue", in group "lite"
+[info][1900-01-01T00:00:00.000000] "node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts"
-[info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+[info][1900-01-01T00:00:00.000000] "dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 [debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=42 --options=forty-two"
-[info][1900-01-01T00:00:00.000000] "pcp" tool is now registered for host "remote_c.example.com", with label "red", in group "lite"
+[info][1900-01-01T00:00:00.000000] "pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 [info][1900-01-01T00:00:00.000000] Collecting system information
 --- pbench.log file contents
 +++ mock-run/metadata.log file contents
@@ -304,11 +304,11 @@ end_run = 1900-01-01T00:00:00.000043
 run_interrupted = true
 
 [tools]
-hosts = remote_a.example.com remote_b.example.com remote_c.example.com testhost.example.com
+hosts = remote-a.example.com remote-b.example.com remote-c.example.com testhost.example.com
 group = lite
 trigger = None
 
-[tools/remote_a.example.com]
+[tools/remote-a.example.com]
 label = 
 tools = mpstat
 hostname-s = agent.example.com
@@ -318,12 +318,12 @@ hostname-a = agent.example.com
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 
-[tools/remote_a.example.com/mpstat]
+[tools/remote-a.example.com/mpstat]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 
-[tools/remote_b.example.com]
+[tools/remote-b.example.com]
 label = blue
 tools = mpstat,node-exporter
 hostname-s = agent.example.com
@@ -334,17 +334,17 @@ rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 node-exporter = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 
-[tools/remote_b.example.com/mpstat]
+[tools/remote-b.example.com/mpstat]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 
-[tools/remote_b.example.com/node-exporter]
+[tools/remote-b.example.com/node-exporter]
 options = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 install_check_status_code = 0
 install_check_output = node_exporter tool properly installed
 
-[tools/remote_c.example.com]
+[tools/remote-c.example.com]
 label = red
 tools = dcgm,pcp
 hostname-s = agent.example.com
@@ -355,12 +355,12 @@ rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 pcp = --interval=42 --options=forty-two
 
-[tools/remote_c.example.com/dcgm]
+[tools/remote-c.example.com/dcgm]
 options = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 install_check_status_code = 0
 install_check_output = dcgm tool properly installed
 
-[tools/remote_c.example.com/pcp]
+[tools/remote-c.example.com/pcp]
 options = --interval=42 --options=forty-two
 install_check_status_code = 0
 install_check_output = pcp tool (pmcd) properly installed
@@ -392,13 +392,13 @@ install_check_output = mpstat: pbench-sysstat-12.0.3 is installed
 Bottle v#.##.## server starting up (using DataSinkWsgiServer(handler_class=<class 'pbench.agent.tool_data_sink.DataSinkWsgiServer.__init__.<locals>.DataSinkWsgiRequestHandler'>))...
 Hit Ctrl-C to quit.
 INFO pbench-tool-data-sink execute -- Tool Data Sink terminating
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_b.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote_c.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote_b.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote_a.example.com HTTP/1.1" 200 0
-INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote_b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /sysinfo-data/27c00bc325171c4893ef3862b4340952/remote-c.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/4a200d14fbab61d26581ad8e0129a73d/remote-b.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote-a.example.com HTTP/1.1" 200 0
+INFO pbench-tool-data-sink log_request -- 127.0.0.1 - - "PUT /tool-data/9e243daecdc01b52d608090bb1c49d95/remote-b.example.com HTTP/1.1" 200 0
 INFO pbench-tool-data-sink tm_log_capture -- Running Tool Meister log capture ...
 INFO pbench-tool-data-sink web_server_run -- Bottle web server exited
 INFO pbench-tool-data-sink web_server_run -- Running Bottle web server ...
@@ -446,44 +446,44 @@ INFO pbench-tool-meister __exit__ -- testhost.example.com: terminating
 --- mock-run/tm/tm-lite-testhost.example.com.out file contents
 +++ mock-run/tm/tm.logs file contents
 pbench-tool-meister-start - verify logging channel up
-remote_a.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
-remote_a.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0002 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0003 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0004 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_a.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_a.example.com 0006 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0007 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com --interval=42 --options=forty-two
-remote_a.example.com 0008 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_a.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_a.example.com 0010 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0011 INFO pbench-tool-meister _send_directory -- remote_a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com
-remote_a.example.com 0012 INFO pbench-tool-meister __exit__ -- remote_a.example.com: terminating
-remote_b.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-remote_b.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
-remote_b.example.com 0003 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0004 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_b.example.com 0006 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_b.example.com 0007 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0008 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com --interval=42 --options=forty-two
-remote_b.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
-remote_b.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
-remote_b.example.com 0011 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0012 INFO pbench-tool-meister _send_directory -- remote_b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com
-remote_b.example.com 0013 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
-remote_b.example.com 0014 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
-remote_b.example.com 0015 INFO pbench-tool-meister __exit__ -- remote_b.example.com: terminating
-remote_c.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-remote_c.example.com 0001 INFO pbench-tool-meister _send_directory -- remote_c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com
-remote_c.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
-remote_c.example.com 0003 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
-remote_c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
-remote_c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
-remote_c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
-remote_c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-remote_c.example.com 0008 INFO pbench-tool-meister __exit__ -- remote_c.example.com: terminating
+remote-a.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
+remote-a.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0002 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0003 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0004 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-a.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-a.example.com 0006 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0007 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com --interval=42 --options=forty-two
+remote-a.example.com 0008 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-a.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-a.example.com 0010 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0011 INFO pbench-tool-meister _send_directory -- remote-a.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com
+remote-a.example.com 0012 INFO pbench-tool-meister __exit__ -- remote-a.example.com: terminating
+remote-b.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+remote-b.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool node-exporter, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter']
+remote-b.example.com 0003 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0004 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0005 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-b.example.com 0006 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-b.example.com 0007 INFO pbench-tool-meister start -- mpstat: start_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --start --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0008 INFO pbench-tool-meister stop -- mpstat: stop_tool -- /var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/mpstat --stop --dir=/var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com --interval=42 --options=forty-two
+remote-b.example.com 0009 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat stop process
+remote-b.example.com 0010 INFO pbench-tool-meister wait -- Waiting for transient tool mpstat start process
+remote-b.example.com 0011 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0012 INFO pbench-tool-meister _send_directory -- remote-b.example.com: PUT tool-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com
+remote-b.example.com 0013 INFO pbench-tool-meister stop -- Terminate issued for persistent tool node-exporter
+remote-b.example.com 0014 INFO pbench-tool-meister wait -- Stopped persistent tool node-exporter
+remote-b.example.com 0015 INFO pbench-tool-meister __exit__ -- remote-b.example.com: terminating
+remote-c.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+remote-c.example.com 0001 INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
+remote-c.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
+remote-c.example.com 0003 INFO pbench-tool-meister start -- Started persistent tool pcp, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd', '--foreground', '--socket=./pmcd.socket', '--port=55677', '--config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf']
+remote-c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
+remote-c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
+remote-c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
+remote-c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
+remote-c.example.com 0008 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
 testhost.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com block,security_mitigations,sos parallel
 testhost.example.com 0001 INFO pbench-tool-meister sysinfo -- testhost.example.com: sysinfo send (no-op) lite /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com
 testhost.example.com 0002 INFO pbench-tool-meister start -- Started persistent tool dcgm, ['/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter']
@@ -506,14 +506,14 @@ testhost.example.com 0015 INFO pbench-tool-meister __exit__ -- testhost.example.
 +++ tools-lite/pcp/pmproxy.file file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmproxy --log=- --foreground --timeseries --port=44566 --redishost=localhost --redisport=17001 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmproxy.conf
 --- tools-lite/pcp/pmproxy.file file contents
-+++ tools-lite/pcp/remote_c.example.com/pmcd_wait.file file contents
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote_c.example.com:55677 -t 30
---- tools-lite/pcp/remote_c.example.com/pmcd_wait.file file contents
-+++ tools-lite/pcp/remote_c.example.com/pmlogger-proc.log file contents
---- tools-lite/pcp/remote_c.example.com/pmlogger-proc.log file contents
-+++ tools-lite/pcp/remote_c.example.com/pmlogger.file file contents
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote_c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote_c.example.com/%Y%m%d.%H.%M
---- tools-lite/pcp/remote_c.example.com/pmlogger.file file contents
++++ tools-lite/pcp/remote-c.example.com/pmcd_wait.file file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote-c.example.com:55677 -t 30
+--- tools-lite/pcp/remote-c.example.com/pmcd_wait.file file contents
++++ tools-lite/pcp/remote-c.example.com/pmlogger-proc.log file contents
+--- tools-lite/pcp/remote-c.example.com/pmlogger-proc.log file contents
++++ tools-lite/pcp/remote-c.example.com/pmlogger.file file contents
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote-c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote-c.example.com/%Y%m%d.%H.%M
+--- tools-lite/pcp/remote-c.example.com/pmlogger.file file contents
 +++ tools-lite/prometheus/prom.log file contents
 --- tools-lite/prometheus/prom.log file contents
 +++ tools-lite/prometheus/prometheus.file file contents
@@ -530,14 +530,14 @@ scrape_configs:
     - targets: ['localhost:9090']
 
 
-  - job_name: 'remote_b.example.com_node-exporter'
+  - job_name: 'remote-b.example.com_node-exporter'
     static_configs:
-    - targets: ['remote_b.example.com:9100']
+    - targets: ['remote-b.example.com:9100']
 
 
-  - job_name: 'remote_c.example.com_dcgm'
+  - job_name: 'remote-c.example.com_dcgm'
     static_configs:
-    - targets: ['remote_c.example.com:9400']
+    - targets: ['remote-c.example.com:9400']
 
 
   - job_name: 'testhost.example.com_dcgm'
@@ -561,9 +561,9 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/mpstat -P ALL --options=forty-two 42
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/node_exporter
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote_b.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote_c.example.com block,security_mitigations,sos parallel
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote_a.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/blue:remote-b.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/remote-a.example.com block,security_mitigations,sos parallel
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
@@ -571,11 +571,11 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pidof -x mpstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd --foreground --socket=./pmcd.socket --port=55677 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmcd.conf
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote_c.example.com:55677 -t 30
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote_c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote_c.example.com/%Y%m%d.%H.%M
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmcd_wait --host=remote-c.example.com:55677 -t 30
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmlogger --log=- --report -t 3s -c /var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmlogger.conf --host=remote-c.example.com:55677 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp/data/red:remote-c.example.com/%Y%m%d.%H.%M
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pmproxy --log=- --foreground --timeseries --port=44566 --redishost=localhost --redisport=17001 --config=/var/tmp/pbench-test-utils/opt/pbench-agent/templates/pmproxy.conf
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/prometheus --config.file=/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus/prometheus.yml --storage.tsdb.path=/var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus --web.console.libraries=/usr/share/prometheus/console_libraries --web.console.templates=/usr/share/prometheus/consoles
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_a.example.com yes
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_b.example.com yes
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote_c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote_c.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-a.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-b.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o StrictHostKeyChecking=no remote-c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-c.example.com yes
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -80,6 +80,15 @@ while true; do
     esac
 done
 
+if [[ -z "${controller}" ]]; then
+    controller=${_pbench_full_hostname}
+    if [[ -z "${controller}" ]]; then
+	error_log "Missing controller name (should be \"hostname -f\" value)"
+	exit 1
+    fi
+fi
+validate_hostname "${controller}" "controller"
+
 # Move into pbench run collection directory
 cd ${pbench_run} >/dev/null
 if [[ ${?} -ne 0 ]]; then
@@ -101,14 +110,6 @@ fi
 if [[ ! -s ${tmp}/results.lis ]]; then
     # Nothing to do
     exit 0
-fi
-
-if [[ -z "${controller}" ]]; then
-    controller=${_pbench_full_hostname}
-    if [[ -z "${controller}" ]]; then
-	error_log "Missing controller name (should be \"hostname -f\" value)"
-	exit 1
-    fi
 fi
 
 if [[ ! -f "${pbench_bin}/id_rsa" ]]; then

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -278,6 +278,19 @@ else
 	fi
 fi
 
+invalids=0
+for (( i=0; ${i} < ${#remotes_A[@]}; i++ )); do
+	remote="${remotes_A[${i}]}"
+	validate-hostname "${remote}"
+	if [[ ${?} -ne 0 ]]; then
+		error_log "Invalid remote specified: '${remote}'"
+		(( invalids++ ))
+	fi
+done
+if [[ ${invalids} -gt 0 ]]; then
+	exit 1
+fi
+
 if [[ ${_do_test_labels} -ne 0 ]]; then
 	# Used by pbench-register-tool-set to avoid duplicating logic, we
 	# have been asked to exit early successfully if all argument

--- a/agent/util-scripts/test-bin/test-client-tool-meister
+++ b/agent/util-scripts/test-bin/test-client-tool-meister
@@ -54,11 +54,11 @@ register mpstat
 register dcgm
 
 if [[ "${2}" == "with-remotes" ]]; then
-    register mpstat remote_a.example.com
-    register mpstat remote_b.example.com blue
-    register node-exporter remote_b.example.com blue
-    register dcgm remote_c.example.com red
-    register pcp remote_c.example.com red
+    register mpstat "remote-a.example.com"
+    register mpstat "remote-b.example.com" blue
+    register node-exporter "remote-b.example.com" blue
+    register dcgm "remote-c.example.com" red
+    register pcp "remote-c.example.com" red
 fi
 
 # We created the benchmark_run_dir directory as the tool meister expects it to

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -31,7 +31,7 @@ mv ${_testopt}/config/pbench-agent.cfg ${_testopt}/config/pbench-agent.cfg.orig
 let res=res+${?}
 cp -a ${_tdir}/../templates/* ${_testopt}/templates/
 let res=res+${?}
-cp -a ${_tdir}/{require-rpm,pbench-*} ${_testopt}/util-scripts/
+cp -a ${_tdir}/{require-rpm,validate-*,pbench-*} ${_testopt}/util-scripts/
 let res=res+${?}
 cp -a ${_tdir}/tool-meister/pbench-* ${_testopt}/util-scripts/tool-meister/
 let res=res+${?}
@@ -345,6 +345,7 @@ let errs=0
 
 declare -A tools=(
     [test-00]="pbench-register-tool"
+    [test-01]="pbench-register-tool"
     [test-05]="pbench-start-tools"
     [test-06]="pbench-stop-tools"
     [test-07]="pbench-postprocess-tools"
@@ -371,6 +372,7 @@ declare -A tools=(
     [test-19]="test-tool-trigger"
     [test-20]="pbench-move-results"
     [test-21]="pbench-move-results"
+    [test-22]="pbench-move-results"
     [test-25]="pbench-verify-sysinfo-options"
     [test-26]="pbench-verify-sysinfo-options"
     [test-27]="pbench-verify-sysinfo-options"
@@ -413,6 +415,7 @@ declare -A sortem=(
 
 declare -A options=(
     [test-00]="--name=mpstat --group=default -- --interval=10"
+    [test-01]="--name=mpstat --group=default --remote=invalid_remote.example.com,good.example.com,bad_remote.example.com"
     [test-05]="--group=default --dir=42-iter/sample42"
     [test-06]="--group=default --dir=42-iter/sample42"
     [test-07]="--group=foobar --dir=${_testdir}/42-iter/sample42"
@@ -445,6 +448,7 @@ declare -A options=(
     [test-20]="--help"
     # pbench-move-results - no args, nothing to do
     #[test-21]=""
+    [test-22]="--controller=bad_host_name.example.com"
     [test-25]="all"
     [test-26]="none"
     [test-27]="default"
@@ -488,6 +492,7 @@ declare -A options=(
 )
 
 declare -A expected_status=(
+    [test-01]=1
     [test-09]=1
     [test-10]=1
     [test-11.07]=1
@@ -495,6 +500,7 @@ declare -A expected_status=(
     [test-11.11]=1
     [test-17]=1
     [test-18]=1
+    [test-22]=1
     [test-29]=1
     [test-44]=1
     [test-46]=1

--- a/agent/util-scripts/validate-hostname
+++ b/agent/util-scripts/validate-hostname
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""validate-hostname - validate the given hostname uses the proper syntax.
+
+Exits with 0 on success, with 1 on failure, only emitting a message on stderr
+if the argument is missing.
+"""
+
+import sys
+
+from pbench.agent.utils import validate_hostname
+
+
+try:
+    host_name = sys.argv[1]
+except IndexError:
+    print("Missing host name argument", file=sys.stderr)
+    exit_val = 1
+else:
+    exit_val = validate_hostname(host_name)
+sys.exit(exit_val)

--- a/agent/util-scripts/validate-ipaddress
+++ b/agent/util-scripts/validate-ipaddress
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""validate-ipaddress - check the first argument to see if it is a valid IP
+address (IPv4 or IPv6).  Returns 0 on success, 1 if the IP address is not
+valid, 2 if the IP address argument is missing, and 3 if an unexpected error
+is encountered.  No error message is emitted if the IP address is invalid.
+"""
+
+import ipaddress
+import sys
+
+try:
+    ipaddress.ip_address(sys.argv[1])
+except ValueError:
+    exit_val = 1
+except IndexError:
+    print("Missing IP address argument", file=sys.stderr)
+    exit_val = 2
+except Exception as exc:
+    print(f"Error processing IP address {sys.argv[1]}: {exc}", file=sys.stderr)
+    exit_val = 3
+else:
+    exit_val = 0
+sys.exit(exit_val)

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -1,5 +1,7 @@
+import ipaddress
 import logging
 import os
+import re
 import subprocess
 import sys
 
@@ -188,3 +190,43 @@ def collect_local_info(pbench_bin):
         hostdata[arg] = cp.stdout.strip() if cp.stdout is not None else ""
 
     return (version, seqno, sha1, hostdata)
+
+
+# Derived from https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+# with a few modifications: take advantage of ignoring case; use non-capturing
+# groups to improve efficiency; take advantage of RFC 1123 modification to RFC
+# 952 relaxing first character to be letter or digit, with the repetition moved
+# to the last group to alleviate backtracking.  Or in other words, a case-blind
+# comparison seeking a letter-or-digit, optionally followed by a sequence of 0
+# to 61 letter-or-digit-or-hyphens followed by a letter-or-digit, follwed by 0
+# or more instances of that same pattern preceded by a period.
+_allowed = re.compile(
+    r"[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?)*",
+    flags=re.IGNORECASE,
+)
+
+
+def validate_hostname(host_name: str):
+    """validate_hostname - validate the given hostname uses the proper syntax.
+
+    A host name that follows RFC 952 (amended by RFC 1123) is accepted only.
+    Host names are not resolved to IP addresses, and IP addresses are also
+    accepted.
+
+    Algorithm taken from: https://stackoverflow.com/questions/2532053/validate-a-hostname-string
+
+    Returns 0 on success, 1 on failure.
+    """
+    if not host_name or len(host_name) > 255:
+        return 1
+
+    if _allowed.fullmatch(host_name):
+        return 0
+
+    # It is not a valid host name, but could be a valid IP address.
+    try:
+        ipaddress.ip_address(host_name)
+    except ValueError:
+        return 1
+
+    return 0

--- a/lib/pbench/test/unit/agent/test_validate_hostname.py
+++ b/lib/pbench/test/unit/agent/test_validate_hostname.py
@@ -1,0 +1,15 @@
+"""Tests for validate_hostname
+"""
+
+from pbench.agent.utils import validate_hostname
+
+
+def test_validate_hostname():
+    assert validate_hostname("test") == 0
+    assert validate_hostname("test.example.com") == 0
+    assert validate_hostname("tes_t.example.com") == 1
+    assert validate_hostname("test-.example.com") == 1
+    assert validate_hostname("--run-label__") == 1
+    assert validate_hostname("127.0.0.1") == 0
+    assert validate_hostname("1270.0.0.1") == 0
+    assert validate_hostname("2001:0db8:85a3:0000:0000:8a2e:0370:7334") == 0


### PR DESCRIPTION
From issue #2201, it became apparent that we weren't validating hostnames, which led to weird, but valid, directory names for
controllers being created on the server.  One way this occurs is when the `_pbench_hostname` and or `_pbench_full_hostname` environment variables are defined with invalid values.

We add the new commands `validate-hostname` and `validate-ipaddress` to ensure the definition of those names are correct.

In the process of doing that, we found that we were using invalid host names in two of our unit tests.

----

Derived from PR #2181.