### PR TITLE
Index documents by user ID instead of username.

### DIFF
--- a/lib/pbench/cli/server/user_create.py
+++ b/lib/pbench/cli/server/user_create.py
@@ -3,7 +3,6 @@ import click
 from pbench import BadConfig
 from pbench.cli.server import pass_cli_context
 from pbench.cli.server.options import common_options
-from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.database.database import Database
 from pbench.server.database.models.users import Roles, User
@@ -18,11 +17,10 @@ class UserCreate:
     def execute(self):
         config = PbenchServerConfig(self.context.config)
 
-        logger = get_pbench_logger(_NAME_, config)
-
         # We're going to need the Postgres DB to track dataset state, so setup
-        # DB access.
-        Database.init_db(config, logger)
+        # DB access. We execute without a logger to avoid unnecessary noise in
+        # CLI gold test output from an incidental tool.
+        Database.init_db(config, None)
 
         user = User(
             username=self.context.username,

--- a/lib/pbench/server/api/auth.py
+++ b/lib/pbench/server/api/auth.py
@@ -31,30 +31,19 @@ class Auth:
     def validate_user(name: str) -> str:
         """
         Encapsulate a query to reject "username" values that don't correspond to
-        a registered user.
-
-        TODO: We need to decide exactly how we're representing our users, and
-        what's mutable. For example, if we allow changing "username" we need to
-        have a stable "userid" field that we use for indexing... in which case
-        this should translate "username" into "userid" for internal use. For
-        now, just return the original username if it was found.
-
-        FIXME: I thought this would be an ArgumentParser "type" so we could
-        do validation during parsing. That's awkward because we need to finish
-        parsing the --config parameter in order to access the config and logger
-        objects required to initialize database access, which needs to be done
-        before we can make a query. Can we work around this without too much
-        mess?
+        a registered user. A valid username is translated to the internal
+        representation for Elasticsearch indexing, which is the stringified
+        user ID number.
 
         Args:
-            :name: The username field of a registered user
+            name: The username field of a registered user
 
         Raises:
             ValueError: The username doesn't correspond to a registered user
             TypeError: Some other error occurred looking for the user
 
         Returns:
-            The specified username if it's valid; does not return on failure
+            The user's ID value (as a string)
         """
         try:
             user = User.query(username=name)
@@ -63,7 +52,7 @@ class Auth:
             raise
         if not user:
             raise UnknownUser(name)
-        return name
+        return str(user.id)
 
     def encode_auth_token(self, token_expire_duration, user_id):
         """

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -103,12 +103,7 @@ def convert_username(value: str) -> str:
     by validating that the specified username exists, and returns the
     desired internal representation of that user.
 
-    TODO: when we get our user model straightened out, this will
-    convert the external user representation (either username or email
-    address) to whatever internal representation we want to store in
-    the Elasticsearch database, whether that's a SQL row ID or something
-    else. For now, it just validates that the username string is a real
-    user.
+    The internal representation is the user row ID as a string.
 
     Args:
         value: external user representation

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -1,3 +1,5 @@
+import sys
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.ext.declarative import declarative_base
@@ -14,10 +16,11 @@ class Database:
             psql = config.get("Postgres", "db_uri")
             return psql
         except (NoSectionError, NoOptionError):
+            msg = "Failed to find a [Postgres] section in configuration file."
             if logger:
-                logger.error(
-                    "Failed to find a [Postgres] section in configuration file."
-                )
+                logger.error(msg)
+            else:
+                print(msg, file=sys.stderr)
             return None
 
     @staticmethod

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -7,6 +7,7 @@ from sqlalchemy import Column, DateTime, Enum, Integer, LargeBinary, String
 from sqlalchemy.orm import relationship, validates
 
 from pbench.server.database.database import Database
+from pbench.server.database.models.active_tokens import ActiveTokens  # noqa[F401]
 
 
 class Roles(enum.Enum):

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -319,7 +319,7 @@ class Index:
                         idxctx.logger.info("Starting {} (size {:d})", tb, size)
                         dataset = None
                         ptb = None
-                        username = None
+                        userid = None
                         try:
                             path = os.path.realpath(tb)
 
@@ -341,13 +341,17 @@ class Index:
                                     "Unable to advance dataset state: {}", str(e)
                                 )
                             else:
-                                username = dataset.owner
+                                # NOTE: we index the owner_id foreign key not the username.
+                                # Although this is technically an integer, I'm clinging to
+                                # the notion that we want to keep this as a "keyword" (string)
+                                # field.
+                                userid = str(dataset.owner_id)
 
                             # "Open" the tar ball represented by the tar ball object
                             idxctx.logger.debug("open tar ball")
                             ptb = PbenchTarBall(
                                 idxctx,
-                                username,
+                                userid,
                                 path,
                                 tmpdir,
                                 Path(self.incoming, controller),

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -111,7 +111,12 @@ def server_config(pytestconfig, monkeypatch):
 
 @pytest.fixture
 def client(server_config):
-    """A test client for the app."""
+    """A test client for the app.
+
+    NOTE: the db_session fixture does something similar, but with implicit
+    cleanup after the test, and without the Flask app setup DB tests don't
+    require.
+    """
     app = create_app(server_config)
 
     app_client = app.test_client()

--- a/server/bin/gold/test-7.10.txt
+++ b/server/bin/gold/test-7.10.txt
@@ -98,7 +98,7 @@ len(actions) = 39
             "@timestamp": "2018-02-02T20:58:04.723258",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -192,7 +192,7 @@ len(actions) = 39
             "@timestamp": "2018-02-02T20:58:04.723258",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -267,7 +267,7 @@ len(actions) = 39
             "@timestamp": "2018-02-02T20:58:04.723258",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i",
             "files": [
@@ -325,7 +325,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1",
             "files": [
@@ -384,7 +384,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/csv",
             "files": [
@@ -422,7 +422,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default",
             "mode": "0o755",
@@ -445,7 +445,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44",
             "mode": "0o755",
@@ -469,7 +469,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/iostat",
             "files": [
@@ -531,7 +531,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/iostat/csv",
             "files": [
@@ -606,7 +606,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/mpstat",
             "files": [
@@ -682,7 +682,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/mpstat/csv",
             "files": [
@@ -722,7 +722,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/perf",
             "files": [
@@ -791,7 +791,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/perf/perf-percpu",
             "files": [
@@ -824,7 +824,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/pidstat",
             "files": [
@@ -942,7 +942,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/pidstat/csv",
             "files": [
@@ -1031,7 +1031,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_rr-64B-8i/sample1/tools-default/dhcp31-44/proc-interrupts",
             "files": [
@@ -2110,7 +2110,7 @@ len(actions) = 75
             "@timestamp_original": "1517605090000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2166,7 +2166,7 @@ len(actions) = 75
             "@timestamp_original": "1517605090000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2222,7 +2222,7 @@ len(actions) = 75
             "@timestamp_original": "1517605090000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2278,7 +2278,7 @@ len(actions) = 75
             "@timestamp_original": "1517605093000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2334,7 +2334,7 @@ len(actions) = 75
             "@timestamp_original": "1517605093000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2390,7 +2390,7 @@ len(actions) = 75
             "@timestamp_original": "1517605093000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2446,7 +2446,7 @@ len(actions) = 75
             "@timestamp_original": "1517605096000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2502,7 +2502,7 @@ len(actions) = 75
             "@timestamp_original": "1517605096000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2558,7 +2558,7 @@ len(actions) = 75
             "@timestamp_original": "1517605096000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2614,7 +2614,7 @@ len(actions) = 75
             "@timestamp_original": "1517605099000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2670,7 +2670,7 @@ len(actions) = 75
             "@timestamp_original": "1517605099000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2726,7 +2726,7 @@ len(actions) = 75
             "@timestamp_original": "1517605099000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2782,7 +2782,7 @@ len(actions) = 75
             "@timestamp_original": "1517605102000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2838,7 +2838,7 @@ len(actions) = 75
             "@timestamp_original": "1517605102000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2894,7 +2894,7 @@ len(actions) = 75
             "@timestamp_original": "1517605102000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2950,7 +2950,7 @@ len(actions) = 75
             "@timestamp_original": "1517605090000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -2998,7 +2998,7 @@ len(actions) = 75
             "@timestamp_original": "1517605093000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3046,7 +3046,7 @@ len(actions) = 75
             "@timestamp_original": "1517605096000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3094,7 +3094,7 @@ len(actions) = 75
             "@timestamp_original": "1517605099000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3142,7 +3142,7 @@ len(actions) = 75
             "@timestamp_original": "1517605102000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3190,7 +3190,7 @@ len(actions) = 75
             "@timestamp_original": "1517605105000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3238,7 +3238,7 @@ len(actions) = 75
             "@timestamp_original": "1517605108000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3286,7 +3286,7 @@ len(actions) = 75
             "@timestamp_original": "1517605111000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3334,7 +3334,7 @@ len(actions) = 75
             "@timestamp_original": "1517605114000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3382,7 +3382,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3430,7 +3430,7 @@ len(actions) = 75
             "@timestamp_original": "1517605120000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3478,7 +3478,7 @@ len(actions) = 75
             "@timestamp_original": "1517605123000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3526,7 +3526,7 @@ len(actions) = 75
             "@timestamp_original": "1517605126000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3574,7 +3574,7 @@ len(actions) = 75
             "@timestamp_original": "1517605129000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3622,7 +3622,7 @@ len(actions) = 75
             "@timestamp_original": "1517605132000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3670,7 +3670,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3726,7 +3726,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3782,7 +3782,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3838,7 +3838,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3894,7 +3894,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -3950,7 +3950,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4006,7 +4006,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4062,7 +4062,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4118,7 +4118,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4174,7 +4174,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4230,7 +4230,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4286,7 +4286,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4342,7 +4342,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4398,7 +4398,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4454,7 +4454,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4510,7 +4510,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4550,7 +4550,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4590,7 +4590,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4630,7 +4630,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4670,7 +4670,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4710,7 +4710,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4750,7 +4750,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4790,7 +4790,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4830,7 +4830,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4870,7 +4870,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4910,7 +4910,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4950,7 +4950,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -4990,7 +4990,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -5030,7 +5030,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -5070,7 +5070,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4342701",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -5110,7 +5110,7 @@ len(actions) = 75
             "@timestamp_original": "1517605087.4672635",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -5315,7 +5315,7 @@ len(actions) = 75
             "@timestamp_original": "1517605090.474774",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -5689,7 +5689,7 @@ len(actions) = 75
             "@timestamp_original": "1517605093.4761894",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -6063,7 +6063,7 @@ len(actions) = 75
             "@timestamp_original": "1517605096.4775674",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -6437,7 +6437,7 @@ len(actions) = 75
             "@timestamp_original": "1517605099.4790628",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -6811,7 +6811,7 @@ len(actions) = 75
             "@timestamp_original": "1517605102.4804482",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -7185,7 +7185,7 @@ len(actions) = 75
             "@timestamp_original": "1517605105.4820454",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -7559,7 +7559,7 @@ len(actions) = 75
             "@timestamp_original": "1517605108.4835188",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -7933,7 +7933,7 @@ len(actions) = 75
             "@timestamp_original": "1517605111.4850786",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -8307,7 +8307,7 @@ len(actions) = 75
             "@timestamp_original": "1517605114.4864337",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -8681,7 +8681,7 @@ len(actions) = 75
             "@timestamp_original": "1517605117.4894974",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -9055,7 +9055,7 @@ len(actions) = 75
             "@timestamp_original": "1517605120.4909515",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -9429,7 +9429,7 @@ len(actions) = 75
             "@timestamp_original": "1517605123.4924142",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -9803,7 +9803,7 @@ len(actions) = 75
             "@timestamp_original": "1517605126.4938262",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",
@@ -10177,7 +10177,7 @@ len(actions) = 75
             "@timestamp_original": "1517605129.4953215",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_rr-64B-8i",

--- a/server/bin/gold/test-7.11.txt
+++ b/server/bin/gold/test-7.11.txt
@@ -98,7 +98,7 @@ len(actions) = 39
             "@timestamp": "2018-02-01T22:41:00.276959",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -192,7 +192,7 @@ len(actions) = 39
             "@timestamp": "2018-02-01T22:41:00.276959",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -260,7 +260,7 @@ len(actions) = 39
             "@timestamp": "2018-02-01T22:41:00.276959",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB",
             "files": [
@@ -297,7 +297,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1",
             "files": [
@@ -370,7 +370,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/clients",
             "mode": "0o755",
@@ -393,7 +393,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/clients/localhost",
             "files": [
@@ -459,7 +459,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/csv",
             "files": [
@@ -511,7 +511,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default",
             "mode": "0o755",
@@ -534,7 +534,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44",
             "mode": "0o755",
@@ -558,7 +558,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/iostat",
             "files": [
@@ -620,7 +620,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/iostat/csv",
             "files": [
@@ -695,7 +695,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/mpstat",
             "files": [
@@ -771,7 +771,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/mpstat/csv",
             "files": [
@@ -811,7 +811,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/perf",
             "files": [
@@ -880,7 +880,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/perf/perf-percpu",
             "files": [
@@ -913,7 +913,7 @@ len(actions) = 39
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-rw-4KiB/sample1/tools-default/dhcp31-44/pidstat",
             "files": [
@@ -1914,7 +1914,7 @@ len(actions) = 46
             "@timestamp_original": "1517524863000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -1970,7 +1970,7 @@ len(actions) = 46
             "@timestamp_original": "1517524863000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2026,7 +2026,7 @@ len(actions) = 46
             "@timestamp_original": "1517524863000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2082,7 +2082,7 @@ len(actions) = 46
             "@timestamp_original": "1517524866000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2138,7 +2138,7 @@ len(actions) = 46
             "@timestamp_original": "1517524866000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2194,7 +2194,7 @@ len(actions) = 46
             "@timestamp_original": "1517524866000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2250,7 +2250,7 @@ len(actions) = 46
             "@timestamp_original": "1517524869000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2306,7 +2306,7 @@ len(actions) = 46
             "@timestamp_original": "1517524869000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2362,7 +2362,7 @@ len(actions) = 46
             "@timestamp_original": "1517524869000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2418,7 +2418,7 @@ len(actions) = 46
             "@timestamp_original": "1517524872000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2474,7 +2474,7 @@ len(actions) = 46
             "@timestamp_original": "1517524872000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2530,7 +2530,7 @@ len(actions) = 46
             "@timestamp_original": "1517524872000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2586,7 +2586,7 @@ len(actions) = 46
             "@timestamp_original": "1517524875000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2642,7 +2642,7 @@ len(actions) = 46
             "@timestamp_original": "1517524875000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2698,7 +2698,7 @@ len(actions) = 46
             "@timestamp_original": "1517524875000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2754,7 +2754,7 @@ len(actions) = 46
             "@timestamp_original": "1517524864000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -2802,7 +2802,7 @@ len(actions) = 46
             "@timestamp_original": "1517524867000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -2850,7 +2850,7 @@ len(actions) = 46
             "@timestamp_original": "1517524870000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -2898,7 +2898,7 @@ len(actions) = 46
             "@timestamp_original": "1517524873000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -2946,7 +2946,7 @@ len(actions) = 46
             "@timestamp_original": "1517524876000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -2994,7 +2994,7 @@ len(actions) = 46
             "@timestamp_original": "1517524864000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3042,7 +3042,7 @@ len(actions) = 46
             "@timestamp_original": "1517524867000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3090,7 +3090,7 @@ len(actions) = 46
             "@timestamp_original": "1517524870000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3138,7 +3138,7 @@ len(actions) = 46
             "@timestamp_original": "1517524873000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3186,7 +3186,7 @@ len(actions) = 46
             "@timestamp_original": "1517524876000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3234,7 +3234,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3274,7 +3274,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3314,7 +3314,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3354,7 +3354,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3394,7 +3394,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3434,7 +3434,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3474,7 +3474,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3514,7 +3514,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3554,7 +3554,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3594,7 +3594,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3634,7 +3634,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3674,7 +3674,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3714,7 +3714,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3754,7 +3754,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3794,7 +3794,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.270328",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -3834,7 +3834,7 @@ len(actions) = 46
             "@timestamp_original": "1517524861.3222935",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -4039,7 +4039,7 @@ len(actions) = 46
             "@timestamp_original": "1517524864.3314548",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -4413,7 +4413,7 @@ len(actions) = 46
             "@timestamp_original": "1517524867.3337727",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -4787,7 +4787,7 @@ len(actions) = 46
             "@timestamp_original": "1517524870.3354142",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -5161,7 +5161,7 @@ len(actions) = 46
             "@timestamp_original": "1517524873.3375843",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",
@@ -5535,7 +5535,7 @@ len(actions) = 46
             "@timestamp_original": "1517524876.3392684",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-rw-4KiB",

--- a/server/bin/gold/test-7.12.txt
+++ b/server/bin/gold/test-7.12.txt
@@ -97,7 +97,7 @@ len(actions) = 16
             "@timestamp": "2018-02-05T20:35:36.317245",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -300,7 +300,7 @@ len(actions) = 16
             "@timestamp": "2018-02-05T20:35:36.317245",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -347,7 +347,7 @@ len(actions) = 16
             "@timestamp": "2018-02-05T20:35:36.317245",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1",
             "mode": "0o755",
@@ -368,7 +368,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result",
             "files": [
@@ -399,7 +399,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default",
             "mode": "0o755",
@@ -422,7 +422,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216",
             "mode": "0o755",
@@ -446,7 +446,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/disk",
             "files": [
@@ -508,7 +508,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/disk/csv",
             "files": [
@@ -576,7 +576,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp",
             "files": [
@@ -1429,7 +1429,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config",
             "mode": "0o755",
@@ -1455,7 +1455,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config/start",
             "files": [
@@ -1497,7 +1497,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/config/stop",
             "files": [
@@ -1538,7 +1538,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/csv",
             "files": [
@@ -2006,7 +2006,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs",
             "mode": "0o755",
@@ -2032,7 +2032,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs/start",
             "files": [
@@ -2074,7 +2074,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/svt_master_1_etcd_1:ip-172-31-47-216/haproxy-ocp/logs/stop",
             "files": [
@@ -2202,7 +2202,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2257,7 +2257,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2312,7 +2312,7 @@ len(actions) = 45
             "@timestamp_original": "1517862959000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2367,7 +2367,7 @@ len(actions) = 45
             "@timestamp_original": "1517862959000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2422,7 +2422,7 @@ len(actions) = 45
             "@timestamp_original": "1517862969000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2477,7 +2477,7 @@ len(actions) = 45
             "@timestamp_original": "1517862969000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2532,7 +2532,7 @@ len(actions) = 45
             "@timestamp_original": "1517862979000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2587,7 +2587,7 @@ len(actions) = 45
             "@timestamp_original": "1517862979000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2642,7 +2642,7 @@ len(actions) = 45
             "@timestamp_original": "1517862989000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2697,7 +2697,7 @@ len(actions) = 45
             "@timestamp_original": "1517862989000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2752,7 +2752,7 @@ len(actions) = 45
             "@timestamp_original": "1517862999000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 5,
@@ -2807,7 +2807,7 @@ len(actions) = 45
             "@timestamp_original": "1517862999000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 5,
@@ -2862,7 +2862,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2917,7 +2917,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2972,7 +2972,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3027,7 +3027,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3082,7 +3082,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3137,7 +3137,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3192,7 +3192,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3247,7 +3247,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3302,7 +3302,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3357,7 +3357,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3412,7 +3412,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3467,7 +3467,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3522,7 +3522,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3577,7 +3577,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3632,7 +3632,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3687,7 +3687,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3725,7 +3725,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3766,7 +3766,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3807,7 +3807,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3848,7 +3848,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3889,7 +3889,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3930,7 +3930,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3971,7 +3971,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4012,7 +4012,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4053,7 +4053,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4094,7 +4094,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4135,7 +4135,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4176,7 +4176,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4220,7 +4220,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4264,7 +4264,7 @@ len(actions) = 45
             "@timestamp_original": "1517862940",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4308,7 +4308,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -4363,7 +4363,7 @@ len(actions) = 45
             "@timestamp_original": "1517862949000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -4418,7 +4418,7 @@ len(actions) = 45
             "@timestamp_original": "1517862959000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,

--- a/server/bin/gold/test-7.13.txt
+++ b/server/bin/gold/test-7.13.txt
@@ -96,7 +96,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -276,7 +276,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -323,7 +323,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1",
             "mode": "0o755",
@@ -344,7 +344,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result",
             "files": [
@@ -375,7 +375,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default",
             "mode": "0o755",
@@ -398,7 +398,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p",
             "mode": "0o755",
@@ -422,7 +422,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/perf",
             "files": [
@@ -491,7 +491,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/perf/perf-percpu",
             "files": [
@@ -965,7 +965,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-interrupts",
             "files": [
@@ -1055,7 +1055,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-interrupts/csv",
             "files": [
@@ -4217,7 +4217,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-vmstat",
             "files": [
@@ -4279,7 +4279,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-vmstat/csv",
             "files": [
@@ -4424,7 +4424,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/sar",
             "files": [
@@ -4563,7 +4563,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/sar/csv",
             "files": [
@@ -5177,7 +5177,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/turbostat",
             "files": [
@@ -5218,7 +5218,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o755",
@@ -5329,7 +5329,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5369,7 +5369,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5409,7 +5409,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5449,7 +5449,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5489,7 +5489,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5529,7 +5529,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5569,7 +5569,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5609,7 +5609,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5649,7 +5649,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5689,7 +5689,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5729,7 +5729,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5769,7 +5769,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5809,7 +5809,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5849,7 +5849,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5889,7 +5889,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5929,7 +5929,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0508895",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6118,7 +6118,7 @@ len(actions) = 30
             "@timestamp_original": "1523386884.0541282",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6460,7 +6460,7 @@ len(actions) = 30
             "@timestamp_original": "1523386887.0567222",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6802,7 +6802,7 @@ len(actions) = 30
             "@timestamp_original": "1523386890.0596917",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7144,7 +7144,7 @@ len(actions) = 30
             "@timestamp_original": "1523386893.0628786",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7486,7 +7486,7 @@ len(actions) = 30
             "@timestamp_original": "1523386896.0657184",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7828,7 +7828,7 @@ len(actions) = 30
             "@timestamp_original": "1523386899.0690217",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8170,7 +8170,7 @@ len(actions) = 30
             "@timestamp_original": "1523386902.0719812",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8512,7 +8512,7 @@ len(actions) = 30
             "@timestamp_original": "1523386905.075373",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8854,7 +8854,7 @@ len(actions) = 30
             "@timestamp_original": "1523386908.0786757",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -9196,7 +9196,7 @@ len(actions) = 30
             "@timestamp_original": "1523386911.0818398",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -9538,7 +9538,7 @@ len(actions) = 30
             "@timestamp_original": "1523386914.0848112",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -9880,7 +9880,7 @@ len(actions) = 30
             "@timestamp_original": "1523386917.0873024",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -10222,7 +10222,7 @@ len(actions) = 30
             "@timestamp_original": "1523386920.0901384",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -10564,7 +10564,7 @@ len(actions) = 30
             "@timestamp_original": "1523386923.0927541",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",

--- a/server/bin/gold/test-7.14.txt
+++ b/server/bin/gold/test-7.14.txt
@@ -96,7 +96,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -276,7 +276,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -323,7 +323,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1",
             "mode": "0o755",
@@ -344,7 +344,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result",
             "files": [
@@ -375,7 +375,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default",
             "mode": "0o755",
@@ -398,7 +398,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p",
             "mode": "0o755",
@@ -422,7 +422,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/mpstat",
             "files": [
@@ -1380,7 +1380,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/mpstat/csv",
             "files": [
@@ -1861,7 +1861,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/perf",
             "files": [
@@ -1930,7 +1930,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/perf/perf-percpu",
             "files": [
@@ -2404,7 +2404,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-interrupts",
             "files": [
@@ -2494,7 +2494,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/proc-interrupts/csv",
             "files": [
@@ -5656,7 +5656,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/sar",
             "files": [
@@ -5795,7 +5795,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/sar/csv",
             "files": [
@@ -6409,7 +6409,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/b03-h01-1029p/turbostat",
             "files": [
@@ -6450,7 +6450,7 @@ len(actions) = 16
             "@timestamp": "2018-04-10T19:01:19.927438",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o755",
@@ -6561,7 +6561,7 @@ len(actions) = 30
             "@timestamp_original": "1523386884000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6609,7 +6609,7 @@ len(actions) = 30
             "@timestamp_original": "1523386887000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6657,7 +6657,7 @@ len(actions) = 30
             "@timestamp_original": "1523386890000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6705,7 +6705,7 @@ len(actions) = 30
             "@timestamp_original": "1523386893000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6753,7 +6753,7 @@ len(actions) = 30
             "@timestamp_original": "1523386896000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6801,7 +6801,7 @@ len(actions) = 30
             "@timestamp_original": "1523386899000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6849,7 +6849,7 @@ len(actions) = 30
             "@timestamp_original": "1523386902000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6897,7 +6897,7 @@ len(actions) = 30
             "@timestamp_original": "1523386905000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6945,7 +6945,7 @@ len(actions) = 30
             "@timestamp_original": "1523386908000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6993,7 +6993,7 @@ len(actions) = 30
             "@timestamp_original": "1523386911000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7041,7 +7041,7 @@ len(actions) = 30
             "@timestamp_original": "1523386914000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7089,7 +7089,7 @@ len(actions) = 30
             "@timestamp_original": "1523386917000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7137,7 +7137,7 @@ len(actions) = 30
             "@timestamp_original": "1523386920000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7185,7 +7185,7 @@ len(actions) = 30
             "@timestamp_original": "1523386923000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7233,7 +7233,7 @@ len(actions) = 30
             "@timestamp_original": "1523386926000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7281,7 +7281,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7321,7 +7321,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7361,7 +7361,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7401,7 +7401,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7441,7 +7441,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7481,7 +7481,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7521,7 +7521,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7561,7 +7561,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7601,7 +7601,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7641,7 +7641,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7681,7 +7681,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7721,7 +7721,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7761,7 +7761,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7801,7 +7801,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7841,7 +7841,7 @@ len(actions) = 30
             "@timestamp_original": "1523386881.0363908",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",

--- a/server/bin/gold/test-7.15.txt
+++ b/server/bin/gold/test-7.15.txt
@@ -98,7 +98,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -370,7 +370,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -445,7 +445,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i",
             "files": [
@@ -503,7 +503,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1",
             "files": [
@@ -562,7 +562,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/csv",
             "files": [
@@ -593,7 +593,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default",
             "mode": "0o755",
@@ -616,7 +616,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb",
             "mode": "0o755",
@@ -640,7 +640,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/iostat",
             "files": [
@@ -702,7 +702,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/iostat/csv",
             "files": [
@@ -777,7 +777,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/mpstat",
             "files": [
@@ -1063,7 +1063,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/mpstat/csv",
             "files": [
@@ -1208,7 +1208,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/perf",
             "files": [
@@ -1277,7 +1277,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/perf/perf-percpu",
             "files": [
@@ -1415,7 +1415,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/pidstat",
             "files": [
@@ -1533,7 +1533,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/pidstat/csv",
             "files": [
@@ -1622,7 +1622,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/proc-interrupts",
             "files": [
@@ -2351,7 +2351,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2406,7 +2406,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2461,7 +2461,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2516,7 +2516,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2571,7 +2571,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2626,7 +2626,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2681,7 +2681,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2736,7 +2736,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2791,7 +2791,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2846,7 +2846,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2893,7 +2893,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2940,7 +2940,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2987,7 +2987,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3034,7 +3034,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3081,7 +3081,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3128,7 +3128,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3175,7 +3175,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3222,7 +3222,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3269,7 +3269,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3316,7 +3316,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3363,7 +3363,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3410,7 +3410,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3457,7 +3457,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3504,7 +3504,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3551,7 +3551,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3606,7 +3606,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3661,7 +3661,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3716,7 +3716,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3771,7 +3771,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3826,7 +3826,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3881,7 +3881,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3936,7 +3936,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3991,7 +3991,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4046,7 +4046,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4101,7 +4101,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4156,7 +4156,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4211,7 +4211,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4266,7 +4266,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4321,7 +4321,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4376,7 +4376,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4415,7 +4415,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4454,7 +4454,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4493,7 +4493,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4532,7 +4532,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4571,7 +4571,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4610,7 +4610,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4649,7 +4649,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4688,7 +4688,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4727,7 +4727,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4766,7 +4766,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4805,7 +4805,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4844,7 +4844,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4883,7 +4883,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4922,7 +4922,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4961,7 +4961,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.3620842",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5144,7 +5144,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.364391",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5475,7 +5475,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.3666246",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5806,7 +5806,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.3689446",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6137,7 +6137,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6192,7 +6192,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6247,7 +6247,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6302,7 +6302,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6357,7 +6357,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6412,7 +6412,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6467,7 +6467,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.4044082",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6650,7 +6650,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.406617",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6981,7 +6981,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.4090216",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7312,7 +7312,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.4113934",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7643,7 +7643,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.0663261",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7826,7 +7826,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.0686305",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -8157,7 +8157,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.0710783",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -8488,7 +8488,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.0734138",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",

--- a/server/bin/gold/test-7.16.txt
+++ b/server/bin/gold/test-7.16.txt
@@ -114,7 +114,7 @@ len(actions) = 35
             "@timestamp": "2018-10-04T06:53:52.212763",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -181,7 +181,7 @@ len(actions) = 35
             "@timestamp": "2018-10-04T06:53:52.212763",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -249,7 +249,7 @@ len(actions) = 35
             "@timestamp": "2018-10-04T06:53:52.212763",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i",
             "files": [
@@ -307,7 +307,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1",
             "files": [
@@ -366,7 +366,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/csv",
             "files": [
@@ -404,7 +404,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default",
             "mode": "0o755",
@@ -427,7 +427,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4",
             "mode": "0o755",
@@ -451,7 +451,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/iostat",
             "files": [
@@ -513,7 +513,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/iostat/csv",
             "files": [
@@ -588,7 +588,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/mpstat",
             "files": [
@@ -706,7 +706,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/mpstat/csv",
             "files": [
@@ -767,7 +767,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/perf",
             "files": [
@@ -836,7 +836,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/perf/perf-percpu",
             "files": [
@@ -890,7 +890,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/pidstat",
             "files": [
@@ -1008,7 +1008,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/pidstat/csv",
             "files": [
@@ -1097,7 +1097,7 @@ len(actions) = 35
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/21-tcp_rr-1024B-1i/sample1/tools-default/rhel8-4/proc-interrupts",
             "files": [
@@ -1956,7 +1956,7 @@ len(actions) = 75
             "@timestamp_original": "1538656645000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2012,7 +2012,7 @@ len(actions) = 75
             "@timestamp_original": "1538656645000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2068,7 +2068,7 @@ len(actions) = 75
             "@timestamp_original": "1538656645000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2124,7 +2124,7 @@ len(actions) = 75
             "@timestamp_original": "1538656648000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2180,7 +2180,7 @@ len(actions) = 75
             "@timestamp_original": "1538656648000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2236,7 +2236,7 @@ len(actions) = 75
             "@timestamp_original": "1538656648000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2292,7 +2292,7 @@ len(actions) = 75
             "@timestamp_original": "1538656651000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2348,7 +2348,7 @@ len(actions) = 75
             "@timestamp_original": "1538656651000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2404,7 +2404,7 @@ len(actions) = 75
             "@timestamp_original": "1538656651000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2460,7 +2460,7 @@ len(actions) = 75
             "@timestamp_original": "1538656654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2516,7 +2516,7 @@ len(actions) = 75
             "@timestamp_original": "1538656654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2572,7 +2572,7 @@ len(actions) = 75
             "@timestamp_original": "1538656654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -2628,7 +2628,7 @@ len(actions) = 75
             "@timestamp_original": "1538656657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2684,7 +2684,7 @@ len(actions) = 75
             "@timestamp_original": "1538656657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2740,7 +2740,7 @@ len(actions) = 75
             "@timestamp_original": "1538656657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2796,7 +2796,7 @@ len(actions) = 75
             "@timestamp_original": "1538656645000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -2844,7 +2844,7 @@ len(actions) = 75
             "@timestamp_original": "1538656648000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -2892,7 +2892,7 @@ len(actions) = 75
             "@timestamp_original": "1538656651000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -2940,7 +2940,7 @@ len(actions) = 75
             "@timestamp_original": "1538656654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -2988,7 +2988,7 @@ len(actions) = 75
             "@timestamp_original": "1538656657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3036,7 +3036,7 @@ len(actions) = 75
             "@timestamp_original": "1538656660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3084,7 +3084,7 @@ len(actions) = 75
             "@timestamp_original": "1538656663000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3132,7 +3132,7 @@ len(actions) = 75
             "@timestamp_original": "1538656666000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3180,7 +3180,7 @@ len(actions) = 75
             "@timestamp_original": "1538656669000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3228,7 +3228,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3276,7 +3276,7 @@ len(actions) = 75
             "@timestamp_original": "1538656675000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3324,7 +3324,7 @@ len(actions) = 75
             "@timestamp_original": "1538656678000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3372,7 +3372,7 @@ len(actions) = 75
             "@timestamp_original": "1538656681000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3420,7 +3420,7 @@ len(actions) = 75
             "@timestamp_original": "1538656684000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3468,7 +3468,7 @@ len(actions) = 75
             "@timestamp_original": "1538656687000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3516,7 +3516,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3572,7 +3572,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3628,7 +3628,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3684,7 +3684,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3740,7 +3740,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3796,7 +3796,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3852,7 +3852,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3908,7 +3908,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -3964,7 +3964,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4020,7 +4020,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4076,7 +4076,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4132,7 +4132,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4188,7 +4188,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4244,7 +4244,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4300,7 +4300,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4356,7 +4356,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4396,7 +4396,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4436,7 +4436,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4476,7 +4476,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4516,7 +4516,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4556,7 +4556,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4596,7 +4596,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4636,7 +4636,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4676,7 +4676,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4716,7 +4716,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4756,7 +4756,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4796,7 +4796,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4836,7 +4836,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4876,7 +4876,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4916,7 +4916,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.7838123",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -4956,7 +4956,7 @@ len(actions) = 75
             "@timestamp_original": "1538656642.839122",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -5167,7 +5167,7 @@ len(actions) = 75
             "@timestamp_original": "1538656645.8423715",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -5553,7 +5553,7 @@ len(actions) = 75
             "@timestamp_original": "1538656648.8459303",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -5939,7 +5939,7 @@ len(actions) = 75
             "@timestamp_original": "1538656651.8492196",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -6325,7 +6325,7 @@ len(actions) = 75
             "@timestamp_original": "1538656654.852475",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -6711,7 +6711,7 @@ len(actions) = 75
             "@timestamp_original": "1538656657.8557394",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -7097,7 +7097,7 @@ len(actions) = 75
             "@timestamp_original": "1538656660.859007",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -7483,7 +7483,7 @@ len(actions) = 75
             "@timestamp_original": "1538656663.8623354",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -7869,7 +7869,7 @@ len(actions) = 75
             "@timestamp_original": "1538656666.865469",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -8255,7 +8255,7 @@ len(actions) = 75
             "@timestamp_original": "1538656669.8687208",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -8641,7 +8641,7 @@ len(actions) = 75
             "@timestamp_original": "1538656672.872014",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -9027,7 +9027,7 @@ len(actions) = 75
             "@timestamp_original": "1538656675.8750713",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -9413,7 +9413,7 @@ len(actions) = 75
             "@timestamp_original": "1538656678.87821",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -9799,7 +9799,7 @@ len(actions) = 75
             "@timestamp_original": "1538656681.8814852",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",
@@ -10185,7 +10185,7 @@ len(actions) = 75
             "@timestamp_original": "1538656684.884761",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "21-tcp_rr-1024B-1i",

--- a/server/bin/gold/test-7.17.txt
+++ b/server/bin/gold/test-7.17.txt
@@ -97,7 +97,7 @@ len(actions) = 16
             "@timestamp": "2018-10-24T14:38:18.299722",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -165,7 +165,7 @@ len(actions) = 16
             "@timestamp": "2018-10-24T14:38:18.299722",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -212,7 +212,7 @@ len(actions) = 16
             "@timestamp": "2018-10-24T14:38:18.299722",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1",
             "mode": "0o755",
@@ -233,7 +233,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result",
             "files": [
@@ -264,7 +264,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default",
             "mode": "0o755",
@@ -287,7 +287,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/ansible-host",
             "mode": "0o755",
@@ -311,7 +311,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/ansible-host/iostat",
             "files": [
@@ -373,7 +373,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/ansible-host/iostat/csv",
             "files": [
@@ -448,7 +448,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/ansible-host/pidstat",
             "files": [
@@ -566,7 +566,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/ansible-host/pidstat/csv",
             "files": [
@@ -654,7 +654,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-0.scale-ci.example.com",
             "mode": "0o755",
@@ -678,7 +678,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-0.scale-ci.example.com/vmstat",
             "files": [
@@ -740,7 +740,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-0.scale-ci.example.com/vmstat/csv",
             "files": [
@@ -807,7 +807,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-1.scale-ci.example.com",
             "mode": "0o755",
@@ -831,7 +831,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-1.scale-ci.example.com/vmstat",
             "files": [
@@ -893,7 +893,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/app-node-1.scale-ci.example.com/vmstat/csv",
             "files": [
@@ -1049,7 +1049,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -1105,7 +1105,7 @@ len(actions) = 45
             "@timestamp_original": "1540392021000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -1161,7 +1161,7 @@ len(actions) = 45
             "@timestamp_original": "1540392081000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -1217,7 +1217,7 @@ len(actions) = 45
             "@timestamp_original": "1540392141000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -1273,7 +1273,7 @@ len(actions) = 45
             "@timestamp_original": "1540392201000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -1329,7 +1329,7 @@ len(actions) = 45
             "@timestamp_original": "1540392261000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 5,
@@ -1385,7 +1385,7 @@ len(actions) = 45
             "@timestamp_original": "1540392321000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 6,
@@ -1441,7 +1441,7 @@ len(actions) = 45
             "@timestamp_original": "1540392381000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 7,
@@ -1497,7 +1497,7 @@ len(actions) = 45
             "@timestamp_original": "1540392441000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 8,
@@ -1553,7 +1553,7 @@ len(actions) = 45
             "@timestamp_original": "1540392501000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 9,
@@ -1609,7 +1609,7 @@ len(actions) = 45
             "@timestamp_original": "1540392561000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 10,
@@ -1665,7 +1665,7 @@ len(actions) = 45
             "@timestamp_original": "1540392621000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 11,
@@ -1721,7 +1721,7 @@ len(actions) = 45
             "@timestamp_original": "1540392681000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 12,
@@ -1777,7 +1777,7 @@ len(actions) = 45
             "@timestamp_original": "1540392741000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 13,
@@ -1833,7 +1833,7 @@ len(actions) = 45
             "@timestamp_original": "1540392801000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 14,
@@ -1889,7 +1889,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -1945,7 +1945,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2001,7 +2001,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2057,7 +2057,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2113,7 +2113,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2169,7 +2169,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2225,7 +2225,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2281,7 +2281,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2337,7 +2337,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2393,7 +2393,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2449,7 +2449,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2505,7 +2505,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2561,7 +2561,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2617,7 +2617,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2673,7 +2673,7 @@ len(actions) = 45
             "@timestamp_original": "1540391961000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2729,7 +2729,7 @@ len(actions) = 45
             "@timestamp_original": "1540391962000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2794,7 +2794,7 @@ len(actions) = 45
             "@timestamp_original": "1540392022000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2859,7 +2859,7 @@ len(actions) = 45
             "@timestamp_original": "1540392082000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2924,7 +2924,7 @@ len(actions) = 45
             "@timestamp_original": "1540392142000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2989,7 +2989,7 @@ len(actions) = 45
             "@timestamp_original": "1540392202000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3054,7 +3054,7 @@ len(actions) = 45
             "@timestamp_original": "1540392262000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3119,7 +3119,7 @@ len(actions) = 45
             "@timestamp_original": "1540392322000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3184,7 +3184,7 @@ len(actions) = 45
             "@timestamp_original": "1540392382000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3249,7 +3249,7 @@ len(actions) = 45
             "@timestamp_original": "1540392442000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3314,7 +3314,7 @@ len(actions) = 45
             "@timestamp_original": "1540392502000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3379,7 +3379,7 @@ len(actions) = 45
             "@timestamp_original": "1540392562000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3444,7 +3444,7 @@ len(actions) = 45
             "@timestamp_original": "1540392622000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3509,7 +3509,7 @@ len(actions) = 45
             "@timestamp_original": "1540392682000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3574,7 +3574,7 @@ len(actions) = 45
             "@timestamp_original": "1540392742000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3639,7 +3639,7 @@ len(actions) = 45
             "@timestamp_original": "1540392802000",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",

--- a/server/bin/gold/test-7.19.txt
+++ b/server/bin/gold/test-7.19.txt
@@ -98,7 +98,7 @@ len(actions) = 38
             "@timestamp": "2019-08-27T15:00:07.506390",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -130,7 +130,7 @@ len(actions) = 38
             "@timestamp": "2019-08-27T15:00:07.506390",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -212,7 +212,7 @@ len(actions) = 38
             "@timestamp": "2019-08-27T15:00:07.506390",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop",
             "files": [
@@ -263,7 +263,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop/sample1",
             "files": [
@@ -903,7 +903,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop/sample1/csv",
             "files": [
@@ -1256,7 +1256,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop/sample1/tools-default",
             "mode": "0o755",
@@ -1279,7 +1279,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop/sample1/tools-default/perf124",
             "mode": "0o755",
@@ -1303,7 +1303,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-forwarding_test.json-5pct_drop/sample1/tools-default/perf124/turbostat",
             "files": [

--- a/server/bin/gold/test-7.20.txt
+++ b/server/bin/gold/test-7.20.txt
@@ -101,7 +101,7 @@ len(actions) = 46
             "@timestamp": "2020-02-27T22:16:14.663380",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -134,7 +134,7 @@ len(actions) = 46
             "@timestamp": "2020-02-27T22:16:14.663380",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -202,7 +202,7 @@ len(actions) = 46
             "@timestamp": "2020-02-27T22:16:14.663380",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio",
             "files": [
@@ -232,7 +232,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0",
             "files": [
@@ -320,7 +320,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/clients",
             "mode": "0o755",
@@ -343,7 +343,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/clients/localhost",
             "files": [
@@ -381,7 +381,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/csv",
             "files": [
@@ -426,7 +426,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/tools-default",
             "mode": "0o755",
@@ -449,7 +449,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/tools-default/ctlrA",
             "mode": "0o755",
@@ -473,7 +473,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample0/tools-default/ctlrA/turbostat",
             "files": [
@@ -517,7 +517,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1",
             "files": [
@@ -605,7 +605,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1/clients",
             "mode": "0o755",
@@ -628,7 +628,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1/clients/localhost",
             "files": [
@@ -666,7 +666,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1/csv",
             "files": [
@@ -711,7 +711,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1/tools-default",
             "mode": "0o755",
@@ -734,7 +734,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__fio/sample1/tools-default/ctlrA",
             "mode": "0o755",

--- a/server/bin/gold/test-7.21.txt
+++ b/server/bin/gold/test-7.21.txt
@@ -100,7 +100,7 @@ len(actions) = 23
             "@timestamp": "2020-02-28T19:49:39.887048",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "host_tools_info": [],
             "run": {
@@ -125,7 +125,7 @@ len(actions) = 23
             "@timestamp": "2020-02-28T19:49:39.887048",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/",
             "files": [
@@ -193,7 +193,7 @@ len(actions) = 23
             "@timestamp": "2020-02-28T19:49:39.887048",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1",
             "files": [
@@ -223,7 +223,7 @@ len(actions) = 23
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0",
             "files": [
@@ -296,7 +296,7 @@ len(actions) = 23
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/clients",
             "mode": "0o755",
@@ -319,7 +319,7 @@ len(actions) = 23
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/clients/perf116",
             "files": [
@@ -700,7 +700,7 @@ len(actions) = 23
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/csv",
             "mode": "0o755",
@@ -722,7 +722,7 @@ len(actions) = 23
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "2"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/tools-default",
             "mode": "0o755",
@@ -3012,7 +3012,7 @@ len(actions) = 38
             "@timestamp": "2020-02-28T20:04:29.505587",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [],
             "run": {
@@ -3037,7 +3037,7 @@ len(actions) = 38
             "@timestamp": "2020-02-28T20:04:29.505587",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -3112,7 +3112,7 @@ len(actions) = 38
             "@timestamp": "2020-02-28T20:04:29.505587",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1",
             "files": [
@@ -3142,7 +3142,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0",
             "files": [
@@ -3215,7 +3215,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/clients",
             "mode": "0o755",
@@ -3238,7 +3238,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/clients/perf116",
             "files": [
@@ -3731,7 +3731,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/csv",
             "files": [
@@ -4238,7 +4238,7 @@ len(actions) = 38
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__device-pairs=0000:01:00.0,0000:01:00.1/sample0/tools-default",
             "mode": "0o755",

--- a/server/bin/gold/test-7.22.txt
+++ b/server/bin/gold/test-7.22.txt
@@ -100,7 +100,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -133,7 +133,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -201,7 +201,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64",
             "files": [
@@ -231,7 +231,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0",
             "files": [
@@ -297,7 +297,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/csv",
             "mode": "0o755",
@@ -319,7 +319,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default",
             "mode": "0o755",
@@ -342,7 +342,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default/ctlrA",
             "mode": "0o755",
@@ -366,7 +366,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default/ctlrA/turbostat",
             "files": [
@@ -407,7 +407,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64",
             "files": [
@@ -437,7 +437,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0",
             "files": [
@@ -503,7 +503,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/csv",
             "mode": "0o755",
@@ -525,7 +525,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default",
             "mode": "0o755",
@@ -548,7 +548,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default/ctlrA",
             "mode": "0o755",
@@ -572,7 +572,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default/ctlrA/turbostat",
             "files": [
@@ -613,7 +613,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/2__linpack-binary=:root:linpack:l_mklb_p_2019.6.005:benchmarks_2019:linux:mkl:benchmarks:linpack:xlinpack_xeon64",
             "files": [
@@ -643,7 +643,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/2__linpack-binary=:root:linpack:l_mklb_p_2019.6.005:benchmarks_2019:linux:mkl:benchmarks:linpack:xlinpack_xeon64/sample0",
             "files": [

--- a/server/bin/gold/test-7.23.txt
+++ b/server/bin/gold/test-7.23.txt
@@ -101,7 +101,7 @@ len(actions) = 46
             "@timestamp": "2020-01-19T00:19:37.656511",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -134,7 +134,7 @@ len(actions) = 46
             "@timestamp": "2020-01-19T00:19:37.656511",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -216,7 +216,7 @@ len(actions) = 46
             "@timestamp": "2020-01-19T00:19:37.656511",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB",
             "files": [
@@ -260,7 +260,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1",
             "files": [
@@ -333,7 +333,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/clients",
             "mode": "0o755",
@@ -356,7 +356,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/clients/ctlrA",
             "files": [
@@ -424,7 +424,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/clients/ctlrA/hist",
             "files": [
@@ -511,7 +511,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/csv",
             "files": [
@@ -563,7 +563,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/hist",
             "files": [
@@ -650,7 +650,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/tools-default",
             "mode": "0o755",
@@ -673,7 +673,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/tools-default/ctlrA",
             "mode": "0o755",
@@ -697,7 +697,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-read-4KiB/sample1/tools-default/ctlrA/turbostat",
             "files": [
@@ -738,7 +738,7 @@ len(actions) = 46
             "@timestamp": "2020-01-19T00:19:37.656511",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-read-64KiB",
             "files": [
@@ -782,7 +782,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-read-64KiB/sample1",
             "files": [
@@ -855,7 +855,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-read-64KiB/sample1/clients",
             "mode": "0o755",
@@ -878,7 +878,7 @@ len(actions) = 46
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-read-64KiB/sample1/clients/ctlrA",
             "files": [

--- a/server/bin/gold/test-7.24.txt
+++ b/server/bin/gold/test-7.24.txt
@@ -100,7 +100,7 @@ len(actions) = 9
             "@timestamp": "2021-01-28T17:22:57.531604",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -132,7 +132,7 @@ len(actions) = 9
             "@timestamp": "2021-01-28T17:22:57.531604",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -193,7 +193,7 @@ len(actions) = 9
             "@timestamp": "2021-01-28T17:22:57.531604",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-default",
             "files": [
@@ -224,7 +224,7 @@ len(actions) = 9
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-default/sample1",
             "files": [
@@ -283,7 +283,7 @@ len(actions) = 9
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-default/sample1/tools-default",
             "mode": "0o755",
@@ -306,7 +306,7 @@ len(actions) = 9
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-default/sample1/tools-default/ctrlA",
             "mode": "0o755",
@@ -330,7 +330,7 @@ len(actions) = 9
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-default/sample1/tools-default/ctrlA/turbostat",
             "files": [
@@ -486,7 +486,7 @@ len(actions) = 16
             "@timestamp": "2020-02-06T15:26:14.978063",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -518,7 +518,7 @@ len(actions) = 16
             "@timestamp": "2020-02-06T15:26:14.978063",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -579,7 +579,7 @@ len(actions) = 16
             "@timestamp": "2020-02-06T15:26:14.978063",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-10U",
             "files": [
@@ -610,7 +610,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-10U/sample1",
             "files": [
@@ -669,7 +669,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-10U/sample1/tools-default",
             "mode": "0o755",
@@ -692,7 +692,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-10U/sample1/tools-default/ctlrA",
             "mode": "0o755",
@@ -716,7 +716,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/1-10U/sample1/tools-default/ctlrA/turbostat",
             "files": [
@@ -757,7 +757,7 @@ len(actions) = 16
             "@timestamp": "2020-02-06T15:26:14.978063",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-20U",
             "files": [
@@ -788,7 +788,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-20U/sample1",
             "files": [
@@ -847,7 +847,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-20U/sample1/tools-default",
             "mode": "0o755",
@@ -870,7 +870,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-20U/sample1/tools-default/ctlrA",
             "mode": "0o755",
@@ -894,7 +894,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/2-20U/sample1/tools-default/ctlrA/turbostat",
             "files": [

--- a/server/bin/gold/test-7.25.txt
+++ b/server/bin/gold/test-7.25.txt
@@ -98,7 +98,7 @@ len(actions) = 41
             "@timestamp": "2019-06-21T01:29:37.976771",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -389,7 +389,7 @@ len(actions) = 41
             "@timestamp": "2019-06-21T01:29:37.976771",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -457,7 +457,7 @@ len(actions) = 41
             "@timestamp": "2019-06-21T01:29:37.976771",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i",
             "files": [
@@ -523,7 +523,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1",
             "files": [
@@ -589,7 +589,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/csv",
             "files": [
@@ -620,7 +620,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default",
             "mode": "0o755",
@@ -643,7 +643,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1",
             "mode": "0o755",
@@ -666,7 +666,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1-2",
             "mode": "0o755",
@@ -690,7 +690,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1-2/turbostat",
             "files": [
@@ -736,7 +736,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1-3",
             "mode": "0o755",
@@ -760,7 +760,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1-3/turbostat",
             "files": [
@@ -807,7 +807,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample1/tools-default/rhel8-1/turbostat",
             "files": [
@@ -851,7 +851,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample2",
             "files": [
@@ -917,7 +917,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample2/csv",
             "files": [
@@ -948,7 +948,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample2/tools-default",
             "mode": "0o755",
@@ -971,7 +971,7 @@ len(actions) = 41
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-64B-1i/sample2/tools-default/rhel8-1",
             "mode": "0o755",

--- a/server/bin/gold/test-7.26.txt
+++ b/server/bin/gold/test-7.26.txt
@@ -71,7 +71,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -104,7 +104,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -172,7 +172,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64",
             "files": [
@@ -202,7 +202,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0",
             "files": [
@@ -268,7 +268,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/csv",
             "mode": "0o755",
@@ -290,7 +290,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default",
             "mode": "0o755",
@@ -313,7 +313,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default/ctlrA",
             "mode": "0o755",
@@ -337,7 +337,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/0__linpack-binary=:root:linpack:xlinpack_xeon64/sample0/tools-default/ctlrA/turbostat",
             "files": [
@@ -378,7 +378,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64",
             "files": [
@@ -408,7 +408,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0",
             "files": [
@@ -474,7 +474,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/csv",
             "mode": "0o755",
@@ -496,7 +496,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default",
             "mode": "0o755",
@@ -519,7 +519,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default/ctlrA",
             "mode": "0o755",
@@ -543,7 +543,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1__linpack-binary=:root:linpack:bob:xlinpack_xeon64/sample0/tools-default/ctlrA/turbostat",
             "files": [
@@ -584,7 +584,7 @@ len(actions) = 22
             "@timestamp": "2020-02-28T19:10:55.645002",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/2__linpack-binary=:root:linpack:l_mklb_p_2019.6.005:benchmarks_2019:linux:mkl:benchmarks:linpack:xlinpack_xeon64",
             "files": [
@@ -614,7 +614,7 @@ len(actions) = 22
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/2__linpack-binary=:root:linpack:l_mklb_p_2019.6.005:benchmarks_2019:linux:mkl:benchmarks:linpack:xlinpack_xeon64/sample0",
             "files": [

--- a/server/bin/gold/test-7.4.txt
+++ b/server/bin/gold/test-7.4.txt
@@ -96,7 +96,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -141,7 +141,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -167,7 +167,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o775",
@@ -188,7 +188,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo",
             "mode": "0o775",
@@ -210,7 +210,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo/end",
             "files": [

--- a/server/bin/gold/test-7.5.txt
+++ b/server/bin/gold/test-7.5.txt
@@ -96,7 +96,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -141,7 +141,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -167,7 +167,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o775",
@@ -188,7 +188,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo",
             "mode": "0o775",
@@ -210,7 +210,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo/end",
             "files": [

--- a/server/bin/gold/test-7.6.txt
+++ b/server/bin/gold/test-7.6.txt
@@ -96,7 +96,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "roger"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -142,7 +142,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "roger"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -168,7 +168,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "roger"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o775",
@@ -189,7 +189,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "roger"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo",
             "mode": "0o775",
@@ -211,7 +211,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "roger"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo/end",
             "files": [

--- a/server/bin/gold/test-7.7.txt
+++ b/server/bin/gold/test-7.7.txt
@@ -96,7 +96,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -142,7 +142,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -168,7 +168,7 @@ len(actions) = 5
             "@timestamp": "2015-09-21T19:31:12.673292",
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo",
             "mode": "0o775",
@@ -189,7 +189,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo",
             "mode": "0o775",
@@ -211,7 +211,7 @@ len(actions) = 5
             ],
             "authorization": {
                 "access": "private",
-                "owner": "test"
+                "owner": "1"
             },
             "directory": "/sysinfo/foo/end",
             "files": [

--- a/server/bin/gold/test-7.8.txt
+++ b/server/bin/gold/test-7.8.txt
@@ -98,7 +98,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -370,7 +370,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -445,7 +445,7 @@ len(actions) = 33
             "@timestamp": "2016-10-06T16:34:08.098427",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i",
             "files": [
@@ -503,7 +503,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1",
             "files": [
@@ -562,7 +562,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/csv",
             "files": [
@@ -593,7 +593,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default",
             "mode": "0o755",
@@ -616,7 +616,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb",
             "mode": "0o755",
@@ -640,7 +640,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/iostat",
             "files": [
@@ -702,7 +702,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/iostat/csv",
             "files": [
@@ -777,7 +777,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/mpstat",
             "files": [
@@ -1063,7 +1063,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/mpstat/csv",
             "files": [
@@ -1208,7 +1208,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/perf",
             "files": [
@@ -1277,7 +1277,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/perf/perf-percpu",
             "files": [
@@ -1415,7 +1415,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/pidstat",
             "files": [
@@ -1533,7 +1533,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/pidstat/csv",
             "files": [
@@ -1622,7 +1622,7 @@ len(actions) = 33
             ],
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "directory": "/1-tcp_stream-16384B-32i/sample1/tools-default/flat7_40gb/proc-interrupts",
             "files": [
@@ -2351,7 +2351,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2406,7 +2406,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2461,7 +2461,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -2516,7 +2516,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2571,7 +2571,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2626,7 +2626,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -2681,7 +2681,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2736,7 +2736,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2791,7 +2791,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -2846,7 +2846,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2893,7 +2893,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2940,7 +2940,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -2987,7 +2987,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3034,7 +3034,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3081,7 +3081,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3128,7 +3128,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3175,7 +3175,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3222,7 +3222,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3269,7 +3269,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3316,7 +3316,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3363,7 +3363,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3410,7 +3410,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3457,7 +3457,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3504,7 +3504,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3551,7 +3551,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3606,7 +3606,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3661,7 +3661,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3716,7 +3716,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3771,7 +3771,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3826,7 +3826,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3881,7 +3881,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3936,7 +3936,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -3991,7 +3991,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4046,7 +4046,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4101,7 +4101,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4156,7 +4156,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4211,7 +4211,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4266,7 +4266,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4321,7 +4321,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4376,7 +4376,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4415,7 +4415,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4454,7 +4454,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4493,7 +4493,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4532,7 +4532,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4571,7 +4571,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4610,7 +4610,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4649,7 +4649,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4688,7 +4688,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4727,7 +4727,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4766,7 +4766,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4805,7 +4805,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4844,7 +4844,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4883,7 +4883,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4922,7 +4922,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.357526",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -4961,7 +4961,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.3620842",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5144,7 +5144,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.364391",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5475,7 +5475,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.3666246",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -5806,7 +5806,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.3689446",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6137,7 +6137,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6192,7 +6192,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6247,7 +6247,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -6302,7 +6302,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6357,7 +6357,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6412,7 +6412,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657000",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -6467,7 +6467,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.4044082",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6650,7 +6650,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.406617",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -6981,7 +6981,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.4090216",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7312,7 +7312,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.4113934",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7643,7 +7643,7 @@ len(actions) = 72
             "@timestamp_original": "1475771651.0663261",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -7826,7 +7826,7 @@ len(actions) = 72
             "@timestamp_original": "1475771654.0686305",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -8157,7 +8157,7 @@ len(actions) = 72
             "@timestamp_original": "1475771657.0710783",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",
@@ -8488,7 +8488,7 @@ len(actions) = 72
             "@timestamp_original": "1475771660.0734138",
             "authorization": {
                 "access": "private",
-                "owner": "fake"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1-tcp_stream-16384B-32i",

--- a/server/bin/gold/test-7.9.txt
+++ b/server/bin/gold/test-7.9.txt
@@ -96,7 +96,7 @@ len(actions) = 16
             "@timestamp": "2017-04-21T20:38:16.618515",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "host_tools_info": [
                 {
@@ -163,7 +163,7 @@ len(actions) = 16
             "@timestamp": "2017-04-21T20:38:16.618515",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/",
             "files": [
@@ -196,7 +196,7 @@ len(actions) = 16
             "@timestamp": "2017-04-21T20:38:16.618515",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1",
             "mode": "0o755",
@@ -217,7 +217,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result",
             "files": [
@@ -248,7 +248,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default",
             "mode": "0o755",
@@ -271,7 +271,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144",
             "mode": "0o755",
@@ -295,7 +295,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/iostat",
             "files": [
@@ -357,7 +357,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/iostat/csv",
             "files": [
@@ -432,7 +432,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/mpstat",
             "files": [
@@ -508,7 +508,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/mpstat/csv",
             "files": [
@@ -548,7 +548,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/perf",
             "files": [
@@ -617,7 +617,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/perf/perf-percpu",
             "files": [
@@ -650,7 +650,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/pidstat",
             "files": [
@@ -768,7 +768,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/pidstat/csv",
             "files": [
@@ -857,7 +857,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/proc-interrupts",
             "files": [
@@ -933,7 +933,7 @@ len(actions) = 16
             ],
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "directory": "/1/reference-result/tools-default/dhcp31-144/proc-interrupts/csv",
             "files": [
@@ -1266,7 +1266,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -1321,7 +1321,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -1376,7 +1376,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 0,
@@ -1431,7 +1431,7 @@ len(actions) = 75
             "@timestamp_original": "1492807104000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -1486,7 +1486,7 @@ len(actions) = 75
             "@timestamp_original": "1492807104000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -1541,7 +1541,7 @@ len(actions) = 75
             "@timestamp_original": "1492807104000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 1,
@@ -1596,7 +1596,7 @@ len(actions) = 75
             "@timestamp_original": "1492807107000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -1651,7 +1651,7 @@ len(actions) = 75
             "@timestamp_original": "1492807107000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -1706,7 +1706,7 @@ len(actions) = 75
             "@timestamp_original": "1492807107000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 2,
@@ -1761,7 +1761,7 @@ len(actions) = 75
             "@timestamp_original": "1492807110000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -1816,7 +1816,7 @@ len(actions) = 75
             "@timestamp_original": "1492807110000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -1871,7 +1871,7 @@ len(actions) = 75
             "@timestamp_original": "1492807110000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 3,
@@ -1926,7 +1926,7 @@ len(actions) = 75
             "@timestamp_original": "1492807113000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -1981,7 +1981,7 @@ len(actions) = 75
             "@timestamp_original": "1492807113000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2036,7 +2036,7 @@ len(actions) = 75
             "@timestamp_original": "1492807113000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iostat": {
                 "@idx": 4,
@@ -2091,7 +2091,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2138,7 +2138,7 @@ len(actions) = 75
             "@timestamp_original": "1492807104000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2185,7 +2185,7 @@ len(actions) = 75
             "@timestamp_original": "1492807107000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2232,7 +2232,7 @@ len(actions) = 75
             "@timestamp_original": "1492807110000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2279,7 +2279,7 @@ len(actions) = 75
             "@timestamp_original": "1492807113000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2326,7 +2326,7 @@ len(actions) = 75
             "@timestamp_original": "1492807116000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2373,7 +2373,7 @@ len(actions) = 75
             "@timestamp_original": "1492807119000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2420,7 +2420,7 @@ len(actions) = 75
             "@timestamp_original": "1492807122000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2467,7 +2467,7 @@ len(actions) = 75
             "@timestamp_original": "1492807125000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2514,7 +2514,7 @@ len(actions) = 75
             "@timestamp_original": "1492807128000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2561,7 +2561,7 @@ len(actions) = 75
             "@timestamp_original": "1492807131000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2608,7 +2608,7 @@ len(actions) = 75
             "@timestamp_original": "1492807134000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2655,7 +2655,7 @@ len(actions) = 75
             "@timestamp_original": "1492807137000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2702,7 +2702,7 @@ len(actions) = 75
             "@timestamp_original": "1492807140000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2749,7 +2749,7 @@ len(actions) = 75
             "@timestamp_original": "1492807143000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2796,7 +2796,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2851,7 +2851,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2906,7 +2906,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -2961,7 +2961,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3016,7 +3016,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3071,7 +3071,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3126,7 +3126,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3181,7 +3181,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3236,7 +3236,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3291,7 +3291,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3346,7 +3346,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3401,7 +3401,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3456,7 +3456,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3511,7 +3511,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3566,7 +3566,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101000",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3621,7 +3621,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3660,7 +3660,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3699,7 +3699,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3738,7 +3738,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3777,7 +3777,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3816,7 +3816,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3855,7 +3855,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3894,7 +3894,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3933,7 +3933,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -3972,7 +3972,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4011,7 +4011,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4050,7 +4050,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4089,7 +4089,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4128,7 +4128,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4167,7 +4167,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7129807",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4206,7 +4206,7 @@ len(actions) = 75
             "@timestamp_original": "1492807098.7500932",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4404,7 +4404,7 @@ len(actions) = 75
             "@timestamp_original": "1492807101.7640526",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -4765,7 +4765,7 @@ len(actions) = 75
             "@timestamp_original": "1492807104.7669783",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5126,7 +5126,7 @@ len(actions) = 75
             "@timestamp_original": "1492807107.7698412",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5487,7 +5487,7 @@ len(actions) = 75
             "@timestamp_original": "1492807110.7726846",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -5848,7 +5848,7 @@ len(actions) = 75
             "@timestamp_original": "1492807113.7755005",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6209,7 +6209,7 @@ len(actions) = 75
             "@timestamp_original": "1492807116.7783818",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6570,7 +6570,7 @@ len(actions) = 75
             "@timestamp_original": "1492807119.7812595",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -6931,7 +6931,7 @@ len(actions) = 75
             "@timestamp_original": "1492807122.7841673",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7292,7 +7292,7 @@ len(actions) = 75
             "@timestamp_original": "1492807125.787123",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -7653,7 +7653,7 @@ len(actions) = 75
             "@timestamp_original": "1492807128.790011",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8014,7 +8014,7 @@ len(actions) = 75
             "@timestamp_original": "1492807131.7927866",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8375,7 +8375,7 @@ len(actions) = 75
             "@timestamp_original": "1492807134.7957523",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -8736,7 +8736,7 @@ len(actions) = 75
             "@timestamp_original": "1492807137.8056715",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",
@@ -9097,7 +9097,7 @@ len(actions) = 75
             "@timestamp_original": "1492807140.808738",
             "authorization": {
                 "access": "private",
-                "owner": "freddie"
+                "owner": "1"
             },
             "iteration": {
                 "name": "1",

--- a/server/bin/pbench-state-manager.py
+++ b/server/bin/pbench-state-manager.py
@@ -19,10 +19,8 @@ from argparse import ArgumentParser
 from pbench import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.api.auth import Auth, UnknownUser
 from pbench.server.database.database import Database
 from pbench.server.database.models.tracker import Dataset, States
-from pbench.server.database.models.users import User
 
 
 _NAME_ = "pbench-state-manager"
@@ -52,28 +50,7 @@ def main(options):
 
         args = {}
         if options.create:
-            user = options.create
-            try:
-                user = Auth.validate_user(user)
-            except UnknownUser:
-                # FIXME: I don't want to be creating the user here or
-                # dealing with a non-existing user. The unittest setup
-                # should create the test users we want ahead of time
-                # using a pbench-user-manager command and we should
-                # depend on having them here! The following is a hack
-                # until that command exists.
-                #
-                # The desired behavior would be to remove this try and
-                # except and allow UnknownUser to be handled below with
-                # an error message and termination.
-                User(
-                    username=user,
-                    first_name=user.capitalize(),
-                    last_name="Account",
-                    password=f"{user}_password",
-                    email=f"{user}@example.com",
-                ).add()
-            args["owner"] = user
+            args["owner"] = options.create
         if options.controller:
             args["controller"] = options.controller
         if options.path:

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -24,6 +24,11 @@ if [[ ! -d $_testbase ]]; then
     exit 1
 fi
 
+# Install the PBENCH code under test, mostly to build CLICK commands for use
+# during setup. This will install (and run) on top of whatever Python
+# environment is in effect; e.g., the tox virtual environment.
+pipenv install ${_gitdir}
+
 function remove_path {
     # PATH ($2) => /bin:/opt/a dir/bin:/sbin
     WORK=:$2:
@@ -224,7 +229,7 @@ function _dump_logs {
     # Be quiet if there's no database, or if the `dataset` table hasn't been
     # created.
     db=${_testroot}/test_db
-    select='select owner,controller,name,state,(select " " || key || " = " || value from dataset_metadata where dataset_ref = datasets.id) from datasets order by owner,controller,name asc'
+    select='select (select users.username from users where users.id = datasets.owner_id),controller,name,state,(select " " || key || " = " || value from dataset_metadata where dataset_ref = datasets.id) from datasets order by (select users.username from users where users.id = datasets.owner_id),controller,name asc'
     sqlite3 ${db} "${select}" > ${_testdir_local}/db 2>/dev/null
     if [ -s ${_testdir_local}/db ] ;then
         echo "+++ SqliteDB Datasets" >> $_testout
@@ -255,6 +260,16 @@ function _verify_output {
         rm ${_testout} ${_testdiff}
     fi
     return ${res}
+}
+
+function _create_user {
+    name=${1}
+    # NOTE: we ignore failures here deliberately; it'll always fail in
+    # the 0[.x] tests because of intentionally corrupted configuration,
+    # and unintentional failure in other tests will result in visible
+    # symptoms later.
+    pbench-user-create --username=${name} --email=${name}@example.com \
+        --first-name=${name^} --last-name=User --password=password >/dev/null 2>&1
 }
 
 function _setup_state {
@@ -457,7 +472,21 @@ function _setup_state {
     fi
 
     # Setup per-test Dataset DB
-    _state_db=${_tdir}/state/${1}.db
+    local _state_db=${_tdir}/state/${1}.db
+
+    # Determine which users the test needs and create them. We discover
+    # users dynamically from the database state ".db" files, but also
+    # always allow use of the quarantiner and satellite users for the
+    # pre-shim and satellite intake tests, as well as "pbench" for
+    # un-owned prep-shim intake success.
+    local users="pbench quarantiner satellite"
+    if [ -f ${_state_db} ]; then
+        users="$(cat ${_state_db} | cut --d ' ' -f 4 | sort -u) ${users}"
+    fi
+    for u in ${users}; do
+        _create_user ${u}
+    done
+
     if [ -f ${_state_db} ]; then
         while read -r controller name state user; do
             pbench-state-manager --create=${user} --controller=${controller} --name=${name} --state=${state}


### PR DESCRIPTION
Whether users are identified primarily by username or email, we want all external forms of identification to be changeable; so we will index Elasticsearch documents using a stable internal identification, the user's table row ID.

This removes the user creation hack from `pbench-state-manager` and utilizes the `pbench-user-create` tool to create users referenced in each test's `.db` file along with a set of "standard" users required by some of the satellite and prep-shim tests.

A number of CLI unit test gold files change in fairly obvious ways.