### PR TITLE
Add missing validate-* scripts

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -51,7 +51,9 @@ util-scripts = \
 	pbench-verify-sysinfo-options \
 	README.md \
 	require-rpm \
-	tool-meister
+	tool-meister \
+	validate-hostname \
+	validate-ipaddress
 
 # Scripts based on the Python Click package, which are generated during
 # installation.


### PR DESCRIPTION
PR #2207 failed to add the `validate-*` scripts it added to the RPM build process.