### PR TITLE
Query fixes

### DIFF
--- a/lib/pbench/server/database/models/tracker.py
+++ b/lib/pbench/server/database/models/tracker.py
@@ -91,7 +91,7 @@ class DatasetBadParameterType(DatasetError):
         )
 
     def __str__(self) -> str:
-        return f'Value "{self.bad_value}" ({type(self.bad_value)}) is not a {type(self.expected_type)}'
+        return f'Value "{self.bad_value}" ({type(self.bad_value)}) is not a {self.expected_type}'
 
 
 class DatasetTransitionError(DatasetError):

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -1,0 +1,72 @@
+import pytest
+import requests
+from requests.exceptions import HTTPError
+
+
+def make_http_exception(status: int) -> HTTPError:
+    """
+    Helper to create a properly annotated HTTPError for testing
+
+    Args:
+        status: HTTP status code
+
+    Returns:
+        HTTPError object
+    """
+    response = requests.Response()
+    response.status_code = status
+    response.reason = "Fake reason"
+    return HTTPError(response=response)
+
+
+@pytest.fixture
+def query_api(client, server_config, requests_mock, request):
+    """
+    query_helper Help controller queries that want to interact with a mocked
+    Elasticsearch service.
+
+    This is a fixture which exposes a function of the same name that can be
+    used to set up and validate a mocked Elasticsearch query with a JSON
+    payload and an expected status.
+
+    Parameters to the mocked Elasticsearch POST are passed as keyword
+    parameters: these can be any of the parameters supported by the
+    request_mock post method. The most common are 'json' for the JSON
+    response payload, and 'exc' to throw an exception.
+
+    NOTE: the expected URI for the server query and the resulting Elasticsearch
+    query come from a test case parameter, which is passed through the Pytest
+    "mark" mechanism and accessed through the "param" attribute of the Pytest
+    request fixture. E.g.,
+
+            @pytest.mark.parametrize(
+                "query_api",
+                [
+                    {
+                        "pbench": "/controllers/list",
+                        "elastic": "/_search?ignore_unavailable=true",
+                    }
+                ],
+                indirect=True,
+            )
+
+    The first parameter must match the name of this fixture, and the second should
+    be a list (or tuple) with a single dict defining the "pbench" and "elastic"
+    URI paths.
+
+    :return: the response object for further checking
+    """
+
+    def query_api(payload, expected_index, expected_status, server_config, **kwargs):
+        host = server_config.get("elasticsearch", "host")
+        port = server_config.get("elasticsearch", "port")
+        es_url = f"http://{host}:{port}{expected_index}{request.param['elastic']}"
+        requests_mock.post(es_url, **kwargs)
+        response = client.post(
+            f"{server_config.rest_uri}{request.param['pbench']}", json=payload
+        )
+        assert requests_mock.last_request.url == es_url
+        assert response.status_code == expected_status
+        return response
+
+    return query_api

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -1,42 +1,7 @@
 import pytest
-import re
 import requests
 from http import HTTPStatus
-
-
-@pytest.fixture
-def query_helper(client, server_config, requests_mock):
-    """
-    query_helper Help controller queries that want to interact with a mocked
-    Elasticsearch service.
-
-    This is a fixture which exposes a function of the same name that can be
-    used to set up and validate a mocked Elasticsearch query with a JSON
-    payload and an expected status.
-
-    Parameters to the mocked Elasticsearch POST are passed as keyword
-    parameters: these can be any of the parameters supported by the
-    request_mock post method. The most common are 'json' for the JSON
-    response payload, and 'exc' to throw an exception.
-
-    :return: the response object for further checking
-    """
-
-    def query_helper(payload, expected_index, expected_status, server_config, **kwargs):
-        host = server_config.get("elasticsearch", "host")
-        port = server_config.get("elasticsearch", "port")
-        es_url = f"http://{host}:{port}"
-        requests_mock.post(re.compile(f"{es_url}"), **kwargs)
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list", json=payload
-        )
-        assert requests_mock.last_request.url == (
-            es_url + expected_index + "/_search?ignore_unavailable=true"
-        )
-        assert response.status_code == expected_status
-        return response
-
-    return query_helper
+from pbench.test.unit.server.query_apis.conftest import make_http_exception
 
 
 class TestControllersList:
