### PR TITLE
Turn off interpolation of `metadata.log`

### DIFF
--- a/agent/util-scripts/gold/pbench-copy-results/test-49.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-49.txt
@@ -45,8 +45,8 @@ turbostat = --interval=3
 controller = testhost.example.com
 start_run = 2018-05-23T03:21:32.387628370
 end_run = 2018-05-23T03:22:39.538437410
-user = ndk20%%
-prefix = foo/bar3%%
+user = ndk20%
+prefix = foo/bar3%
 raw_size = #####
 
 [iterations/1]

--- a/agent/util-scripts/gold/test-add-metalog-%-option/test-48.txt
+++ b/agent/util-scripts/gold/test-add-metalog-%-option/test-48.txt
@@ -11,6 +11,6 @@
 --- pbench tree state
 +++ mock-run/metadata.log file contents
 [run]
-percent = 30%%
+percent = 30%
 
 --- mock-run/metadata.log file contents

--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -10,21 +10,21 @@
 # where the iterations are in the <iterations.file>, one iteration per line.
 
 import sys
-from configparser import ConfigParser, NoSectionError
+from configparser import NoSectionError
+
+from pbench.common import MetadataLog
 
 
 def main(lfile, section, option):
-    config = ConfigParser()
-    config.read(lfile)
-    # python3
-    # config[section][option] = ', '.join(sys.stdin.read().split())
-    sin = sys.stdin.read().replace("%", "%%")
+    mdlog = MetadataLog()
+    mdlog.read(lfile)
+    sin = sys.stdin.read()
     try:
-        config.set(section, option, ", ".join(sin.split()))
+        mdlog.set(section, option, ", ".join(sin.split()))
     except NoSectionError:
-        config.add_section(section)
-        config.set(section, option, ", ".join(sin.split()))
-    config.write(open(lfile, "w"))
+        mdlog.add_section(section)
+        mdlog.set(section, option, ", ".join(sin.split()))
+    mdlog.write(open(lfile, "w"))
 
 
 if __name__ == "__main__":

--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -1,35 +1,56 @@
 #!/usr/bin/env python3
 
-# Usage: pbench-add-metalog-option <metadata log file> <section> <option>
-
-# Add an option to a section of the metadata.log file.
-# E.g. using an 'iterations' arg for the option
-#
-# iterations: 1-iter, 2-iter, 3-iter
-#
-# where the iterations are in the <iterations.file>, one iteration per line.
-
 import sys
-from configparser import NoSectionError
+from argparse import ArgumentParser
 
-from pbench.common import MetadataLog
+from pbench.cli.agent.commands.log import add_metalog_option
 
 
-def main(lfile, section, option):
-    mdlog = MetadataLog()
-    mdlog.read(lfile)
-    sin = sys.stdin.read()
+def main(prog, parsed):
+    """main - main program entry point to add an option to, or update an option
+    in, a section of a given metadata.log file.
+
+    To create a section name "run", with an option named, "iterations", having
+    a value of "1-iter, 2-iter, 3-iter", you would do the following:
+
+      $ echo "1-iter 2-iter 3-iter" \
+        | pbench-add-metalog-option ./metadata.log run iterations
+
+    Exits with 0 on success, 1 on failure.
+    """
     try:
