### PR TITLE
More query_api unit test cleanup and refactoring

### DIFF
--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -39,7 +39,7 @@ def query_api(client, server_config):
             response = client.post(
                 f"{server_config.rest_uri}{pbench_uri}", json=payload
             )
-            assert rsp.assert_call_count(es_url, 1) is True
+            assert len(rsp.calls) == 1
         assert response.status_code == expected_status
         return response
 

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -1,7 +1,6 @@
 import pytest
 import requests
 from http import HTTPStatus
-from pbench.test.unit.server.query_apis.conftest import make_http_exception
 
 
 class TestControllersList:
@@ -76,17 +75,7 @@ class TestControllersList:
             == "Value '2020-19' (str) cannot be parsed as a date/time string"
         )
 
-    @pytest.mark.parametrize(
-        "query_api",
-        [
-            {
-                "pbench": "/controllers/list",
-                "elastic": "/_search?ignore_unavailable=true",
-            }
-        ],
-        indirect=True,
-    )
-    def test_query(self, client, server_config, query_api, user_ok, find_template):
+    def test_query(self, server_config, query_api, user_ok, find_template):
         """
         test_query Check the construction of Elasticsearch query URI
         and filtering of the response body.
@@ -133,7 +122,13 @@ class TestControllersList:
 
         index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
         response = query_api(
-            json, index, HTTPStatus.OK, server_config, json=response_payload
+            "/controllers/list",
+            "/_search?ignore_unavailable=true",
+            json,
+            index,
+            HTTPStatus.OK,
+            status=HTTPStatus.OK,
+            json=response_payload,
         )
         res_json = response.json
         assert isinstance(res_json, list)
@@ -149,16 +144,6 @@ class TestControllersList:
         assert res_json[1]["last_modified_value"] == 1.6
         assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
 
-    @pytest.mark.parametrize(
-        "query_api",
-        [
-            {
-                "pbench": "/controllers/list",
-                "elastic": "/_search?ignore_unavailable=true",
-            }
-        ],
-        indirect=True,
-    )
     def test_empty_query(
         self, client, server_config, query_api, user_ok, find_template
     ):
@@ -183,49 +168,39 @@ class TestControllersList:
 
         index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
         response = query_api(
-            json, index, HTTPStatus.OK, server_config, json=response_payload
+            "/controllers/list",
+            "/_search?ignore_unavailable=true",
+            json,
+            index,
+            HTTPStatus.OK,
+            status=HTTPStatus.OK,
+            json=response_payload,
         )
-        res_json = response.json
-        assert res_json == []
+        assert response.json == []
 
     @pytest.mark.parametrize(
         "exceptions",
         (
             {
-                "exception": make_http_exception(HTTPStatus.BAD_REQUEST),
+                "exception": requests.exceptions.ConnectionError(),
                 "status": HTTPStatus.BAD_GATEWAY,
             },
             {
-                "exception": requests.exceptions.ConnectionError,
-                "status": HTTPStatus.BAD_GATEWAY,
-            },
-            {
-                "exception": requests.exceptions.Timeout,
+                "exception": requests.exceptions.Timeout(),
                 "status": HTTPStatus.GATEWAY_TIMEOUT,
             },
             {
-                "exception": requests.exceptions.InvalidURL,
+                "exception": requests.exceptions.InvalidURL(),
                 "status": HTTPStatus.INTERNAL_SERVER_ERROR,
             },
-            {"exception": Exception, "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+            {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
-    @pytest.mark.parametrize(
-        "query_api",
-        [
-            {
-                "pbench": "/controllers/list",
-                "elastic": "/_search?ignore_unavailable=true",
-            }
-        ],
-        indirect=True,
-    )
-    def test_http_error(
-        self, client, server_config, query_api, exceptions, user_ok, find_template
+    def test_http_exception(
+        self, server_config, query_api, exceptions, user_ok, find_template
     ):
         """
