### PR TITLE
Quick-n-Dirty bit-rot detection for tar balls

### DIFF
--- a/server/user/README.md
+++ b/server/user/README.md
@@ -1,0 +1,14 @@
+Quick-n-Dirty installation of bit-rot detection in the `pbench` user's home
+directory:
+
+  1. mkdir -p /home/pbench/bin
+  2. cp bitrot-detect /home/pbench/bin/bitrot-detect
+  3. chmod 755 /home/pbench/bin/bitrot-detect
+  4. # Modify bitrot-detect.service to reference archive hierarchy path
+     # - either /srv/pbench/archive/fs-version-001 or the archive directory
+     # - on the NFS volume. 
+     # Modify bitrot-detect.timer to use the time and date to run the bit-rot
+     # - detection periodically.
+  5. cp bitrot-detect.timer bitrot-detect.service /home/pbench/.config/systemd/user/
+  6. systemctl --user enable bitrot-detect.service
+  7. systemctl --user enable bitrot-detect.timer

--- a/server/user/bitrot-detect
+++ b/server/user/bitrot-detect
@@ -18,18 +18,37 @@ mkdir -p ${WORKDIR}
 # Clean up previous run.
 rm -f ${WORKDIR}/tbs.md5-*
 
-find ${TARGETDIR}/ -maxdepth 1 -type d -printf '%P\n' | sort | while read ctrl; do
-    cat ${TARGETDIR}/${ctrl}/*.md5 2> /dev/null | while read hash file; do
-        echo "${hash} ${TARGETDIR}/${ctrl}/${file}"
+# We "find" all the controller directories and process them in alphabetical
+# order.
+find ${TARGETDIR} -maxdepth 1 -mindepth 1 -type d -printf '%P\n' | sort | while read ctrl; do
+    find ${TARGETDIR}/${ctrl} -maxdepth 1 -mindepth 1 -type f -name '*.tar.xz' | while read tb; do
+        # Detect empty tar balls
+        if [[ ! -s ${tb} ]]; then
+            printf -- "Empty tar ball found: %s\n" "${tb}" >&2
+            continue
+        fi
+        _md5=${tb}.md5
+        if [[ ! -f ${_md5} ]]; then
+            printf -- "MD5 file for tar ball missing: %s\n" "${tb}" >&2
+        elif [[ ! -s ${_md5} ]]; then
+            printf -- "Empty tar ball MD5 file found: %s\n" "${_md5}" >&2
+        else
+            # For each controller, we read all the .md5 file contents re-
+            # emitting those contents with a file name that contains the full
+            # path.
+            awk "{ print \$1, \"${TARGETDIR}/${ctrl}/\" \$2 }" ${_md5}
+        fi
     done
+    # All the output is captured into one file so that the requested
+    # concurrency can be provided below.
 done > ${WORKDIR}/tbs.md5 2> ${WORKDIR}/tbs.err
 
 cat ${WORKDIR}/tbs.err; echo ""
 
-# We use the `--number=r/N` form so that all the workers below will
-# chew through the list together in alphabetical order, and reduces
-# the possibility of one workre getting all the biggest tar balls to
-# process.
+# We use the `--number=r/N` form so that all the workers below will chew
+# through the list together in alphabetical order. This makes it convenient
+# for an observer to understand how far along the bit-rot detection process
+# has progressed.
 split --number=r/${NCPUS} ${WORKDIR}/tbs.md5 ${WORKDIR}/tbs.md5-
 
 for i in ${WORKDIR}/tbs.md5-*; do

--- a/server/user/bitrot-detect
+++ b/server/user/bitrot-detect
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+NCPUS=${1}
+if [[ -z "${NCPUS}" ]]; then
+    echo "Missing number of CPUs to use" >&2
+    exit 1
+fi
+
+TARGETDIR=${2}
+if [[ -z "${TARGETDIR}" ]]; then
+    echo "Missing target directory argument" >&2
+    exit 1
+fi
+
+WORKDIR=/var/tmp/bitrot-detect
+mkdir -p ${WORKDIR}
+
+# Clean up previous run.
+rm -f ${WORKDIR}/tbs.md5-*
+
+find ${TARGETDIR}/ -maxdepth 1 -type d -printf '%P\n' | sort | while read ctrl; do
+    cat ${TARGETDIR}/${ctrl}/*.md5 2> /dev/null | while read hash file; do
+        echo "${hash} ${TARGETDIR}/${ctrl}/${file}"
+    done
+done > ${WORKDIR}/tbs.md5 2> ${WORKDIR}/tbs.err
+
+cat ${WORKDIR}/tbs.err; echo ""
+
+# We use the `--number=r/N` form so that all the workers below will
+# chew through the list together in alphabetical order, and reduces
+# the possibility of one workre getting all the biggest tar balls to
+# process.
+split --number=r/${NCPUS} ${WORKDIR}/tbs.md5 ${WORKDIR}/tbs.md5-
+
+for i in ${WORKDIR}/tbs.md5-*; do
+    md5sum --check ${i} > ${i}.out 2> ${i}.err &
+done
+wait
+
+cat ${WORKDIR}/tbs.md5-*.err; echo ""
+
+grep -v "OK" ${WORKDIR}/tbs.md5-*.out
+
+exit 0

--- a/server/user/bitrot-detect.service
+++ b/server/user/bitrot-detect.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=the bit-rot detection script
+Wants=bitrot-detect.timer
+
+[Service]
+Type=oneshot
+ExecStart=/home/pbench/bin/bitrot-detect 1 /srv/pbenchbackup/archive.backup
+
+[Install]
+WantedBy=default.target

--- a/server/user/bitrot-detect.timer
+++ b/server/user/bitrot-detect.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly bit-rot detection job
+Requires=bitrot-detect.service
+
+[Timer]
+Unit=bitrot-detect.service
+OnCalendar=Sat *-*-* 12:42:42
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
This is a quick capture of the current bit-rot detection that has been deployed as a stop-gap whilest backup-verification is off.

The first commit contains the originally deployed stop-gap, include a bug where empty or missing `.md5` files for `.tar.xz` files are not detected.

The second commit contains the fixes to address those problems and all the code-review feedback.