### PR TITLE
Fix CentOS 7 / RHEL 7 pbench-agent installations

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -76,6 +76,21 @@ cp -a agent/* %{?buildroot}/%{installdir}/
 if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
 
 %post
+%if 0%{?rhel} == 7
+# This is a very ugly work-around for RHEL 7 / CentOS 7 environments. The
+# version of `pip3` that is available in those environments no longer works
+# to install the latest Python3 modules, which we need. So we have to fetch
+# our own copy of `pip3`, as described at:
+#   https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py 
+# We then install it separately from the existing verion and set `PATH` and
+# `PYTHONPATH` so that we use this updated version when we install our module
+# dependencies below.
+curl -X GET -o /%{installdir}/get-pip.py https://bootstrap.pypa.io/get-pip.py > /%{installdir}/pip3-update.log 2>&1
+python3 /%{installdir}/get-pip.py --prefix=/%{installdir} >> /%{installdir}/pip3-update.log 2>&1
+export PYTHONPATH=/%{installdir}/lib/python3.6/site-packages:${PYTHONPATH}
+export PATH=/%{installdir}/bin:${PATH}
+%endif
+
 # Install python dependencies
 pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
 


### PR DESCRIPTION
It looks like we need the latest version of `pip` to install all of the module dependencies we have.  For all but CentOS 7 / RHEL 7 we have the correct version.  So for those environments we now have to install the latest version of `pip3` directly in order for us to have our Python3 dependencies satisfied.

The days of our RHEL 7 support are numbered.

Fixes https://github.com/distributed-system-analysis/pbench/issues/2245.