### PR TITLE
Simplify and consolidate Elasticsearch queries

### DIFF
--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -1,13 +1,11 @@
 import re
-from logging import Logger
-
+from flask import request, jsonify
 from flask.globals import current_app
 from flask_restful import Resource, abort
-from flask import request, jsonify
+from logging import Logger
 from urllib.parse import urljoin
 
 from pbench.server import PbenchServerConfig
-from pbench.server.api.resources.query_apis import get_index_prefix
 
 
 class EndpointConfig(Resource):
@@ -40,7 +38,7 @@ class EndpointConfig(Resource):
         self.logger = logger
         self.host = config.get("pbench-server", "host")
         self.uri_prefix = config.rest_uri
-        self.prefix = get_index_prefix(config)
+        self.prefix = config.get("Indexing", "index_prefix")
         self.commit_id = config.COMMIT_ID
 
     def get(self):

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -1,94 +1,504 @@
-"""
-Helper functions to get the elasticsearch specific configurations
-"""
+from datetime import datetime
+from enum import Enum
+from logging import Logger
+from typing import Any, AnyStr, Callable, Dict, List
+from urllib.parse import urljoin
 
+import requests
+from dateutil import parser as date_parser
 from dateutil import rrule
+from dateutil.relativedelta import relativedelta
+from flask import request
+from flask_restful import Resource, abort
 
-from configparser import NoSectionError, NoOptionError
+from pbench.server import PbenchServerConfig
+from pbench.server.api.auth import Auth
 
 
-def get_user_term(user: str):
-    """Elasticsearch doesn't index (or search for) null values, and it's not
-    clear we really want to consider "owner": null to be "owned" datasets, in
-    any case. (Nor will they be possible beyond the transition period where we
-    may retain limited support for 0.69 data.)
-
-    Instead, let a query for data with a missing or null "user" parameter find
-    all data that's set to allow public access. This by default includes all
-    "unowned" data, but also data owned by a user that's been published.
+class SchemaError(TypeError):
     """
-    if user:
-        term = {"authorization.owner": user}
-    else:
-        term = {"authorization.access": "public"}
-    return term
-
-
-def get_es_host(config):
-    try:
-        return config.get("elasticsearch", "host")
-    except (NoOptionError, NoSectionError):
-        return ""
-
-
-def get_es_port(config):
-    try:
-        return config.get("elasticsearch", "port")
-    except (NoOptionError, NoSectionError):
-        return ""
-
-
-def get_es_url(config):
-    try:
-        return f"http://{get_es_host(config)}:{get_es_port(config)}"
-    except (NoOptionError, NoSectionError):
-        return ""
-
-
-def get_index_prefix(config):
-    try:
-        return config.get("Indexing", "index_prefix")
-    except (NoOptionError, NoSectionError):
-        return ""
-
-
-def gen_month_range(prefix, index, start, end):
+    Generic base class for errors in processing a JSON schema.
     """
-    gen_month_range Construct a comma-separated list of index names
-    qualified by year and month suitable for use in the Elasticsearch
-    /_search query URI.
 
-    The month is incremented by 1 from "start" to "end"; for example,
+    pass
 
-    gen_month_range('drb.', 'v4.run.', '2020-08', '2020-10') will result
-    in
 
-        'drb.v4.run.2020-08,drb.v4.run.2020-09,drb.v4.run.2020-10,'
+class InvalidRequestPayload(SchemaError):
+    """
+    A required client JSON input document is missing.
+    """
 
-    This code is adapted from Javascript in the Pbench dashboard's
-    'moment_constants.js' getAllMonthsWithinRange function.
+    def __str__(self):
+        return "Invalid request payload"
+
+
+class MissingParameters(SchemaError):
+    """
+    One or more required JSON keys are missing, or the values are unexpectedly
+    empty.
+    """
+
+    def __init__(self, keys: List[AnyStr]):
+        self.keys = keys
+
+    def __str__(self):
+        return f"Missing required parameters: {','.join(self.keys)}"
+
+
+class ConversionError(SchemaError):
+    """
+    ConversionError Used to report an invalid parameter type
+    """
+
+    def __init__(self, value: Any, expected_type: str, actual_type: str):
+        """
+        __init__ Construct a ConversionError exception
+
+        Args:
+            value: The value we tried to convert
+            expected_type: The expected type
+            actual_type: The actual type
+        """
+        self.value = value
+        self.expected_type = expected_type
+        self.actual_type = actual_type
+
+    def __str__(self):
+        return f"Value {self.value!r} ({self.actual_type}) cannot be parsed as a {self.expected_type}"
+
+
+def convert_date(value: str) -> datetime:
+    """
+    convert_date Convert a date/time string to a datetime.datetime object.
 
     Args:
-        prefix ([string]): The Pbench server index prefix
-        index ([string]): The desired monthly index root
-        start ([datetime.datetime]): The start time
-        end ([datetime.datetime]): The end time
+        value: String representation of date/time
+
+    Raises:
+        ConversionError: input can't be converted
 
     Returns:
