### PR TITLE
Don't validate params for `pbench-fio` install

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -15,7 +15,7 @@ benchmark_rpm=${benchmark}
 export benchmark_run_dir=""
 # allow unit tests to override
 if [[ -z "${benchmark_bin}" ]]; then
-        benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
+	benchmark_bin="$(resolve_benchmark_bin "${benchmark}")"
 	if [[ -z "${benchmark_bin}" ]]; then
 		error_log "[${script_name}] ${benchmark} executable not found on PATH=${PATH}"
 		exit 1
@@ -164,9 +164,6 @@ function usage {
 	printf -- "\t--max-failures=<int>\n"
 	printf "\t\tthe maximum number of failures to get below stddev\n"
 	printf "\n"
-	printf -- "\t--install\n"
-	printf "\t\tinstall only (default is False)\n"
-	printf "\n"
 	printf -- "\t--histogram-interval-sec=<int>\n"
 	printf "\t\tset the histogram logging interval in seconds (default $histogram_interval_sec)\n"
 	printf "\n"
@@ -174,6 +171,17 @@ function usage {
 	printf "\t\tavailable: $(pbench-display-sysinfo-options)\n"
 	printf "\n"
 	printf -- "\t--unique-ports           Use unique ports for each server\n"
+}
+
+function fio_local_check_install() {
+	if check_install_rpm ${benchmark_rpm} ${ver}; then
+		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is installed"
+		_rc=0
+	else
+		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is not installed, exiting"
+		_rc=1
+	fi
+	return ${_rc}
 }
 
 function fio_process_options() {
@@ -449,6 +457,12 @@ function fio_process_options() {
 			;;
 		esac
 	done
+
+	if [[ "${install_only}" == "y" ]]; then
+		fio_local_check_install
+		exit ${?}
+	fi
+
 	verify_common_bench_script_options $tool_group $sysinfo
 
 	if [[ ${job_mode} != "serial" && ${job_mode} != "concurrent" ]]; then
@@ -523,10 +537,8 @@ function record_iteration {
 
 # Ensure the right version of the benchmark is installed
 function fio_install() {
-	if check_install_rpm ${benchmark_rpm} ${ver}; then
-		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is installed"
-	else
-		debug_log "[${script_name}] ${benchmark_rpm}-${ver} is not installed, exiting"
+	fio_local_check_install
+	if [[ ${?} -ne 0 ]]; then
 		exit 1
 	fi
 	if [ ! -z "$clients" ] ; then

--- a/agent/bench-scripts/tests/pbench-fio/test-03.opts
+++ b/agent/bench-scripts/tests/pbench-fio/test-03.opts
@@ -1,0 +1,1 @@
+--install

--- a/agent/bench-scripts/tests/pbench-fio/test-03.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-03.txt
@@ -1,0 +1,16 @@
++++ Running test-03 pbench-fio
+--- Finished test-03 pbench-fio (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-bench/pbench-agent
+/var/tmp/pbench-test-bench/pbench-agent/pbench.log
+/var/tmp/pbench-test-bench/pbench-agent/tmp
+/var/tmp/pbench-test-bench/pbench-agent/tools-v1-default
+/var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/__trigger__
+/var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/testhost.example.com/mpstat
+/var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/testhost.example.com/sar
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] [check_install_rpm] fio-3.21 is installed
+[debug][1900-01-01T00:00:00.000000] [pbench-fio] fio-3.21 is installed
+--- pbench.log file contents

--- a/agent/bench-scripts/tests/pbench-fio/test-14.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-14.txt
@@ -76,9 +76,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-17.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-17.txt
@@ -76,9 +76,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-18.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-18.txt
@@ -79,9 +79,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-21.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-21.txt
@@ -79,9 +79,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-26.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-26.txt
@@ -79,9 +79,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-27.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-27.txt
@@ -79,9 +79,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/pbench-fio/test-29.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-29.txt
@@ -79,9 +79,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 

--- a/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
+++ b/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
@@ -235,9 +235,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 
@@ -328,9 +325,6 @@ The following options are available:
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
 
-	--install
-		install only (default is False)
-
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)
 
@@ -420,9 +414,6 @@ The following options are available:
 
 	--max-failures=<int>
 		the maximum number of failures to get below stddev
-
-	--install
-		install only (default is False)
 
 	--histogram-interval-sec=<int>
 		set the histogram logging interval in seconds (default 10)


### PR DESCRIPTION
Now that we have tools only registered on the local host, `pbench-fio` cannot validate the tool group on remote hosts when it has been given the `--install` parameter.

We also remove `--install` from `pbench-fio` usage text since it is really an internal interface.