### PR TITLE
Validate all passed in `_pbench_hostname_ip` values

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -119,11 +119,13 @@ validate_hostname "${_pbench_full_hostname}" "_pbench_full_hostname"
 if [[ -z "${_pbench_hostname_ip}" ]]; then
     export _pbench_hostname_ip=$(hostname -i)
 fi
-validate-ipaddress "${_pbench_hostname_ip}"
-if [[ ${?} -ne 0 ]]; then
-    error_log "[${script_name}] Invalid IP address: '${_pbench_hostname_ip}'"
-    exit 1
-fi
+for _ip in ${_pbench_hostname_ip}; do
+    validate-ipaddress "${_ip}"
+    if [[ ${?} -ne 0 ]]; then
+        error_log "[${script_name}] Invalid IP address: '${_ip}'"
+        exit 1
+    fi
+done
 
 if [[ -z "$ssh_opts" ]]; then
     ssh_opts=$(pbench-config ssh_opts results)

--- a/agent/base
+++ b/agent/base
@@ -109,15 +109,17 @@ function validate_hostname {
 }
 
 if [[ -z "${_pbench_hostname}" ]]; then
-    export _pbench_hostname=$(hostname -s)
+    export _pbench_hostname=$(hostname --short)
 fi
 validate_hostname "${_pbench_hostname}" "_pbench_hostname"
+
 if [[ -z "${_pbench_full_hostname}" ]]; then
-    export _pbench_full_hostname=$(hostname -f)
+    export _pbench_full_hostname=$(hostname --fqdn)
 fi
 validate_hostname "${_pbench_full_hostname}" "_pbench_full_hostname"
+
 if [[ -z "${_pbench_hostname_ip}" ]]; then
-    export _pbench_hostname_ip=$(hostname -i)
+    export _pbench_hostname_ip=$(hostname --ip-address)
 fi
 for _ip in ${_pbench_hostname_ip}; do
     validate-ipaddress "${_ip}"

--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -99,10 +99,14 @@ iterations = 0-iter-zero, 1-iter-one
 
 [controller]
 hostname = testhost.example.com
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 ssh_opts = -o StrictHostKeyChecking=no
 
 [run]
@@ -118,10 +122,14 @@ trigger = None
 [tools/testhost.example.com]
 label = 
 tools = dcgm,mpstat
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 mpstat = --interval=42 --options=forty-two

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -314,10 +314,14 @@ iterations = 0-iter-zero, 1-iter-one
 
 [controller]
 hostname = testhost.example.com
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 ssh_opts = -o StrictHostKeyChecking=no
 
 [run]
@@ -333,10 +337,14 @@ trigger = None
 [tools/remote-a.example.com]
 label = 
 tools = mpstat
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 
@@ -348,10 +356,14 @@ install_check_output = mpstat: pbench-sysstat-12.0.3-1 is installed
 [tools/remote-b.example.com]
 label = blue
 tools = mpstat,node-exporter
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 node-exporter = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
@@ -369,10 +381,14 @@ install_check_output = node_exporter tool properly installed
 [tools/remote-c.example.com]
 label = red
 tools = dcgm,pcp
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 pcp = --interval=42 --options=forty-two
@@ -390,10 +406,14 @@ install_check_output = pcp tool (pmcd) properly installed
 [tools/testhost.example.com]
 label = 
 tools = dcgm,mpstat
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 mpstat = --interval=42 --options=forty-two

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -286,10 +286,14 @@ iterations = 0-iter-zero, 1-iter-one
 
 [controller]
 hostname = testhost.example.com
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 ssh_opts = -o StrictHostKeyChecking=no
 
 [run]
@@ -306,10 +310,14 @@ trigger = None
 [tools/remote-a.example.com]
 label = 
 tools = mpstat
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 
@@ -321,10 +329,14 @@ install_check_output = mpstat: pbench-sysstat-12.0.3-1 is installed
 [tools/remote-b.example.com]
 label = blue
 tools = mpstat,node-exporter
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = --interval=42 --options=forty-two
 node-exporter = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