-        [string]: A comma-separated list of month-qualified index names
+        datetime.datetime object
     """
-    monthResults = list()
-    queryString = ""
-    for m in rrule.rrule(rrule.MONTHLY, dtstart=start, until=end):
-        monthResults.append(m.strftime("%Y-%m"))
+    try:
+        return date_parser.parse(value)
+    except Exception:
+        raise ConversionError(value, "date/time string", type(value).__name__)
 
-    # TODO: hardcoding the index here is risky. We need a framework to
-    # help the web services understand index versions and template
-    # formats, probably by building a persistent database from the
-    # index template documents at startup. This is TBD.
-    for monthValue in monthResults:
-        if index == "v4.result-data.":
-            queryString += f"{prefix + index + monthValue}-*,"
+
+def convert_username(value: str) -> str:
+    """
+    convert_username Convert the external representation of a username
+    by validating that the specified username exists, and returns the
+    desired internal representation of that user.
+
+    TODO: when we get our user model straightened out, this will
+    convert the external user representation (either username or email
+    address) to whatever internal representation we want to store in
+    the Elasticsearch database, whether that's a SQL row ID or something
+    else. For now, it just validates that the username string is a real
+    user.
+
+    Args:
+        value: external user representation
+
+    Raises:
+        ConversionError: input can't be converted
+
+    Returns:
+        internal username representation
+    """
+    try:
+        return Auth.validate_user(value)
+    except Exception:
+        raise ConversionError(value, "username", type(value).__name__)
+
+
+def convert_json(value: dict) -> dict:
+    """
+    convert_json Process a parameter of JSON type; currently just by validating
+    that it's a Python dict.
+
+    Args:
+        value: JSON dict
+
+    Raises:
+        ConversionError: input can't be converted
+
+    Returns:
+        The JSON dict
+    """
+    if type(value) is not dict:
+        raise ConversionError(value, dict.__name__, type(value).__name__)
+    return value
+
+
+def convert_string(value: str) -> str:
+    """
+    convert_string Verify that the parameter value is a string (e.g.,
+    not a JSON dict, or an int), and return it.
+
+    Args:
+        value: parameter value
+
+    Raises:
+        ConversionError: input can't be converted
+
+    Returns:
+        the input value
+    """
+    if type(value) is not str:
+        raise ConversionError(value, str.__name__, type(value).__name__)
+    return value
+
+
+class ParamType(Enum):
+    """
+    Define the possible JSON query parameter keys, and their type.
+
+    The common code can perform conversions on the required parameters with
+    known types.
+    """
+
+    DATE = ("Date", convert_date)
+    USER = ("User", convert_username)
+    JSON = ("Json", convert_json)
+    STRING = ("String", convert_string)
+
+    def __init__(self, name: AnyStr, convert: Callable[[AnyStr], Any]):
+        """
+        ParamType Enum initializer: this uses a mixed-case name string in
+        addition to the conversion method simply because with only the
+        Callable value I ran into naming issues.
+        """
+        self.friendly = name
+        self.convert = convert
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class Parameter:
+    """
+    Define the attributes of a parameter using the ParamType ENUM
+
+    Note that a parameter that's "required" must also be non-empty.
+    """
+
+    def __init__(self, name: AnyStr, type: ParamType, required: bool = False):
+        """
+        __init__ Initialize a Parameter object describing a JSON parameter
+        with its type and attributes.
+
+        Args:
+            name: Parameter name
+            type: Parameter type
+            required: whether the parameter is required (default to False)
+        """
+        self.name = name
+        self.type = type
+        self.required = required
+
+    def invalid(self, json: Dict[AnyStr, Any]) -> bool:
+        """
+        Check whether the value of this parameter in the JSON document
+        is invalid.
+
+        If the parameter is required and missing (or null), then it's invalid;
+        if the parameter is not required and specified as null, it's invalid.
+
+        Args:
+            json: The client JSON document being validated.
+
+        Returns:
+            True if unacceptable
+        """
+        return not json[self.name] if self.name in json else self.required
+
+    def __str__(self) -> str:
+        return f"Parameter<{self.name}:{self.type}>"
+
+
+class Schema:
+    """
+    Define the client input schema for a server query that's based on
+    Elasticsearch.
+
+    This provides methods to help validate a JSON client request payload as
+    well as centralizing some type conversions.
+
+    This (and supporting classes above) are part of this module because they're
+    currently used only by the ElasticBase class. If they're found later to
+    have wider use they can be split out into a separate module.
+    """
+
+    def __init__(self, *parameters: Parameter):
+        """
+        __init__ Specify an interface schema as a list of Parameter objects.
+
+        Args:
+            parameters: a list of Parameter objects
+        """
+        self.parameters = {p.name: p for p in parameters}
+
+    def validate(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """
+        validate Validate an incoming JSON document against the schema and
+        return a new JSON dict with translated values.
+
+        Args:
+            json_data: Incoming client JSON document
+
+        Returns:
+            New JSON document with validated and possibly translated values
+        """
+        if not json_data:
+            raise InvalidRequestPayload()
+
+        bad_keys = [n for n, p in self.parameters.items() if p.invalid(json_data)]
+        if len(bad_keys) > 0:
+            raise MissingParameters(bad_keys)
+
+        processed = {}
+        for p in json_data:
+            tp = self.parameters.get(p)
+            processed[p] = tp.type.convert(json_data[p]) if tp else json_data[p]
+        return processed
+
+    def __str__(self) -> str:
+        return f"Schema<{self.parameters}>"
+
+
+class ElasticBase(Resource):
+    """
+    ElasticBase A base class for Elasticsearch queries that allows subclasses
+    to provide customers pre- and post- processing.
+
+    This class extends the Flask Resource class in order to connect the post
+    and get methods to Flask's URI routing algorithms. It implements a common
+    JSON client payload intake and validation, along with the mechanism for
+    calling Elasticsearch and processing errors.
+
+    Hooks are defined for subclasses extending this class to "assemble" the
+    Elasticsearch request payload from Pbench server data and the client's
+    JSON payload, and to "postprocess" a successful response payload from
+    Elasticsearch.
+    """
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger, schema: Schema):
+        """
+        __init__ Construct the base class
+
+        Args:
+            config: server configuration
+            logger: logger object
+            schema: API schema: for example,
+                    Schema(
+                        Parameter("user", ParamType.USER, required=True),
+                        Parameter("start", ParamType.DATE)
+                    )
+
+        NOTE: each class currently only supports one HTTP method, so we can
+        describe only one set of parameters. If we ever need to change this,
+        we can add a level and describe parameters by method.
+        """
+        super().__init__()
+        self.logger = logger
+        self.prefix = config.get("Indexing", "index_prefix")
+        host = config.get("elasticsearch", "host")
+        port = config.get("elasticsearch", "port")
+        self.es_url = f"http://{host}:{port}"
+        self.schema = schema
+
+    def _get_user_term(self, user: str) -> dict:
+        """
+        _get_user_term Generate the user term for an Elasticsearch document
+        query. If the specified user parameter is not None, search for
+        documents with that value as the authorized owner. If the user
+        parameter is None, instead search for documents with public access.
+
+        Args:
+            user: Pbench internal username or None
+
+        Returns:
+            An assembled Elasticsearch query term
+        """
+        if user:
+            term = {"authorization.owner": user}
         else:
-            queryString += f"{prefix + index + monthValue},"
-    return queryString
+            term = {"authorization.access": "public"}
+        return term
+
+    def _gen_month_range(self, index: str, start: datetime, end: datetime) -> str:
+        """
+        _gen_month_range Construct a comma-separated list of index names
+        qualified by year and month suitable for use in the Elasticsearch
+        /_search query URI.
+
+        The month is incremented by 1 from "start" to "end"; for example,
+        _gen_month_range('v4.run.', '2020-08', '2020-10') will result
+        in
+
+            'drb.v4.run.2020-08,drb.v4.run.2020-09,drb.v4.run.2020-10,'
+
+        Args:
+            index: The desired monthly index root
+            start: The start time
+            end: The end time
+
+        Returns:
+            A comma-separated list of month-qualified index names
+        """
+        monthResults = list()
+        queryString = ""
+        first_month = start.replace(day=1)
+        last_month = end + relativedelta(day=31)
+        for m in rrule.rrule(rrule.MONTHLY, dtstart=first_month, until=last_month):
+            monthResults.append(m.strftime("%Y-%m"))
+
+        # TODO: hardcoding the index here is risky. We need a framework to
+        # help the web services understand index versions and template
+        # formats, probably by building a persistent database from the
+        # index template documents at startup. This is TBD.
+        for monthValue in monthResults:
+            if index == "v4.result-data.":
+                queryString += f"{self.prefix + index + monthValue}-*,"
+            else:
+                queryString += f"{self.prefix + index + monthValue},"
+        return queryString
+
+    def assemble(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """
+        assemble Assemble the Elasticsearch parameters
+
+        This must be overridden by the subclasses!
+
+        Args:
+            json_data: Input JSON payload, processed by type conversion
+
+        Raises:
+            Any errors in the assemble method shall be reported by exceptions
+            which will be logged and will terminate the operation.
+
+        Returns:
+            A dict describing the URI path, the json body, and query parameters
+            to pass to Elasticsearch:
+                path: The path part of the Elasticsearch URI
+                kwargs: A kwargs dict for the requests API; e.g.,
+                    json: The JSON query to pass to Elasticsearch
+                    params: Query parameters to pass to Elasticsearch
+                    headers: Request headers
+        """
+        raise NotImplementedError()
+
+    def postprocess(self, es_json: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """
+        postprocess Given the Elasticsearch Response object, construct a JSON
+                dict to be returned to the original caller.
+
+        This must be overridden by the subclasses!
+
+        Args:
+            response: Response object
+
+        Raises:
+            Any errors in the postprocess method shall be reported by
+            exceptions which will be logged and will terminate the operation.
+
+        Returns:
+            The JSON payload to be returned to the caller
+        """
+        raise NotImplementedError()
+
+    def _call(self, method: Callable, json_data: Dict[AnyStr, Any]):
+        """
+        _call Perform the requested call to Elasticsearch, and handle any
+        exceptions.
+
+        Args:
+            method: Any requests HTTP method (e.g., requests.post)
+            json_data: Type-normalized client JSON input
+
+        Returns:
+            Postprocessed JSON body to return to client
+        """
+        try:
+            es_request = self.assemble(json_data)
+            path = es_request.get("path")
+            url = urljoin(self.es_url, path)
+        except Exception as e:
+            self.logger.exception("Blew it in setup: {}", type(e).__name__)
+            abort(500, message="INTERNAL ERROR")
+
+        try:
+            # query Elasticsearch
+            es_response = method(url, **es_request["kwargs"])
+            es_response.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            self.logger.exception("HTTP error {} from Elasticsearch request", e)
+            abort(
+                502,
+                message="Elasticsearch query failure {e.response.reason} ({e.response.status_code})",
+            )
+        except requests.exceptions.ConnectionError:
+            self.logger.exception("Connection refused during the Elasticsearch request")
+            abort(502, message="Network problem, could not reach Elasticsearch")
+        except requests.exceptions.Timeout:
+            self.logger.exception(
+                "Connection timed out during the Elasticsearch request"
+            )
+            abort(504, message="Connection timed out, could reach Elasticsearch")
+        except requests.exceptions.InvalidURL:
+            self.logger.exception(
+                "Invalid url {} during the Elasticsearch request", url
+            )
+            abort(500, message="INTERNAL ERROR")
+        except Exception as e:
+            self.logger.exception(
+                "Exception {} occurred during the Elasticsearch request",
+                type(e).__name__,
+            )
+            abort(500, message="INTERNAL ERROR")
+
+        try:
+            return self.postprocess(es_response.json())
+        except Exception as e:
+            self.logger.exception(
+                "Unexpected problem postprocessing Elasticsearch response {}: {}",
+                es_response.json(),
+                e,
+            )
+            abort(500, message="INTERNAL ERROR")
+
+    def post(self):
+        """
+        Handle a Pbench server POST operation that will involve a call to the
+        server's configured Elasticsearch instance. The assembly and
+        post-processing of the Elasticsearch query are handled by the
+        subclasses through the assemble() and postprocess() methods;
+        we do basic parameter validation and conversions here.
+
+        Each subclass provides a schema for allowed JSON parameters: this
+        code processes each JSON parameter in the dict to perform type
+        validation/conversion where necessary. Missing "required" parameters
+        and any parameter with a null value are rejected. Parameters that
+        are not in the class schema are ignored but logged.
+        """
+        json_data = request.get_json(silent=True)
+        try:
+            new_data = self.schema.validate(json_data)
+        except SchemaError as e:
+            # The format string here is important as the value we're
+            # trying to convert might contain "{}" brackets that would
+            # be interpreted as formatting commands.
+            self.logger.warning("{}", str(e))
+            abort(400, message=str(e))
+        return self._call(requests.post, new_data)
+
+    def get(self):
+        """
+        Handle a GET operation involving a call to the server's Elasticsearch
+        instance. The post-processing of the Elasticsearch query is handled
+        the subclasses through their postprocess() methods.
+        """
+        return self._call(requests.get, None)

--- a/lib/pbench/server/api/resources/query_apis/controllers_list.py
+++ b/lib/pbench/server/api/resources/query_apis/controllers_list.py
@@ -1,39 +1,35 @@
-from dateutil import parser
+from flask import jsonify
 from logging import Logger
-
-from flask import request, jsonify
-from flask_restful import Resource, abort
-import requests
+from typing import Any, AnyStr, Dict
 
 from pbench.server import PbenchServerConfig
 from pbench.server.api.resources.query_apis import (
-    get_es_url,
-    get_index_prefix,
-    gen_month_range,
-    get_user_term,
+    ElasticBase,
+    Schema,
+    Parameter,
+    ParamType,
 )
 
 
-class ControllersList(Resource):
+class ControllersList(ElasticBase):
     """
     Get the names of controllers within a date range.
     """
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
-        """
-        __init__ Initialize the resource with info each call will need.
+        super().__init__(
+            config,
+            logger,
+            Schema(
+                Parameter("user", ParamType.USER, required=True),
+                Parameter("start", ParamType.DATE, required=True),
+                Parameter("end", ParamType.DATE, required=True),
+            ),
+        )
 