@@ -111,7 +76,17 @@ class TestControllersList:
             == "Value '2020-19' (str) cannot be parsed as a date/time string"
         )
 
-    def test_query(self, client, server_config, query_helper, user_ok, find_template):
+    @pytest.mark.parametrize(
+        "query_api",
+        [
+            {
+                "pbench": "/controllers/list",
+                "elastic": "/_search?ignore_unavailable=true",
+            }
+        ],
+        indirect=True,
+    )
+    def test_query(self, client, server_config, query_api, user_ok, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -157,7 +132,7 @@ class TestControllersList:
         }
 
         index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
-        response = query_helper(
+        response = query_api(
             json, index, HTTPStatus.OK, server_config, json=response_payload
         )
         res_json = response.json
@@ -174,8 +149,18 @@ class TestControllersList:
         assert res_json[1]["last_modified_value"] == 1.6
         assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
 
+    @pytest.mark.parametrize(
+        "query_api",
+        [
+            {
+                "pbench": "/controllers/list",
+                "elastic": "/_search?ignore_unavailable=true",
+            }
+        ],
+        indirect=True,
+    )
     def test_empty_query(
-        self, client, server_config, query_helper, user_ok, find_template
+        self, client, server_config, query_api, user_ok, find_template
     ):
         """
         Check proper handling of a query resulting in no Elasticsearch matches.
@@ -197,7 +182,7 @@ class TestControllersList:
         }
 
         index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
-        response = query_helper(
+        response = query_api(
             json, index, HTTPStatus.OK, server_config, json=response_payload
         )
         res_json = response.json
@@ -207,7 +192,7 @@ class TestControllersList:
         "exceptions",
         (
             {
-                "exception": requests.exceptions.HTTPError,
+                "exception": make_http_exception(HTTPStatus.BAD_REQUEST),
                 "status": HTTPStatus.BAD_GATEWAY,
             },
             {
@@ -225,20 +210,30 @@ class TestControllersList:
             {"exception": Exception, "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
+    @pytest.mark.parametrize(
+        "query_api",
+        [
+            {
+                "pbench": "/controllers/list",
+                "elastic": "/_search?ignore_unavailable=true",
+            }
+        ],
+        indirect=True,
+    )
     def test_http_error(
-        self, client, server_config, query_helper, exceptions, user_ok, find_template
+        self, client, server_config, query_api, exceptions, user_ok, find_template
     ):
         """
         test_http_error Check that an Elasticsearch error is reported
         correctly.
-       """
+        """
         json = {
             "user": "drb",
             "start": "2020-08",
             "end": "2020-08",
         }
         index = self.build_index(server_config, ("2020-08",))
-        query_helper(
+        query_api(
             json,
             index,
             exceptions["status"],

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -259,12 +259,16 @@ function _verify_output {
 
 function _create_user {
     name=${1}
-    # NOTE: we ignore failures here deliberately; it'll always fail in
-    # the 0[.x] tests because of intentionally corrupted configuration,
-    # and unintentional failure in other tests will result in visible
-    # symptoms later.
+    # NOTE: we ignore chatty stdout messages; we fail on a return status of
+    # 1, which means a problem creating the user, while ignoring failure status
+    # of 2, which means bad configuration. This is because some unittests
+    # deliberately run with a bad configuration file, and we don't want user
+    # creation to obscure "real" problems.
     pbench-user-create --username=${name} --email=${name}@example.com \
-        --first-name=${name^} --last-name=User --password=password >/dev/null 2>&1
+        --first-name=${name^} --last-name=User --password=password >/dev/null
+    if [[ ${?} -eq 1 ]]; then
+        exit 101
+    fi
 }
 
 function _setup_state {
@@ -934,7 +938,7 @@ for testname in $tests ;do
         fi
     fi
 done
-if [ $count -eq 0 ]; then
+if [[ $count -eq 0 ]]; then
     printf "No tests run!\n" >&2
     let failures=1
 elif [[ $mode == "parallel" ]]; then


### PR DESCRIPTION
This began as simply fixing the bad parameter type error, grew to cover a few other minor fixes, such as limiting the attempt to hide `pbench-user-create` failures in the unittests, and then to accommodate my attempt to utilize the `datasets/list` and `datasets/detail` APIs in the dashboard.

This also starts the move towards consolidating unit testing across the `ElasticBase` subclasses by moving them into a subdirectory with their own `conftest.py` fixtures.