### PR TITLE
Only measure coverage in `lib/pbench`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 parallel = True
 data_file = /tmp/${USER}/cov/coverage.db
-omit = */site-packages/*
+source = lib/pbench


### PR DESCRIPTION
We tell `coverage` to explicitly check all modules in the `lib/pbench` tree only.  Since we can only measure code coverage when using `pytest`, anyways, we won't see any measurements of modules outside of the `lib/pbench` tree that we care about, so using this option is a simple way to make sure we have a clean data set that considers all of our measurable code.

This change ensures that all of the modules under `lib/pbench` are considered when generating coverage reports, instead of only those modules that were touched by tests.