### PR TITLE
Allow live metric visualization for remote runs

### DIFF
--- a/agent/containers/images/visualizers/DockerfileLive
+++ b/agent/containers/images/visualizers/DockerfileLive
@@ -3,7 +3,7 @@ FROM fedora:33
 
 WORKDIR /
 
-ENV GRAFANA_VERSION=7.3.6-1
+ARG GRAFANA_VERSION=7.3.6-1
 
 RUN dnf install -y wget python3-pip && \
     pip3 install requests && \
@@ -16,19 +16,10 @@ ADD nodefull.json .
 ADD dcgm.json .
 ADD combo.json .
 
-## THE FOLLOWING LINE WAS PARTIALLY TAKEN FROM https://github.com/grafana/grafana-docker/blob/master/Dockerfile#L7#L13
-ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
-    GF_DEFAULT_APP_MODE="development" \
-    GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
-    GF_PATHS_DATA="/var/lib/grafana" \
-    GF_PATHS_HOME="/usr/share/grafana" \
-    GF_PATHS_LOGS="/var/log/grafana" \
-    GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
-    GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+ENV PATH=/usr/share/grafana/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 EXPOSE 3000
 
-ENV VIS_TYPE="live" \
-    COLLECTOR=""
+# ENV VARS THAT CAN BE CHANGED: HOST, PROM_HOST, PM_HOST, PROM_PORT, PM_PORT
 
-CMD ["python3", "run.py"]
+CMD ["python3", "run.py", "live"]

--- a/agent/containers/images/visualizers/DockerfilePostPCP
+++ b/agent/containers/images/visualizers/DockerfilePostPCP
@@ -1,10 +1,9 @@
 # Use with the following command from the 'visualizers' directory: podman build -t <name> -f DockerfilePostPCP .
 FROM quay.io/pbench/live-metric-visualizer:latest
 
-ENV VIS_TYPE="pcp" \
-    COLLECTOR="/usr/libexec/pcp/bin/pmproxy --foreground --timeseries --port=44322 --redishost=localhost --redisport=6379 --config=/etc/pcp/pmproxy/pmproxy.conf" \
-    PCP_VERSION="5.2.1-1.fc33" \
-    PCP_ARCHIVE_DIR="/var/log/pcp/pmlogger"
+ARG PCP_VERSION="5.2.5-2.fc33"
+    
+# ENV VARS THAT CAN BE CHANGED: REDIS_HOST, REDIS_PORT
 
 RUN dnf install -y --setopt=tsflags=nodocs procps-ng gettext pcp-${PCP_VERSION} pcp-zeroconf-${PCP_VERSION} && \
     dnf install -y pcp-doc-${PCP_VERSION} pcp-gui-${PCP_VERSION} pcp-system-tools-${PCP_VERSION} && \
@@ -12,5 +11,7 @@ RUN dnf install -y --setopt=tsflags=nodocs procps-ng gettext pcp-${PCP_VERSION} 
     dnf clean all && \
     rm -rf /etc/pcp/pmlogger/control.d/local
 
-EXPOSE 44322
+EXPOSE 44566
 EXPOSE 3000
+
+CMD ["python3", "run.py", "pcp"]

--- a/agent/containers/images/visualizers/DockerfilePostProm
+++ b/agent/containers/images/visualizers/DockerfilePostProm
@@ -1,15 +1,18 @@
 # Use with the following command from the 'visualizers' directory: podman build -t <name> -f DockerfilePostProm .
 FROM quay.io/pbench/live-metric-visualizer:latest
 
-ENV PROM_VERSION=2.18.1 \
-    VIS_TYPE="prom"
-
-ENV COLLECTOR="/prometheus-${PROM_VERSION}.linux-amd64/prometheus --config.file=/data/prometheus.yml --storage.tsdb.path=/data"
+ARG PROM_VERSION=2.18.1
 
 RUN wget -P /opt/ https://github.com/prometheus/prometheus/releases/download/v${PROM_VERSION}/prometheus-${PROM_VERSION}.linux-amd64.tar.gz && \
     tar xf /opt/prometheus-${PROM_VERSION}.linux-amd64.tar.gz && \
     rm -f /prometheus-${PROM_VERSION}.linux-amd64/prometheus.yml && \
-    mkdir data
+    mkdir data && \
+    mv nodefull.json /prometheus-${PROM_VERSION}.linux-amd64/nodefull.json && \
+    mv dcgm.json /prometheus-${PROM_VERSION}.linux-amd64/dcgm.json && \
+    mv combo.json /prometheus-${PROM_VERSION}.linux-amd64/combo.json
 
 EXPOSE 3000
 EXPOSE 9090
