### PR TITLE
Update PCP repo for container builds

### DIFF
--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -9,6 +9,6 @@ COPY ./{{ distro }}-pcp.repo /etc/yum.repos.d/pcp.repo
 #
 # FIXME: this is not exhaustive, it does not include RPMs to support
 #        Kubernetes or RHV environments.
-RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y --setopt=tsflags=nodocs {% if distro == 'centos-8' %}--enablerepo powertools {% endif %}{% if kind in ('tools', 'all') %}--enablerepo pcp {% endif %}{{ rpms }} && \
+RUN {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} install -y --setopt=tsflags=nodocs {% if distro == 'centos-8' %}--enablerepo powertools {% endif %}{% if kind in ('tools', 'all') %}--enablerepo pcp-rpm-release {% endif %}{{ rpms }} && \
     {% if distro == 'centos-7' %}yum{% else %}dnf{% endif %} -y clean all && \
     rm -rf /var/cache/{% if distro == 'centos-7' %}yum{% else %}dnf{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -27,22 +27,16 @@ IMAGE_REPO = docker://quay.io/pbench
 # Not intended to be overridden with an environment variable.
 _REPO_TEMPLATE = ../../ansible/pbench/agent/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
 
-# NOTE: Currently we require 5.2.2 of the PCP RPMs because using the 5.2.3
-# version prevents us from integrating with Grafana, see PCP Issue #1183,
-# https://github.com/performancecopilot/pcp/issues/1183.
-# NOTE: We also have to enumerate so many RPMs because for CentOS 7 the RPM
-# dependency resolver does not properly resolve to the same version RPMs. Once
-# we no longer have to use v5.2.2, we can just list 3 RPMs: pcp-zeroconf,
-# pcp-system-tools, and pcp-gui.
+# This list of PCP RPMs we need to provide all the required features.  We use
+# pcp-gui to ensure pmchart is installed in the tools container so that users
+# have a native way to review PCP data.  The pcp-zeroconf RPM provides a
+# comprehensive set of pre-configurations for various PMDAs.  Finally, the
+# pcp-system-tools various "sysstat" replacement tools (along with others),
+# and the dependency on the base `pcp` package.
 _PCP_RPMS = \
-	pcp-doc-5.2.2 \
-	pcp-gui-5.2.2 \
-	pcp-pmda-dm-5.2.2 \
-	pcp-pmda-nfsclient-5.2.2 \
-	pcp-pmda-openmetrics-5.2.2 \
-	pcp-system-tools-5.2.2 \
-	pcp-zeroconf-5.2.2 \
-	python3-pcp-5.2.2
+	pcp-gui \
+	pcp-system-tools \
+	pcp-zeroconf
 # The list of RPMs which provide the various tools we offer.
 # Not intended to be overridden with an environment variable.
 # Please keep the lists sorted.
@@ -293,16 +287,16 @@ all-dockerfiles: $(foreach distro, ${_DISTROS}, ${distro}-base.Dockerfile ${dist
 	jinja2 repo.yml.j2 -D distro=$* -D url_prefix=${URL_PREFIX} -D test_suffix=${_TEST_SUFFIX} -D user=${USER} -o $@
 
 fedora-33-pcp.repo: pcp.repo.j2
-	jinja2 pcp.repo.j2 -D target=f33 -o $@
+	jinja2 pcp.repo.j2 -D distro=fedora -D version=33 -o $@
 
 fedora-32-pcp.repo: pcp.repo.j2
-	jinja2 pcp.repo.j2 -D target=f32 -o $@
+	jinja2 pcp.repo.j2 -D distro=fedora -D version=32 -o $@
 
 centos-8-pcp.repo: pcp.repo.j2
-	jinja2 pcp.repo.j2 -D target=el8 -o $@
+	jinja2 pcp.repo.j2 -D distro=centos -D version=8 -o $@
 
 centos-7-pcp.repo: pcp.repo.j2
-	jinja2 pcp.repo.j2 -D target=el7 -o $@
+	jinja2 pcp.repo.j2 -D distro=centos -D version=7 -o $@
 
 clean:
 	rm -f *.Dockerfile *.repo *.yml *-tags.lis

--- a/agent/containers/images/pcp.repo.j2
+++ b/agent/containers/images/pcp.repo.j2
@@ -1,6 +1,7 @@
-[pcp]
-name=pcp
-baseurl=https://dl.bintray.com/pcp/{{ target }}
-gpgcheck=0
-repo_gpgcheck=0
+[pcp-rpm-release]
+name=pcp-rpm-release
+baseurl=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ distro }}/{{ version }}/x86_64
 enabled=1
+gpgcheck=0
+gpgkey=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ distro }}/{{ version }}/x86_64/repodata/repomd.xml.key
+repo_gpgcheck=1

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -76,6 +76,21 @@ cp -a agent/* %{?buildroot}/%{installdir}/
 if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
 
 %post
+%if 0%{?rhel} == 7
+# This is a very ugly work-around for RHEL 7 / CentOS 7 environments. The
+# version of `pip3` that is available in those environments no longer works
+# to install the latest Python3 modules, which we need. So we have to fetch
+# our own copy of `pip3`, as described at:
+#   https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py 
+# We then install it separately from the existing verion and set `PATH` and
+# `PYTHONPATH` so that we use this updated version when we install our module
+# dependencies below.
+curl -X GET -o /%{installdir}/get-pip.py https://bootstrap.pypa.io/get-pip.py > /%{installdir}/pip3-update.log 2>&1
+python3 /%{installdir}/get-pip.py --prefix=/%{installdir} >> /%{installdir}/pip3-update.log 2>&1
+export PYTHONPATH=/%{installdir}/lib/python3.6/site-packages:${PYTHONPATH}
+export PATH=/%{installdir}/bin:${PATH}
+%endif
+
 # Install python dependencies
 pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
 


### PR DESCRIPTION
For some reason the bintray.com repos have stopped working, giving us '401 Forbidden' errors.  It appears the new repos are using the jFrog Artifactory instance for PCP.

We also drop the 5.2.2 version requirement for PCP.

----

This PR is based on PR #2248 in order to make both testable.