### PR TITLE
Various fixes to pbench-list-tools

### DIFF
--- a/lib/pbench/cli/agent/commands/tools/base.py
+++ b/lib/pbench/cli/agent/commands/tools/base.py
@@ -15,7 +15,7 @@ class ToolCommand(BaseCommand):
         """List all tools in a given path"""
         return sorted(
             [
-                p.name
+                p
                 for p in path.iterdir()
                 if p.name != "__label__" and p.suffix != ".__noinstall__"
             ]

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -47,11 +47,12 @@ class ClearTools(ToolCommand):
                 )
                 continue
 
+            # N.B. self.context.name is a singleton list (when non-empty)
             if self.context.name:
                 names = self.context.name
             else:
                 # Discover all the tools registered for this remote
-                names = self.tools(tg_dir_r)
+                names = [tool.name for tool in self.tools(tg_dir_r)]
 
             for name in names:
                 status = self._clear_tools(name, remote)
@@ -152,7 +153,7 @@ def _name_option(f):
         expose_value=False,
         callback=callback,
         help=(
-            "list the tool groups in which <tool-name> is used.\n"
+            "clear the tool groups in which <tool-name> is used.\n"
             "Not allowed with the --group option"
         ),
     )(f)

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -49,10 +49,12 @@ class ListTools(ToolCommand):
                     for path in self.gen_tools_group_dir(group).glob("*/**"):
                         if self.context.with_option:
                             host_tools[group][path.name] = [
-                                p.read_text() for p in self.tools(path)
+                                {p.name: p.read_text()} for p in self.tools(path)
                             ]
                         else:
-                            host_tools[group][path.name] = [p.name for p in self.tools(path)]
+                            host_tools[group][path.name] = [
+                                p.name for p in self.tools(path)
+                            ]
                 except BadToolGroup:
                     self.logger.error("Bad tool group name: %s", group)
                     return 1
@@ -77,9 +79,18 @@ class ListTools(ToolCommand):
                 for path in tg_dir.iterdir():
                     # Check to see if the tool is in any of the hosts.
                     if self.context.name in [tool.name for tool in self.tools(path)]:
-                        group_list.append(group)
+                        if self.context.with_option:
+                            p = path / self.context.name
+                            group_list.append({group: p.read_text()})
+                        else:
+                            group_list.append(group)
             if group_list:
-                print(f"tool name: {self.context.name} groups: {', '.join(group_list)}")
+                if self.context.with_option:
+                    print(
+                        f"tool name: {self.context.name} groups and options: {group_list}"
+                    )
+                else:
+                    print(f"tool name: {self.context.name} groups: {group_list}")
             elif status == 0:
                 # the group list is empty but not because of a bad tool group, so set an "other"
                 status = 2

--- a/lib/pbench/test/functional/agent/cli/commands/conftest.py
+++ b/lib/pbench/test/functional/agent/cli/commands/conftest.py
@@ -30,7 +30,7 @@ def pbench_run(tmp_path):
 
 
 @pytest.fixture
-def agent_config(tmp_path, opt_pbench, pbench_cfg, pbench_run):
+def agent_config(monkeypatch, tmp_path, opt_pbench, pbench_cfg, pbench_run):
     shutil.copyfile("./agent/config/pbench-agent-default.cfg", pbench_cfg)
 
     config = configparser.ConfigParser()
@@ -39,3 +39,4 @@ def agent_config(tmp_path, opt_pbench, pbench_cfg, pbench_run):
     config["pbench-agent"]["pbench_run"] = str(pbench_run)
     with open(pbench_cfg, "w") as f:
         config.write(f)
+    monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -1,31 +1,159 @@
 import pytest
 
 