+
+WORKDIR /prometheus-${PROM_VERSION}.linux-amd64
+CMD ["python3", "../run.py", "prom"]

--- a/agent/containers/images/visualizers/README.md
+++ b/agent/containers/images/visualizers/README.md
@@ -7,6 +7,11 @@
 - Directions:
   -   `podman pull pbench/live-metric-visualizer`
   -   `podman run --network host pbench/live-metric-visualizer`
+  -   To visualize a run on a remote host, add `-e HOST=<host>`
+    - If prometheus is on a different host, it can be individually set with `-e PROM_HOST=<host>`
+    - If pmproxy is on a different host, it can be individually set with `-e PM_HOST=<host>`
+  -   To change to a custom prometheus port, add `-e PROM_PORT=<port>`
+  -   To change to a custom pmproxy port, add `-e PM_PORT=<port>`
 
 - NOTES:
   - Container includes grafana server with preconfigured data sources and dashboards for both prometheus and PCP
@@ -38,7 +43,10 @@
 
 - Directions:
   -   `podman pull pbench/pcp-graf-visualizer`
-  -   `podman run -p 3000:3000 -p 44322:44322 -v /<path>/<to>/<pcp_log_folder>/data:/var/log/pcp/pmlogger:Z  pbench/pcp-graf-visualizer`
+  -   `podman run --network host -v /<path>/<to>/<pcp_log_folder>/data:/var/log/pcp/pmlogger:Z  pbench/pcp-graf-visualizer`
+  - If you would rather use your own existing redis instance rather than have one launch internally:
+    - You must specify redis host with `-e REDIS_HOST=<port>`
+    - If not on the default port (6379), you can also add `-e REDIS_PORT=<port>`
 
 - NOTES:
   - PCP data (from pcp data tarball in tools-default) is available within pbench results.

--- a/agent/containers/images/visualizers/run.py
+++ b/agent/containers/images/visualizers/run.py
@@ -2,56 +2,87 @@
 Starts by starting up grafana server, as well as any collectors (prometheus, pmproxy) if needed.
 
 Then sets up all grafana plugins, data sources, and dashboards through grafana API.
-Chooses what to upload/enable based off VIS_TYPE environment variable.
+Chooses what to upload/enable based off the visualizer type argument.
 
-If VIS_TYPE is 'live' (default for live-metric-visualizer):
+If the type is 'live' (default for live-metric-visualizer):
     - Node exporter/DCGM dashboards will be uploaded and enabled
     - Prometheus data source will be configured
     - Grafana-pcp plugin will be enabled
     - PCP redis and vector datasources will be configured
     - PCP default dashboards will be enabled
-If VIS_TYPE is 'prom' (default for prom-graf-visualizer):
+If the type is 'prom' (default for prom-graf-visualizer):
     - Node exporter/DCGM dashboards will be uploaded and enabled
     - Prometheus data source will be configured