-        mdlog.set(section, option, ", ".join(sin.split()))
-    except NoSectionError:
-        mdlog.add_section(section)
-        mdlog.set(section, option, ", ".join(sin.split()))
-    mdlog.write(open(lfile, "w"))
+        value = ", ".join(sys.stdin.read().split())
+        add_metalog_option(parsed.metadata_log, parsed.section, parsed.option, value)
+    except FileNotFoundError:
+        print(f"{prog}: {parsed.metadata_log}, file not found", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(
+            f"{prog}: ERROR - unexpected error encountered adding option"
+            f" {parsed.option} to section {parsed.section}, {exc}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
 
+
+_NAME_ = "pbench-add-metalog-option"
 
 if __name__ == "__main__":
-    lfile = sys.argv[1]
-    section = sys.argv[2]
-    option = sys.argv[3]
-    status = main(lfile, section, option)
+    parser = ArgumentParser(
+        f"Usage: {_NAME_} <metadata log file> <section> <option>; option value"
+        " read from stdin"
+    )
+    parser.add_argument(
+        "metadata_log",
+        help="The full path and name of the target metadata.log file to modify",
+    )
+    parser.add_argument(
+        "section", help="The name of the section containing the option",
+    )
+    parser.add_argument(
+        "option", help="The name of the option to be added or modified",
+    )
+    parsed = parser.parse_args()
+    status = main(sys.argv[0], parsed)
     sys.exit(status)

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -3,13 +3,13 @@ import errno
 import os
 import tarfile
 import urllib.parse
-from configparser import ConfigParser
 from logging import Logger
 from pathlib import Path
 
 import requests
 
 from pbench.agent import PbenchAgentConfig
+from pbench.common import MetadataLog
 from pbench.common.exceptions import BadMDLogFormat
 from pbench.common.utils import md5sum, validate_hostname
 
@@ -90,7 +90,7 @@ class MakeResultTb:
             )
 
         mdlog_name = self.result_dir / "metadata.log"
-        mdlog = ConfigParser()
+        mdlog = MetadataLog()
         try:
             with mdlog_name.open("r") as fp:
                 mdlog.read_file(fp)

--- a/lib/pbench/cli/agent/commands/log/__init__.py
+++ b/lib/pbench/cli/agent/commands/log/__init__.py
@@ -1,22 +1,23 @@
-import errno
-from configparser import NoSectionError
+import configparser
 
 from pbench.common import MetadataLog
 
 
-def add_metalog_option(log_file, section, option, value):
+def add_metalog_option(log_file: str, section: str, option: str, value: str):
+    """add_metalog_option - add the value to the option in the section of the
+    provided log file.
+
+    If the section does not exist, it is created.
+
+    If the option already exists, the value is updated.
+
+    No return value is provided; all exceptions are exposed to the caller.
+    """
     mdlog = MetadataLog()
-
-    try:
-        mdlog.read(log_file)
-    except OSError as ex:
-        if ex.errno == errno.ENOENT:
-            raise Exception(f"Log file does not exist: {log_file}")
-        raise
-
+    mdlog.read(log_file)
     try:
         mdlog.set(section, option, value)
-    except NoSectionError:
+    except configparser.NoSectionError:
         mdlog.add_section(section)
         mdlog.set(section, option, value)
     mdlog.write(open(log_file, "w"))

--- a/lib/pbench/cli/agent/commands/log/__init__.py
+++ b/lib/pbench/cli/agent/commands/log/__init__.py
@@ -1,20 +1,22 @@
 import errno
-from configparser import ConfigParser, NoSectionError
+from configparser import NoSectionError
+
+from pbench.common import MetadataLog
 
 
 def add_metalog_option(log_file, section, option, value):
-    config = ConfigParser()
+    mdlog = MetadataLog()
 
     try:
-        config.read(log_file)
+        mdlog.read(log_file)
     except OSError as ex:
         if ex.errno == errno.ENOENT:
             raise Exception(f"Log file does not exist: {log_file}")
         raise
 
     try:
-        config.set(section, option, value)
+        mdlog.set(section, option, value)
     except NoSectionError:
-        config.add_section(section)
-        config.set(section, option, value)
-    config.write(open(log_file, "w"))
+        mdlog.add_section(section)
+        mdlog.set(section, option, value)
+    mdlog.write(open(log_file, "w"))

--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -1,0 +1,13 @@
+import configparser
+
+
+class MetadataLog(configparser.ConfigParser):
+    """MetadataLog - a sub-class of ConfigParser that always has interpolation
+    turned off with no other behavioral changes.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """ Constructor - overrides `interpolation` to always be None.
+        """
+        kwargs["interpolation"] = None
+        super().__init__(*args, **kwargs)

--- a/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
+++ b/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
@@ -1,0 +1,68 @@
+import configparser
+from pathlib import Path
+
+from pbench.cli.agent.commands.log import add_metalog_option
+
+
+class TestAddMetalogOption:
+    @staticmethod
+    def test_add_metalog_option(pytestconfig):
+        TMP = pytestconfig.cache.get("TMP", None)
+        mdlog = Path(TMP) / "metadata.log"
+        mdlog.write_text(
+            """[existing]
+            existing_option = 41
+            """
+        )
+        # New section, new option
+        add_metalog_option(mdlog, "new", "new_option", "420")
+
+        cfg = configparser.ConfigParser()
+        cfg.read(mdlog)
+
+        sections = cfg.sections()
+        assert len(sections) == 2
+
+        options = cfg.options("new")
+        assert len(options) == 1
+        assert cfg.get("new", "new_option") == "420"
+
+        options = cfg.options("existing")
+        assert len(options) == 1
+        assert cfg.get("existing", "existing_option") == "41"
+
+        # Existing section, new option
+        add_metalog_option(mdlog, "existing", "new_option", "142")
+
+        cfg = configparser.ConfigParser()
+        cfg.read(mdlog)
+
+        sections = cfg.sections()
+        assert len(sections) == 2
+
+        options = cfg.options("new")
+        assert len(options) == 1
+        assert cfg.get("new", "new_option") == "420"
+
+        options = cfg.options("existing")
+        assert len(options) == 2
+        assert cfg.get("existing", "new_option") == "142"
+        assert cfg.get("existing", "existing_option") == "41"
+
+        # Existing section, existing option
+        add_metalog_option(mdlog, "existing", "existing_option", "42")
+
+        cfg = configparser.ConfigParser()
+        cfg.read(mdlog)
+
+        sections = cfg.sections()
+        assert len(sections) == 2
+
+        options = cfg.options("new")
+        assert len(options) == 1
+        assert cfg.get("new", "new_option") == "420"
+
+        options = cfg.options("existing")
+        assert len(options) == 2
+        assert cfg.get("existing", "new_option") == "142"
+        assert cfg.get("existing", "existing_option") == "42"

--- a/lib/pbench/test/unit/common/test_metadatalog.py
+++ b/lib/pbench/test/unit/common/test_metadatalog.py
@@ -1,0 +1,15 @@
+"""Test Pbench MetadataLog behaviors
+"""
+
+from pbench.common import MetadataLog
+
+
+class TestMetadataLog:
+    @staticmethod
+    def test_ensure_no_interpolation():
+        """Test to ensure interpolation is off."""
+        mdlog = MetadataLog()
+        mdlog.add_section("foo")
+        val = "This is a % that should not fail."
+        mdlog.set("foo", "bar", val)
+        assert mdlog.get("foo", "bar") == val

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -18,17 +18,18 @@ links).
 
 """
 
-import sys
+import configparser
 import os
 import re
 import shutil
+import sys
 import tempfile
-from pathlib import Path
-from datetime import datetime
 from argparse import ArgumentParser
-from configparser import ConfigParser, NoOptionError
+from datetime import datetime
+from pathlib import Path
 
 import pbench.server
+from pbench.common import MetadataLog
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
@@ -87,7 +88,7 @@ def fetch_username(tb_incoming_dir):
     """fetch_username - Return the pbench "run"'s "user" value from the
     `metadata.log` file, if it exists.
     """
-    config = ConfigParser()
+    config = MetadataLog()
     try:
         config.read(Path(tb_incoming_dir, "metadata.log"))
     except Exception:
@@ -353,7 +354,7 @@ def main(options):
     # in the INCOMING tree.
     try:
         max_unpacked_age = config.conf.get("pbench-server", "max-unpacked-age")
-    except NoOptionError as e:
+    except configparser.NoOptionError as e:
         logger.error(f"{e}")
         return 5
     try:


### PR DESCRIPTION
Instead of trying to prevent any unwanted `%` characters landing in a `metadata.log` file, we just turn off `ConfigParser` interpolation.