### PR TITLE
Add a role to install the EPEL repo

### DIFF
--- a/agent/ansible/pbench/agent/galaxy.yml
+++ b/agent/ansible/pbench/agent/galaxy.yml
@@ -9,7 +9,7 @@ namespace: pbench
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.3
+version: 1.0.4
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: install the EPEL repo
+  package:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: latest
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
+  

--- a/agent/ansible/pbench_agent_install.yml
+++ b/agent/ansible/pbench_agent_install.yml
@@ -9,6 +9,7 @@
     pbench_configuration_environment: "{{ cenv | default('production') }}"
 
   roles:
+    - epel_repo_install
     - pbench_repo_install
     - pbench_agent_install
     - pbench_agent_config

--- a/server/ansible/pbench-server-install.yml
+++ b/server/ansible/pbench-server-install.yml
@@ -9,6 +9,7 @@
     apache_options: "+Indexes +FollowSymLinks"
 
   roles:
+    - epel_repo_install
     - pbench-repo-install
     - pbench-server-install
     - pbench-server-config

--- a/server/ansible/roles/epel_repo_install/tasks/main.yml
+++ b/server/ansible/roles/epel_repo_install/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: install the EPEL repo
+  package:
+    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
+    state: latest
+  when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
+  


### PR DESCRIPTION
Fixes #1987

Separately added to both server and agent roles.

Add it to the pbench_<agent|server>_install.yml playbooks.

Bump the version in galaxy.yml in preparation for a new upload
of the agent roles.