-If VIS_TYPE is 'pcp' (default for soon-to-come pcp-graf-visualizer):
+If the type is 'pcp' (default for soon-to-come pcp-graf-visualizer):
     - Grafana-pcp plugin will be enabled
     - PCP redis and vector datasources will be configured
     - PCP default dashboards will be enabled
 """
 
 import os
+import sys
 import json
 import requests
 import time
 import subprocess
 
 # Start the collector (if needed)
-collector_cmd = os.environ["COLLECTOR"]
-if not collector_cmd == "":
-    collector = subprocess.Popen(collector_cmd.split(" "))
-    if os.environ["VIS_TYPE"] == "pcp":
+collector = None
+metric_type = sys.argv[1]
+if metric_type == "pcp":
+    cmd = [
+        "/usr/libexec/pcp/bin/pmproxy",
+        "--foreground",
+        "--timeseries",
+        "--port=44566",
+        "--redishost=localhost",
+        "--redisport=6379",
+        "--config=/etc/pcp/pmproxy/pmproxy.conf",
+    ]
+    redis_host = os.environ.get("REDIS_HOST", "NO_HOST")
+    if not redis_host == "NO_HOST":
+        cmd[4] = f"--redishost={redis_host}"
+        redis_port = os.environ.get("REDIS_PORT", "NO_PORT")
+        if not redis_port == "NO_PORT":
+            cmd[5] = f"--redisport={redis_port}"
+    else:
         subprocess.Popen("redis-server")
-        log_path = os.environ["PCP_ARCHIVE_DIR"]
-        for item in os.scandir(log_path):
-            if os.path.isdir(item):
-                rec_path = os.path.join(log_path, item.name)
-                args = [
-                    "pmseries",
-                    "--load",
-                    rec_path,
-                ]
-                print(args)
-                subprocess.Popen(args)
-else:
-    collector = None
+    collector = subprocess.Popen(cmd)
+    log_path = "/var/log/pcp/pmlogger"
+    for item in os.scandir(log_path):
+        if os.path.isdir(item):
+            rec_path = os.path.join(log_path, item.name)
+            args = [
+                "pmseries",
+                "--load",
+                rec_path,
+            ]
+            print(args)
+            subprocess.Popen(args)
+elif metric_type == "prom":
+    cmd = [
+        "./prometheus",
+        "--config.file=/data/prometheus.yml",
+        "--storage.tsdb.path=/data",
+    ]
+    collector = subprocess.Popen(cmd)
 
 # Start the grafana server
+os.environ["GF_DEFAULT_APP_MODE"] = os.environ.get("GF_DEFAULT_APP_MODE", "development")
+os.environ["GF_PATHS_DATA"] = os.environ.get("GF_PATHS_DATA", "/var/lib/grafana")
+os.environ["GF_PATHS_LOGS"] = os.environ.get("GF_PATHS_LOGS", "/var/log/grafana")
+os.environ["GF_PATHS_PLUGINS"] = os.environ.get(
+    "GF_PATHS_PLUGINS", "/var/lib/grafana/plugins"
+)
+os.environ["GF_PATHS_PROVISIONING"] = os.environ.get(
+    "GF_PATHS_PROVISIONING", "/etc/grafana/provisioning"
+)
 args = [
     "grafana-server",
     "-homepath",
-    os.environ["GF_PATHS_HOME"],
+    os.environ.get("GF_PATHS_HOME", "/usr/share/grafana"),
     "-config",
-    os.environ["GF_PATHS_CONFIG"],
+    os.environ.get("GF_PATHS_CONFIG", "/etc/grafana/grafana.ini"),
     "$@",
     "cfg:default.log.mode=console",
 ]
@@ -75,13 +106,26 @@ response = requests.post(
 token = json.loads(response.content.decode("utf-8"))["key"]
 headers["Authorization"] = f"Bearer {token}"
 
-metric_type = os.environ["VIS_TYPE"]
+if metric_type == "live":
+    host = os.environ.get("HOST", "localhost")
+    prom_host = os.environ.get("PROM_HOST", host)
+    pm_host = os.environ.get("PM_HOST", host)
+    prom_url = f"http://{prom_host}:"
+    pm_url = f"http://{pm_host}:"
+    prom_port = os.environ.get("PROM_PORT", "9090")
+    pm_port = os.environ.get("PM_PORT", "44566")
+else:
+    prom_url = "http://localhost:"
+    pm_url = prom_url
+    prom_port = "9090"
+    pm_port = "44566"
+
 if metric_type == "live" or metric_type == "prom":
     prom_source_url = f"{graf_base}api/datasources"
     payload = {
         "name": "prometheus",
         "type": "prometheus",
-        "url": "http://localhost:9090",
+        "url": prom_url + prom_port,
         "access": "proxy",
         "basicAuth": False,
     }
@@ -116,7 +160,7 @@ if metric_type == "live" or metric_type == "pcp":
     payload = {
         "name": "PCP Redis",
         "type": "pcp-redis-datasource",
-        "url": "http://localhost:44566",
+        "url": pm_url + pm_port,
         "access": "proxy",
         "basicAuth": False,
     }
@@ -126,7 +170,7 @@ if metric_type == "live" or metric_type == "pcp":
     payload = {
         "name": "PCP Vector",
         "type": "pcp-vector-datasource",
-        "url": "http://localhost:44566",
+        "url": pm_url + pm_port,
         "access": "proxy",
         "basicAuth": False,
     }


### PR DESCRIPTION
Adds new options for live-metric-visualizer:
 - Can now specify a remote host
 - Can select individual hosts for prometheus and pmproxy as well
 - Can now change the ports for prometheus and pmproxy

Adds new option for pcp-graf-visualizer:
 - Use an external redis server instead of built-in

Also cleans up unnecessary environment variables and moves work/defaults to run.py

All three visualizers updated, tested, and working as expected