-        Args:
-            :config: The Pbench server config object
-            :logger: a logger
+    def assemble(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
         """
-        self.logger = logger
-        self.es_url = get_es_url(config)
-        self.prefix = get_index_prefix(config)
-
-    def post(self):
-        """
-        POST to search for Pbench controller names which have registered
+        Construct a search for Pbench controller names which have registered
         datasets within a specified date range and which are either owned
         by a specified username, or have been made publicly accessible.
 
@@ -43,7 +39,7 @@ class ControllersList(Resource):
             "end": "end-time"
         }
 
-        JSON parameters:
+        json_data: JSON dictionary of type-normalized parameters
             user: specifies the owner of the data to be searched; it need not
                 necessarily be the user represented by the session token
                 header, assuming the session user is authorized to view "user"s
@@ -58,9 +54,66 @@ class ControllersList(Resource):
                 "access": "public", "access": "private", or "access": "all" to
                 include both private and public data.
 
-            "start" and "end" are time strings representing a set of Elasticsearch
+            "start" and "end" are datetime objects representing a set of Elasticsearch
                 run document indices in which to search.
+        """
+        user = json_data["user"]
+        start = json_data["start"]
+        end = json_data["end"]
 
+        # We need to pass string dates as part of the Elasticsearch query; we
+        # use the unconverted strings passed by the caller rather than the
+        # adjusted and normalized datetime objects for this.
+        start_arg = f"{start:%Y-%m}"
+        end_arg = f"{end:%Y-%m}"
+
+        self.logger.info(
+            "Discover controllers for user {}, prefix {}: ({} - {})",
+            user,
+            self.prefix,
+            start,
+            end,
+        )
+
+        # TODO: Need to refactor the template processing code from indexer.py
+        # to maintain the essential indexing information in a persistent DB
+        # (probably a Postgresql table) so that it can be shared here and by
+        # the indexer without re-loading on each access. For now, the index
+        # version is hardcoded.
+        uri_fragment = self._gen_month_range(".v6.run-data.", start, end)
+        return {
+            "path": f"/{uri_fragment}/_search",
+            "kwargs": {
+                "json": {
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {"term": self._get_user_term(user)},
+                                {
+                                    "range": {
+                                        "@timestamp": {"gte": start_arg, "lte": end_arg}
+                                    }
+                                },
+                            ]
+                        }
+                    },
+                    "size": 0,  # Don't return "hits", only aggregations
+                    "aggs": {
+                        "controllers": {
+                            "terms": {
+                                "field": "run.controller",
+                                "order": [{"runs": "desc"}],
+                            },
+                            "aggs": {"runs": {"max": {"field": "run.start"}}},
+                        }
+                    },
+                },
+                "params": {"ignore_unavailable": "true"},
+            },
+        }
+
+    def postprocess(self, es_json: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """
         Returns a summary of the returned Elasticsearch query results, showing
         the Pbench controller name, the number of runs using that controller
         name, and the start timestamp of the latest run both in binary and