@@ -342,10 +354,14 @@ install_check_output = node_exporter tool properly installed
 [tools/remote-c.example.com]
 label = red
 tools = dcgm,pcp
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 pcp = --interval=42 --options=forty-two
@@ -363,10 +379,14 @@ install_check_output = pcp tool (pmcd) properly installed
 [tools/testhost.example.com]
 label = 
 tools = dcgm,mpstat
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 dcgm = --inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
 mpstat = --interval=42 --options=forty-two

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -69,10 +69,14 @@ script = fake-bm
 
 [controller]
 hostname = testhost.example.com
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 ssh_opts = -o StrictHostKeyChecking=no
 
 [run]
@@ -88,10 +92,14 @@ trigger = None
 [tools/testhost.example.com]
 label = 
 tools = mpstat,perf
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = 
 perf = --record-opts="-a -freq=100 -g --event=branch-misses --event=cache-misses --event=instructions" --report-opts="-I -g"
@@ -123,8 +131,8 @@ DEBUG pbench-tool-data-sink __enter__ -- web server 'run' thread started, proces
 INFO pbench-tool-data-sink tm_log_capture -- Running Tool Meister log capture ...
 DEBUG pbench-tool-data-sink __enter__ -- 'tm_log_capture' thread started, processing Tool Meister logs ...
 DEBUG pbench-tool-data-sink fetch_message -- next pbench-agent-cli-from-tms