-def test_pbench_list_tools_help():
-    command = ["pbench-list-tools", "--help"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert b"Usage: pbench-list-tools [OPTIONS]" in out
-    assert exitcode == 0
+class Test_list_tool_no_tools_registered:
+    def test_help(self):
+        command = ["pbench-list-tools", "--help"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert exitcode == 0
+
+    def test_no_args(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert exitcode == 0
+
+    def test_name(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--name", "foo"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_group(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "foo"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_group_name(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "foo", "--name", "iostat"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_group_options(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "foo", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_group_name_options(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "foo", "--name", "iostat", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_option(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
 
 
-def test_list_tool(monkeypatch, agent_config, pbench_run, pbench_cfg):
-    monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-    p = pbench_run / "tools-v1-default" / "testhost.example.com"
-    p.mkdir(parents=True)
-    tool = p / "perf"
-    tool.touch()
+class Test_list_tool_tools_registered:
+    @pytest.fixture
+    def tool(self, pbench_run):
+        p = pbench_run / "tools-v1-default" / "testhost.example.com"
+        p.mkdir(parents=True)
+        tool = p / "perf"
+        tool.touch()
+        return tool
 
-    command = ["pbench-list-tools"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"default: testhost.example.com ['perf']" in out
+    def test_help(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        command = ["pbench-list-tools", "--help"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert exitcode == 0
 
-    command = ["pbench-list-tools", "--group", "default"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"default: testhost.example.com ['perf']" in out
+    def test_no_args(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
-    command = ["pbench-list-tools", "-n", "perf"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"tool name: perf groups: default" in out
+        command = ["pbench-list-tools"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_group_existing(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "default"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_name_existing(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "-n", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_non_existent_group(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_non_existent_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "-n", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_existing_group_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "default", "--name", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_existing_group_non_existent_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "default", "--name", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_non_existent_group_existing_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "unknown", "--name", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_existing_group_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "default", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_non_existent_group_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "unknown", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_existing_group_name_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--group", "default", "--name", "perf", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_option(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+
+        command = ["pbench-list-tools", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -8,47 +8,33 @@ class Test_list_tool_no_tools_registered:
         assert b"Usage: pbench-list-tools [OPTIONS]" in out
         assert exitcode == 0
 
-    def test_no_args(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_no_args(self, agent_config):
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"" == out
         assert exitcode == 0
 
-    def test_name(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_name(self, agent_config):
         command = ["pbench-list-tools", "--name", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 2
 
-    def test_group(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_group(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_group_name(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_group_name(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo", "--name", "iostat"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_group_options(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_group_options(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_group_name_options(
-        self, monkeypatch, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_group_name_options(self, agent_config):
         command = [
             "pbench-list-tools",
             "--group",
@@ -60,9 +46,7 @@ class Test_list_tool_no_tools_registered:
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_option(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_option(self, agent_config):
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"" == out
@@ -78,82 +62,52 @@ class Test_list_tool_tools_registered:
         tool.touch()
         return tool
 
-    def test_help(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_help(self, tool, agent_config):
         command = ["pbench-list-tools", "--help"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"Usage: pbench-list-tools [OPTIONS]" in out
         assert exitcode == 0
 
-    def test_no_args(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_no_args(self, tool, agent_config):
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"default: testhost.example.com ['perf']\n" == out
         assert exitcode == 0
 
-    def test_group_existing(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_group_existing(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"default: testhost.example.com ['perf']\n" == out
         assert exitcode == 0
 
-    def test_name_existing(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_name_existing(self, tool, agent_config):
         command = ["pbench-list-tools", "-n", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"tool name: perf groups: ['default']\n" == out
         assert exitcode == 0
 
-    def test_non_existent_group(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_non_existent_group(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_non_existent_name(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_non_existent_name(self, tool, agent_config):
         command = ["pbench-list-tools", "-n", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 2
 
-    def test_existing_group_name(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_existing_group_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"tool name: perf groups: ['default']\n" == out
         assert exitcode == 0
 
-    def test_existing_group_non_existent_name(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_existing_group_non_existent_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--name", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 2
 
-    def test_non_existent_group_existing_name(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_non_existent_group_existing_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
@@ -162,7 +116,6 @@ class Test_list_tool_tools_registered:
 class Test_list_tool_tools_registered_with_options:
     @pytest.fixture
     def tool(self, pbench_run):
-
         for group in ["default", "test"]:
             p = pbench_run / f"tools-v1-{group}" / "testhost.example.com"
             p.mkdir(parents=True)
@@ -172,11 +125,7 @@ class Test_list_tool_tools_registered_with_options:
             tool.write_text("--interval=300")
         return
 
-    def test_existing_group_options(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_existing_group_options(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert (
@@ -185,20 +134,12 @@ class Test_list_tool_tools_registered_with_options:
         )
         assert exitcode == 0
 
-    def test_non_existent_group_options(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_non_existent_group_options(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert exitcode == 1
 
-    def test_existing_group_name_options(
-        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
-    ):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_existing_group_name_options(self, tool, agent_config):
         command = [
             "pbench-list-tools",
             "--group",
@@ -214,9 +155,7 @@ class Test_list_tool_tools_registered_with_options:
         )
         assert exitcode == 0
 
-    def test_option(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
-        monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-
+    def test_option(self, tool, agent_config):
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert (

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -21,41 +21,51 @@ class Test_list_tool_no_tools_registered:
 
         command = ["pbench-list-tools", "--name", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 2
 
     def test_group(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
     def test_group_name(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "foo", "--name", "iostat"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
     def test_group_options(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "foo", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
-    def test_group_name_options(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
+    def test_group_name_options(
+        self, monkeypatch, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
-        command = ["pbench-list-tools", "--group", "foo", "--name", "iostat", "--with-option"]
+        command = [
+            "pbench-list-tools",
+            "--group",
+            "foo",
+            "--name",
+            "iostat",
+            "--with-option",
+        ]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
     def test_option(self, monkeypatch, agent_config, pbench_run, pbench_cfg):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
         assert exitcode == 0
 
 
@@ -79,76 +89,111 @@ class Test_list_tool_tools_registered:
 
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"default: testhost.example.com ['perf']\n" == out
         assert exitcode == 0
 
-    def test_group_existing(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_group_existing(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "default"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"default: testhost.example.com ['perf']\n" == out
         assert exitcode == 0
 
-    def test_name_existing(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_name_existing(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "-n", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"tool name: perf groups: default\n" == out
         assert exitcode == 0
 
-    def test_non_existent_group(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_non_existent_group(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
-    def test_non_existent_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_non_existent_name(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "-n", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 2
 
-    def test_existing_group_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_existing_group_name(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "default", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"tool name: perf groups: default\n" == out
         assert exitcode == 0
 
-    def test_existing_group_non_existent_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_existing_group_non_existent_name(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "default", "--name", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 2
 
-    def test_non_existent_group_existing_name(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_non_existent_group_existing_name(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "unknown", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
-    def test_existing_group_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_existing_group_options(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "default", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
+        # FIX
+        assert b"" == out
         assert exitcode == 0
 
-    def test_non_existent_group_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_non_existent_group_options(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
         command = ["pbench-list-tools", "--group", "unknown", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert exitcode == 1
 
-    def test_existing_group_name_options(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
+    def test_existing_group_name_options(
+        self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg
+    ):
         monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
 
-        command = ["pbench-list-tools", "--group", "default", "--name", "perf", "--with-option"]
+        command = [
+            "pbench-list-tools",
+            "--group",
+            "default",
+            "--name",
+            "perf",
+            "--with-option",
+        ]
         out, err, exitcode = pytest.helpers.capture(command)
+        # FIX
+        assert b"" == out
         assert exitcode == 0
 
     def test_option(self, monkeypatch, tool, agent_config, pbench_run, pbench_cfg):
@@ -156,4 +201,6 @@ class Test_list_tool_tools_registered:
 
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
+        # FIX
+        assert b"" == out
         assert exitcode == 0


### PR DESCRIPTION
Fixes #2302.

pbench-list-tools produces tracebacks in various benign
situations. This PR add a bunch of functional tests for
various scenarios (but the set is probably not exhaustive yet).

The current set of tests just checks for exit status, so it catches
all the situations where a traceback was produced, but the tests
don't check the output yet.

THere are two fixes:

- in list.py, we catch BadToolGroup exceptions (and log them).

- in base.py, we return a Path as list.py expects, not the
corresponding name.

TBD:

- return error status appropriately and change the functional tests to
expect that: currently, we always return 0.

- the tests should check the program output, at least in some cases:
in particular, calling the command with `--with-option` prints out the
options without the corresponding tool name.