@@ -76,115 +129,16 @@ class ControllersList(Resource):
             }
         ]
         """
-        json_data = request.get_json(silent=True)
-        if not json_data:
-            self.logger.info("Invalid JSON object. Query: {}", request.url)
-            abort(400, message="Invalid request payload")
-
-        try:
-            user = json_data["user"]
-            start_arg = json_data["start"]
-            end_arg = json_data["end"]
-        except KeyError:
-            keys = [k for k in ("user", "start", "end") if k not in json_data]
-            self.logger.info("Missing required JSON keys {}", ",".join(keys))
-            abort(400, message=f"Missing request data: {','.join(keys)}")
-
-        try:
-            start = parser.parse(start_arg).replace(day=1)
-            end = parser.parse(end_arg).replace(day=1)
-        except Exception as e:
-            self.logger.info(
-                "Invalid start or end time string: {}, {}: {}", start_arg, end_arg, e
-            )
-            abort(400, message="Invalid start or end time string")
-
-        self.logger.info(
-            "Discover controllers for user {}, prefix {}: ({} - {})",
-            user,
-            self.prefix,
-            start,
-            end,
-        )
-
-        payload = {
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"term": get_user_term(user)},
-                        {"range": {"@timestamp": {"gte": start_arg, "lte": end_arg}}},
-                    ]
-                }
-            },
-            "size": 0,  # Don't return "hits", only aggregations
-            "aggs": {
-                "controllers": {
-                    "terms": {"field": "run.controller", "order": [{"runs": "desc"}]},
-                    "aggs": {"runs": {"max": {"field": "run.start"}}},
-                }
-            },
-        }
-
-        # TODO: Need to refactor the template processing code from indexer.py
-        # to maintain the essential indexing information in a persistent DB
-        # (probably a Postgresql table) so that it can be shared here and by
-        # the indexer without re-loading on each access. For now, the index
-        # version is hardcoded.
-        uri_fragment = gen_month_range(self.prefix, ".v6.run-data.", start, end)
-
-        uri = f"{self.es_url}/{uri_fragment}/_search"
-        try:
-            # query Elasticsearch
-            es_response = requests.post(
-                uri,
-                params={"ignore_unavailable": "true"},
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
-                json=payload,
-            )
-            es_response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            self.logger.exception("HTTP error {} from Elasticsearch post request", e)
-            abort(502, message="INTERNAL ERROR")
-        except requests.exceptions.ConnectionError:
-            self.logger.exception(
-                "Connection refused during the Elasticsearch post request"
-            )
-            abort(502, message="Network problem, could not post to Elasticsearch")
-        except requests.exceptions.Timeout:
-            self.logger.exception(
-                "Connection timed out during the Elasticsearch post request"
-            )
-            abort(504, message="Connection timed out, could not post to Elasticsearch")
-        except requests.exceptions.InvalidURL:
-            self.logger.exception(
-                "Invalid url {} during the Elasticsearch post request", uri
-            )
-            abort(500, message="INTERNAL ERROR")
-        except Exception:
-            self.logger.exception(
-                "Exception occurred during the Elasticsearch post request"
-            )
-            abort(500, message="INTERNAL ERROR")
-        else:
-            controllers = []
-            try:
-                es_json = es_response.json()
-                buckets = es_json["aggregations"]["controllers"]["buckets"]
-                self.logger.info("{} controllers found", len(buckets))
-                for controller in buckets:
-                    c = {}
-                    c["key"] = controller["key"]
-                    c["controller"] = controller["key"]
-                    c["results"] = controller["doc_count"]
-                    c["last_modified_value"] = controller["runs"]["value"]
-                    c["last_modified_string"] = controller["runs"]["value_as_string"]
-                    controllers.append(c)
-            except KeyError:
-                self.logger.exception("ES response not formatted as expected")
-                abort(500, message="INTERNAL ERROR")
-            else:
-                # construct response object
-                return jsonify(controllers)
+        controllers = []
+        buckets = es_json["aggregations"]["controllers"]["buckets"]
+        self.logger.info("{} controllers found", len(buckets))
+        for controller in buckets:
+            c = {}
+            c["key"] = controller["key"]
+            c["controller"] = controller["key"]
+            c["results"] = controller["doc_count"]
+            c["last_modified_value"] = controller["runs"]["value"]
+            c["last_modified_string"] = controller["runs"]["value_as_string"]
+            controllers.append(c)
+        # construct response object
+        return jsonify(controllers)

--- a/lib/pbench/server/api/resources/query_apis/datasets_list.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_list.py
@@ -1,37 +1,35 @@
-from logging import Logger
-
-from flask import request, jsonify
-from flask_restful import Resource, abort
-import requests
-
 from dateutil import parser
+from flask import jsonify
+from logging import Logger
+from typing import Any, AnyStr, Dict
+
 from pbench.server import PbenchServerConfig
 from pbench.server.api.resources.query_apis import (
-    get_es_url,
-    get_index_prefix,
-    gen_month_range,
-    get_user_term,
+    ElasticBase,
+    Schema,
+    Parameter,
+    ParamType,
 )
 
 
-class DatasetsList(Resource):
+class DatasetsList(ElasticBase):
     """
     Get a list of dataset run documents for a controller.
     """
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
-        """
-        __init__ Initialize the resource with info each call will need.
+        super().__init__(
+            config,
+            logger,
+            Schema(
+                Parameter("user", ParamType.USER, required=True),
+                Parameter("controller", ParamType.STRING, required=True),
+                Parameter("start", ParamType.DATE, required=True),
+                Parameter("end", ParamType.DATE, required=True),
+            ),
+        )
 
