### PR TITLE
Rework upload API to move filename to URI

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -8,4 +8,3 @@ python-pidfile
 redis
 requests
 sh
-werkzeug

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -18,7 +18,7 @@ Requires:  gcc python3-devel
 %if 0%{?rhel} == 8
 Requires:  python36, python3-pip
 # RPMs for modules in requirements.txt
-Requires:  python3-cffi, python3-click, python3-requests, python3-werkzeug
+Requires:  python3-cffi, python3-click, python3-requests
 # RPMs for module dependencies
 Requires:  python3-docutils, python3-psutil
 %endif
@@ -27,8 +27,7 @@ Requires:  python3-docutils, python3-psutil
 Requires:  python3, python3-pip
 # RPMs for modules in requirements.txt
 Requires:  python3-bottle, python3-cffi, python3-click, python3-daemon
-Requires:  python3-jinja2, python3-redis, python3-requests, python3-werkzeug
-Requires:  python3-sh
+Requires:  python3-jinja2, python3-redis, python3-requests, python3-sh
 # RPMs for module dependencies
 Requires:  python3-psutil
 %endif

--- a/agent/rpm/python-module-mapping.table
+++ b/agent/rpm/python-module-mapping.table
@@ -9,4 +9,3 @@ python-pidfile   -                  -         -                  Neither Fedora 
 redis            python3-redis      -         -
 requests         python3-requests   -         python3-requests
 sh               python3-sh         -         -
-werkzeug         python3-werkzeug   -         python3-werkzeug

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -132,8 +132,8 @@ from pbench.agent.utils import (
     error_log,
     info_log,
     RedisServerCommon,
-    validate_hostname,
 )
+from pbench.common.utils import validate_hostname
 
 
 # Wait at most 60 seconds for the Tool Data Sink to start listening on its

--- a/agent/util-scripts/validate-hostname
+++ b/agent/util-scripts/validate-hostname
@@ -7,7 +7,7 @@ if the argument is missing.
 
 import sys
 
-from pbench.agent.utils import validate_hostname
+from pbench.common.utils import validate_hostname
 
 
 try:

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -93,7 +93,6 @@ RUN \
         python3-sphinx \
         python3-tox \
         python3-tox-current-env \
-        python3-werkzeug \
         redis \
         rpmdevtools \
         rpmlint \

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -1,7 +1,5 @@
-import ipaddress
 import logging
 import os
-import re
 import signal
 import subprocess
 import sys
@@ -15,6 +13,7 @@ from pbench.agent.constants import (
     sysinfo_opts_convenience,
     sysinfo_opts_default,
 )
+from pbench.common.utils import validate_hostname
 
 
 class BaseReturnCode:
@@ -382,43 +381,3 @@ def collect_local_info(pbench_bin):
         hostdata[arg] = cp.stdout.strip() if cp.stdout is not None else ""
 
     return (version, seqno, sha1, hostdata)
-
-
-# Derived from https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
-# with a few modifications: take advantage of ignoring case; use non-capturing
-# groups to improve efficiency; take advantage of RFC 1123 modification to RFC
-# 952 relaxing first character to be letter or digit, with the repetition moved
-# to the last group to alleviate backtracking.  Or in other words, a case-blind
-# comparison seeking a letter-or-digit, optionally followed by a sequence of 0
-# to 61 letter-or-digit-or-hyphens followed by a letter-or-digit, follwed by 0
-# or more instances of that same pattern preceded by a period.
-_allowed = re.compile(
-    r"[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?)*",
-    flags=re.IGNORECASE,
-)
-
-
-def validate_hostname(host_name: str):
-    """validate_hostname - validate the given hostname uses the proper syntax.
-
-    A host name that follows RFC 952 (amended by RFC 1123) is accepted only.
-    Host names are not resolved to IP addresses, and IP addresses are also
-    accepted.
-
-    Algorithm taken from: https://stackoverflow.com/questions/2532053/validate-a-hostname-string
-
-    Returns 0 on success, 1 on failure.
-    """
-    if not host_name or len(host_name) > 255:
-        return 1
-
-    if _allowed.fullmatch(host_name):
-        return 0
-
-    # It is not a valid host name, but could be a valid IP address.
-    try:
-        ipaddress.ip_address(host_name)
-    except ValueError:
-        return 1
-
-    return 0

--- a/lib/pbench/common/utils.py
+++ b/lib/pbench/common/utils.py
@@ -2,11 +2,13 @@
 Utility functions common to both agent and server.
 """
 import hashlib
+import ipaddress
+import re
 
 from functools import partial
 
 
-def md5sum(filename):
+def md5sum(filename: str) -> (int, str):
     """
     md5sum - return the MD5 check-sum of a given file without reading the
              entire file into memory.