-        test_http_error Check that an Elasticsearch error is reported
-        correctly.
+        Check that an exception in calling Elasticsearch is reported correctly.
         """
         json = {
             "user": "drb",
@@ -234,9 +209,31 @@ class TestControllersList:
         }
         index = self.build_index(server_config, ("2020-08",))
         query_api(
+            "/controllers/list",
+            "/_search?ignore_unavailable=true",
             json,
             index,
             exceptions["status"],
-            server_config,
-            exc=exceptions["exception"],
+            body=exceptions["exception"],
+        )
+
+    @pytest.mark.parametrize("errors", (400, 500, 409))
+    def test_http_error(self, server_config, query_api, errors, user_ok, find_template):
+        """
+        Check that an Elasticsearch error is reported correctly through the
+        response.raise_for_status() and Pbench handlers.
+        """
+        json = {
+            "user": "drb",
+            "start": "2020-08",
+            "end": "2020-08",
+        }
+        index = self.build_index(server_config, ("2020-08",))
+        query_api(
+            "/controllers/list",
+            "/_search?ignore_unavailable=true",
+            json,
+            index,
+            HTTPStatus.BAD_GATEWAY,
+            status=errors,
         )

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -194,6 +194,7 @@ class TestControllersList:
                 "status": HTTPStatus.INTERNAL_SERVER_ERROR,
             },
             {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+            {"exception": ValueError(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
     def test_http_exception(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
@@ -1,7 +1,6 @@
 import pytest
 import requests
 from http import HTTPStatus
-from pbench.test.unit.server.query_apis.conftest import make_http_exception
 
 
 class TestDatasetsList:
@@ -132,7 +131,12 @@ class TestDatasetsList:
 
         index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
         response = query_api(
-            json, index, HTTPStatus.OK, server_config, json=response_payload
+            "/datasets/list",
+            "/_search?ignore_unavailable=true",
+            json,
+            index,
+            HTTPStatus.OK,
+            json=response_payload,
         )
         res_json = response.json
         assert isinstance(res_json, dict)
@@ -158,36 +162,26 @@ class TestDatasetsList:
         "exceptions",
         (
             {
-                "exception": make_http_exception(HTTPStatus.BAD_REQUEST),
+                "exception": requests.exceptions.ConnectionError(),
                 "status": HTTPStatus.BAD_GATEWAY,
             },
             {
-                "exception": requests.exceptions.ConnectionError,
-                "status": HTTPStatus.BAD_GATEWAY,
-            },
-            {
-                "exception": requests.exceptions.Timeout,
+                "exception": requests.exceptions.Timeout(),
                 "status": HTTPStatus.GATEWAY_TIMEOUT,
             },
             {
-                "exception": requests.exceptions.InvalidURL,
+                "exception": requests.exceptions.InvalidURL(),
                 "status": HTTPStatus.INTERNAL_SERVER_ERROR,
             },
-            {"exception": Exception, "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+            {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
-    @pytest.mark.parametrize(
-        "query_api",
-        [{"pbench": "/datasets/list", "elastic": "/_search?ignore_unavailable=true"}],
-        indirect=True,
-    )
-    def test_http_error(
+    def test_http_exception(
         self, client, server_config, query_api, exceptions, user_ok, find_template
     ):
         """
-        test_http_error Check that an Elasticsearch error is reported
-        correctly.
-       """
+        Check that an exception in calling Elasticsearch is reported correctly.
+        """
         json = {
             "user": "drb",
             "controller": "foobar",
@@ -196,9 +190,32 @@ class TestDatasetsList:
         }
         index = self.build_index(server_config, ("2020-08",))
         query_api(
+            "/datasets/list",
+            "/_search?ignore_unavailable=true",
             json,
             index,
             exceptions["status"],
-            server_config,
-            exc=exceptions["exception"],
+            body=exceptions["exception"],
+        )
+
+    @pytest.mark.parametrize("errors", (400, 500, 409))
+    def test_http_error(self, server_config, query_api, errors, user_ok, find_template):
+        """
+        Check that an Elasticsearch error is reported correctly through the
+        response.raise_for_status() and Pbench handlers.
+        """
+        json = {
+            "user": "drb",
+            "controller": "foobar",
+            "start": "2020-08",
+            "end": "2020-08",
+        }
+        index = self.build_index(server_config, ("2020-08",))
+        query_api(
+            "/datasets/list",
+            "/_search?ignore_unavailable=true",
+            json,
+            index,
+            HTTPStatus.BAD_GATEWAY,
+            status=errors,
         )

--- a/lib/pbench/test/unit/server/query_apis/test_month_indices.py
+++ b/lib/pbench/test/unit/server/query_apis/test_month_indices.py
@@ -30,7 +30,7 @@ def get_helper(client, server_config):
         with responses.RequestsMock() as rsp:
             rsp.add(responses.GET, es_url, **kwargs)
             response = client.get(f"{server_config.rest_uri}/controllers/months")
-            assert rsp.assert_call_count(es_url, 1) is True
+            assert len(rsp.calls) == 1
         assert response.status_code == expected_status
         return response
 
@@ -122,6 +122,7 @@ class TestMonthIndices:
                 "status": HTTPStatus.INTERNAL_SERVER_ERROR,
             },
             {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+            {"exception": KeyError(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
         ),
     )
     def test_http_exception(self, get_helper, exceptions, find_template):


### PR DESCRIPTION
Webb pointed out a few things about the query unit tests that I decided I wanted to clean up.

- I realized that the clever use of `@pytest.mark.parametrize()` to pass parameters to a fixture was unnecessary, as the fixture is returning a local method that does the heavy lifting anyway.
- By directly raising exceptions that would normally be raised through the requests package `raise_for_status()` method, we're excessively interfering with normal behavior. However, connection errors _are_ raised directly by requests, so I've split off the `HTTPError` exception behavior (`raise_for_status`) from the testing of other exceptions.
- I decided to switch to the `responses` package instead of `requests_mock`, which streamlines some code.