-        Args:
-            :config: The Pbench server config object
-            :logger: a logger
-        """
-        self.logger = logger
-        self.es_url = get_es_url(config)
-        self.prefix = get_index_prefix(config)
-
-    def post(self):
+    def assemble(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
         """
         Get a list of datasets recorded for a particular controller and either
         owned by a specified username, or publicly accessible, within the set
@@ -57,7 +55,60 @@ class DatasetsList(Resource):
             "start" and "end" are time strings representing a set of
                 Elasticsearch run document indices in which the dataset will be
                 found.
+            """
+        user = json_data["user"]
+        controller = json_data["controller"]
+        start = json_data["start"]
+        end = json_data["end"]
 
+        self.logger.info(
+            "Discover datasets for user {}, prefix {}: ({}: {} - {})",
+            user,
+            self.prefix,
+            controller,
+            start,
+            end,
+        )
+
+        # TODO: Need to refactor the template processing code from indexer.py
+        # to maintain the essential indexing information in a persistent DB
+        # (probably a Postgresql table) so that it can be shared here and by
+        # the indexer without re-loading on each access. For now, the index
+        # version is hardcoded.
+        uri_fragment = self._gen_month_range(".v6.run-data.", start, end)
+        return {
+            "path": f"/{uri_fragment}/_search",
+            "kwargs": {
+                "json": {
+                    "_source": {
+                        "includes": [
+                            "@metadata.controller_dir",
+                            "@metadata.satellite",
+                            "run.controller",
+                            "run.start",
+                            "run.end",
+                            "run.name",
+                            "run.config",
+                            "run.prefix",
+                            "run.id",
+                        ]
+                    },
+                    "sort": {"run.end": {"order": "desc"}},
+                    "query": {
+                        "bool": {
+                            "filter": [
+                                {"term": self._get_user_term(user)},
+                                {"term": {"run.controller": controller}},
+                            ]
+                        }
+                    },
+                    "size": 5000,
+                }
+            },
+        }
+
+    def postprocess(self, es_json: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        """
         Returns a list of run documents including the name, the associated
         controller, start and end timestamps:
         [
@@ -71,152 +122,41 @@ class DatasetsList(Resource):
             }
         ]
         """
-        json_data = request.get_json(silent=True)
-        if not json_data:
-            self.logger.info("Invalid JSON object. Query: {}", request.url)
-            abort(400, message="Invalid request payload")
-
-        try:
-            user = json_data["user"]
-            controller = json_data["controller"]
-            start_arg = json_data["start"]
-            end_arg = json_data["end"]
-        except KeyError:
-            keys = [
-                k for k in ("user", "controller", "start", "end") if k not in json_data
-            ]
-            self.logger.info("Missing required JSON keys {}", ",".join(keys))
-            abort(400, message=f"Missing request data: {','.join(keys)}")
-
-        try:
-            start = parser.parse(start_arg).replace(day=1)
-            end = parser.parse(end_arg).replace(day=1)
-        except Exception as e:
-            self.logger.info(
-                "Invalid start or end time string: {}, {}: {}", start_arg, end_arg, e
-            )
-            abort(400, message="Invalid start or end time string")
-
-        self.logger.info(
-            "Discover datasets for user {}, prefix {}: ({}: {} - {})",
-            user,
-            self.prefix,
-            controller,
-            start,
-            end,
-        )
-
-        payload = {
-            "_source": {
-                "includes": [
-                    "@metadata.controller_dir",
-                    "@metadata.satellite",
-                    "run.controller",
-                    "run.start",
-                    "run.end",
-                    "run.name",
-                    "run.config",
-                    "run.prefix",
-                    "run.id",
-                ]
-            },
-            "sort": {"run.end": {"order": "desc"}},
-            "query": {
-                "bool": {
-                    "filter": [
-                        {"term": get_user_term(user)},
-                        {"term": {"run.controller": controller}},
-                    ]
-                }
-            },
-            "size": 5000,
-        }
-
-        # TODO: Need to refactor the template processing code from indexer.py
-        # to maintain the essential indexing information in a persistent DB
-        # (probably a Postgresql table) so that it can be shared here and by
-        # the indexer without re-loading on each access. For now, the index
-        # version is hardcoded.
-        uri_fragment = gen_month_range(self.prefix, ".v6.run-data.", start, end)
-
-        uri = f"{self.es_url}/{uri_fragment}/_search"
-        try:
-            # query Elasticsearch
-            es_response = requests.post(
-                uri,
-                params={"ignore_unavailable": "true"},
-                headers={
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
-                json=payload,
-            )
-            es_response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            self.logger.exception("HTTP error {} from Elasticsearch post request", e)
-            abort(502, message="INTERNAL ERROR")
-        except requests.exceptions.ConnectionError:
-            self.logger.exception(
-                "Connection refused during the Elasticsearch post request"
-            )
-            abort(502, message="Network problem, could not post to Elasticsearch")
-        except requests.exceptions.Timeout:
-            self.logger.exception(
-                "Connection timed out during the Elasticsearch post request"
-            )
-            abort(504, message="Connection timed out, could not post to Elasticsearch")
-        except requests.exceptions.InvalidURL:
-            self.logger.exception(
-                "Invalid url {} during the Elasticsearch post request", uri
-            )
-            abort(500, message="INTERNAL ERROR")
-        except Exception:
-            self.logger.exception(
-                "Exception occurred during the Elasticsearch post request"
-            )
-            abort(500, message="INTERNAL ERROR")
-        else:
-            datasets = []
+        datasets = []
+        hits = es_json["hits"]["hits"]
+        self.logger.info("{} controllers found", len(hits))
+        for dataset in hits:
+            src = dataset["_source"]
+            run = src["run"]
+            d = {
+                "key": run["name"],
+                "run.name": run["name"],
+                "run.controller": run["controller"],
+                "run.start": run["start"],
+                "run.end": run["end"],
+                "id": run["id"],
+            }
             try:
-                es_json = es_response.json()
-                hits = es_json["hits"]["hits"]
-                self.logger.info("{} controllers found", len(hits))
-                for dataset in hits:
-                    src = dataset["_source"]
-                    run = src["run"]
-                    d = {
-                        "key": run["name"],
-                        "run.name": run["name"],
-                        "run.controller": run["controller"],
-                        "run.start": run["start"],
-                        "run.end": run["end"],
-                        "id": run["id"],
-                    }
-                    try:
-                        timestamp = parser.parse(run["start"]).utcfromtimestamp()
-                    except Exception as e:
-                        self.logger.info(
-                            "Can't parse start time {} to integer timestamp: {}",
-                            run["start"],
-                            e,
-                        )
-                        timestamp = dataset["sort"][0]
+                timestamp = parser.parse(run["start"]).utcfromtimestamp()
+            except Exception as e:
+                self.logger.info(
+                    "Can't parse start time {} to integer timestamp: {}",
+                    run["start"],
+                    e,
+                )
+                timestamp = dataset["sort"][0]
 
-                    d["startUnixTimestamp"] = timestamp
-                    if "config" in run:
-                        d["run.config"] = run["config"]
-                    if "prefix" in run:
-                        d["run.prefix"] = run["prefix"]
-                    if "@metadata" in src:
-                        meta = src["@metadata"]
-                        if "controller_dir" in meta:
-                            d["@metadata.controller_dir"] = meta["controller_dir"]
-                        if "satellite" in meta:
-                            d["@metadata.satellite"] = meta["satellite"]
-                    datasets.append(d)
-            except KeyError:
-                self.logger.exception("ES response not formatted as expected")
-                abort(500, message="INTERNAL ERROR")
-            else:
-                # construct response object
-                return jsonify(datasets)
+            d["startUnixTimestamp"] = timestamp
+            if "config" in run:
+                d["run.config"] = run["config"]
+            if "prefix" in run:
+                d["run.prefix"] = run["prefix"]
+            if "@metadata" in src:
+                meta = src["@metadata"]
+                if "controller_dir" in meta:
+                    d["@metadata.controller_dir"] = meta["controller_dir"]
+                if "satellite" in meta:
+                    d["@metadata.satellite"] = meta["satellite"]
+            datasets.append(d)
+        # construct response object
+        return jsonify(datasets)

--- a/lib/pbench/server/api/resources/query_apis/month_indices.py
+++ b/lib/pbench/server/api/resources/query_apis/month_indices.py
@@ -1,92 +1,36 @@
-from logging import Logger
-
 from flask import jsonify
-from flask_restful import Resource, abort
-import requests
+from logging import Logger
+from typing import Any, AnyStr, Dict
 
 from pbench.server import PbenchServerConfig
-from pbench.server.api.resources.query_apis import get_es_url, get_index_prefix
+from pbench.server.api.resources.query_apis import ElasticBase, Schema
 
 
-class MonthIndices(Resource):
+class MonthIndices(ElasticBase):
     """
     Get the range of dates in which datasets exist.
     """
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
-        """
-        __init__ Initialize the resource with info each call will need.
+        super().__init__(config, logger, Schema())
 
