### PR TITLE
Improve error handling in Elasticsearch queries

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/controllers_list.py
+++ b/lib/pbench/server/api/resources/query_apis/controllers_list.py
@@ -143,10 +143,10 @@ class ControllersList(ElasticBase):
                 return jsonify(controllers)
         except KeyError as e:
             raise PostprocessError(
-                f"Can't find Elasticsearch match data {e} in {es_json}"
+                f"Can't find Elasticsearch match data {e} in {es_json!r}"
             )
         except ValueError as e:
-            raise PostprocessError(f"Elasticsearch hit count {count} value: {e}")
+            raise PostprocessError(f"Elasticsearch hit count {count!r} value: {e}")
         buckets = es_json["aggregations"]["controllers"]["buckets"]
         self.logger.info("{} controllers found", len(buckets))
         for controller in buckets:

--- a/lib/pbench/server/api/resources/query_apis/controllers_list.py
+++ b/lib/pbench/server/api/resources/query_apis/controllers_list.py
@@ -8,6 +8,7 @@ from pbench.server.api.resources.query_apis import (
     Schema,
     Parameter,
     ParamType,
+    PostprocessError,
 )
 
 
@@ -130,6 +131,22 @@ class ControllersList(ElasticBase):
         ]
         """
         controllers = []
+        # If there are no matches for the user, controller name,
+        # and time range, return the empty list rather than failing.
+        # Note that we can't check the length of ["hits"]["hits"]
+        # because we've told Elasticsearch to return only aggregations,
+        # not source documents.
+        try:
+            count = es_json["hits"]["total"]["value"]
+            if int(count) == 0:
+                self.logger.warning("No data returned by Elasticsearch")
+                return jsonify(controllers)
+        except KeyError as e:
+            raise PostprocessError(
+                f"Can't find Elasticsearch match data {e} in {es_json}"
+            )
+        except ValueError as e:
+            raise PostprocessError(f"Elasticsearch hit count {count} value: {e}")
         buckets = es_json["aggregations"]["controllers"]["buckets"]
         self.logger.info("{} controllers found", len(buckets))
         for controller in buckets:

--- a/lib/pbench/server/api/resources/query_apis/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_detail.py
@@ -8,6 +8,7 @@ from pbench.server.api.resources.query_apis import (
     Schema,
     Parameter,
     ParamType,
+    PostprocessError,
 )
 
 
@@ -118,8 +119,10 @@ class DatasetsDetail(ElasticBase):
 
         # NOTE: we're expecting just one. We're matching by just the
         # dataset name, which ought to be unique.
-        if len(hits) != 1:
-            self.logger.warn("{} datasets found: expected exactly 1!", len(hits))
+        if len(hits) == 0:
+            raise PostprocessError("The specified dataset has gone missing")
+        elif len(hits) > 1:
+            raise PostprocessError("Too many hits for a unique query")
         src = hits[0]["_source"]
 
         # We're merging the "run" and "@metadata" sub-documents into

--- a/lib/pbench/test/unit/server/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/test_controllers_list.py
@@ -199,8 +199,7 @@ class TestControllersList:
             json, index, HTTPStatus.OK, server_config, json=response_payload
         )
         res_json = response.json
-        assert isinstance(res_json, list)
-        assert len(res_json) == 0
+        assert res_json == []
 
     @pytest.mark.parametrize(
         "exceptions",


### PR DESCRIPTION
Addresses two issues with edge case errors when target datasets aren't found, avoiding "internal error" and unhelpful stack traces.

Closes #2259
Closes #2241