### PR TITLE
Ensure redis does not persist any data to disk

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -161,6 +161,8 @@ INFO pbench-tool-data-sink web_server_run -- Bottle web server exited
 bind localhost
 daemonize yes
 dir /var/tmp/pbench-test-utils/pbench/mock-run/tm
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile /var/tmp/pbench-test-utils/pbench/mock-run/tm/redis.log
 loglevel notice

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -455,6 +455,8 @@ Listening on http://localhost:8080/
 bind localhost
 daemonize yes
 dir /var/tmp/pbench-test-utils/pbench/mock-run/tm
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile /var/tmp/pbench-test-utils/pbench/mock-run/tm/redis.log
 loglevel notice

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -425,6 +425,8 @@ Listening on http://localhost:8080/
 bind localhost
 daemonize yes
 dir /var/tmp/pbench-test-utils/pbench/mock-run/tm
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile /var/tmp/pbench-test-utils/pbench/mock-run/tm/redis.log
 loglevel notice

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -191,6 +191,8 @@ DEBUG pbench-tool-data-sink __exit__ -- Exiting Tool Data Sink context ...
 bind localhost
 daemonize yes
 dir /var/tmp/pbench-test-utils/pbench/mock-run/tm
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile /var/tmp/pbench-test-utils/pbench/mock-run/tm/redis.log
 loglevel notice

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -191,6 +191,8 @@ DEBUG pbench-tool-data-sink __exit__ -- Exiting Tool Data Sink context ...
 bind localhost
 daemonize yes
 dir /var/tmp/pbench-test-utils/pbench/mock-run/tm
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile /var/tmp/pbench-test-utils/pbench/mock-run/tm/redis.log
 loglevel notice

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -469,6 +469,8 @@ class RedisServer(RedisServerCommon):
     conf_tmpl = """bind {bind_host_names}
 daemonize yes
 dir {tm_dir}
+save ""
+appendonly no
 dbfilename pbench-redis.rdb
 logfile {tm_dir}/redis.log
 loglevel notice


### PR DESCRIPTION
The unit tests are failing on Fedora 34 because Redis is now persisting changes to the database to disk.  We are really not ready for that right now, so we explicitly turn that off.