### PR TITLE
Add python3-psycopg2 require in the server spec file

### DIFF
--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -15,7 +15,7 @@ Requires: python3 python3-devel gcc
 Requires:       policycoreutils
 %if 0%{?rhel} != 7
 Requires: policycoreutils-python-utils
-Requires: libselinux-python3
+Requires: libselinux-python3 python3-psycopg2
 %else
 Requires: policycoreutils-python
 Requires: python3-libselinux


### PR DESCRIPTION
Fixes #2094

Although `psycopg2` is in the `server/requirements.txt` file, we prefer to install it as part of the RPM installation of pbench-server. The `pip3` install phase of it will then be a no-op.