### PR TITLE
Add a template DB table and integrate with index template management

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/controllers_list.py
+++ b/lib/pbench/server/api/resources/query_apis/controllers_list.py
@@ -76,12 +76,7 @@ class ControllersList(ElasticBase):
             end,
         )
 
-        # TODO: Need to refactor the template processing code from indexer.py
-        # to maintain the essential indexing information in a persistent DB
-        # (probably a Postgresql table) so that it can be shared here and by
-        # the indexer without re-loading on each access. For now, the index
-        # version is hardcoded.
-        uri_fragment = self._gen_month_range(".v6.run-data.", start, end)
+        uri_fragment = self._gen_month_range("run", start, end)
         return {
             "path": f"/{uri_fragment}/_search",
             "kwargs": {

--- a/lib/pbench/server/api/resources/query_apis/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_detail.py
@@ -66,12 +66,7 @@ class DatasetsDetail(ElasticBase):
             end,
         )
 
-        # TODO: Need to refactor the template processing code from indexer.py
-        # to maintain the essential indexing information in a persistent DB
-        # (probably a Postgresql table) so that it can be shared here and by
-        # the indexer without re-loading on each access. For now, the index
-        # version is hardcoded.
-        uri_fragment = self._gen_month_range(".v6.run-data.", start, end)
+        uri_fragment = self._gen_month_range("run", start, end)
         return {
             "path": f"/{uri_fragment}/_search",
             "kwargs": {

--- a/lib/pbench/server/api/resources/query_apis/datasets_list.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_list.py
@@ -70,12 +70,7 @@ class DatasetsList(ElasticBase):
             end,
         )
 
-        # TODO: Need to refactor the template processing code from indexer.py
-        # to maintain the essential indexing information in a persistent DB
-        # (probably a Postgresql table) so that it can be shared here and by
-        # the indexer without re-loading on each access. For now, the index
-        # version is hardcoded.
-        uri_fragment = self._gen_month_range(".v6.run-data.", start, end)
+        uri_fragment = self._gen_month_range("run", start, end)
         return {
             "path": f"/{uri_fragment}/_search",
             "kwargs": {

--- a/lib/pbench/server/api/resources/query_apis/month_indices.py
+++ b/lib/pbench/server/api/resources/query_apis/month_indices.py
@@ -4,6 +4,7 @@ from typing import Any, AnyStr, Dict
 
 from pbench.server import PbenchServerConfig
 from pbench.server.api.resources.query_apis import ElasticBase, Schema
+from pbench.server.database.models.template import Template
 
 
 class MonthIndices(ElasticBase):
@@ -13,6 +14,9 @@ class MonthIndices(ElasticBase):
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
         super().__init__(config, logger, Schema())
+        template = Template.find("run")
+        self.template_name = template.template_name + "."
+        self.logger.info("month index key is {}", self.template_name)
 
     def assemble(self, json_data: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
         """
@@ -25,10 +29,9 @@ class MonthIndices(ElasticBase):
 
     def postprocess(self, es_json: Dict[AnyStr, Any]) -> Dict[AnyStr, Any]:
         months = []
-        target = f"{self.prefix}.v6.run-data."
-        self.logger.info("looking for {} in {}", target, es_json)
+        self.logger.debug("looking for {} in {}", self.template_name, es_json)
         for index in es_json.keys():
-            if target in index:
+            if self.template_name in index:
                 months.append(index.split(".")[-1])
         months.sort(reverse=True)
         self.logger.info("found months {!r}", months)

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -14,15 +14,16 @@ class Database:
             psql = config.get("Postgres", "db_uri")
             return psql
         except (NoSectionError, NoOptionError):
-            logger.error(
-                "Failed to find an [Postgres] section" " in configuration file."
-            )
+            if logger:
+                logger.error(
+                    "Failed to find a [Postgres] section in configuration file."
+                )
             return None
 
     @staticmethod
     def init_db(server_config, logger):
         # Attach the logger to the base class for models to find
-        if not hasattr(Database.Base, "logger"):
+        if logger and not hasattr(Database.Base, "logger"):
             Database.Base.logger = logger
 
         # WARNING:

--- a/lib/pbench/server/database/models/template.py
+++ b/lib/pbench/server/database/models/template.py
@@ -1,0 +1,236 @@
+import datetime
+from pathlib import Path
+from sqlalchemy import Column, Integer, String, event
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.sql.sqltypes import DateTime, JSON
+
+from pbench.server.database.database import Database
+
+
+class TemplateError(Exception):
+    """
+    This is a base class for errors reported by the Template class. It is
+    never raised directly, but may be used in "except" clauses.
+    """
+
+    pass
+
+
+class TemplateSqlError(TemplateError):
+    """
+    SQLAlchemy errors reported through Template operations.
+
+    The exception will identify the base name of the template index,
+    along with the operation being attempted; the __cause__ will specify the
+    original SQLAlchemy exception.
+    """
+
+    def __init__(self, operation: str, name: str):
+        self.operation = operation
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"Error {self.operation} index {self.name!r}"
+
+
+class TemplateFileMissing(TemplateError):
+    """
+    Template requires a file name.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"Template {self.name!r} is missing required file"
+
+
+class TemplateNotFound(TemplateError):
+    """
+    Attempt to find a Template that doesn't exist.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"No template {self.name!r}"
+
+
+class TemplateDuplicate(TemplateError):
+    """
+    Attempt to commit a duplicate Template.
+    """
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"Duplicate template {self.name!r}"
+
+
+class TemplateMissingParameter(TemplateError):
+    """
+    Attempt to commit a Template with missing parameters.
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Missing required parameters in {self.name!r}: {self.cause}"
+
+
+class Template(Database.Base):
+    """
+    Identify a Pbench Elasticsearch document template
+
+    Columns:
+        id              Generated unique ID of table row
+        name            Index name key (e.g., "fio")
+        idxname         Base index name (e.g., "tool-data-fio")
+        template_name   The Elasticsearch template name
+        file            The source JSON mapping file
+        mtime           Template file modification timestamp
+        template_pattern The template for the Elasticsearch index name
+        index_template  The full index name template "p.v.i.y-m[-d]"
+        settings        The JSON settings payload
+        mappings        The JSON mappings payload
+        version         The template version metadata
+    """
+
+    __tablename__ = "templates"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String(255), unique=True, nullable=False)
+    idxname = Column(String(255), unique=True, nullable=False)
+    template_name = Column(String(255), unique=True, nullable=False)
+    file = Column(String(255), unique=False, nullable=False)
+    mtime = Column(DateTime, unique=False, nullable=False)
+    template_pattern = Column(String(255), unique=False, nullable=False)
+    index_template = Column(String(225), unique=False, nullable=False)
+    settings = Column(JSON, unique=False, nullable=False)
+    mappings = Column(JSON, unique=False, nullable=False)
+    version = Column(String(255), unique=False, nullable=False)
+
+    @staticmethod
+    def create(**kwargs) -> "Template":
+        """
+        A simple factory method to construct a new Template object and
+        add it to the database.
+
+        Args:
+            kwargs: any of the column names defined above
+
+        Returns:
+            A new Template object initialized with the keyword parameters.
+        """
+        template = Template(**kwargs)
+        template.add()
+        return template
+
+    @staticmethod
+    def find(name: str) -> "Template":
+        """
+        Return a Template object with the specified base name. For
+        example, find("run-data").
+
+        Args:
+            name: Base index name
+
+        Raises:
+            TemplateSqlError: problem interacting with Database
+            TemplateNotFound: the specified template doesn't exist
+
+        Returns:
+            Template: a template object with the specified base name
+        """
+        try:
+            template = Database.db_session.query(Template).filter_by(name=name).first()
+        except SQLAlchemyError as e:
+            Template.logger.warning("Error looking for {}: {}", name, str(e))
+            raise TemplateSqlError("finding", name)
+
+        if template is None:
+            raise TemplateNotFound(name)
+        return template
+
+    def __str__(self) -> str:
+        """
+        Return a string representation of the template
+
+        Returns:
+            string: Representation of the template
+        """
+        return f"{self.name}: {self.index_template}"
+
+    def _decode(self, exception: IntegrityError) -> Exception:
+        """
+        Decode a SQLAlchemy IntegrityError to look for a recognizable UNIQUE
+        or NOT NULL constraint violation. Return the original exception if
+        it doesn't match.
+
+        Args:
+            exception: An IntegrityError to decode
+
+        Returns:
+            a more specific exception, or the original if decoding fails
+        """
+        # Postgres engine returns (code, message) but sqlite3 engine only
+        # returns (message); so always take the last element.
+        cause = exception.orig.args[-1]
+        if cause.find("UNIQUE constraint") != -1:
+            Template.logger.warning("Duplicate template {!r}: {}", self.name, cause)
+            return TemplateDuplicate(self.name)
+        elif cause.find("NOT NULL constraint") != -1:
+            Template.logger.warning("Missing parameter {!r}, {}", self.name, cause)
+            return TemplateMissingParameter(self.name, cause)
+        Template.logger.exception("Other integrity error {}", cause)
+        return exception
+
+    def add(self):
+        """
+        Add the Template object to the database
+        """
+        try:
+            Database.db_session.add(self)
+            Database.db_session.commit()
+        except IntegrityError as e:
+            Database.db_session.rollback()
+            raise self._decode(e)
+        except Exception:
+            self.logger.exception("Can't add {} to DB", str(self))
+            Database.db_session.rollback()
+            raise TemplateSqlError("adding", self.name)
+
+    def update(self):
+        """
+        Update the database row with the modified version of the
+        Template object.
+        """
+        try:
+            Database.db_session.commit()
+        except IntegrityError as e:
+            Database.db_session.rollback()
+            raise self._decode(e)
+        except Exception:
+            self.logger.error("Can't update {} in DB", str(self))
+            Database.db_session.rollback()
+            raise TemplateSqlError("updating", self.name)
+
+
+@event.listens_for(Template, "init")
+def check_required(target, args, kwargs):
+    """
+    Listen for an init event on Template to validate that a filename was
+    specified; and automatically capture the file's modification timestamp
+    if it wasn't given.
+    """
+    if "file" not in kwargs:
+        raise TemplateFileMissing(kwargs["name"])
+
+    if "mtime" not in kwargs:
+        kwargs["mtime"] = datetime.datetime.fromtimestamp(
+            Path(kwargs["file"]).stat().st_mtime
+        )

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -34,7 +34,6 @@ from pbench.common.exceptions import (
     BadIterationName,
     BadSampleName,
 )
-from pbench.common.logger import get_pbench_logger
 from pbench.server.templates import PbenchTemplates
 import pbench.server
 
@@ -3995,12 +3994,13 @@ class IdxContext:
     state, provided as an object.
     """
 
-    def __init__(self, options, name, _dbg=0):
+    def __init__(self, options, name, config, logger, _dbg=0):
         self.options = options
         self.name = name
+        self.config = config
+        self.logger = logger
         self._dbg = _dbg
         self.opctx = []
-        self.config = pbench.server.PbenchServerConfig(options.cfg_name)
         try:
             self.idx_prefix = self.config.get("Indexing", "index_prefix")
         except Exception as e:
@@ -4048,7 +4048,6 @@ class IdxContext:
             self.getuid = os.getuid
         self.TS = self.config.TS
 
-        self.logger = get_pbench_logger(self.name, self.config)
         self.es = get_es(self.config, self.logger)
         self.templates = PbenchTemplates(
             self.config.BINDIR,

--- a/lib/pbench/server/templates.py
+++ b/lib/pbench/server/templates.py
@@ -1,13 +1,15 @@
 import copy
-import glob
 import json
-import os
-import pyesbulk
 import re
 import sys
 
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
+from typing import Any, AnyStr, Dict
+
+import pyesbulk
+from sqlalchemy.sql.sqltypes import JSON
 
 from pbench.common.exceptions import (
     BadDate,
@@ -16,202 +18,242 @@ from pbench.common.exceptions import (
     TemplateError,
 )
 from pbench.server import tstos
+from pbench.server.database.models.template import (
+    Template,
+    TemplateNotFound,
+)
 
 
-class PbenchTemplates:
-    """Encapsulation of methods for loading / working with all the Pbench
-    templates for Elasticsearch.
+class JsonFile:
+    """
+    Describes a single JSON file, which might be a settings file or a
+    mapping file.
     """
 
-    @staticmethod
-    def _load_json(json_fn):
-        """Simple wrapper function to load a JSON object from the given file,
-        raising the JsonFileError when bad JSON data is encountered.
+    def __init__(self, file: Path = None):
         """
-        with open(json_fn, "r") as jsonfp:
+        Initialize a JSON file object by resolving the file name and reading
+        the modification date.
+
+        Args:
+            file: JSON file path. Defaults to None to allow initializing an
+                object to store DB query results rather than loading from a
+                file.
+        """
+        if file:
+            self.file = file.resolve(strict=True)
+            self.modified = datetime.fromtimestamp(self.file.stat().st_mtime)
+        else:
+            self.file = None
+            self.modified = None
+        self.json = None
+
+    @staticmethod
+    def raw_json(json: Dict[AnyStr, Any], modified: datetime) -> "JsonFile":
+        """
+        An alternate constructor that can be loaded directly with a JSON
+        document in order to capture the data from a Template DB object.
+
+        Returns:
+            An instance of JsonFile
+        """
+        new = JsonFile()
+        new.json = json
+        new.modified = modified
+        return new
+
+    def extract_version(self, meta: JSON) -> str:
+        """
+        Extract the "version" field from a document mapping file's metadata.
+
+        Args:
+            meta: Mapping file metadata
+
+        Raises:
+            MappingFileError: "version" field is missing
+
+        Returns:
+            Mapping file version
+        """
+        try:
+            version = meta["version"]
+        except KeyError as e:
+            raise MappingFileError(f"missing {e} in {meta!r}")
+        return version
+
+    def get_version(self) -> str:
+        """
+        Parse the metadata version information from the mapping file. This is
+        done on standalone template files and on "tool" template files, but
+        not on the "base" skeleton files shared by the tool templates. The
+        context is under control of the TemplateFile class load methods.
+
+        Raises:
+            MappingFileError: Mapping file doesn't contain metadata
+
+        Returns:
+            Template file metadata version
+        """
+        try:
+            return self.extract_version(self.json["_meta"])
+        except KeyError as e:
+            raise MappingFileError(f"mapping missing {e} in {self.file}: {self.json}")
+
+    def load(self) -> bool:
+        """
+        Simple wrapper function to load a JSON object from the object's file,
+        raising a JsonFileError when bad JSON data is encountered.
+
+        Raises:
+            JsonFileError: Improperly formatted JSON
+
+        Returns:
+            True if the file was loaded, False if it had already been loaded
+        """
+
+        # Don't load the file again if we've already done it
+        if self.json:
+            return False
+        with self.file.open(mode="r") as jsonfp:
             try:
                 data = json.load(jsonfp)
             except ValueError as err:
-                raise JsonFileError("{}: {}".format(json_fn, err))
-        return data
+                raise JsonFileError("{}: {}".format(self.file, err))
+        self.json = data
+        return True
 
-    @staticmethod
-    def _fetch_mapping(mapping_fn):
-        """Fetch the mapping JSON data from the given file.
-
-        Returns a tuple consisting of the mapping name pulled from the file, and
-        the python dictionary loaded from the JSON file.
-
-        Raises MappingFileError if it encounters any problem loading the file.
+    def merge(self, name: str, base: "JsonFile"):
         """
-        key = Path(mapping_fn).stem
-        mapping = PbenchTemplates._load_json(mapping_fn)
-        try:
-            idxver = mapping["_meta"]["version"]
-        except KeyError:
-            raise MappingFileError(
-                "{} mapping missing _meta field in {}".format(key, mapping_fn)
-            )
-        return key, idxver, mapping
+        Merge a tool-specific sub-document into the common base Elasticsearch
+        template document by linking the tool's mapping and meta-version into
+        a copy of the base document.
 
-    _fpat = re.compile(r"tool-data-frag-(?P<toolname>.+)\.json")
+        Args:
+            name: property name
+            base: The base JsonFile
+        """
+        raise NotImplementedError(f"{type(self).__name__} doesn't implement merge")
 
-    def __init__(self, basepath, idx_prefix, logger, known_tool_handlers=None, _dbg=0):
-        # Where to find the mappings
-        MAPPING_DIR = os.path.join(os.path.dirname(basepath), "lib", "mappings")
-        # Where to find the settings
-        SETTING_DIR = os.path.join(os.path.dirname(basepath), "lib", "settings")
+    def add_mapping(self, name: str, body: Dict[AnyStr, Any]):
+        """
+        Add a template property sub-document to the mappings.
 
-        self.versions = {}
-        self.templates = {}
-        self.idx_prefix = idx_prefix
-        self.logger = logger
-        self.known_tool_handlers = known_tool_handlers
-        self._dbg = _dbg
 
-        # Pbench report status mapping and settings.
-        mfile = os.path.join(MAPPING_DIR, "server-reports.json")
-        key, idxver, mapping = self._fetch_mapping(mfile)
-        server_reports_settings = self._load_json(
-            os.path.join(SETTING_DIR, "server-reports.json")
-        )
+        Args:
+            name: Property name
+            body: Subdocument description
 
-        ip = self.index_patterns[key]
-        idxname = ip["idxname"]
-        server_reports_template_name = ip["template_name"].format(
-            prefix=self.idx_prefix, version=idxver, idxname=idxname
-        )
-        server_reports_template_body = dict(
-            index_patterns=ip["template_pat"].format(
-                prefix=self.idx_prefix, version=idxver, idxname=idxname
-            ),
-            settings=server_reports_settings,
-            mappings=mapping,
-        )
-        self.templates[server_reports_template_name] = server_reports_template_body
-        self.versions["server-reports"] = idxver
+        Raises:
+            KeyError: the loaded template body doesn't have the expected
+                "properties" key.
+        """
+        self.json["properties"][name] = body
 
-        run_settings = self._load_json(os.path.join(SETTING_DIR, "run.json"))
-        for mapping_fn in glob.iglob(os.path.join(MAPPING_DIR, "run*.json")):
-            key, idxver, mapping = self._fetch_mapping(mapping_fn)
-            ip = self.index_patterns[key]
-            idxname = ip["idxname"]
-            # The API body for the template create() contains a dictionary with the
-            # settings and the mappings.
-            run_template_name = ip["template_name"].format(
-                prefix=self.idx_prefix, version=idxver, idxname=idxname
-            )
-            run_template_body = dict(
-                index_patterns=ip["template_pat"].format(
-                    prefix=self.idx_prefix, version=idxver, idxname=idxname
-                ),
-                settings=run_settings,
-                mappings=mapping,
-            )
-            self.templates[run_template_name] = run_template_body
-            self.versions[key] = idxver
 
-        # Next we load the result-data mappings and settings.
-        result_settings = self._load_json(os.path.join(SETTING_DIR, "result-data.json"))
-        for mapping_fn in glob.iglob(os.path.join(MAPPING_DIR, "result-data*.json")):
-            mfile = os.path.join(MAPPING_DIR, mapping_fn)
-            key, idxver, mapping = self._fetch_mapping(mfile)
-            ip = self.index_patterns[key]
-            idxname = ip["idxname"]
-            result_template_name = ip["template_name"].format(
-                prefix=self.idx_prefix, version=idxver, idxname=idxname
-            )
-            result_template_body = dict(
-                index_patterns=ip["template_pat"].format(
-                    prefix=self.idx_prefix, version=idxver, idxname=idxname
-                ),
-                settings=result_settings,
-                mappings=mapping,
-            )
-            self.templates[result_template_name] = result_template_body
-            self.versions[key] = idxver
+class JsonToolFile(JsonFile):
+    """
+    Extend the JSON template file handling to provide the capability of merging
+    JSON tool templates with a base skeleton.
+    """
 
-        # Now for the tool data mappings. First we fetch the base skeleton they
-        # all share.
-        skel = self._load_json(os.path.join(MAPPING_DIR, "tool-data-skel.json"))
-        ip = self.index_patterns["tool-data"]
+    def load(self) -> bool:
+        """
+        Tool mapping files define a sub-document in the Elasticsearch template
+        specific to the tool (e.g., "iostat") which exists within a common
+        base skeleton. The merge of the two includes elevating the "_meta"
+        version from the sub-document into the base document.
 
-        # Next we load all the tool fragments
-        tool_mapping_frags = {}
-        for mapping_fn in glob.iglob(
-            os.path.join(MAPPING_DIR, "tool-data-frag-*.json")
-        ):
-            m = self._fpat.match(os.path.basename(mapping_fn))
-            toolname = m.group("toolname")
-            if self.known_tool_handlers is not None:
-                if toolname not in self.known_tool_handlers:
-                    raise MappingFileError(
-                        "Unsupported tool '{}' mapping file {}".format(
-                            toolname, mapping_fn
-                        )
-                    )
-            mapping = self._load_json(mapping_fn)
+        Here we extend the JsonFile load method to remove the sub-document
+        metadata and save it to be spliced into the base document by merge.
+
+        Returns:
+            True if the file was loaded, False if it had already been loaded
+        """
+        loaded = super().load()
+        if loaded:
             try:
-                idxver = mapping["_meta"]["version"]
-            except KeyError:
-                raise MappingFileError(
-                    "{} mapping missing _meta field in {}".format(key, mapping_fn)
+                self.meta = self.json["_meta"]
+                del self.json["_meta"]
+            except KeyError as e:
+                raise TemplateError(
+                    f"Mapping file {self.file.name} is missing {e} property"
                 )
-            if self._dbg > 5:
-                print(
-                    "fetch_mapping: {} -- {}\n{}\n".format(
-                        mapping_fn,
-                        toolname,
-                        json.dumps(mapping, indent=4, sort_keys=True),
-                    )
-                )
-            del mapping["_meta"]
-            tool_mapping_frags[toolname] = mapping
-            self.versions[ip["idxname"].format(tool=toolname)] = idxver
+        return loaded
 
-        tool_settings = self._load_json(os.path.join(SETTING_DIR, "tool-data.json"))
+    def get_version(self) -> str:
+        """
+        Parse the metadata version information from the mapping file. This is
+        done on standalone template files and on "tool" template files, but
+        not on the "base" skeleton files shared by the tool templates. The
+        context is under control of the TemplateFile class load methods.
 
-        for toolname, frag in tool_mapping_frags.items():
-            tool_mapping = copy.deepcopy(skel)
-            idxname = ip["idxname"].format(tool=toolname)
-            idxver = self.versions[idxname]
-            tool_mapping["_meta"] = dict(version=self.versions[idxname])
-            tool_mapping["properties"][toolname] = frag
-            tool_template_name = ip["template_name"].format(
-                prefix=self.idx_prefix, version=idxver, idxname=idxname
-            )
-            tool_template_body = dict(
-                index_patterns=ip["template_pat"].format(
-                    prefix=self.idx_prefix,
-                    version=self.versions[idxname],
-                    idxname=idxname,
-                ),
-                settings=tool_settings,
-                mappings=tool_mapping,
-            )
-            self.templates[tool_template_name] = tool_template_body
+        This produces a similar result to the superclass method; except that
+        JsonToolFile has already sequestered the version metadata to prepare
+        for merging with the skeleton.
 
-        # Add a standard "authorization" sub-document into each of the
-        # document templates we've collected. With the single exception
-        # of the server reports template, which isn't owned by any
-        # user.
-        for name, body in self.templates.items():
-            if name != server_reports_template_name:
-                body["mappings"]["properties"]["authorization"] = {
-                    "properties": {
-                        "owner": {"type": "keyword"},
-                        "access": {"type": "keyword"},
-                    }
-                }
+        Raises:
+            MappingFileError: Mapping file doesn't contain proper version
 
-        self.counters = Counter()
+        Returns:
+            Template file metadata version
+        """
+        return self.extract_version(self.meta)
 
+    def merge(self, name: str, base: JsonFile):
+        """
+        Merge a tool-specific sub-document into the common base Elasticsearch
+        template document by linking the tool's mapping and meta-version into
+        a copy of the base document.
+
+        Args:
+            name: property name
+            base: The base JsonFile
+        """
+        tool_mapping = copy.deepcopy(base.json)
+        tool_mapping["_meta"] = self.meta
+        sub_map = self.json
+        self.json = tool_mapping
+        self.add_mapping(name, sub_map)
+
+
+class TemplateFile:
+    """
+    Describes an Elasticsearch template. This may include both mapping file
+    and settings file, as a complete template. Tool templates are built from a
+    "base" skeleton and a tool-specific overlay, with a shared JsonFile object
+    describing the common framework and a JsonToolFile providing the version
+    and tool-specific properties.
+
+    Loading the JSON files from disk is deferred to the resolve() method; this
+    will check modification dates against the Template database. We can use the
+    DB cached data unless the on-disk JSON is newer, in which case we'll fully
+    resolve it and update the DB.
+    """
+
+    # Internal fixed "pattern" information for processing index templates; each
+    # of these defines properties associated with a particular Elasticsearch
+    # index and document template pair. The exception is the final "tool-data"
+    # element which describes a set of index/template documents, one for each
+    # tool-specific document. (E.g., iostat, pidstat.)
+    #
+    # Properties:
+    #     (key):            The internal reference name.
+    #     idxname:          The root name of the Elasticsearch index
+    #     template_name:    The document template name to be registered with
+    #                       Elasticsearch
+    #     template_pat:     The index name to be registered with Elasticsearch
+    #     template:         The format of Elasticsearch's generated timeseries
+    #                       indices associated with the "template_pat"
+    #     owned             Documents using this template are "owned" by a user
+    #     desc              A description string reported when templates are
+    #                       dumped by the pbench-index command.
     index_patterns = {
         "result-data": {
             "idxname": "result-data",
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}-{day}",
+            "owned": True,
             "desc": "Daily result data (any data generated by the"
             " benchmark) for all pbench result tar balls;"
             " e.g prefix.v0.result-data.YYYY-MM-DD",
@@ -221,6 +263,7 @@ class PbenchTemplates:
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}-{day}",
+            "owned": True,
             "desc": "Daily result data (any data generated by the"
             " benchmark) for all pbench result tar balls;"
             " e.g prefix.v0.result-data-sample.YYYY-MM-DD",
@@ -230,6 +273,7 @@ class PbenchTemplates:
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}",
+            "owned": True,
             "desc": "Monthly pbench run metadata for index tar balls;"
             " contains directories, file names, and their size,"
             " permissions, etc.; e.g. prefix.v0.run.YYYY-MM",
@@ -239,6 +283,7 @@ class PbenchTemplates:
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}",
+            "owned": True,
             "desc": "Monthly table of contents metadata for index tar"
             " balls; contains directories, file names, and their size,"
             " permissions, etc.; e.g. prefix.v0.run.YYYY-MM",
@@ -248,6 +293,7 @@ class PbenchTemplates:
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}",
+            "owned": False,
             "desc": "Monthly pbench server status reports for all"
             " cron jobs; e.g. prefix.v0.server-reports.YYYY-MM",
         },
@@ -256,22 +302,360 @@ class PbenchTemplates:
             "template_name": "{prefix}.v{version}.{idxname}",
             "template_pat": "{prefix}.v{version}.{idxname}.*",
             "template": "{prefix}.v{version}.{idxname}.{year}-{month}-{day}",
+            "owned": True,
             "desc": "Daily tool data for all tools land in indices"
             " named by tool; e.g. prefix.v0.tool-data-iostat.YYYY-MM-DD",
         },
     }
 
