### PR TITLE
Separate logger name from module name

### DIFF
--- a/lib/pbench/common/logger.py
+++ b/lib/pbench/common/logger.py
@@ -168,7 +168,7 @@ def get_pbench_logger(caller, config):
 
         handler.setLevel(logging.DEBUG)
         if config.log_fmt is None:
-            logfmt = "{asctime} {levelname} {process} {thread} {name}.{module} {funcName} {lineno} -- {message}"
+            logfmt = "{asctime} {levelname} {process} {thread} {name} {module} {funcName} {lineno} -- {message}"
         else:
             logfmt = config.log_fmt
         formatter = _PbenchLogFormatter(fmt=logfmt)


### PR DESCRIPTION
We really don't want to have the module name "dotted" with the module name, they are separate ids, and need to be treated as such.