### PR TITLE
Add Authorization header to upload PUT API

### DIFF
--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -1,10 +1,32 @@
-import os
 import socket
-import pytest
-
 from pathlib import Path
+
+import pytest
 from werkzeug.utils import secure_filename
+
 from pbench.server.database.models.tracker import Dataset, States
+from pbench.test.unit.server.test_user_auth import login_user, register_user
+
+
+def get_pbench_token(client, server_config):
+    # First create a user
+    response = register_user(
+        client,
+        server_config,
+        username="user",
+        firstname="firstname",
+        lastname="lastName",
+        email="user@domain.com",
+        password="12345",
+    )
+    assert response.status_code, 201
+
+    # Login user to get valid pbench token
+    response = login_user(client, server_config, "user", "12345")
+    assert response.status_code == 200
+    data = response.json
+    assert data["auth_token"]
+    return data["auth_token"]
 
 
 class TestHostInfo:
@@ -67,97 +89,190 @@ class TestGraphQL:
 
 class TestUpload:
     @staticmethod
-    def test_missing_filename_header_upload(client, caplog, server_config):
-        expected_message = (
-            "Missing filename header, "
-            "POST operation requires a filename header to name the uploaded file"
-        )
-        response = client.put(
-            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}"
-        )
-        assert response.status_code == 400
-        assert response.json.get("message") == expected_message
-        for record in caplog.records:
-            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
-
-    @staticmethod
-    def test_missing_md5sum_header_upload(client, caplog, server_config):
-        expected_message = "Missing md5sum header, POST operation requires md5sum of an uploaded file in header"
+    def test_missing_authorization_header(client, caplog, server_config):
         response = client.put(
             f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
             headers={"filename": "f.tar.xz"},
         )
-        assert response.status_code == 400
-        assert response.json.get("message") == expected_message
+        assert response.status_code == 401
         for record in caplog.records:
-            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+            assert record.levelname not in ("ERROR", "CRITICAL")
+
+    @staticmethod
+    def test_malformed_authorization_header(client, caplog, server_config):
+        response = client.put(
+            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+            headers={"filename": "f.tar.xz", "Authorization": "Bearer " + "malformed"},
+        )
+        assert response.status_code == 401
+        for record in caplog.records:
+            assert record.levelname not in ("ERROR", "CRITICAL")
+
+    @staticmethod
+    def test_missing_filename_header_upload(client, caplog, server_config):
+        with client:
+            auth_token = get_pbench_token(client, server_config)
+
+            expected_message = (
+                "Missing filename header, "
+                "POST operation requires a filename header to name the uploaded file"
+            )
+            response = client.put(
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+                headers={"Authorization": "Bearer " + auth_token},
+            )
+            assert response.status_code == 400
+            assert response.json.get("message") == expected_message
+            for record in caplog.records:
+                assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+
+    @staticmethod
+    def test_missing_md5sum_header_upload(client, caplog, server_config):
+        with client:
+            auth_token = get_pbench_token(client, server_config)
+
+            expected_message = "Missing md5sum header, POST operation requires md5sum of an uploaded file in header"
+            response = client.put(
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+                headers={
+                    "Authorization": "Bearer " + auth_token,
+                    "filename": "f.tar.xz",
+                },
+            )
+            assert response.status_code == 400
+            assert response.json.get("message") == expected_message
+            for record in caplog.records:
+                assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+
+    @staticmethod
+    def test_mismatched_md5sum_header(client, caplog, server_config):
+        with client:
+            auth_token = get_pbench_token(client, server_config)
+
+            filename = "log.tar.xz"
+            datafile = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
+            controller = socket.gethostname()
+
+            with open(datafile, "rb") as data_fp:
+                response = client.put(
+                    f"{server_config.rest_uri}/upload/ctrl/{controller}",
+                    data=data_fp,
+                    headers={
+                        "Authorization": "Bearer " + auth_token,
+                        "filename": filename,
+                        "Content-MD5": "md5sum",  # Wrong md5 hash
+                    },
+                )
+            assert response.status_code == 400
+            assert (
+                response.json.get("message")
+                == f"md5sum check failed for {filename}, upload failed"
+            )
 
     @staticmethod
     @pytest.mark.parametrize("bad_extension", ("test.tar.bad", "test.tar", "test.tar."))
     def test_bad_extension_upload(client, bad_extension, caplog, server_config):
-        expected_message = "File extension not supported. Only .xz"
-        response = client.put(
-            f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
-            headers={"filename": bad_extension, "Content-MD5": "md5sum"},
-        )
-        assert response.status_code == 400
-        assert response.json.get("message") == expected_message
-        for record in caplog.records:
-            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+        with client:
+            auth_token = get_pbench_token(client, server_config)
+
+            expected_message = "File extension not supported. Only .xz"
+            response = client.put(
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+                headers={
+                    "Authorization": "Bearer " + auth_token,
+                    "filename": bad_extension,
+                    "Content-MD5": "md5sum",
+                },
+            )
+            assert response.status_code == 400
+            assert response.json.get("message") == expected_message
+            for record in caplog.records:
+                assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+
+    @staticmethod
+    def test_invalid_authorization_upload(client, caplog, server_config):
+        with client:
+            auth_token = get_pbench_token(client, server_config)
+            # Log the token out
+            response = client.post(
+                f"{server_config.rest_uri}/logout",
+                headers={"Authorization": "Bearer " + auth_token},
+            )
+
+            # Upload with invalid token
+            response = client.put(
+                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+                headers={
+                    "Authorization": "Bearer " + auth_token,
+                    "Content-MD5": "md5sum",
+                },
+            )
+            assert response.status_code == 401
 
     @staticmethod
     def test_empty_upload(client, pytestconfig, caplog, server_config):
