### PR TITLE
Fix standalone db.init issue

### DIFF
--- a/lib/pbench/cli/server/user_create.py
+++ b/lib/pbench/cli/server/user_create.py
@@ -4,7 +4,7 @@ from pbench import BadConfig
 from pbench.cli.server import pass_cli_context
 from pbench.cli.server.options import common_options
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.server.database.models.users import Roles, User
 
 _NAME_ = "pbench-user-create"
@@ -20,7 +20,7 @@ class UserCreate:
         # We're going to need the Postgres DB to track dataset state, so setup
         # DB access. We execute without a logger to avoid unnecessary noise in
         # CLI gold test output from an incidental tool.
-        Database.init_db(config, None)
+        init_db(config, None)
 
         user = User(
             username=self.context.username,

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -18,6 +18,7 @@ from pbench.server.api.resources.graphql_api import GraphQL
 from pbench.server.api.resources.endpoint_configure import EndpointConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
+from pbench.server.database import init_db
 from pbench.server.database.database import Database
 from pbench.server.api.resources.query_apis.controllers_list import ControllersList
 from pbench.server.api.resources.query_apis.datasets_list import DatasetsList
@@ -134,7 +135,7 @@ def create_app(server_config):
     register_endpoints(api, app, server_config)
 
     try:
-        Database.init_db(server_config=server_config, logger=app.logger)
+        init_db(server_config=server_config, logger=app.logger)
     except Exception:
         app.logger.exception("Exception while initializing sqlalchemy database")
         sys.exit(1)

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -284,7 +284,7 @@ class Logout(Resource):
             else:
                 self.logger.debug("User {} logged out", user.username)
         else:
-            self.logger.debug("User logout with invalid or expired token")
+            self.logger.info("User logout with invalid or expired token")
 
         return "", 200
 

--- a/lib/pbench/server/database/__init__.py
+++ b/lib/pbench/server/database/__init__.py
@@ -1,0 +1,26 @@
+"""
+For any new database model added in the models directory
+an import statement of the same is required here.
+"""
+from pbench.server.database.models.active_tokens import ActiveTokens  # noqa F401
+from pbench.server.database.models.users import User  # noqa F401
+from pbench.server.database.models.tracker import Dataset, Metadata  # noqa F401
+from pbench.server.database.models.template import Template  # noqa F401
+
+from pbench.server.database.database import Database
+
+
+def init_db(server_config, logger):
+    """
+    Utility method for initializing the database.
+
+    In order to register all the tables properly in our database, the db models
+    need to be imported before the call to the Database.init_db() function.
+
+    A lot of independent functionality in our code depends on database
+    access without creating the flask app.  Invoking init_db() from here
+    makes sure all models are imported properly; therefore, all of the code
+    where we need standalone db access should invoke this function instead
+    of directly invoking Database.init_db().
+    """
+    Database.init_db(server_config=server_config, logger=logger)

--- a/server/bin/pbench-backup-tarballs.py
+++ b/server/bin/pbench-backup-tarballs.py
@@ -21,7 +21,7 @@ from pbench.server.database.models.tracker import (
     Metadata,
     DatasetError,
 )
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 
 
 _NAME_ = "pbench-backup-tarballs"
@@ -463,7 +463,7 @@ def main(cfg_name):
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     # Add a BACKUP and QDIR field to the config object
     config.BACKUP = config.conf.get("pbench-server", "pbench-backup-dir")

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -32,7 +32,7 @@ import pbench.server
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.server.indexer import _STD_DATETIME_FMT
 from pbench.server.report import Report
 
@@ -330,7 +330,7 @@ def main(options):
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     archivepath = config.ARCHIVE
 

--- a/server/bin/pbench-import-datasets.py
+++ b/server/bin/pbench-import-datasets.py
@@ -33,9 +33,9 @@ from typing import Generator
 from pbench import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
+from pbench.server.database import init_db
 from pbench.server.database.models.tracker import Dataset, States, DatasetNotFound
 from pbench.server.database.models.users import User
-from pbench.server.database.database import Database
 
 
 _NAME_ = "pbench-import-datasets"
@@ -166,7 +166,7 @@ def main(options):
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     # NOTE: the importer will ignore datasets that already exist in the DB;
     # we do the ACTION links first to get set up, and then sweep other links

--- a/server/bin/pbench-index.py
+++ b/server/bin/pbench-index.py
@@ -15,7 +15,7 @@ from configparser import Error as ConfigParserError
 
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.common.exceptions import (
     BadConfig,
     ConfigFileError,
@@ -110,7 +110,7 @@ def main(options, name):
         # Logger independently.
         config = PbenchServerConfig(options.cfg_name)
         logger = get_pbench_logger(name, config)
-        Database.init_db(config, logger)
+        init_db(config, logger)
 
         # Now we can initialize the index context
         idxctx = IdxContext(options, name, config, logger, _dbg=_DEBUG)

--- a/server/bin/pbench-reindex.py
+++ b/server/bin/pbench-reindex.py
@@ -30,7 +30,7 @@ from pbench.server.database.models.tracker import (
     Metadata,
     DatasetError,
 )
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.common.logger import get_pbench_logger
 
 
@@ -184,7 +184,7 @@ def main(options):
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     archive_p = config.ARCHIVE
 

--- a/server/bin/pbench-report-status.py
+++ b/server/bin/pbench-report-status.py
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 from socket import gethostname
 
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.common.exceptions import BadConfig
 from pbench.server.report import Report
 
@@ -74,7 +74,7 @@ except BadConfig as e:
 # We're going to need the Postgres DB to track dataset state, so setup
 # DB access. We don't pass a Logger here, because that introduces lots
 # of spurious changes in the gold CLI test output.
-Database.init_db(config, None)
+init_db(config, None)
 
 hostname = gethostname()
 pid = parsed.pid

--- a/server/bin/pbench-server-prep-shim-002.py
+++ b/server/bin/pbench-server-prep-shim-002.py
@@ -24,7 +24,7 @@ from pbench.server import PbenchServerConfig
 from pbench.server.report import Report
 from pbench.server.utils import quarantine
 from pbench.server.database.models.tracker import Dataset, States, DatasetError
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 
 
 _NAME_ = "pbench-server-prep-shim-002"
@@ -313,7 +313,7 @@ def main(cfg_name):
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     qdir, receive_dir = fetch_config_val(config, logger)
 

--- a/server/bin/pbench-state-manager.py
+++ b/server/bin/pbench-state-manager.py
@@ -19,7 +19,7 @@ from argparse import ArgumentParser
 from pbench import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.server.database.models.tracker import Dataset, States
 
 
@@ -46,7 +46,7 @@ def main(options):
 
         # We're going to need the Postgres DB to track dataset state, so setup
         # DB access.
-        Database.init_db(config, logger)
+        init_db(config, logger)
 
         args = {}
         if options.create:

--- a/server/bin/pbench-verify-backup-tarballs.py
+++ b/server/bin/pbench-verify-backup-tarballs.py
@@ -52,7 +52,7 @@ from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
 from pbench.server import PbenchServerConfig
-from pbench.server.database.database import Database
+from pbench.server.database import init_db
 from pbench.server.report import Report
 from pbench.server.s3backup import S3Config, Entry
 
@@ -294,7 +294,7 @@ def main():
 
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
-    Database.init_db(config, logger)
+    init_db(config, logger)
 
     # add a BACKUP field to the config object
     config.BACKUP = backup = config.conf.get("pbench-server", "pbench-backup-dir")


### PR DESCRIPTION
- Creates a utility init_db method in `lib/pbench/server/api/__init__.py` that other functionalities in our code can use to initialize the standalone db access and make sure all the models are imported before the call to Database.init_db. 