@@ -20,3 +22,43 @@ def md5sum(filename):
             length += len(buf)
             d.update(buf)
     return length, d.hexdigest()
+
+
+# Derived from https://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address
+# with a few modifications: take advantage of ignoring case; use non-capturing
+# groups to improve efficiency; take advantage of RFC 1123 modification to RFC
+# 952 relaxing first character to be letter or digit, with the repetition moved
+# to the last group to alleviate backtracking.  Or in other words, a case-blind
+# comparison seeking a letter-or-digit, optionally followed by a sequence of 0
+# to 61 letter-or-digit-or-hyphens followed by a letter-or-digit, follwed by 0
+# or more instances of that same pattern preceded by a period.
+_allowed = re.compile(
+    r"[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9\-]{0,61}[A-Z0-9])?)*",
+    flags=re.IGNORECASE,
+)
+
+
+def validate_hostname(host_name: str) -> int:
+    """validate_hostname - validate the given hostname uses the proper syntax.
+
+    A host name that follows RFC 952 (amended by RFC 1123) is accepted only.
+    Host names are not resolved to IP addresses, and IP addresses are also
+    accepted.
+
+    Algorithm taken from: https://stackoverflow.com/questions/2532053/validate-a-hostname-string
+
+    Returns 0 on success, 1 on failure.
+    """
+    if not host_name or len(host_name) > 255:
+        return 1
+
+    if _allowed.fullmatch(host_name):
+        return 0
+
+    # It is not a valid host name, but could be a valid IP address.
+    try:
+        ipaddress.ip_address(host_name)
+    except ValueError:
+        return 1
+
+    return 0

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -47,7 +47,7 @@ def register_endpoints(api, app, config):
 
     api.add_resource(
         Upload,
-        f"{base_uri}/upload/ctrl/<string:controller>",
+        f"{base_uri}/upload/<string:filename>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -22,9 +22,10 @@ class TestCopyResults:
 
     @responses.activate
     def test_copy_tar(self, valid_config):
+        tbname = os.path.basename(tarball)
         responses.add(
             responses.PUT,
-            "http://pbench.example.com/api/v1/upload/ctrl/controller",
+            f"http://pbench.example.com/api/v1/upload/{tbname}",
             status=200,
         )
         crt = CopyResultTb("controller", tarball, self.config, self.logger)
@@ -34,7 +35,7 @@ class TestCopyResults:
     def test_bad_tar(self, caplog, valid_config):
         responses.add(
             responses.PUT,
-            "http://pbench.example.com/api/v1/upload/ctrl/controller",
+            f"http://pbench.example.com/api/v1/upload/{bad_tarball}",
             status=200,
         )
         expected_error_message = (

--- a/lib/pbench/test/unit/common/test_validate_hostname.py
+++ b/lib/pbench/test/unit/common/test_validate_hostname.py
@@ -1,7 +1,7 @@
 """Tests for validate_hostname
 """
 
-from pbench.agent.utils import validate_hostname
+from pbench.common.utils import validate_hostname
 
 
 def test_validate_hostname():

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -32,6 +32,9 @@ port = 7081
 
 [logging]
 logger_type = file
+# We run with DEBUG level logging during the server unit tests to help
+# verify we are not emitting too many logs.
+logging_level = DEBUG
 
 [Indexing]
 index_prefix = unit-test

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -60,7 +60,7 @@ class TestEnpointConfig:
                 "logout": f"{uri}/logout",
                 "user": f"{uri}/user/",
                 "host_info": f"{uri}/host_info",
-                "upload_ctrl": f"{uri}/upload/ctrl/",
+                "upload": f"{uri}/upload/",
             },
         }
 


### PR DESCRIPTION
The upload API now requires the file name, moving the controller to a required header.  This was chosen with an eye towards the future, where the "controller" value is not needed by the pbench server for processing.  At the time this code was written, the current pbench-agent and the pbench-server use the controller to organize on-disk where the files are placed.  In the future, the controller value will simply be another piece of metadata about the file.

The API is now `/api/v1/upload/<filename>`, with the controller name provided in the `controller` header.  This removes it from prominence in the URI, which is why we did not move it to a URI parameter.

We also change a number of error responses to use the appropriate error codes via `http.HTTPStatus`, and update the messages to be more succinct while improving the context given in the logs.

Further, we fix up the `upload_api.py` module to wrap long lines, and emit 400 response messages in the logs as warnings.  We also tighten down some of the tests to ensure the correct log levels are being emitted.

Finally, we:

 * bump the read & write chunk size to 64K for better through-put.
 * drop the `werkzeug` module entirely (yeah!)
 * enable DEBUG logging during server unit tests

----

Requires PR #2264 to land first.