-        expected_message = "Upload failed, Content-Length received in header is 0"
-        filename = "tmp.tar.xz"
-        tmp_d = pytestconfig.cache.get("TMP", None)
-        Path(tmp_d, filename).touch()
+        with client:
+            auth_token = get_pbench_token(client, server_config)
 
-        with open(Path(tmp_d, filename), "rb") as data_fp:
-            response = client.put(
-                f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
-                data=data_fp,
-                headers={
-                    "filename": "log.tar.xz",
-                    "Content-MD5": "d41d8cd98f00b204e9800998ecf8427e",
-                },
-            )
-        assert response.status_code == 400
-        assert response.json.get("message") == expected_message
-        for record in caplog.records:
-            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+            expected_message = "Upload failed, Content-Length received in header is 0"
+            filename = "tmp.tar.xz"
+            tmp_d = pytestconfig.cache.get("TMP", None)
+            Path(tmp_d, filename).touch()
+
+            with open(Path(tmp_d, filename), "rb") as data_fp:
+                response = client.put(
+                    f"{server_config.rest_uri}/upload/ctrl/{socket.gethostname()}",
+                    data=data_fp,
+                    headers={
+                        "Authorization": "Bearer " + auth_token,
+                        "filename": filename,
+                        "Content-MD5": "d41d8cd98f00b204e9800998ecf8427e",  # MD5 hash of an empty file
+                    },
+                )
+            assert response.status_code == 400
+            assert response.json.get("message") == expected_message
+            for record in caplog.records:
+                assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
 
     @staticmethod
     def test_upload(client, pytestconfig, caplog, server_config):
-        filename = "log.tar.xz"
-        datafile = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
-        controller = socket.gethostname()
-        with open(f"{datafile}.md5") as md5sum_check:
-            md5sum = md5sum_check.read()
+        with client:
+            auth_token = get_pbench_token(client, server_config)
 
-        with open(datafile, "rb") as data_fp:
-            response = client.put(
-                f"{server_config.rest_uri}/upload/ctrl/{controller}",
-                data=data_fp,
-                headers={"filename": filename, "Content-MD5": md5sum},
+            filename = "log.tar.xz"
+            datafile = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
+            controller = socket.gethostname()
+            with open(f"{datafile}.md5") as md5sum_check:
+                md5sum = md5sum_check.read()
+
+            with open(datafile, "rb") as data_fp:
+                response = client.put(
+                    f"{server_config.rest_uri}/upload/ctrl/{controller}",
+                    data=data_fp,
+                    headers={
+                        "Authorization": "Bearer " + auth_token,
+                        "filename": filename,
+                        "Content-MD5": md5sum,
+                    },
+                )
+
+            assert response.status_code == 201, repr(response)
+            sfilename = secure_filename(filename)
+            tmp_d = pytestconfig.cache.get("TMP", None)
+            receive_dir = Path(
+                tmp_d, "srv", "pbench", "pbench-move-results-receive", "fs-version-002"
+            )
+            assert receive_dir.exists(), (
+                f"receive_dir = '{receive_dir}', filename = '{filename}',"
+                f" sfilename = '{sfilename}'"
             )
 
-        assert response.status_code == 201, repr(response)
-        sfilename = secure_filename(filename)
-        tmp_d = pytestconfig.cache.get("TMP", None)
-        receive_dir = os.path.join(
-            tmp_d, "srv", "pbench", "pbench-move-results-receive", "fs-version-002"
-        )
-        assert os.path.exists(receive_dir), (
-            f"receive_dir = '{receive_dir}', filename = '{filename}',"
-            f" sfilename = '{sfilename}'"
-        )
+            dataset = Dataset.attach(controller=controller, path=filename)
+            assert dataset is not None
+            assert dataset.md5 == md5sum
+            assert dataset.controller == controller
+            assert dataset.name == "log"
+            assert dataset.state == States.UPLOADED
 
-        dataset = Dataset.attach(controller=controller, path=filename)
-        assert dataset is not None
-        assert dataset.md5 == md5sum
-        assert dataset.controller == controller
-        assert dataset.name == "log"
-        assert dataset.state == States.UPLOADED
-
-        for record in caplog.records:
-            assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")
+            for record in caplog.records:
+                assert record.levelname not in ("WARNING", "ERROR", "CRITICAL")


### PR DESCRIPTION
 - Adds a strict Bearer `Authorization` header requirement to upload API
- Dataset owner's username is extracted from the authorization header 