### PR TITLE
Replace use of become/become_user with remote_user

### DIFF
--- a/agent/ansible/pbench_agent_config.yml
+++ b/agent/ansible/pbench_agent_config.yml
@@ -1,8 +1,7 @@
 ---
 - name: install pbench-agent config and key files
   hosts: servers
-  become: yes
-  become_user: root
+  remote_user: root
 
   # The default value ('production') can be overridden by cenv, a host-specific
   # inventory variable.

--- a/agent/ansible/pbench_agent_install.yml
+++ b/agent/ansible/pbench_agent_install.yml
@@ -1,8 +1,7 @@
 ---
 - name: install pbench-agent
   hosts: servers
-  become: yes
-  become_user: root
+  remote_user: root
 
   # The default value ('production') can be overridden by cenv, a host-specific
   # inventory variable.

--- a/agent/ansible/pbench_repo_install.yml
+++ b/agent/ansible/pbench_repo_install.yml
@@ -1,8 +1,7 @@
 ---
 - name: install pbench-agent repo
   hosts: servers
-  become: yes
-  become_user: root
+  remote_user: root
 
   roles:
     - pbench_repo_install


### PR DESCRIPTION
Fixes #2077

Do not use `become` or `become_user` in playbooks. Replace them
with `remote_user`.