-        Args:
-            :config: The Pbench server config object
-            :logger: a logger
-        """
-        self.logger = logger
-        self.es_url = get_es_url(config)
-        self.prefix = get_index_prefix(config)
-
-    def get(self):
+    def assemble(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
         """
         Report the month suffixes for run data indices.
 
-        NOTE: No authorization or input parameters are required for this API.
-
-        Returns a list of "YYYY-mm" date strings corresponding to the months in
-        which tarballs were indexed into the appropriate run-data index. (E.g.,
-        drb.v6.run-data.2020-11). This list is in DESCENDING order:
-
-        [
-            "2020-12",
-            "2020-11",
-            "2020-04"
-        ]
+        NOTE: No authorization or input parameters are required for this API,
+        and there is no JSON query to form.
         """
-        self.logger.info(
-            "Discover months for run-data index prefix {}", self.prefix,
-        )
+        return {"path": "/_aliases", "kwargs": {}}
 
-        uri = f"{self.es_url}/_aliases"
-        try:
-            # query Elasticsearch
-            es_response = requests.get(uri, headers={"Accept": "application/json"})
-            es_response.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            self.logger.exception("HTTP error {} from Elasticsearch post request", e)
-            abort(502, message="INTERNAL ERROR")
-        except requests.exceptions.ConnectionError:
-            self.logger.exception(
-                "Connection refused during the Elasticsearch post request"
-            )
-            abort(502, message="Network problem, could not post to Elasticsearch")
-        except requests.exceptions.Timeout:
-            self.logger.exception(
-                "Connection timed out during the Elasticsearch post request"
-            )
-            abort(504, message="Connection timed out, could not post to Elasticsearch")
-        except requests.exceptions.InvalidURL:
-            self.logger.exception(
-                "Invalid url {} during the Elasticsearch post request", uri
-            )
-            abort(500, message="INTERNAL ERROR")
-        except Exception:
-            self.logger.exception(
-                "Exception occurred during the Elasticsearch post request"
-            )
-            abort(500, message="INTERNAL ERROR")
-        else:
-            months = []
-            target = f"{self.prefix}.v6.run-data."
-            try:
-                es_json = es_response.json()
-                self.logger.info("looking for {} in {}", target, es_json)
-                for index in es_json.keys():
-                    if target in index:
-                        months.append(index.split(".")[-1])
-                months.sort(reverse=True)
-                self.logger.info("found months {!r}", months)
-            except KeyError:
-                self.logger.exception("ES response not formatted as expected")
-                abort(500, message="INTERNAL ERROR")
-            else:
-                # construct response object
-                return jsonify(months)
+    def postprocess(self, es_json: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
+        months = []
+        target = f"{self.prefix}.v6.run-data."
+        self.logger.info("looking for {} in {}", target, es_json)
+        for index in es_json.keys():
+            if target in index:
+                months.append(index.split(".")[-1])
+        months.sort(reverse=True)
+        self.logger.info("found months {!r}", months)
+        # construct response object
+        return jsonify(months)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -3,6 +3,7 @@ import tempfile
 import pytest
 from pathlib import Path
 from pbench.server.api import create_app, get_server_config
+from pbench.server.api.auth import Auth
 
 
 server_cfg_tmpl = """[DEFAULT]
@@ -103,3 +104,16 @@ def client(server_config):
     app_client.debug = True
     app_client.testing = True
     return app_client
+
+
+@pytest.fixture
+def user_ok(monkeypatch):
+    """
+    Override the Auth.validate_user method to pass without checking the
+    database.
+    """
+
+    def ok(user: str) -> str:
+        return user
+
+    monkeypatch.setattr(Auth, "validate_user", ok)

--- a/lib/pbench/test/unit/server/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/test_datasets_detail.py
@@ -2,8 +2,6 @@ import pytest
 import re
 import requests
 