+    # REGEX pattern to pull the tool name out of the standard file name pattern
+    # for tool mapping files. The "toolname" group becomes the internal name of
+    # the template and the DB key.
+    _fpat = re.compile(r"tool-data-frag-(?P<toolname>.+)\.json")
+
+    def __init__(
+        self,
+        prefix: str,
+        mappings: Path,
+        settings: JsonFile,
+        skeleton: JsonFile = None,
+        tool: str = None,
+    ):
+        """
+        Describe an Elasticsearch template including a JSON document mappings
+        file and a JSON settings file, which will be merged into a full
+        Elasticsearch template payload.
+
+        A "skeleton" JSON file may also be linked, from which the mappings will
+        be built by merging tool-specific properties and version into a common
+        base template.
+
+        Args:
+            prefix: Pbench index prefix string
+            mappings: JSON document description.
+            settings: JSON index settings.
+            skeleton: A versionless skeleton mappings file to merge with the tool
+                mappings.
+            tool: The index_patterns dict key when it differs from the tool name:
+                e.g., all "tool" documents share the "tool-data" key but have
+                distinct names.
+        """
+        self.prefix = prefix
+        self.settings = settings
+        if tool:
+            self.mappings = JsonToolFile(mappings)
+            self.key = tool
+            m = self._fpat.match(mappings.name)
+            if m:
+                self.name = m.group("toolname")
+            else:
+                raise TemplateError(
+                    f"Tool template {mappings.name} ({tool}) doesn't match expected pattern."
+                )
+        else:
+            self.mappings = JsonFile(mappings)
+            self.name = mappings.stem
+            self.key = self.name
+        try:
+            self.index_info = self.index_patterns[self.key]
+        except KeyError:
+            raise TemplateError(
+                f"Template {self.name} (key {self.key}) does not resolve to a known index pattern"
+            )
+        self.idxname = self.index_info["idxname"].format(tool=self.name)
+        self.version = None
+        self.tool = tool
+        self.skeleton = skeleton
+        if skeleton:
+            self.modified = max(self.mappings.modified, self.skeleton.modified)
+        else:
+            self.modified = self.mappings.modified
+        self.loaded = False
+
+    def load(self):
+        """
+        Load the associated JSON files into memory; including both the "main"
+        mapping file, the settings file, and, if specified, a "skeleton"
+        mapping file which provides a common base for a set of tool mappings.
+
+        Expand templates to create all the information necessary to register a
+        document template with Elasticsearch.
+
+        Once this method returns, the body() method can be called to return
+        the full Elasticsearch JSON payload necessary to register a document
+        template and its index pattern.
+        """
+        # Don't go further if we've already loaded and processed
+        if self.loaded:
+            return
+        self.mappings.load()
+        self.version = self.mappings.get_version()
+        if self.skeleton:
+            self.skeleton.load()
+            self.mappings.merge(self.name, self.skeleton)
+        self.settings.load()
+        idxver = self.version
+        ip = self.index_info
+        self.template_name = ip["template_name"].format(
+            prefix=self.prefix, version=idxver, idxname=self.idxname
+        )
+        self.index_pattern = ip["template_pat"].format(
+            prefix=self.prefix, version=idxver, idxname=self.idxname
+        )
+        self.index_template = ip["template"]
+
+        # Add a standard "authorization" sub-document into the document
+        # template if this document type is "owned" by a Pbench user.
+        if ip["owned"]:
+            self.add_mapping(
+                "authorization",
+                {
+                    "properties": {
+                        "owner": {"type": "keyword"},
+                        "access": {"type": "keyword"},
+                    }
+                },
+            )
+        self.loaded = True
+
+    def add_mapping(self, name: str, body: Dict[AnyStr, Any]):
+        """
+        Add a template property sub-document to the mappings.
+
+        Args:
+            name: Property name
+            body: Subdocument description
+
+        Raises:
+            Any exception raised by the mapping object's add_mapping method.
+        """
+        self.mappings.add_mapping(name, body)
+
+    def update(self, template: Template):
+        """
+        Update the template object from a database model object rather than
+        loading and processing mapping and setting files from disk.
+
+        Args:
+            template: DB Template instance
+        """
+        self.modified = template.mtime
+        self.version = template.version
+        self.mappings = JsonFile.raw_json(template.mappings, template.mtime)
+        self.settings = JsonFile.raw_json(template.settings, template.mtime)
+        self.template_name = template.template_name
+        self.index_pattern = template.template_pattern
+        self.index_template = template.index_template
+        self.idxname = template.idxname
+
+    def resolve(self):
+        """
+        Check the on-disk template mapping files' modification dates against
+        the templates DB. Only if the template's base index name doesn't exist
+        in the DB, or if the DB object is older than the on-disk template do
+        we load the mapping files from disk.
+        """
+        try:
+            template = Template.find(self.name)
+            # If we found a match that's not older, use it
+            if template.mtime >= self.modified:
+                self.update(template)
+                return
+        except TemplateNotFound:
+            template = None
+
+        # We didn't return, so the DB template is missing or older than the
+        # on-disk JSON. We now need to fully resolve the mapping files. If we
+        # found an older DB object, we'll update it with the new data;
+        # otherwise we'll create a new Template object.
+        self.load()
+        if not template:
+            template = Template(
+                name=self.name,
+                idxname=self.idxname,
+                template_name=self.template_name,
+                file=str(self.mappings.file),
+                template_pattern=self.index_pattern,
+                index_template=self.index_template,
+                settings=self.settings.json,
+                mappings=self.mappings.json,
+                mtime=self.modified,
+                version=self.version,
+            )
+            template.add()
+        else:
+            template.version = self.version
+            template.mappings = self.mappings.json
+            template.settings = self.settings.json
+            template.mtime = self.modified
+            template.update()
+
+    def generate_index_name(self, source) -> str:
+        """
+        Return a fully formed index name for the template given a source
+        document.
+
+        Args:
+            source: JSON source document providing an @timestamp
+
+        Raises:
+            TemplateError: A problem with the index template descriptor.
+            BadDate: A problem decoding the date from the source document.
+
+        Returns:
+            The Elasticsearch index into which the source document will be indexed.
+        """
+        version = self.version
+        idxname = self.idxname
+
+        try:
+            ts_val = source["@timestamp"]
+        except KeyError as e:
+            raise BadDate(f"missing {e} in a source document: {source!r}")
+
+        year, month, day = ts_val.split("T", 1)[0].split("-")[0:3]
+        return self.index_template.format(
+            prefix=self.prefix,
+            version=version,
+            idxname=idxname,
+            year=year,
+            month=month,
+            day=day,
+        )
+
+    def body(self) -> Dict[AnyStr, Any]:
+        """
+        Return a JSON payload suitable to POST to Elasticsearch in order to
+        register an indexed document template.
+
+        Returns:
+            Elasticsearch template payload
+        """
+        return {
+            "index_patterns": self.index_pattern,
+            "settings": self.settings.json,
+            "mappings": self.mappings.json,
+        }
+
+
+class PbenchTemplates:
+    """
+    Encapsulation of methods for loading / working with all the Pbench
+    templates needed to define our Elasticsearch document schema.
+    """
+
+    def __init__(self, basepath, idx_prefix, logger, known_tool_handlers=None, _dbg=0):
+        """
+        This contains the embedded knowledge of how the Pbench server defines
+        and managed Elasticsearch template documents and indices. It relies on
+        secondary classes to encapsulate low-level mechanism to deal with each
+        template and the associated JSON data.
+
+        This class, for example, understands which template patterns share a
+        particular file describing Elasticsearch index settings, and which
+        template documents are derived from common skeleton mappings.
+
+        Args:
+            basepath:               The base Pbench server installation
+                                    directory
+            idx_prefix:             The server's Elasticsearch index prefix
+            logger:                 A Python Logger
+            known_tool_handlers:    Describes the set of tools that will have
+                                    templates generated from a common tool-data
+                                    skeleton.
+            _dbg:                   Debug level for output (historical: not
+                                    used)
+        """
+        base_dir = Path(basepath).parent / "lib"
+        mapping_dir = base_dir / "mappings"
+        setting_dir = base_dir / "settings"
+
+        self.versions = {}
+        self.templates = {}
+        self.idx_prefix = idx_prefix
+        self.logger = logger
+        self.known_tool_handlers = known_tool_handlers
+        self._dbg = _dbg
+        self.counters = Counter()
+
+        # Pbench report status mapping and settings.
+        self.add_template(
+            TemplateFile(
+                prefix=idx_prefix,
+                mappings=mapping_dir / "server-reports.json",
+                settings=JsonFile(setting_dir / "server-reports.json"),
+            )
+        )
+
+        run_settings = JsonFile(setting_dir / "run.json")
+        for mapping_fn in mapping_dir.glob("run*.json"):
+            self.add_template(
+                TemplateFile(
+                    prefix=idx_prefix,
+                    mappings=mapping_dir / mapping_fn,
+                    settings=run_settings,
+                )
+            )
+
+        result_settings = JsonFile(setting_dir / "result-data.json")
+        for mapping_fn in mapping_dir.glob("result-data*.json"):
+            self.add_template(
+                TemplateFile(
+                    prefix=idx_prefix,
+                    mappings=mapping_dir / mapping_fn,
+                    settings=result_settings,
+                )
+            )
+
+        skeleton = JsonFile(mapping_dir / "tool-data-skel.json")
+        tool_settings = JsonFile(setting_dir / "tool-data.json")
+        for mapping_fn in mapping_dir.glob("tool-data-frag-*.json"):
+            self.add_template(
+                TemplateFile(
+                    prefix=idx_prefix,
+                    mappings=mapping_dir / mapping_fn,
+                    settings=tool_settings,
+                    skeleton=skeleton,
+                    tool="tool-data",
+                )
+            )
+        self.resolve()
+
+    def add_template(self, template: TemplateFile):
+        """
+        Add a template to the mapping dictionary by the proper key.
+
+        Args:
+            template: Template document
+        """
+        self.templates[template.idxname] = template
+
+    def resolve(self):
+        """
+        Using the Template database table and the information gathered during
+        PbenchTemplate construction, decide which templates we need to load
+        and resolve from disk, and which we can load from the database.
+        """
+        for template in self.templates.values():
+            template.resolve()
+
     def dump_idx_patterns(self):
