### PR TITLE
Quiet Redis server connections by default

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -1,8 +1,6 @@
 +++ Running test-53 test-client-tool-meister 
 "mpstat" tool is now registered for host "testhost.example.com" in group "default"
 "dcgm" tool is now registered for host "testhost.example.com" in group "default"
-pbench-tool-data-sink: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
 Collecting system information
 --- Finished test-53 test-client-tool-meister (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -6,11 +6,6 @@
 "node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 "dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 "pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
-pbench-tool-data-sink: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
 Collecting system information
 --- Finished test-56 test-client-tool-meister (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -6,11 +6,6 @@
 "node-exporter" tool is now registered for host "remote-b.example.com", with label "blue", in group "lite"
 "dcgm" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
 "pcp" tool is now registered for host "remote-c.example.com", with label "red", in group "lite"
-pbench-tool-data-sink: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
 system information not collected when --interrupt specified
 --- Finished test-57 test-client-tool-meister (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -19,8 +19,6 @@ next pbench-agent-cli-to-client
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "end", "kind": "ds", "status": "success"}'}
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "init", "kind": "ds", "status": "success"}'}
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "startup", "kind": "ds", "status": "success"}'}
-pbench-tool-data-sink: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
 publish end on chan pbench-agent-cli-from-client
 publish init on chan pbench-agent-cli-from-client
 publish terminate on chan pbench-agent-cli-from-client

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -19,8 +19,6 @@ next pbench-agent-cli-to-client
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "end", "kind": "ds", "status": "success"}'}
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "init", "kind": "ds", "status": "success"}'}
 payload from pbench-agent-cli-to-client: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-to-client', 'data': b'{"action": "startup", "kind": "ds", "status": "success"}'}
-pbench-tool-data-sink: connected to redis server localhost:17001
-pbench-tool-meister: connected to redis server localhost:17001
 publish end on chan pbench-agent-cli-from-client
 publish init on chan pbench-agent-cli-from-client
 publish terminate on chan pbench-agent-cli-from-client

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -2055,9 +2055,7 @@ def main(argv):
 
     try:
         # Wait for the parameter key value to show up.
-        params_str = wait_for_conn_and_key(
-            redis_server, param_key, PROG, redis_host, redis_port
-        )
+        params_str = wait_for_conn_and_key(redis_server, param_key, PROG)
         # The expected parameters for this "data-sink" is what "channel" to
         # subscribe to for the tool meister operational life-cycle.  The
         # data-sink listens for the actions, sysinfo | init | start | stop |

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1925,9 +1925,7 @@ def main(argv):
 
     try:
         # Wait for the key to show up with a value.
-        params_str = wait_for_conn_and_key(
-            redis_server, param_key, PROG, redis_host, redis_port
-        )
+        params_str = wait_for_conn_and_key(redis_server, param_key, PROG)
         params = json.loads(params_str)
         # Validate the tool meister parameters without constructing an object
         # just yet, as we want to make sure we can talk to the redis server


### PR DESCRIPTION
We only emit messages on connection failures, on re-established connections, or when we encounter a missing key, and will emit a summary message if it took more than one attempt to connect.

Also fixes #2211.