-DEBUG pbench-tool-data-sink fetch_message -- payload from pbench-agent-cli-from-tms: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-from-tms', 'data': b'{"hostname": "testhost.example.com", "hostname_A": "agent.example.com", "hostname_I": "agent.example.com", "hostname_f": "agent.example.com", "hostname_i": "agent.example.com", "hostname_s": "agent.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'}
-DEBUG pbench-tool-data-sink fetch_message -- channel pbench-agent-cli-from-tms payload, '{"hostname": "testhost.example.com", "hostname_A": "agent.example.com", "hostname_I": "agent.example.com", "hostname_f": "agent.example.com", "hostname_i": "agent.example.com", "hostname_s": "agent.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'
+DEBUG pbench-tool-data-sink fetch_message -- payload from pbench-agent-cli-from-tms: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-from-tms', 'data': b'{"hostdata": {"alias": "bond", "all-fqdns": "agent.example.com bond.example.com", "all-ip-addresses": "192.168.0.1 172.0.0.1 127.0.0.1", "domain": "example.com", "fqdn": "agent.example.com", "ip-address": "172.0.0.1 127.0.0.1", "nis": "hostname[mock]: Local domain name not set", "short": "agent"}, "hostname": "testhost.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'}
+DEBUG pbench-tool-data-sink fetch_message -- channel pbench-agent-cli-from-tms payload, '{"hostdata": {"alias": "bond", "all-fqdns": "agent.example.com bond.example.com", "all-ip-addresses": "192.168.0.1 172.0.0.1 127.0.0.1", "domain": "example.com", "fqdn": "agent.example.com", "ip-address": "172.0.0.1 127.0.0.1", "nis": "hostname[mock]: Local domain name not set", "short": "agent"}, "hostname": "testhost.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'
 DEBUG pbench-tool-data-sink execute -- publish pbench-agent-cli-to-client
 DEBUG pbench-tool-data-sink execute -- published pbench-agent-cli-to-client
 DEBUG pbench-tool-data-sink fetch_message -- next pbench-agent-cli-from-client

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -69,10 +69,14 @@ script = fake-bm
 
 [controller]
 hostname = testhost.example.com
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 ssh_opts = -o StrictHostKeyChecking=no
 
 [run]
@@ -88,10 +92,14 @@ trigger = None
 [tools/testhost.example.com]
 label = 
 tools = mpstat,perf
-hostname-s = agent.example.com
-hostname-f = agent.example.com
-hostname-i = agent.example.com
-hostname-a = agent.example.com
+hostname-alias = bond
+hostname-all-fqdns = agent.example.com bond.example.com
+hostname-all-ip-addresses = 192.168.0.1 172.0.0.1 127.0.0.1
+hostname-domain = example.com
+hostname-fqdn = agent.example.com
+hostname-ip-address = 172.0.0.1 127.0.0.1
+hostname-nis = hostname[mock]: Local domain name not set
+hostname-short = agent
 rpm-version = v(unknown)-g(unknown)
 mpstat = 
 perf = --record-opts="-a -freq=100 -g --event=branch-misses --event=cache-misses --event=instructions" --report-opts="-I -g"
@@ -123,8 +131,8 @@ DEBUG pbench-tool-data-sink __enter__ -- web server 'run' thread started, proces
 INFO pbench-tool-data-sink tm_log_capture -- Running Tool Meister log capture ...
 DEBUG pbench-tool-data-sink __enter__ -- 'tm_log_capture' thread started, processing Tool Meister logs ...
 DEBUG pbench-tool-data-sink fetch_message -- next pbench-agent-cli-from-tms
-DEBUG pbench-tool-data-sink fetch_message -- payload from pbench-agent-cli-from-tms: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-from-tms', 'data': b'{"hostname": "testhost.example.com", "hostname_A": "agent.example.com", "hostname_I": "agent.example.com", "hostname_f": "agent.example.com", "hostname_i": "agent.example.com", "hostname_s": "agent.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'}
-DEBUG pbench-tool-data-sink fetch_message -- channel pbench-agent-cli-from-tms payload, '{"hostname": "testhost.example.com", "hostname_A": "agent.example.com", "hostname_I": "agent.example.com", "hostname_f": "agent.example.com", "hostname_i": "agent.example.com", "hostname_s": "agent.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'
+DEBUG pbench-tool-data-sink fetch_message -- payload from pbench-agent-cli-from-tms: {'type': 'message', 'pattern': None, 'channel': b'pbench-agent-cli-from-tms', 'data': b'{"hostdata": {"alias": "bond", "all-fqdns": "agent.example.com bond.example.com", "all-ip-addresses": "192.168.0.1 172.0.0.1 127.0.0.1", "domain": "example.com", "fqdn": "agent.example.com", "ip-address": "172.0.0.1 127.0.0.1", "nis": "hostname[mock]: Local domain name not set", "short": "agent"}, "hostname": "testhost.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'}
+DEBUG pbench-tool-data-sink fetch_message -- channel pbench-agent-cli-from-tms payload, '{"hostdata": {"alias": "bond", "all-fqdns": "agent.example.com bond.example.com", "all-ip-addresses": "192.168.0.1 172.0.0.1 127.0.0.1", "domain": "example.com", "fqdn": "agent.example.com", "ip-address": "172.0.0.1 127.0.0.1", "nis": "hostname[mock]: Local domain name not set", "short": "agent"}, "hostname": "testhost.example.com", "installs": {"mpstat": [0, "mpstat: pbench-sysstat-12.0.3-1 is installed"], "perf": [0, "perf: perf is installed"]}, "kind": "tm", "label": "", "pid": NNNNN, "seqno": "", "sha1": "(unknown)", "version": "(unknown)"}'
 DEBUG pbench-tool-data-sink execute -- publish pbench-agent-cli-to-client
 DEBUG pbench-tool-data-sink execute -- published pbench-agent-cli-to-client
 DEBUG pbench-tool-data-sink fetch_message -- next pbench-agent-cli-from-client

--- a/agent/util-scripts/test-bin/hostname
+++ b/agent/util-scripts/test-bin/hostname
@@ -1,4 +1,40 @@
-#! /bin/bash
+#!/usr/bin/env python3
 
-# fake out the hostname -f in pbench-move-results
-echo "agent.example.com"
+"""hostname - mock the behavior of the hostname command for the unit tests."""
+
+import sys
+
+short = "agent"
+alias = "bond"
+domain = "example.com"
+fqdn = f"{short}.{domain}"
+alt_fqdn = f"{alias}.{domain}"
+ip_addrs = "172.0.0.1 127.0.0.1"
+all_ip_addrs = f"192.168.0.1 {ip_addrs}"
+
+exit_code = 0
+if len(sys.argv) <= 1:
+    print(fqdn)
+elif sys.argv[1] in ("-a", "--alias"):
+    print(alias)
+elif sys.argv[1] in ("-A", "--all-fqdns"):
+    print(f"{fqdn} {alt_fqdn}")
+elif sys.argv[1] in ("-d", "--domain"):
+    print(domain)
+elif sys.argv[1] in ("-f", "--fqdn", "--long"):
+    print(fqdn)
+elif sys.argv[1] in ("-i", "--ip-address"):
+    print(ip_addrs)
+elif sys.argv[1] in ("-I", "--all-ip-addresses"):
+    print(all_ip_addrs)
+elif sys.argv[1] in ("-s", "--short"):
+    print(short)
+elif sys.argv[1] in ("-y", "--yp", "--nis"):
+    print("hostname[mock]: Local domain name not set")
+    exit_code = 1
+else:
+    print(
+        f"hostname[mock]: unexpected hostname invocation: {sys.argv!r}", file=sys.stderr
+    )
+    exit_code = 101
+sys.exit(exit_code)

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -1155,11 +1155,8 @@ class ToolDataSink(Bottle):
         section = "controller"
         mdlog.add_section(section)
         mdlog.set(section, "hostname", self.hostname)
-        mdlog.set(section, "hostname-s", hostdata["s"])
-        mdlog.set(section, "hostname-f", hostdata["f"])
-        mdlog.set(section, "hostname-i", hostdata["i"])
-        mdlog.set(section, "hostname-A", hostdata["A"])
-        mdlog.set(section, "hostname-I", hostdata["I"])
+        for hd_key, hd_val in sorted(hostdata.items()):
+            mdlog.set(section, f"hostname-{hd_key}", hd_val)
         mdlog.set(section, "ssh_opts", self.optional_md["ssh_opts"])
 
         section = "run"
@@ -1181,11 +1178,8 @@ class ToolDataSink(Bottle):
             mdlog.set(section, "tools", tools_string)
 
             # add host data
-            mdlog.set(section, "hostname-s", tm["hostname_s"])
-            mdlog.set(section, "hostname-f", tm["hostname_f"])
-            mdlog.set(section, "hostname-i", tm["hostname_i"])
-            mdlog.set(section, "hostname-A", tm["hostname_A"])
-            mdlog.set(section, "hostname-I", tm["hostname_I"])
+            for hd_key, hd_val in sorted(tm["hostdata"].items()):
+                mdlog.set(section, f"hostname-{hd_key}", hd_val)
             ver, seq, sha = tm["version"], tm["seqno"], tm["sha1"]
             rpm_version = f"v{ver}-{seq}g{sha}"
             try:

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -841,11 +841,7 @@ class ToolMeister:
             version=version,
             seqno=seqno,
             sha1=sha1,
-            hostname_f=hostdata["f"],
-            hostname_s=hostdata["s"],
-            hostname_i=hostdata["i"],
-            hostname_I=hostdata["I"],
-            hostname_A=hostdata["A"],
+            hostdata=hostdata,
             installs=tool_installs,
         )
 

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -370,9 +370,18 @@ def collect_local_info(pbench_bin):
         sha1 = "(unknown)"
 
     hostdata = {}
-    for arg in ["f", "s", "i", "I", "A"]:
+    for arg in [
+        "fqdn",
+        "all-fqdns",
+        "short",
+        "alias",
+        "ip-address",
+        "all-ip-addresses",
+        "domain",
+        "nis",
+    ]:
         cp = subprocess.run(
-            ["hostname", f"-{arg}"],
+            ["hostname", f"--{arg}"],
             stdin=None,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
Since `hostname -i` will return a space separated list of IP addresses for the given host name, validate all of them instead of assuming incorrectly that only one is returned.

I have not seen this behavior on Fedora derived systems, but on Debian, when you get a container, it auto creates an entry for the current host name in the container's view of its `/etc/hosts`, which has a value of `127.0.1.1` (yes, `.1.1`, go figure).  In this case, `hostname -i` will return the original IP address and the `127.0.1.1` address.

You can make this happen arbitrarily by modifying the `/etc/hosts` of some system to have an alternate IP for localhost or your official DHCP host name. Then `hostname -i` returns N IP addresses.

----

Added a second commit to fix the proper handling of the `hostname` output.

We now use the long options to `hostname` so that the ConfigParser behavior of lowercasing key names won't lose `-a` vs `-A`, or `-i` vs `-I`.  And while we are at it, we refactor to make sure there is one source of what we are collecting, adding a proper mock of the data collected, and add the other options for data that can be collected.