-        patterns = self.index_patterns
-        pattern_names = [idx for idx in patterns]
-        pattern_names.sort()
-        for idx in pattern_names:
+        """
+        List the registered index template patterns to the user.
+
+        NOTE: This doesn't do a simple traversal of the templates dictionary
+        in order to retain an output style identical to the previous, with the
+        generic "tool-data" description appearing only once following the last
+        tool data pattern.
+        """
+        patterns = TemplateFile.index_patterns
+        for idx in sorted(patterns.keys()):
             if idx != "tool-data":
                 idxname = patterns[idx]["idxname"]
                 print(
                     patterns[idx]["template"].format(
                         prefix=self.idx_prefix,
-                        version=self.versions[idx],
+                        version=self.templates[idxname].version,
                         idxname=idxname,
                         year="YYYY",
                         month="MM",
@@ -279,18 +663,14 @@ class PbenchTemplates:
                     )
                 )
             else:
-                tool_names = [
-                    tool
-                    for tool in self.known_tool_handlers
-                    if self.known_tool_handlers[tool] is not None
-                ]
-                tool_names.sort()
-                for tool_name in tool_names:
+                for tool_name in sorted(self.known_tool_handlers.keys()):
+                    if not self.known_tool_handlers[tool_name]:
+                        continue
                     idxname = patterns[idx]["idxname"].format(tool=tool_name)
                     print(
                         patterns[idx]["template"].format(
                             prefix=self.idx_prefix,
-                            version=self.versions[idxname],
+                            version=self.templates[idxname].version,
                             idxname=idxname,
                             year="YYYY",
                             month="MM",
@@ -301,42 +681,46 @@ class PbenchTemplates:
         sys.stdout.flush()
 
     def dump_templates(self):
-        template_names = [name for name in self.templates]
-        template_names.sort()
-        for name in template_names:
+        """
+        List all of the registered template documents
+        """
+        templates = {t.template_name: t for t in self.templates.values()}
+        for name in sorted(templates.keys()):
             print(
                 "\n\nTemplate: {}\n\n{}\n".format(
-                    name, json.dumps(self.templates[name], indent=4, sort_keys=True)
+                    name, json.dumps(templates[name].body(), indent=4, sort_keys=True)
                 )
             )
         sys.stdout.flush()
 
     def update_templates(self, es, target_name=None):
-        """Push the various Elasticsearch index templates required by pbench.
         """
-        if target_name is not None:
-            idxname = self.index_patterns[target_name]["idxname"]
-        else:
-            idxname = None
-        template_names = [name for name in self.templates]
-        template_names.sort()
+        Register with Elasticsearch the set of index templates used by the
+        Pbench server.
+
+        Args
+            es:             Elasticsearch object to connect to server
+            target_name:    Optional template name to update just one template
+
+        Raises
+            TemplateError   Problem updating the template to server
+        """
+        template_names = {t.template_name: t for t in self.templates.values()}
         successes = retries = 0
         beg = end = None
-        for name in template_names:
-            if idxname is not None and not name.endswith(idxname):
+        for name in sorted(template_names.keys()):
+            template = template_names[name]
+            if target_name is not None and target_name != template.idxname:
                 # If we were asked to only load a given template name, skip
                 # all non-matching templates.
                 continue
             try:
                 _beg, _end, _retries, _stat = pyesbulk.put_template(
-                    es,
-                    name,
-                    "pbench-{}".format(name.split(".")[2]),
-                    self.templates[name],
+                    es, name, "pbench-{}".format(template.name), template.body(),
                 )
             except Exception as e:
                 self.counters["put_template_failures"] += 1
-                raise TemplateError(e)
+                raise TemplateError(f"Tool {name} update failed: {e}")
             else:
                 successes += 1
                 if beg is None:
@@ -354,49 +738,37 @@ class PbenchTemplates:
             retries,
         )
 
-    def generate_index_name(self, template_name, source, toolname=None):
-        """Return a fully formed index name given its template, prefix, source
-        data (for an @timestamp field) and an optional tool name."""
-        try:
-            template = self.index_patterns[template_name]["template"]
-            idxname_tmpl = self.index_patterns[template_name]["idxname"]
-        except KeyError as e:
-            self.counters["invalid_template_name"] += 1
-            raise Exception("Invalid template name, '{}': {}".format(template_name, e))
-        if toolname is not None:
-            idxname = idxname_tmpl.format(tool=toolname)
-            try:
-                version = self.versions[idxname]
-            except KeyError as e:
-                self.counters["invalid_tool_index_name"] += 1
-                raise Exception(
-                    "Invalid tool index name for version, '{}':"
-                    " {}".format(idxname, e)
-                )
+    def generate_index_name(self, template_name, source, toolname=None) -> str:
+        """
+        Return a fully formed index name given its template, prefix, source
+        data (for an @timestamp field) and an optional tool name.
+
+        Args
+            template_name:  Name of template pattern
+            source:         JSON source document with @timestamp
+            toolname:       Shared tool skeleton name (optional)
+
+        Raises
+            Exception   Template name wasn't found
+
+        Returns
+            expanded index name including date
+        """
+        for t in self.templates.values():
+            if t.key == template_name and (toolname is None or t.name == toolname):
+                template = t
+                break
         else:
-            idxname = idxname_tmpl
-            try:
-                version = self.versions[template_name]
-            except KeyError as e:
-                self.counters["invalid_template_name"] += 1
-                raise Exception(
-                    "Invalid index template name for version,"
-                    " '{}': {}".format(idxname, e)
-                )
+            self.counters["invalid_template_name"] += 1
+            raise Exception(
+                "Invalid template name, '{}': {}".format(template_name, template_name)
+            )
+
         try:
-            ts_val = source["@timestamp"]
-        except KeyError:
+            return template.generate_index_name(source)
+        except BadDate:
             self.counters["ts_missing_at_timestamp"] += 1
-            raise BadDate(f"missing @timestamp in a source document: {source!r}")
-        except TypeError as e:
+            raise
+        except JsonFileError:
             self.counters["bad_source"] += 1
-            raise Exception(f"Failed to generate index name, {e}, source: {source!r}")
-        year, month, day = ts_val.split("T", 1)[0].split("-")[0:3]
-        return template.format(
-            prefix=self.idx_prefix,
-            version=version,
-            idxname=idxname,
-            year=year,
-            month=month,
-            day=day,
-        )
+            raise

--- a/lib/pbench/test/unit/server/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/test_controllers_list.py
@@ -111,7 +111,7 @@ class TestControllersList:
             == "Value '2020-19' (str) cannot be parsed as a date/time string"
         )
 
-    def test_query(self, client, server_config, query_helper, user_ok):
+    def test_query(self, client, server_config, query_helper, user_ok, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -174,7 +174,9 @@ class TestControllersList:
         assert res_json[1]["last_modified_value"] == 1.6
         assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
 
-    def test_empty_query(self, client, server_config, query_helper, user_ok):
+    def test_empty_query(
+        self, client, server_config, query_helper, user_ok, find_template
+    ):
         """
         Check proper handling of a query resulting in no Elasticsearch matches.
         """
@@ -223,7 +225,9 @@ class TestControllersList:
             {"exception": Exception, "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
-    def test_http_error(self, client, server_config, query_helper, exceptions, user_ok):
+    def test_http_error(
+        self, client, server_config, query_helper, exceptions, user_ok, find_template
+    ):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/test_datasets_detail.py
@@ -118,7 +118,7 @@ class TestDatasetsDetail:
             == "Value '2020-19' (str) cannot be parsed as a date/time string"
         )
 
-    def test_query(self, client, server_config, query_helper, user_ok):
+    def test_query(self, client, server_config, query_helper, user_ok, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -237,7 +237,9 @@ class TestDatasetsDetail:
         }
         assert expected == res_json
 
-    def test_empty_query(self, client, server_config, query_helper, user_ok):
+    def test_empty_query(
+        self, client, server_config, query_helper, user_ok, find_template
+    ):
         """
         Check the handling of a query that doesn't return any data.
         """
@@ -261,7 +263,9 @@ class TestDatasetsDetail:
         )
         assert response.json["message"].find("dataset has gone missing") != -1
 
-    def test_nonunique_query(self, client, server_config, query_helper, user_ok):
+    def test_nonunique_query(
+        self, client, server_config, query_helper, user_ok, find_template
+    ):
         """
         Check the handling of a query that returns too much data.
         """
@@ -307,7 +311,9 @@ class TestDatasetsDetail:
             {"exception": Exception, "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
-    def test_http_error(self, client, server_config, query_helper, exceptions, user_ok):
+    def test_http_error(
+        self, client, server_config, query_helper, exceptions, user_ok, find_template
+    ):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -113,7 +113,7 @@ class TestDatasetsList:
             == "Value '2020-19' (str) cannot be parsed as a date/time string"
         )
 
-    def test_query(self, client, server_config, query_helper, user_ok):
+    def test_query(self, client, server_config, query_helper, user_ok, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -189,7 +189,9 @@ class TestDatasetsList:
             {"exception": Exception, "status": 500},
         ),
     )
-    def test_http_error(self, client, server_config, query_helper, exceptions, user_ok):
+    def test_http_error(
+        self, client, server_config, query_helper, exceptions, user_ok, find_template
+    ):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_month_indices.py
+++ b/lib/pbench/test/unit/server/test_month_indices.py
@@ -43,7 +43,7 @@ class TestMonthIndices:
     constructor and `post` service.
     """
 
-    def test_query(self, client, server_config, get_helper):
+    def test_query(self, client, server_config, get_helper, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -113,7 +113,9 @@ class TestMonthIndices:
             {"exception": Exception, "status": 500},
         ),
     )
-    def test_http_error(self, client, server_config, get_helper, exceptions):
+    def test_http_error(
+        self, client, server_config, get_helper, exceptions, find_template
+    ):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.

--- a/lib/pbench/test/unit/server/test_template_db.py
+++ b/lib/pbench/test/unit/server/test_template_db.py
@@ -1,0 +1,160 @@
+import datetime
+import pytest
+
+from pbench.server.database.models.template import (
+    Template,
+    TemplateDuplicate,
+    TemplateFileMissing,
+    TemplateMissingParameter,
+    TemplateNotFound,
+)
+
+
+class TestTemplate:
+    def test_construct(self, fake_mtime, db_session):
+        """ Test dataset constructor
+        """
+        template = Template(
+            name="run",
+            idxname="run-data",
+            template_name="tname",
+            file="run.json",
+            template_pattern="drb.v1.run.*",
+            index_template="drb.v1.run.{year}-{month}",
+            settings={"none": False},
+            mappings={"properties": None},
+            version=5,
+        )
+        template.add()
+        assert template.name == "run"
+        assert template.mtime == datetime.datetime(2021, 1, 29, 0, 0, 0)
+        assert "run: drb.v1.run.{year}-{month}" == str(template)
+
+    def test_construct_duplicate(self, fake_mtime, db_session):
+        """ Test dataset constructor
+        """
+        template = Template(
+            name="run",
+            idxname="run-data",
+            template_name="tname",
+            file="run.json",
+            template_pattern="drb.v1.run.*",
+            index_template="drb.v1.run.{year}-{month}",
+            settings={"none": False},
+            mappings={"properties": None},
+            version=5,
+        )
+        template.add()
+        with pytest.raises(TemplateDuplicate) as e:
+            template1 = Template(
+                name="run",
+                idxname="run-data",
+                template_name="tname",
+                file="run.json",
+                template_pattern="drb.v1.run.*",
+                index_template="drb.v1.run.{year}-{month}",
+                settings={"none": False},
+                mappings={"properties": None},
+                version=5,
+            )
+            template1.add()
+        assert str(e).find("run") != -1
+
+    def test_construct_fileless(self, fake_mtime, db_session):
+        """ Test dataset constructor without a file column
+        """
+        with pytest.raises(TemplateFileMissing) as e:
+            Template(
+                name="run",
+                idxname="run-data",
+                template_name="tname",
+                template_pattern="drb.v1.run.*",
+                index_template="drb.v1.run.{year}-{month}",
+                settings={"none": False},
+                mappings={"properties": None},
+                version=5,
+            )
+        assert str(e).find("run") != -1
+
+    def test_construct_missing(self, fake_mtime, db_session):
+        """ Test dataset constructor when non-nullable columns are omitted;
+        the constuctor works, but SQL will throw an IntegrityError when we
+        try to commit to the DB.
+        """
+        with pytest.raises(TemplateMissingParameter) as e:
+            template = Template(
+                name="run",
+                file="map.json",
+                template_name="tname",
+                template_pattern="drb.v1.run.*",
+                index_template="drb.v1.run.{year}-{month}",
+                version=5,
+            )
+            template.add()
+        assert str(e).find("run") != -1
+
+    def test_find_exists(self, fake_mtime, db_session):
+        """ Test that we can find a template
+        """
+        template1 = Template(
+            name="run",
+            idxname="run-data",
+            template_name="run",
+            file="run-toc.json",
+            template_pattern="drb.v2.run-toc.*",
+            index_template="drb.v2.run-toc.{year}-{month}",
+            settings={"none": False},
+            mappings={"properties": None},
+            version=5,
+        )
+        template1.add()
+
+        template2 = Template.find(name="run")
+        assert template2.name == template1.name
+        assert template2.id is template1.id
+
+    def test_find_none(self, fake_mtime, db_session):
+        """ Test expected failure when we try to find a template that
+        does not exist.
+        """
+        with pytest.raises(TemplateNotFound):
+            Template.find(name="data")
+
+    def test_update(self, fake_mtime, db_session):
+        """ Test template update
+        """
+        template = Template(
+            name="run",
+            file="run.json",
+            idxname="run-data",
+            template_name="tname",
+            template_pattern="drb.v1.run.*",
+            index_template="drb.v1.run.{year}-{month}",
+            settings={"none": False},
+            mappings={"properties": None},
+            version=5,
+        )
+        template.add()
+        template.mappings = {"properties": "something"}
+        template.update()
+
+    def test_update_missing(self, fake_mtime, db_session):
+        """ Test template update
+        """
+        template = Template(
+            name="run",
+            file="run.json",
+            idxname="run-data",
+            template_name="tname",
+            template_pattern="drb.v1.run.*",
+            index_template="drb.v1.run.{year}-{month}",
+            settings={"none": False},
+            mappings={"properties": None},
+            version=5,
+        )
+        template.add()
+        template.idxname = None
+        with pytest.raises(TemplateMissingParameter) as e:
+            template.update()
+        assert str(e).find("run") != -1
+        assert str(e).find("idxname") != -1

--- a/lib/pbench/test/unit/server/test_templates.py
+++ b/lib/pbench/test/unit/server/test_templates.py
@@ -1,0 +1,176 @@
+import datetime
+import io
+from pathlib import Path
+import pytest
+
+from pbench.server.templates import JsonFile, JsonToolFile
+
+
+@pytest.fixture()
+def fake_resolve(monkeypatch):
+    """
+    JsonFile objects use Path().resolve(strict=True) to get a full path; fake
+    it so we don't need real files.
+
+    Args:
+        monkeypatch: Patching fixture
+    """
+
+    def fake_resolve(self: Path, strict: bool = False):
+        """
+        Return a "full" fake file name
+
+        Args:
+            strict: Not used in the mock
+
+        Returns:
+            new Path with fake resolution
+        """
+        return Path("/fake/path/") / self.name
+
+    with monkeypatch.context() as m:
+        m.setattr(Path, "resolve", fake_resolve)
+        yield
+
+
+@pytest.fixture()
+def fake_open(monkeypatch, request):
+    """
+    JsonFile objects use Path().resolve(mode="r") to read the JSON file; fake
+    it so we don't need real files.
+
+    Args:
+        monkeypatch: Patching fixture
+    """
+    data = request.node.get_closest_marker("open_data")
+    if data is None:
+        data = "{'default': 'test'}"
+
+    def fake_open(self: Path, mode: str = "r"):
+        """
+        Return an IO stream
+
+        Args:
+            mode: file mode (assumed to be "r")
+
+        Returns:
+            IO channel from string
+        """
+        assert mode == "r"
+        return io.StringIO(data)
+
+    with monkeypatch.context() as m:
+        m.setattr(Path, "open", fake_open)
+        yield
+
+
+class TestJsonFile:
+    """
+    Tests for the JsonFile class
+    """
+
+    def test_json_file(self, fake_resolve, fake_mtime):
+        """
+        Test a simple object construction
+        """
+        json = JsonFile(Path("mapping.json"))
+        assert str(json.file) == "/fake/path/mapping.json"
+        assert json.json is None
+        assert json.modified == datetime.datetime(2021, 1, 29, 0, 0, 0)
+
+    def test_json_load(self, monkeypatch, fake_resolve, fake_mtime):
+        """
+        Test "loading" a JsonFile object from a fake JSON file to verify that
+        the JSON content and version are processed properly.
+        """
+        json = JsonFile(Path("mapping.json"))
+        with monkeypatch.context() as m:
+
+            def fake_open(self: Path, mode: str = "r"):
+                return io.StringIO('{"_meta": {"version": 6}}\n')
+
+            m.setattr(Path, "open", fake_open)
+            json.load()
+        assert json.get_version() == 6
+        assert json.json == {"_meta": {"version": 6}}
+
+    def test_json_add(self):
+        """
+        Test that JSON "mapping" properties file can be patched into the main
+        JSON document.
+        """
+        expected = {"properties": {"bar": "string"}}
+        now = datetime.datetime.now()
+        json = JsonFile.raw_json(expected, now)
+        assert json.json == expected
+        json.add_mapping("iostat", {"run": "no"})
+        assert json.json["properties"]["iostat"] == {"run": "no"}
+        assert json.modified == now
+
+
+class TestJsonToolFile:
+    """
+    Test the JsonToolFile subclass.
+    """
+
+    def test_json_file(self, fake_resolve, fake_mtime):
+        """
+        Test a simple object construction
+        """
+        json = JsonToolFile(Path("mapping.json"))
+        assert str(json.file) == "/fake/path/mapping.json"
+        assert json.json is None
+        assert json.modified == datetime.datetime(2021, 1, 29, 0, 0, 0)
+
+    def test_json_load(self, fake_resolve, fake_mtime, monkeypatch):
+        """
+        Test "loading" a JsonToolFile object from a fake JSON file to verify
+        that the JSON content and version are processed properly. Unlike the
+        base class, this sequesters the "_meta" version information to be
+        patched into a merged skeleton/tool document.
+        """
+        json = JsonToolFile(Path("mapping.json"))
+        with monkeypatch.context() as m:
+
+            def fake_open(self: Path, mode: str = "r"):
+                return io.StringIO('{"_meta": {"version": 6}}\n')
+
+            m.setattr(Path, "open", fake_open)
+            json.load()
+        assert json.get_version() == 6
+
+        # The "_meta" is sequestered, so we shouldn't see it
+        assert json.json == {}
+        assert json.meta == {"version": 6}
+
+    def test_json_merge(self, fake_resolve, fake_mtime, monkeypatch):
+        """
+        Test merging a tool properties file with a skeleton file
+        """
+        json = JsonToolFile(Path("mapping.json"))
+        base = JsonFile(Path("tool.json"))
+        with monkeypatch.context() as m:
+
+            def fake_open(self: Path, mode: str = "r"):
+                return io.StringIO(
+                    '{"_meta": {"version": 6}, "iostat": {"run": "far and fast"}}\n'
+                )
+
+            m.setattr(Path, "open", fake_open)
+            json.load()
+        with monkeypatch.context() as m:
+
+            def fake_open(self: Path, mode: str = "r"):
+                return io.StringIO('{"properties": {"@meta": "at meta friend"}}')
+
+            m.setattr(Path, "open", fake_open)
+            base.load()
+        json.merge("tool", base)
+        assert json.get_version() == 6
+        assert json.json == {
+            "_meta": {"version": 6},
+            "properties": {
+                "@meta": "at meta friend",
+                "tool": {"iostat": {"run": "far and fast"}},
+            },
+        }

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -29,9 +29,10 @@ from argparse import ArgumentParser
 from configparser import ConfigParser, NoOptionError
 
 import pbench.server
-from pbench.server import PbenchServerConfig
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
+from pbench.server import PbenchServerConfig
+from pbench.server.database.database import Database
 from pbench.server.indexer import _STD_DATETIME_FMT
 from pbench.server.report import Report
 
@@ -326,6 +327,10 @@ def main(options):
         return 2
 
     logger = get_pbench_logger(_NAME_, config)
+
+    # We're going to need the Postgres DB to track dataset state, so setup
+    # DB access.
+    Database.init_db(config, logger)
 
     archivepath = config.ARCHIVE
 

--- a/server/bin/pbench-report-status.py
+++ b/server/bin/pbench-report-status.py
@@ -7,6 +7,7 @@ from argparse import ArgumentParser
 from socket import gethostname
 
 from pbench.server import PbenchServerConfig
+from pbench.server.database.database import Database
 from pbench.common.exceptions import BadConfig
 from pbench.server.report import Report
 
@@ -64,13 +65,16 @@ parser.add_argument(
 )
 parsed = parser.parse_args()
 
-
 try:
     config = PbenchServerConfig(parsed.cfg_name)
 except BadConfig as e:
     print(f"{_prog}: {e}", file=sys.stderr)
     sys.exit(1)
 
+# We're going to need the Postgres DB to track dataset state, so setup
+# DB access. We don't pass a Logger here, because that introduces lots
+# of spurious changes in the gold CLI test output.
+Database.init_db(config, None)
 
 hostname = gethostname()
 pid = parsed.pid

--- a/server/bin/pbench-verify-backup-tarballs.py
+++ b/server/bin/pbench-verify-backup-tarballs.py
@@ -52,6 +52,7 @@ from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
 from pbench.server import PbenchServerConfig
+from pbench.server.database.database import Database
 from pbench.server.report import Report
 from pbench.server.s3backup import S3Config, Entry
 
@@ -290,6 +291,10 @@ def main():
         return 1
 
     logger = get_pbench_logger(_NAME_, config)
+
+    # We're going to need the Postgres DB to track dataset state, so setup
+    # DB access.
+    Database.init_db(config, logger)
 
     # add a BACKUP field to the config object
     config.BACKUP = backup = config.conf.get("pbench-server", "pbench-backup-dir")

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -403,6 +403,8 @@ function _setup_state {
     printf "[DEFAULT]\n"                   >> ${_testtmp}/pbench-server.cfg
     printf "unittest-dir = ${_testroot}\n" >> ${_testtmp}/pbench-server.cfg
     cat ${_state_config}                   >> ${_testtmp}/pbench-server.cfg
+    printf "[Postgres]\n"                  >> ${_testtmp}/pbench-server.cfg
+    printf "db_uri = sqlite:///${_testroot}/test_db\n" >> ${_testtmp}/pbench-server.cfg
 
     # Next we activate the satellite pbench server.
     echo "$_testopt_sat/bin/pbench-server-config-activate ${_testtmp}/pbench-server.cfg" >> $_testactout


### PR DESCRIPTION
This is separated into staged commits which may or may not make review easier.

1. Refactor PbenchTemplates
    
    Add a new Template DB model that will allow persisting our Elasticsearch templates to be shared between indexing and the server APIs.

    This also refactors the templates.py class which supports indexing, with the goal of integrating with the new DB table although the base commit stops short of implementing the integration to allow reviewing the basic refactoring separately.

1. Improve encapsulation

    Push some TemplateFile methods down into JsonFile and a new JsonToolFile subclass for cleaner encapsulation.

1. Integrate DB into template management
    
    The resolve() method now attempts to look up the root index name in the templates DB table. If found, it'll check modification timestamps to determine whether the on disk JSON (currently just resolved and stat-ed, not read) is more recent. If not, the cached DB information is used to create a TemplateFile object rather than reading from disk. If the DB object doesn't exist, it's created; if it exists but is older, it's updated.

1. The server Elasticsearch query APIs now use the Template DB to determine the index version and pattern rather than hardcoding these with the root index name.