### PR TITLE
Documents index mappings api

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -23,6 +23,7 @@ from pbench.server.database.database import Database
 from pbench.server.api.resources.query_apis.controllers_list import ControllersList
 from pbench.server.api.resources.query_apis.datasets_list import DatasetsList
 from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetail
+from pbench.server.api.resources.query_apis.index_mappings import IndexMappings
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.month_indices import MonthIndices
 from pbench.server.api.auth import Auth
@@ -70,6 +71,11 @@ def register_endpoints(api, app, config):
         ControllersList,
         f"{base_uri}/controllers/list",
         resource_class_args=(config, logger),
+    )
+    api.add_resource(
+        IndexMappings,
+        f"{base_uri}/index/mappings/<string:index_name>",
+        resource_class_args=(logger,),
     )
     api.add_resource(
         MonthIndices,

--- a/lib/pbench/server/api/resources/query_apis/index_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/index_mappings.py
@@ -1,0 +1,88 @@
+from http import HTTPStatus
+from logging import Logger
+from typing import Any, AnyStr, Dict
+
+from flask import jsonify
+from flask_restful import Resource, abort
+
+from pbench.server.database.models.template import Template, TemplateNotFound
+
+
+class IndexMappings(Resource):
+    """
+    Get properties of the run-data document type on which the dashboard can search.
+    This API currently only returns mapping properties of run-data documents.
+
+    TODO: In future we can tweak this API to take the document type name from the user
+    and query that type name against the template table to return the appropriate mappings
+
+    :return:
+    {
+        "@metadata":
+            [
+                "controller_dir",
+                "file-date",
+                "file-name",
+                "file-size",
+                "md5",
+                ...
+            ],
+       "host_tools_info":
+            [
+                "hostname",
+                "hostname-f",
+                ...
+            ],
+        "authorization":
+            [
+                "access",
+                "owner"
+            ]
+        "run":
+            [
+                "id",
+                "controller",
+                "user",
+                "name",
+                ...
+            ],
+        "sosreports":
+            [
+                "hostname-f",
+                "sosreport-error",
+                "hostname-s",
+                ...
+            ]
+    }
+    """
+
+    def __init__(self, logger: Logger):
+        self.logger = logger
+
+    def get(self, index_name: AnyStr) -> Dict[AnyStr, Any]:
+        """
+        Return mapping properties of the document specified by the index name in the URI.
+        For example, user can get the run document properties by making a GET request on
+        index/mappings/run. Similarly other index documents can be fetched by making a GET
+        request on appropriate index names.
+        We fetch the mapping by querying the template database. If the template is not found
+        in the database NOT_FOUND error will be raised.
+        """
+        try:
+            template = Template.find(index_name)
+            mappings = template.mappings
+
+            result = {}
+            for property in mappings["properties"]:
+                if "properties" in mappings["properties"][property]:
+                    result[property] = list(
+                        mappings["properties"][property]["properties"].keys()
+                    )
+
+            # construct response object
+            return jsonify(result)
+        except TemplateNotFound:
+            self.logger.exception(
+                "Document template {} not found in the database.", index_name
+            )
+            abort(HTTPStatus.NOT_FOUND, message="Mapping not found")

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -222,17 +222,179 @@ def find_template(monkeypatch, fake_mtime):
     """
 
     def fake_find(name: str) -> Template:
-        return Template(
-            name="run",
-            idxname="run-data",
-            template_name="unit-test.v6.run-data",
-            file="run.json",
-            template_pattern="unit-test.v6.run-data.*",
-            index_template="unit-test.v6.run-data.{year}-{month}",
-            settings={"none": False},
-            mappings={"properties": None},
-            version=5,
-        )
+        if name == "run":
+            return Template(
+                name="run",
+                idxname="run-data",
+                template_name="unit-test.v6.run-data",
+                file="run.json",
+                template_pattern="unit-test.v6.run-data.*",
+                index_template="unit-test.v6.run-data.{year}-{month}",
+                settings={"none": False},
+                mappings={
+                    "_meta": {"version": "6"},
+                    "date_detection": "false",
+                    "properties": {
+                        "@generated-by": {"type": "keyword"},
+                        "@metadata": {
+                            "properties": {
+                                "controller_dir": {"type": "keyword"},
+                                "file-date": {"type": "date"},
+                                "file-name": {"type": "keyword"},
+                                "file-size": {"type": "long"},
+                                "md5": {"type": "keyword"},
+                                "pbench-agent-version": {"type": "keyword"},
+                                "raw_size": {"type": "long"},
+                                "result-prefix": {"type": "text"},
+                                "satellite": {"type": "keyword"},
+                                "tar-ball-creation-timestamp": {"type": "date"},
+                                "toc-prefix": {"type": "text"},
+                            }
+                        },
+                        "@timestamp": {"type": "date"},
+                        "authorization": {
+                            "properties": {
+                                "access": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 256,
+                                        }
+                                    },
+                                },
+                                "owner": {
+                                    "type": "text",
+                                    "fields": {
+                                        "keyword": {
+                                            "type": "keyword",
+                                            "ignore_above": 256,
+                                        }
+                                    },
+                                },
+                            }
+                        },
+                        "host_tools_info": {
+                            "type": "nested",
+                            "properties": {
+                                "hostname": {"type": "keyword"},
+                                "hostname-f": {"type": "keyword"},
+                                "hostname-s": {"type": "keyword"},
+                                "label": {"type": "keyword"},
+                                "tools": {
+                                    "properties": {
+                                        "disk": {"type": "text"},
+                                        "haproxy-ocp": {"type": "text"},
+                                        "iostat": {"type": "text"},
+                                        "mpstat": {"type": "text"},
+                                        "oc": {"type": "text"},
+                                        "perf": {"type": "text"},
+                                        "pidstat": {"type": "text"},
+                                        "pprof": {"type": "text"},
+                                        "proc-interrupts": {"type": "text"},
+                                        "proc-vmstat": {"type": "text"},
+                                        "prometheus-metrics": {"type": "text"},
+                                        "sar": {"type": "text"},
+                                        "turbostat": {"type": "text"},
+                                        "vmstat": {"type": "text"},
+                                    }
+                                },
+                            },
+                        },
+                        "run": {
+                            "properties": {
+                                "config": {"type": "keyword"},
+                                "controller": {"type": "keyword"},
+                                "date": {"type": "date"},
+                                "end": {"type": "date"},
+                                "id": {"type": "keyword"},
+                                "iterations": {"type": "text"},
+                                "name": {"type": "keyword"},
+                                "script": {"type": "keyword"},
+                                "start": {"type": "date"},
+                                "toolsgroup": {"type": "keyword"},
+                                "user": {"type": "keyword"},
+                            }
+                        },
+                        "sosreports": {
+                            "type": "nested",
+                            "properties": {
+                                "hostname-f": {"type": "keyword"},
+                                "hostname-s": {"type": "keyword"},
+                                "inet": {
+                                    "type": "nested",
+                                    "properties": {
+                                        "ifname": {"type": "keyword"},
+                                        "ipaddr": {"type": "ip"},
+                                    },
+                                },
+                                "inet6": {
+                                    "type": "nested",
+                                    "properties": {
+                                        "ifname": {"type": "keyword"},
+                                        "ipaddr": {"type": "keyword"},
+                                    },
+                                },
+                                "md5": {"type": "keyword"},
+                                "name": {"type": "keyword"},
+                                "sosreport-error": {"type": "text"},
+                            },
+                        },
+                    },
+                },
+                version=5,
+            )
+        elif name == "result":
+            return Template(
+                name="result",
+                idxname="result-data",
+                template_name="unit-test.v5.result-data",
+                file="run.json",
+                template_pattern="unit-test.v5.result-data.*",
+                index_template="unit-test.v5.result-data.{year}-{month}",
+                settings={"none": False},
+                mappings={
+                    "_meta": {"version": "5"},
+                    "date_detection": "false",
+                    "properties": {
+                        "@timestamp": {"type": "date", "format": "dateOptionalTime"},
+                        "@timestamp_original": {"type": "keyword", "index": "false"},
+                        "result_data_sample_parent": {"type": "keyword"},
+                        "run": {
+                            "properties": {
+                                "id": {"type": "keyword"},
+                                "name": {"type": "keyword"},
+                            }
+                        },
+                        "iteration": {
+                            "properties": {
+                                "name": {"type": "keyword"},
+                                "number": {"type": "long"},
+                            }
+                        },
+                        "sample": {
+                            "properties": {
+                                "@idx": {"type": "long"},
+                                "name": {"type": "keyword"},
+                                "measurement_type": {"type": "keyword"},
+                                "measurement_idx": {"type": "long"},
+                                "measurement_title": {"type": "text"},
+                                "uid": {"type": "keyword"},
+                            }
+                        },
+                        "result": {
+                            "properties": {
+                                "@idx": {"type": "long"},
+                                "read_or_write": {"type": "long"},
+                                "value": {"type": "double"},
+                            }
+                        },
+                    },
+                },
+                version=5,
+            )
+        else:
+            return None
 
     with monkeypatch.context() as m:
         m.setattr(Template, "find", fake_find)

--- a/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
@@ -1,0 +1,122 @@
+import pytest
+from http import HTTPStatus
+from sqlalchemy.exc import DatabaseError
+
+from pbench.server.database.models.template import Template
+
+
+@pytest.fixture()
+def database_error(monkeypatch):
+    def raise_db_error(name: str):
+        raise DatabaseError("DB Error")
+
+    with monkeypatch.context() as m:
+        m.setattr(Template, "find", raise_db_error)
+        yield
+
+
+class TestIndexMappings:
+    """
+    Unit testing for resources/IndexMappings class.
+
+    In a web service context, we access class functions mostly via the
+    Flask test client rather than trying to directly invoke the class
+    constructor and `post` service.
+    """
+
+    def test_run_template_query(self, client, server_config, find_template):
+        """
+        Check the construction of index mappings API and filtering of the
+        response body.
+        """
+        with client:
+            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            assert response.status_code == HTTPStatus.OK
+            res_json = response.json
+            assert res_json == {
+                "@metadata": [
+                    "controller_dir",
+                    "file-date",
+                    "file-name",
+                    "file-size",
+                    "md5",
+                    "pbench-agent-version",
+                    "raw_size",
+                    "result-prefix",
+                    "satellite",
+                    "tar-ball-creation-timestamp",
+                    "toc-prefix",
+                ],
+                "authorization": ["access", "owner"],
+                "host_tools_info": [
+                    "hostname",
+                    "hostname-f",
+                    "hostname-s",
+                    "label",
+                    "tools",
+                ],
+                "run": [
+                    "config",
+                    "controller",
+                    "date",
+                    "end",
+                    "id",
+                    "iterations",
+                    "name",
+                    "script",
+                    "start",
+                    "toolsgroup",
+                    "user",
+                ],
+                "sosreports": [
+                    "hostname-f",
+                    "hostname-s",
+                    "inet",
+                    "inet6",
+                    "md5",
+                    "name",
+                    "sosreport-error",
+                ],
+            }
+
+    def test_result_template_query(self, client, server_config, find_template):
+        """
+        Check the construction of index mappings API and filtering of the
+        response body.
+        """
+        with client:
+            response = client.get(f"{server_config.rest_uri}/index/mappings/result")
+            assert response.status_code == HTTPStatus.OK
+            res_json = response.json
+            assert res_json == {
+                "iteration": ["name", "number"],
+                "result": ["@idx", "read_or_write", "value"],
+                "run": ["id", "name"],
+                "sample": [
+                    "@idx",
+                    "name",
+                    "measurement_type",
+                    "measurement_idx",
+                    "measurement_title",
+                    "uid",
+                ],
+            }
+
+    def test_with_no_index_document(self, client, server_config):
+        """
+        Check the index mappings API if there is no index document (specified by the index name in the URI)
+        present in the database.
+        """
+        with client:
+            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            assert response.status_code == HTTPStatus.NOT_FOUND
+            assert response.json["message"] == "Mapping not found"
+
+    def test_with_db_error(self, client, server_config, database_error):
+        """
+        Check the index mappings API if there is an error connecting to sql database.
+        """
+        with client:
+            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+            assert response.json["message"] == "Internal Server Error"

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -55,6 +55,7 @@ class TestEnpointConfig:
                 "controllers_months": f"{uri}/controllers/months",
                 "datasets_list": f"{uri}/datasets/list",
                 "datasets_detail": f"{uri}/datasets/detail",
+                "index_mappings": f"{uri}/index/mappings/",
                 "datasets_publish": f"{uri}/datasets/publish",
                 "register": f"{uri}/register",
                 "login": f"{uri}/login",


### PR DESCRIPTION
API for returning documents mappings.
- The mapping index name need to be specified in the URI `/api/v1/mappings/<index_name>` for example to get `run-data` document mappings one can perform the GET request on `/api/v1/mappings/run`
- Internally we return the mappings by querying the `Template` table instead of making a direct ES query.