### PR TITLE
Ensure that tarball upload gets desired HTTP headers

### DIFF
--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -194,9 +194,18 @@ class CopyResultTb:
                 # we got what we want before we send the request.  Also,
                 # confirm that the contents of the Content-Length header
                 # is what we expect.
-                assert "Transfer-Encoding" not in request.headers
-                assert "Content-Length" in request.headers
-                assert request.headers["Content-Length"] == str(content_length)
+                assert (
+                    "Transfer-Encoding" not in request.headers
+                ), "Upload request unexpectedly contains a `Transfer-Encoding` header"
+                assert (
+                    "Content-Length" in request.headers
+                ), "Upload request unexpectedly missing a `Content-Length` header"
+                assert request.headers["Content-Length"] == str(content_length), (
+                    "Upload request `Content-Length` header contains {} -- "
+                    "expected {}".format(
+                        request.headers["Content-Length"], content_length
+                    )
+                )
 
                 response = requests.Session().send(request)
                 response.raise_for_status()

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -6,7 +6,6 @@ import urllib.parse
 from configparser import ConfigParser
 from logging import Logger
 from pathlib import Path
-from typing import IO, Iterator
 
 import requests
 
@@ -148,8 +147,6 @@ class MakeResultTb:
 class CopyResultTb:
     """CopyResultTb - Use the server's HTTP PUT method to upload a tarball
     """
-
-    CHUNK_SIZE = 65536
 
     def __init__(
         self, controller: str, tarball: str, config: PbenchAgentConfig, logger: Logger


### PR DESCRIPTION
In today's Jam Session, we ran into a curious problem with tarball upload.  As best as we could discern, the Flask server used by `gunicorn` was trying to parse the upload as though it were being sent with `Transfer-Encoding: chunked`, but the stream was clearly not formatted that way.  This lead to a great deal of sleuthing around the agent's use of the Python `requests` package.

Per [RFC 2616](http://pretty-rfc.herokuapp.com/RFC2616#message.length), a request must not contain both `Content-Length` and `Transfer-Encoding` headers; however, the server would like to receive the `Content-Length` header, but the `requests` package may opt to generate the `Transfer-Encoding` header instead, depending on how the data for the request is specified.

This commit replaces the previous generator-based data source approach (which prompts `requests` to add the `Transfer-Encoding` header) with a straightforward "file-like" data source (which prompts `requests` to instead add the `Content-Length` header).  It also adds a few assertions to the code to make ensure that the headers come out the way we expect.

The result passes the existing unit tests (which doesn't prove a _great_ deal, since the previous code passed them, too...), and it also works with the server from the Jam Session using a 29532560 byte file.