### PR TITLE
Clean up LGTM complaints

### DIFF
--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -36,7 +36,7 @@ def replace_all(dct, old, new):
     keys = list(dct.keys())
     for k in keys:
         if isinstance(dct[k], dict):
-            dct[k] = replace_all(dct[k], old, new)
+            replace_all(dct[k], old, new)
         elif dct[k] is not None:
             assert isinstance(dct[k], str)
             old_val = dct[k]
@@ -52,7 +52,7 @@ def replace_val(dct, magic, delta):
     keys = list(dct.keys())
     for k in keys:
         if isinstance(dct[k], dict):
-            dct[k] = replace_val(dct[k], magic, delta)
+            replace_val(dct[k], magic, delta)
         elif dct[k] is not None:
             assert isinstance(dct[k], str)
             if magic in dct[k]:

--- a/agent/tool-scripts/datalog/haproxy-ocp-datalog
+++ b/agent/tool-scripts/datalog/haproxy-ocp-datalog
@@ -267,8 +267,6 @@ def operation(routers, ts_str):
     new_routers = curr_routers - prev_routers
     # These are all the routers that have died since the last time.
     dead_routers = prev_routers - curr_routers
-    # Remember for the next iteration of the loop.
-    prev_routers = curr_routers
 
     for pod_name in dead_routers:
         # Clear out any dead routers
@@ -399,7 +397,7 @@ while not terminate:
     next_start = time_stamp + interval
 
 # First wait on any existing sub-processes to complete.
-for router in _routers.values():
+for router in _routers.values():  # lgtm [py/unreachable-statement]
     router.wait(all=True)
 
 ts_str = datetime.utcfromtimestamp(time()).strftime("%s.%f")

--- a/agent/tool-scripts/datalog/oc-datalog
+++ b/agent/tool-scripts/datalog/oc-datalog
@@ -124,7 +124,7 @@ try:
     for component in components:
         if terminate:
             # During the creation of sub-processes we were told to terminate.
-            break
+            break  # lgtm [py/unreachable-statement]
 
         # Wait 5 seconds between starting watchers.
         time.sleep(_OC_DELAY)

--- a/agent/tool-scripts/datalog/pprof-datalog
+++ b/agent/tool-scripts/datalog/pprof-datalog
@@ -288,7 +288,7 @@ if parent:
                         operation.op_id,
                         exc,
                     )
-    sys.exit(0)
+    sys.exit(0)  # lgtm [py/unreachable-statement]
 
 # We are now in the "child" ONLY at this point.
 

--- a/agent/tool-scripts/datalog/prometheus-metrics-datalog
+++ b/agent/tool-scripts/datalog/prometheus-metrics-datalog
@@ -180,7 +180,7 @@ if parent:
                         host,
                         exc,
                     )
-    sys.exit(0)
+    sys.exit(0)  # lgtm [py/unreachable-statement]
 
 # We are in the child process from here on down ...
 

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -32,7 +32,6 @@ import pbench.server
 from pbench.common import MetadataLog
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
-from pbench.server import PbenchServerConfig
 from pbench.server.database import init_db
 from pbench.server.indexer import _STD_DATETIME_FMT
 from pbench.server.report import Report
@@ -322,7 +321,7 @@ def main(options):
         return 1
 
     try:
-        config = PbenchServerConfig(options.cfg_name)
+        config = pbench.server.PbenchServerConfig(options.cfg_name)
     except BadConfig as e:
         print(f"{_NAME_}: {e}", file=sys.stderr)
         return 2

--- a/server/bin/pbench-pp-status
+++ b/server/bin/pbench-pp-status
@@ -7,7 +7,6 @@
 
 import sys
 import json
-from operator import itemgetter
 
 with open(sys.argv[1], 'r') as fp:
     doc = json.load(fp)

--- a/server/bin/pbench-reindex.py
+++ b/server/bin/pbench-reindex.py
@@ -22,9 +22,8 @@ import re
 from datetime import datetime
 from argparse import ArgumentParser
 
-from pbench import BadConfig
 import pbench.server
-from pbench.server import PbenchServerConfig
+from pbench import BadConfig
 from pbench.server.database.models.tracker import (
     Dataset,
     Metadata,
@@ -175,7 +174,7 @@ def main(options):
         return 1
 
     try:
-        config = PbenchServerConfig(options.cfg_name)
+        config = pbench.server.PbenchServerConfig(options.cfg_name)
     except BadConfig as e:
         print(f"{_NAME_}: {e}", file=sys.stderr)
         return 2


### PR DESCRIPTION
Apparently LGTM only reports "new" (or newly-fixed) problems, and we now have a backlog of 40 issues.  This PR addresses many of the ones which refer to Python code.  (I did not take on the `.js` ones.)

In some cases, the changes correct the issues that LGTM raised (useless return values, unused variables, imports via both `import` and `from`, an unguarded `next()` call in a generator, a potentially confusing variable shadowing, an `else` on a `for` loop containing no `break`, unused imports).

In other cases, the changes add directives to suppress false positives.  (E.g., [unreachable code](https://github.com/github/codeql/issues/5910).)

And, I made a couple of tiny code improvements, which I couldn't resist....

Note that there are a number of cases which I did not address.  These are false-positives referring to [duplicate-import](https://github.com/github/codeql/issues/5912) and [self-import](https://github.com/github/codeql/issues/5913) cases.  I can add the suppressions to these if we like, but for whatever reason it didn't strike me as worthwhile.

(@portante, I didn't add any labels, projects, or milestones to this, as I don't know when you would prefer to see it merged, if indeed we want these changes at all -- I was just shocked to find the backlog (at least one of which is significant), so I figured I would knock a bunch of them down and put this PR up.)