-from pbench.server.api.resources.query_apis import get_es_url, get_index_prefix
-
 
 @pytest.fixture
 def query_helper(client, server_config, requests_mock):
@@ -24,7 +22,9 @@ def query_helper(client, server_config, requests_mock):
     """
 
     def query_helper(payload, expected_index, expected_status, server_config, **kwargs):
-        es_url = get_es_url(server_config)
+        host = server_config.get("elasticsearch", "host")
+        port = server_config.get("elasticsearch", "port")
+        es_url = f"http://{host}:{port}"
         requests_mock.post(re.compile(f"{es_url}"), **kwargs)
         response = client.post(
             f"{server_config.rest_uri}/datasets/detail", json=payload
@@ -54,8 +54,7 @@ class TestDatasetsDetail:
         Args:
             dates (iterable): list of date strings
         """
-        prefix = get_index_prefix(server_config)
-        idx = prefix + ".v6.run-data."
+        idx = server_config.get("Indexing", "index_prefix") + ".v6.run-data."
         index = "/"
         for d in dates:
             index += f"{idx}{d},"
@@ -82,7 +81,7 @@ class TestDatasetsDetail:
             {"start": "2020", "end": "2020"},
         ),
     )
-    def test_missing_keys(self, client, server_config, keys):
+    def test_missing_keys(self, client, server_config, keys, user_ok):
         """
         test_missing_keys Test behavior when JSON payload does not contain
         all required keys.
@@ -95,10 +94,11 @@ class TestDatasetsDetail:
         assert response.status_code == 400
         missing = [k for k in ("user", "name", "start", "end") if k not in keys]
         assert (
-            response.json.get("message") == f"Missing request data: {','.join(missing)}"
+            response.json.get("message")
+            == f"Missing required parameters: {','.join(missing)}"
         )
 
-    def test_bad_dates(self, client, server_config):
+    def test_bad_dates(self, client, server_config, user_ok):
         """
         test_bad_dates Test behavior when a bad date string is given
         """
@@ -107,14 +107,17 @@ class TestDatasetsDetail:
             json={
                 "user": "drb",
                 "name": "footest",
-                "start": "2020-15",
+                "start": "2020-12",
                 "end": "2020-19",
             },
         )
         assert response.status_code == 400
-        assert response.json.get("message") == "Invalid start or end time string"
+        assert (
+            response.json.get("message")
+            == "Value '2020-19' (str) cannot be parsed as a date/time string"
+        )
 
-    def test_query(self, client, server_config, query_helper):
+    def test_query(self, client, server_config, query_helper, user_ok):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -241,7 +244,7 @@ class TestDatasetsDetail:
             {"exception": Exception, "status": 500},
         ),
     )
-    def test_http_error(self, client, server_config, query_helper, exceptions):
+    def test_http_error(self, client, server_config, query_helper, exceptions, user_ok):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -2,8 +2,6 @@ import pytest
 import re
 import requests
 
-from pbench.server.api.resources.query_apis import get_es_url, get_index_prefix
-
 
 @pytest.fixture
 def query_helper(client, server_config, requests_mock):
@@ -24,12 +22,12 @@ def query_helper(client, server_config, requests_mock):
     """
 
     def query_helper(payload, expected_index, expected_status, server_config, **kwargs):
-        es_url = get_es_url(server_config)
+        host = server_config.get("elasticsearch", "host")
+        port = server_config.get("elasticsearch", "port")
+        es_url = f"http://{host}:{port}"
         requests_mock.post(re.compile(f"{es_url}"), **kwargs)
         response = client.post(f"{server_config.rest_uri}/datasets/list", json=payload)
-        assert requests_mock.last_request.url == (
-            es_url + expected_index + "/_search?ignore_unavailable=true"
-        )
+        assert requests_mock.last_request.url == (es_url + expected_index + "/_search")
         assert response.status_code == expected_status
         return response
 
@@ -52,8 +50,7 @@ class TestDatasetsList:
         Args:
             dates (iterable): list of date strings
         """
-        prefix = get_index_prefix(server_config)
-        idx = prefix + ".v6.run-data."
+        idx = server_config.get("Indexing", "index_prefix") + ".v6.run-data."
         index = "/"
         for d in dates:
             index += f"{idx}{d},"
@@ -93,7 +90,8 @@ class TestDatasetsList:
         assert response.status_code == 400
         missing = [k for k in ("user", "controller", "start", "end") if k not in keys]
         assert (
-            response.json.get("message") == f"Missing request data: {','.join(missing)}"
+            response.json.get("message")
+            == f"Missing required parameters: {','.join(missing)}"
         )
 
     def test_bad_dates(self, client, server_config):
@@ -105,14 +103,17 @@ class TestDatasetsList:
             json={
                 "user": "drb",
                 "controller": "dbutenho.csb",
-                "start": "2020-15",
+                "start": "2020-12",
                 "end": "2020-19",
             },
         )
         assert response.status_code == 400
-        assert response.json.get("message") == "Invalid start or end time string"
+        assert (
+            response.json.get("message")
+            == "Value '2020-19' (str) cannot be parsed as a date/time string"
+        )
 
-    def test_query(self, client, server_config, query_helper):
+    def test_query(self, client, server_config, query_helper, user_ok):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -188,7 +189,7 @@ class TestDatasetsList:
             {"exception": Exception, "status": 500},
         ),
     )
-    def test_http_error(self, client, server_config, query_helper, exceptions):
+    def test_http_error(self, client, server_config, query_helper, exceptions, user_ok):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -1,7 +1,5 @@
 from urllib.parse import urljoin
 
-from pbench.server.api.resources.query_apis import get_index_prefix
-
 
 class TestEnpointConfig:
     """
@@ -39,7 +37,7 @@ class TestEnpointConfig:
         uri_prefix = server_config.rest_uri
         host = "http://" + host
         uri = urljoin(host, uri_prefix)
