### PR TITLE
Fix pbench-register-tool-trigger

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-15.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-15.txt
@@ -1,8 +1,0 @@
-+++ Running test-15 pbench-register-tool-trigger --group=default --start-trigger="START DEFAULT" --stop-trigger="STOP DEFAULT"
-tool trigger strings for start: ""START" and for stop: ""STOP" are now registered for tool group: default
---- Finished test-15 pbench-register-tool-trigger (status=0)
-+++ pbench tree state
-/var/tmp/pbench-test-utils/pbench
-/var/tmp/pbench-test-utils/pbench/tmp
-/var/tmp/pbench-test-utils/pbench/tool-triggers
---- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.00.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.00.txt
@@ -1,0 +1,8 @@
++++ Running test-35.00 pbench-register-tool-trigger 
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.00 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.01.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.01.txt
@@ -1,0 +1,8 @@
++++ Running test-35.01 pbench-register-tool-trigger --help
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.01 pbench-register-tool-trigger (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.02.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.02.txt
@@ -1,0 +1,12 @@
++++ Running test-35.02 pbench-register-tool-trigger --wrong
+
+--wrong
+pbench-register-tool-trigger: you specified an invalid option
+
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.02 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.03.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.03.txt
@@ -1,0 +1,9 @@
++++ Running test-35.03 pbench-register-tool-trigger --group=foobar
+Both --start-trigger and --stop-trigger must be specified and must be non-empty.
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.03 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.04.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.04.txt
@@ -1,0 +1,9 @@
++++ Running test-35.04 pbench-register-tool-trigger --group=foobar --start-trigger=foo
+Both --start-trigger and --stop-trigger must be specified and must be non-empty.
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.04 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.05.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.05.txt
@@ -1,0 +1,9 @@
++++ Running test-35.05 pbench-register-tool-trigger --group=foobar --stop-trigger=bar
+Both --start-trigger and --stop-trigger must be specified and must be non-empty.
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.05 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.06.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.06.txt
@@ -1,6 +1,6 @@
-+++ Running test-35 pbench-register-tool-trigger --group=default --start-trigger="START:DEFAULT" --stop-trigger="STOP DEFAULT"
++++ Running test-35.06 pbench-register-tool-trigger --group=default --start-trigger="START:DEFAULT" --stop-trigger="STOP DEFAULT"
 pbench-register-tool-trigger: the start trigger cannot have a colon in it: ""START:DEFAULT""
---- Finished test-35 pbench-register-tool-trigger (status=1)
+--- Finished test-35.06 pbench-register-tool-trigger (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/tmp

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.07.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.07.txt
@@ -1,6 +1,6 @@
-+++ Running test-36 pbench-register-tool-trigger --group=default --start-trigger="START DEFAULT" --stop-trigger="STOP:DEFAULT"
++++ Running test-35.07 pbench-register-tool-trigger --group=default --start-trigger="START DEFAULT" --stop-trigger="STOP:DEFAULT"
 pbench-register-tool-trigger: the stop trigger cannot have a colon in it: ""STOP:DEFAULT""
---- Finished test-36 pbench-register-tool-trigger (status=1)
+--- Finished test-35.07 pbench-register-tool-trigger (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/tmp

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.08.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.08.txt
@@ -1,0 +1,9 @@
++++ Running test-35.08 pbench-register-tool-trigger --group=default --start-trigger="START DEFAULT" --stop-trigger=
+Both --start-trigger and --stop-trigger must be specified and must be non-empty.
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.08 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.09.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-trigger/test-35.09.txt
@@ -1,0 +1,9 @@
++++ Running test-35.09 pbench-register-tool-trigger --group=default --start-trigger= --stop-trigger="STOP DEFAULT"
+Both --start-trigger and --stop-trigger must be specified and must be non-empty.
+usage:
+pbench-register-tool-trigger [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>
+--- Finished test-35.09 pbench-register-tool-trigger (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.10.txt
+++ b/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.10.txt
@@ -1,0 +1,12 @@
++++ Running test-35.10 test-pbench-register-tool-trigger one
+tool trigger strings for start: "START DEFAULT" and for stop: "STOP DEFAULT" are now registered for tool group: default
++++ tool-triggers file contents
+#group:start-trigger:stop-trigger
+default:START DEFAULT:STOP DEFAULT
+--- tool-triggers file contents
+--- Finished test-35.10 test-pbench-register-tool-trigger (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tool-triggers
+--- pbench tree state

--- a/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.11.txt
+++ b/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.11.txt
@@ -1,0 +1,12 @@
++++ Running test-35.11 test-pbench-register-tool-trigger two
+tool trigger strings for start: "START OTHER" and for stop: "STOP OTHER" are now registered for tool group: other
++++ tool-triggers file contents
+#group:start-trigger:stop-trigger
+other:START OTHER:STOP OTHER
+--- tool-triggers file contents
+--- Finished test-35.11 test-pbench-register-tool-trigger (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tool-triggers
+--- pbench tree state

--- a/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.12.txt
+++ b/agent/util-scripts/gold/test-pbench-register-tool-trigger/test-35.12.txt
@@ -1,0 +1,12 @@
++++ Running test-35.12 test-pbench-register-tool-trigger three
+tool trigger strings for start: "START DEFAULT" and for stop: "STOP DEFAULT" are now registered for tool group: default
++++ tool-triggers file contents
+#group:start-trigger:stop-trigger
+default:START DEFAULT:STOP DEFAULT
+--- tool-triggers file contents
+--- Finished test-35.12 test-pbench-register-tool-trigger (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tool-triggers
+--- pbench tree state

--- a/agent/util-scripts/pbench-register-tool-trigger
+++ b/agent/util-scripts/pbench-register-tool-trigger
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; sh-indent-for-case-alt: + -*-
 
 script_path=`dirname $0`
 script_name=`basename $0`
@@ -19,16 +20,19 @@ stop_trigger=""
 
 function usage() {
 	printf "usage:\n"
-	printf "$script_name --group=<tool group> --start-trigger=<string to match> --stop-trigger=<string to match>"
+	printf "$script_name [--group=<tool group>] --start-trigger=<string to match> --stop-trigger=<string to match>\n"
 }
+
+if [[ "${#}" == 0 ]] ;then
+        usage >&2
+        exit 1
+fi
 
 # Process options and arguments
 opts=$(getopt -q -o h --longoptions "help,group:,start-trigger:,stop-trigger:" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
-	printf "\n"
-	printf "%s\n" $*
-	printf "$script_name: you specified an invalid option\n\n"
-	usage
+	printf "\n%s\n%s: you specified an invalid option\n\n" "${*}" "${script_name}" >&2
+	usage >&2
 	exit 1
 fi
 eval set -- "$opts";
@@ -69,12 +73,17 @@ while true; do
 	esac
 done
 
-if [ "$start_trigger" != "${start_trigger%%:*}" ]; then
-	printf "$script_name: the start trigger cannot have a colon in it: \"${start_trigger}\"\n"
+if [[ -z "$start_trigger" || -z "$stop_trigger" ]] ;then
+	printf "Both --start-trigger and --stop-trigger must be specified and must be non-empty.\n" >&2
+	usage >&2
+	exit 1
+fi
+if [[ "$start_trigger" != "${start_trigger%%:*}" ]]; then
+	printf "$script_name: the start trigger cannot have a colon in it: \"${start_trigger}\"\n" >&2
 	exit 1
 fi
 if [ "$stop_trigger" != "${stop_trigger%%:*}" ]; then
-	printf "$script_name: the stop trigger cannot have a colon in it: \"${stop_trigger}\"\n"
+	printf "$script_name: the stop trigger cannot have a colon in it: \"${stop_trigger}\"\n" >&2
 	exit 1
 fi
 

--- a/agent/util-scripts/test-bin/test-pbench-register-tool-trigger
+++ b/agent/util-scripts/test-bin/test-pbench-register-tool-trigger
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+case $1 in
+    one)
+        pbench-register-tool-trigger --group=default --start-trigger="START DEFAULT" --stop-trigger="STOP DEFAULT"
+        sts=${?}
+        ;;
+    two)
+        pbench-register-tool-trigger --group=other --start-trigger="START OTHER" --stop-trigger="STOP OTHER"
+        sts=${?}
+        ;;
+    three)
+        pbench-register-tool-trigger --start-trigger="START DEFAULT" --stop-trigger="STOP DEFAULT"
+        sts=${?}
+        ;;
+    *)
+        exit 123
+esac
+
+echo "+++ tool-triggers file contents"
+cat ${_testdir}/tool-triggers
+echo "--- tool-triggers file contents"
+exit ${sts}

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -324,7 +324,6 @@ declare -A tools=(
     [test-12.05]="pbench-list-tools"
     [test-13]="pbench-postprocess-tools"
     [test-14]="pbench-agent-config-activate"
-    [test-15]="pbench-register-tool-trigger"
     [test-16]="pbench-list-triggers"
     [test-17]="pbench-list-triggers"
     [test-18]="pbench-list-triggers"
@@ -345,8 +344,19 @@ declare -A tools=(
     [test-32]="pbench-copy-results"
     [test-33]="pbench-move-results"
     [test-34]="pbench-move-results"
-    [test-35]="pbench-register-tool-trigger"
-    [test-36]="pbench-register-tool-trigger"
+    [test-35.00]="pbench-register-tool-trigger"
+    [test-35.01]="pbench-register-tool-trigger"
+    [test-35.02]="pbench-register-tool-trigger"
+    [test-35.03]="pbench-register-tool-trigger"
+    [test-35.04]="pbench-register-tool-trigger"
+    [test-35.05]="pbench-register-tool-trigger"
+    [test-35.06]="pbench-register-tool-trigger"
+    [test-35.07]="pbench-register-tool-trigger"
+    [test-35.08]="pbench-register-tool-trigger"
+    [test-35.09]="pbench-register-tool-trigger"
+    [test-35.10]="test-pbench-register-tool-trigger"
+    [test-35.11]="test-pbench-register-tool-trigger"
+    [test-35.12]="test-pbench-register-tool-trigger"
     [test-37]="pbench-move-results"
     [test-38]="pbench-move-results"
     [test-39]="pbench-copy-results"
@@ -408,7 +418,6 @@ declare -A options=(
     [test-12.05]="--group default --name iostat"
     [test-13]="--dir=${_testdir}/mock-run/mock-iteration/mock-sample --group=default"
     [test-14]="${_testdir}/tmp/pbench-agent.cfg"
-    [test-15]="--group=default --start-trigger=\"START DEFAULT\" --stop-trigger=\"STOP DEFAULT\""
     [test-17]="--group=default"
     [test-18]="--group=foo"
     [test-20]="--dir=${_testdir}/mock-run/mock-iteration/mock-sample --group=default"
@@ -430,8 +439,19 @@ declare -A options=(
     #[test-33]=""
     # pbench-move-results
     [test-34]="--help"
-    [test-35]="--group=default --start-trigger=\"START:DEFAULT\" --stop-trigger=\"STOP DEFAULT\""
-    [test-36]="--group=default --start-trigger=\"START DEFAULT\" --stop-trigger=\"STOP:DEFAULT\""
+    [test-35.00]=""
+    [test-35.01]="--help"
+    [test-35.02]="--wrong"
+    [test-35.03]="--group=foobar"
+    [test-35.04]="--group=foobar --start-trigger=foo"
+    [test-35.05]="--group=foobar --stop-trigger=bar"
+    [test-35.06]="--group=default --start-trigger=\"START:DEFAULT\" --stop-trigger=\"STOP DEFAULT\""
+    [test-35.07]="--group=default --start-trigger=\"START DEFAULT\" --stop-trigger=\"STOP:DEFAULT\""
+    [test-35.08]="--group=default --start-trigger=\"START DEFAULT\" --stop-trigger="
+    [test-35.09]="--group=default --start-trigger= --stop-trigger=\"STOP DEFAULT\""
+    [test-35.10]="one"
+    [test-35.11]="two"
+    [test-35.12]="three"
     # pbench-move-results
     [test-37]="--prefix="
     # pbench-move-results
@@ -468,8 +488,15 @@ declare -A expected_status=(
     [test-13]=2
     [test-21.00]=1
     [test-29]=1
-    [test-35]=1
-    [test-36]=1
+    [test-35.00]=1
+    [test-35.02]=1
+    [test-35.03]=1
+    [test-35.04]=1
+    [test-35.05]=1
+    [test-35.06]=1
+    [test-35.07]=1
+    [test-35.08]=1
+    [test-35.09]=1
     [test-37]=1
     [test-38]=1
     [test-44]=1


### PR DESCRIPTION
Fixes #2268

Fix pbench-register-tool-trigger to detect missing arguments: at least
one of --start-trigger or --stop-trigger is always required.

Add unit tests for the various cases.