### PR TITLE
Add the `Content-Length` header to the PUT req

### DIFF
--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -175,9 +175,11 @@ class CopyResultTb:
                     authorized to make the PUT request on behalf of a
                     specific user.
         """
+        content_length, content_md5 = md5sum(self.tarball)
         headers = {
             "filename": secure_filename(str(self.tarball)),
-            "Content-MD5": md5sum(self.tarball),
+            "Content-MD5": content_md5,
+            "Content-Length": str(content_length),
             "Authorization": f"Bearer {token}",
         }
         with self.tarball.open("rb") as f:

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1314,7 +1314,7 @@ class ToolMeister:
                     failures += 1
                 else:
                     try:
-                        tar_md5 = md5sum(tar_file)
+                        (_, tar_md5) = md5sum(tar_file)
                     except Exception:
                         self.logger.exception("Failed to read tar ball, '%s'", tar_file)
                         failures += 1

--- a/lib/pbench/common/utils.py
+++ b/lib/pbench/common/utils.py
@@ -11,10 +11,12 @@ def md5sum(filename):
     md5sum - return the MD5 check-sum of a given file without reading the
              entire file into memory.
 
-    Returns hex digest string of the given file.
+    Returns a tuple of the length and the hex digest string of the given file.
     """
     with open(filename, mode="rb") as f:
         d = hashlib.md5()
+        length = 0
         for buf in iter(partial(f.read, 2 ** 20), b""):
+            length += len(buf)
             d.update(buf)
-    return d.hexdigest()
+    return length, d.hexdigest()

--- a/lib/pbench/test/unit/common/test_utils.py
+++ b/lib/pbench/test/unit/common/test_utils.py
@@ -9,8 +9,12 @@ class TestMd5sum:
         # Reuse the existing file from the server upload fixture.
         filename = "log.tar.xz"
         test_file = Path("./lib/pbench/test/unit/server/fixtures/upload/", filename)
+        expected_length = test_file.stat().st_size
         expected_hash_md5 = open(f"{test_file}.md5", "r").read().split()[0]
-        hash_md5 = md5sum(test_file)
+        length, hash_md5 = md5sum(test_file)
+        assert (
+            length == expected_length
+        ), f"Expected length '{expected_length}', got '{length}'"
         assert (
             hash_md5 == expected_hash_md5
         ), f"Expected MD5 '{expected_hash_md5}', got '{hash_md5}'"

--- a/server/bin/pbench-backup-tarballs.py
+++ b/server/bin/pbench-backup-tarballs.py
@@ -343,7 +343,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
 
         # match md5sum of the tarball to its md5 file
         try:
-            archive_tar_hex_value = md5sum(tar)
+            (_, archive_tar_hex_value) = md5sum(tar)
         except Exception:
             # Could not read file.
             quarantine(qdir, logger, tb)

--- a/server/bin/pbench-server-prep-shim-002.py
+++ b/server/bin/pbench-server-prep-shim-002.py
@@ -93,7 +93,7 @@ def md5_check(tb, tbmd5, logger):
 
     # get hex value of the tarball's md5sum
     try:
-        archive_tar_hex_value = md5sum(tb)
+        (_, archive_tar_hex_value) = md5sum(tb)
     except Exception:
         archive_tar_hex_value = None
         logger.exception("Quarantine: Could not read {}", tb)

--- a/server/bin/pbench-verify-backup-tarballs.py
+++ b/server/bin/pbench-verify-backup-tarballs.py
@@ -170,7 +170,7 @@ class BackupObject:
             self.indicator_file_fail, "w"
         ) as f_fail:
             for tar in self.content_list:
-                md5_returned = md5sum(Path(self.dirname, tar.name))
+                (_, md5_returned) = md5sum(Path(self.dirname, tar.name))
                 if tar.md5 == md5_returned:
                     f_ok.write(f"{tar.name}: {'OK'}\n")
                 else:


### PR DESCRIPTION
We were missing the `Content-Length` header on the PUT API request as generated by the CLI `pbench-push-results` command.

We modify the `md5sum` utility method to also return the length so that we won't have to stat the file separately.

----

Fixes #2260.