-        prefix = get_index_prefix(server_config)
+        prefix = server_config.get("Indexing", "index_prefix")
         expected_results = {
             "identification": f"Pbench server {server_config.COMMIT_ID}",
             "indices": {

--- a/lib/pbench/test/unit/server/test_month_indices.py
+++ b/lib/pbench/test/unit/server/test_month_indices.py
@@ -2,8 +2,6 @@ import pytest
 import re
 import requests
 
-from pbench.server.api.resources.query_apis import get_es_url
-
 
 @pytest.fixture
 def get_helper(client, server_config, requests_mock):
@@ -24,7 +22,9 @@ def get_helper(client, server_config, requests_mock):
     """
 
     def get_helper(expected_status, server_config, **kwargs):
-        es_url = get_es_url(server_config)
+        host = server_config.get("elasticsearch", "host")
+        port = server_config.get("elasticsearch", "port")
+        es_url = f"http://{host}:{port}"
         requests_mock.get(re.compile(f"{es_url}"), **kwargs)
         response = client.get(f"{server_config.rest_uri}/controllers/months")
         assert requests_mock.last_request.url == (es_url + "/_aliases")

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -29,7 +29,7 @@ class TestElasticsearch:
     def test_json_object(client, caplog, server_config):
         response = client.post(f"{server_config.rest_uri}/elasticsearch")
         assert response.status_code == 400
-        assert response.json.get("message") == "Invalid json object in the query"
+        assert response.json.get("message") == "Invalid request payload"
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
 
@@ -39,9 +39,7 @@ class TestElasticsearch:
             f"{server_config.rest_uri}/elasticsearch", json={"indices": ""}
         )
         assert response.status_code == 400
-        assert (
-            response.json.get("message") == "Missing indices path in the post request"
-        )
+        assert response.json.get("message") == "Missing required parameters: indices"
         assert len(caplog.records) == 1
         assert caplog.records[0].levelname == "WARNING"
 
@@ -55,14 +53,6 @@ class TestElasticsearch:
             json={"indices": "some_invalid_url", "payload": '{ "babble": "42" }'},
         )
         assert response.status_code == 400
-
-        # This is a bit awkward, but the requests_mock throws in its own
-        # DEBUG log record to announce the POST; so allow it. (But don't
-        # fail if it's missing.)
-        if len(caplog.records) > 0:
-            assert len(caplog.records) == 2
-            assert caplog.records[0].levelname == "DEBUG"
-            assert caplog.records[0].name == "requests_mock.adapter"
 
 
 class TestGraphQL:

--- a/lib/pbench/test/unit/server/test_schema.py
+++ b/lib/pbench/test/unit/server/test_schema.py
@@ -1,0 +1,153 @@
+import dateutil
+import pytest
+from typing import Callable
+
+from pbench.server.api.auth import Auth, UnknownUser
+from pbench.server.api.resources.query_apis import (
+    ParamType,
+    ConversionError,
+    InvalidRequestPayload,
+    MissingParameters,
+    Parameter,
+    Schema,
+)
+
+
+class TestParamType:
+    """
+    Tests on the ParamType enum
+    """
+
+    def test_enum(self):
+        assert (
+            len(ParamType.__members__) == 4
+        ), "Number of ParamType ENUM values has changed; confirm test coverage!"
+        for n, t in ParamType.__members__.items():
+            assert str(t) == t.friendly.upper()
+            assert isinstance(t.convert, Callable)
+
+    @pytest.mark.parametrize(
+        "test",
+        (
+            (ParamType.STRING, "x", "x"),
+            (ParamType.JSON, {"key": "value"}, {"key": "value"}),
+            (ParamType.DATE, "2021-06-29", dateutil.parser.parse("2021-06-29")),
+            (ParamType.USER, "drb", "drb"),
+        ),
+    )
+    def test_successful_conversions(self, test, monkeypatch):
+        def ok(user: str) -> str:
+            return user
+
+        monkeypatch.setattr(Auth, "validate_user", ok)
+
+        ptype, value, expected = test
+        result = ptype.convert(value)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "test",
+        (
+            (ParamType.STRING, {"not": "string"}),
+            (ParamType.JSON, "not_json"),
+            (ParamType.DATE, "2021-06-45"),
+            (ParamType.USER, "drb"),
+        ),
+    )
+    def test_failed_conversions(self, test, monkeypatch):
+        def not_ok(user: str) -> str:
+            raise UnknownUser()
+
+        monkeypatch.setattr(Auth, "validate_user", not_ok)
+
+        ptype, value = test
+        with pytest.raises(ConversionError) as exc:
+            ptype.convert(value)
+        assert str(exc).find(str(value))
+
+
+class TestParameter:
+    """
+    Tests on the Parameter class
+    """
+
+    def test_constructor(self):
+        x = Parameter("test", ParamType.STRING)
+        assert not x.required
+        assert x.name == "test"
+        assert x.type is ParamType.STRING
+
+        y = Parameter("foo", ParamType.JSON, required=True)
+        assert y.required
+        assert y.name == "foo"
+        assert y.type is ParamType.JSON
+
+    @pytest.mark.parametrize(
+        "test",
+        (
+            ({"data": "yes"}, False),
+            ({"data": None}, True),
+            ({"foo": "yes"}, True),
+            ({"foo": None, "data": "yes"}, False),
+        ),
+    )
+    def test_invalid_required(self, test):
+        x = Parameter("data", ParamType.STRING, required=True)
+        json, expected = test
+        assert x.invalid(json) is expected
+
+    @pytest.mark.parametrize(
+        "test",
+        (
+            ({"data": "yes"}, False),
+            ({"data": None}, True),
+            ({"foo": "yes"}, False),
+            ({"foo": None}, False),
+        ),
+    )
+    def test_invalid_optional(self, test):
+        x = Parameter("data", ParamType.STRING)
+        json, expected = test
+        assert x.invalid(json) is expected
+
+
+class TestSchema:
+    """
+    Tests on the Schema class
+    """
+
+    schema = Schema(
+        Parameter("key1", ParamType.STRING, required=True),
+        Parameter("key2", ParamType.JSON),
+        Parameter("key3", ParamType.DATE),
+    )
+
+    def test_bad_payload(self):
+        with pytest.raises(InvalidRequestPayload):
+            self.schema.validate(None)
+
+    def test_missing_required(self):
+        with pytest.raises(MissingParameters):
+            self.schema.validate({"key2": "abc"})
+
+    def test_missing_optional(self):
+        test = {"key1": "OK"}
+        assert test == self.schema.validate(test)
+
+    def test_bad_dates(self):
+        with pytest.raises(ConversionError):
+            self.schema.validate({"key1": "yes", "key3": "2000-02-56"})
+
+    def test_bad_json(self):
+        with pytest.raises(ConversionError):
+            self.schema.validate({"key1": 1, "key2": "not JSON"})
+
+    def test_all_clear(self):
+        payload = {
+            "key1": "name",
+            "key3": "2021-06-29",
+            "key2": {"json": True, "key": "abc"},
+        }
+        expected = payload.copy()
+        expected["key3"] = dateutil.parser.parse(expected["key3"])
+        assert expected == self.schema.validate(payload)

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -6,3 +6,4 @@ pytest>=4.6.3, < 5
 pytest-helpers-namespace==2019.1.8
 pytest-mock>=1.10.4
 requests_mock
+responses


### PR DESCRIPTION
This change unifies all of our Elasticsearch queries, including the client passthrough, under a class hierarchy that allows factoring
most of the boilerplate into a common superclass.

Getting fancy, I've also built in a JSON parameter schema to help with validation and type checking/conversions.

I've also added type hints.

This will make it easier to implement the remaining APIs consistently. (Note that similar refactoring of the pytests might be beneficial, but I didn't attempt that here.)