### PR TITLE
Ensure we always pull jenkins devel images

### DIFF
--- a/jenkins/run
+++ b/jenkins/run
@@ -63,7 +63,7 @@ fi
 # in the container.
 find . -name __pycache__ -exec rm -r {} \; > /dev/null 2>&1
 
-podman run -it --userns=keep-id \
+podman run -it --userns=keep-id --pull=always \
     --volume ${_tmp}:/tmp:z \
     --volume ${_var_tmp}:/var/tmp:z \
     --volume ${_dev_log}:/dev/log:z \


### PR DESCRIPTION
We need to use the `podman` option `--pull=always` to ensure we properly fetch the updated `pbench-devel` image when running our CI jobs.

The default behavior is `missing`, which means only pull the image from the repository if it is not found on the local host.