### PR TITLE
pbench-agent.cfg is no longer a ghost

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -108,7 +108,6 @@ fi
 /%{installdir}/profile
 
 %ghost %attr(0400,pbench,pbench) /%{installdir}/id_rsa
-%ghost %attr(0664,pbench,pbench) /%{installdir}/config/pbench-agent.cfg
 
 %defattr(775,pbench,pbench,775)
 /%{installdir}/util-scripts


### PR DESCRIPTION
Fixes #2343 (again and finally)

The example config file was renamed in PR #2358, but there is still a problem: the %ghost line in the spec file is preventing its installation.  This PR fixes that.