### PR TITLE
Remove redundant query API test code

### DIFF
--- a/lib/pbench/test/unit/server/__init__.py
+++ b/lib/pbench/test/unit/server/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("pbench.test.unit.server.query_apis.commons")

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -186,6 +186,7 @@ class Commons:
         for key, p in self.cls_obj.schema.parameters.items():
             # Modify date/time key in the payload to make it look invalid
             if p.type == ParamType.DATE and key in self.payload:
+                original_date_value = self.payload[key]
                 self.payload[key] = "2020-19"
                 response = client.post(
                     server_config.rest_uri + self.pbench_endpoint,
@@ -197,6 +198,7 @@ class Commons:
                     response.json.get("message")
                     == "Value '2020-19' (str) cannot be parsed as a date/time string"
                 )
+                self.payload[key] = original_date_value
 
     def test_empty_query(
         self,

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -1,0 +1,233 @@
+import pytest
+import requests
+from http import HTTPStatus
+from typing import Any, AnyStr, Dict
+
+
+class Commons:
+    """
+    Unit testing for all the elasticsearch resources class.
+
+    In a web service context, we access class functions mostly via the
+    Flask test client rather than trying to directly invoke the class
+    constructor and `post` service.
+    """
+
+    def _setup(
+        self,
+        pbench_endpoint: AnyStr = None,
+        elastic_endpoint: AnyStr = None,
+        payload: [AnyStr, Any] = None,
+        bad_date_payload: [AnyStr, Any] = None,
+        error_payload: Dict[AnyStr, Any] = None,
+        empty_response_payload: Dict[AnyStr, Any] = None,
+    ):
+        self.pbench_endpoint = pbench_endpoint
+        self.elastic_endpoint = elastic_endpoint
+        self.payload = payload
+        self.bad_date_payload = bad_date_payload
+        self.error_payload = error_payload
+        self.empty_response_payload = empty_response_payload
+
+    def build_index(self, server_config, dates):
+        """
+        Build the index list for query
+
+        Args:
+            dates (iterable): list of date strings
+        """
+        idx = server_config.get("Indexing", "index_prefix") + ".v6.run-data."
+        index = "/"
+        for d in dates:
+            index += f"{idx}{d},"
+        return index
+
+    def test_non_accessible_user_data(self, client, server_config, pbench_token):
+        """
+        Test behavior when Authorization header does not have access to other user's data
+        """
+        # The pbench_token fixture logs in as user "drb"
+        # Trying to access the data belong to the user "pp"
+        if not self.payload.get("user", None):
+            pytest.skip("skipping non accessible user data test")
+        self.payload["user"] = "pp"
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+            json=self.payload,
+        )
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    @pytest.mark.parametrize(
+        "user", ("drb", "pp"),
+    )
+    def test_accessing_user_data_with_invalid_token(
+        self, client, server_config, pbench_token, user
+    ):
+        """
+        Test behavior when expired Authorization header provided
+        """
+        if not self.payload.get("user", None):
+            pytest.skip("skipping accessing user data with invalid token test")
+        # valid token logout
+        response = client.post(
+            f"{server_config.rest_uri}/logout",
+            headers=dict(Authorization="Bearer " + pbench_token),
+        )
+        assert response.status_code == HTTPStatus.OK
+        self.payload["user"] = user
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+            json=self.payload,
+        )
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    def test_missing_json_object(self, client, server_config, pbench_token):
+        """
+        Test behavior when no JSON payload is given
+        """
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json.get("message") == "Invalid request payload"
+
+    def missing_keys(self, client, server_config, keys, user_ok, pbench_token):
+        """
+        Test behavior when JSON payload does not contain all required keys.
+
+        Note that Pbench will silently ignore any additional keys that are
+        specified but not required.
+       """
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+            json=keys,
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        missing = [k for k in self.required_keys if k not in keys]
+        assert (
+            response.json.get("message")
+            == f"Missing required parameters: {','.join(missing)}"
+        )
+
+    def test_bad_dates(self, client, server_config, user_ok, pbench_token):
+        """
+        Test behavior when a bad date string is given
+        """
+        if not self.bad_date_payload:
+            pytest.skip("skipping the bad date test")
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+            json=self.bad_date_payload,
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert (
+            response.json.get("message")
+            == "Value '2020-19' (str) cannot be parsed as a date/time string"
+        )
+
+    def test_empty_query(
+        self,
+        client,
+        server_config,
+        query_api,
+        user_ok,
+        find_template,
+        build_auth_header,
+    ):
+        """
+        Check proper handling of a query resulting in no Elasticsearch matches.
+        The test will run thrice with different values of the build_auth_header
+        fixture.
+        """
+        if not self.empty_response_payload or not self.elastic_endpoint:
+            pytest.skip(
+                "skipping the empty query test since the empty response payload is not set"
+            )
+        expected_status = HTTPStatus.OK
+        if build_auth_header["header_param"] != "valid":
+            expected_status = HTTPStatus.FORBIDDEN
+
+        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        response = query_api(
+            self.pbench_endpoint,
+            self.elastic_endpoint,
+            self.payload,
+            index,
+            expected_status,
+            headers=build_auth_header["header"],
+            status=HTTPStatus.OK,
+            json=self.empty_response_payload,
+        )
+        assert response.status_code == expected_status
+        if response.status_code == HTTPStatus.OK:
+            assert response.json == []
+
+    @pytest.mark.parametrize(
+        "exceptions",
+        (
+            {
+                "exception": requests.exceptions.ConnectionError(),
+                "status": HTTPStatus.BAD_GATEWAY,
+            },
+            {
+                "exception": requests.exceptions.Timeout(),
+                "status": HTTPStatus.GATEWAY_TIMEOUT,
+            },
+            {
+                "exception": requests.exceptions.InvalidURL(),
+                "status": HTTPStatus.INTERNAL_SERVER_ERROR,
+            },
+            {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+            {"exception": ValueError(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
+        ),
+    )
+    def test_http_exception(
+        self,
+        server_config,
+        query_api,
+        exceptions,
+        user_ok,
+        find_template,
+        pbench_token,
+    ):
+        """
+        Check that an exception in calling Elasticsearch is reported correctly.
+        """
+        if not self.elastic_endpoint or not self.error_payload:
+            pytest.skip("skipping the http exception test")
+        index = self.build_index(server_config, ("2020-08",))
+        query_api(
+            self.pbench_endpoint,
+            self.elastic_endpoint,
+            self.error_payload,
+            index,
+            exceptions["status"],
+            body=exceptions["exception"],
+            headers={"Authorization": "Bearer " + pbench_token},
+        )
+
+    @pytest.mark.parametrize("errors", (400, 500, 409))
+    def test_http_error(
+        self, server_config, query_api, user_ok, find_template, pbench_token, errors
+    ):
+        """
+        Check that an Elasticsearch error is reported correctly through the
+        response.raise_for_status() and Pbench handlers.
+        """
+        if not self.elastic_endpoint or not self.error_payload:
+            pytest.skip("skipping the http error test")
+        index = self.build_index(server_config, ("2020-08",))
+        query_api(
+            self.pbench_endpoint,
+            self.elastic_endpoint,
+            self.error_payload,
+            index,
+            HTTPStatus.BAD_GATEWAY,
+            status=errors,
+            headers={"Authorization": "Bearer " + pbench_token},
+        )

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -269,9 +269,6 @@ class Commons:
         if not self.elastic_endpoint:
             pytest.skip("skipping " + self.test_http_exception.__name__)
 
-        # Make the start and end time in payload the same to result in an exception
-        self.payload["end"] = self.payload["start"]
-
         index = self.build_index(
             server_config, self.date_range(self.payload["start"], self.payload["end"])
         )

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -132,7 +132,7 @@ class Commons:
 
         Note that Pbench will silently ignore any additional keys that are
         specified but not required.
-       """
+        """
 
         def missing_key_helper(keys):
             response = client.post(

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -183,24 +183,20 @@ class Commons:
         """
         Test behavior when a bad date string is given
         """
-        skip = True
         for key, p in self.cls_obj.schema.parameters.items():
             # Modify date/time key in the payload to make it look invalid
             if p.type == ParamType.DATE and key in self.payload:
                 self.payload[key] = "2020-19"
-                skip = False
-        if skip:
-            pytest.skip("skipping " + self.test_bad_dates.__name__)
-        response = client.post(
-            server_config.rest_uri + self.pbench_endpoint,
-            headers={"Authorization": "Bearer " + pbench_token},
-            json=self.payload,
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert (
-            response.json.get("message")
-            == "Value '2020-19' (str) cannot be parsed as a date/time string"
-        )
+                response = client.post(
+                    server_config.rest_uri + self.pbench_endpoint,
+                    headers={"Authorization": "Bearer " + pbench_token},
+                    json=self.payload,
+                )
+                assert response.status_code == HTTPStatus.BAD_REQUEST
+                assert (
+                    response.json.get("message")
+                    == "Value '2020-19' (str) cannot be parsed as a date/time string"
+                )
 
     def test_empty_query(
         self,

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -1,9 +1,10 @@
 import pytest
-import requests
 from http import HTTPStatus
+from pbench.server.api.resources.query_apis.controllers_list import ControllersList
+from pbench.test.unit.server.query_apis.commons import Commons
 
 
-class TestControllersList:
+class TestControllersList(Commons):
     """
     Unit testing for resources/ControllersList class.
 
@@ -12,64 +13,25 @@ class TestControllersList:
     constructor and `post` service.
     """
 
-    def build_index(self, server_config, dates):
-        """
-        Build the index list for query
-
-        Args:
-            dates (iterable): list of date strings
-        """
-        idx = server_config.get("Indexing", "index_prefix") + ".v6.run-data."
-        index = "/"
-        for d in dates:
-            index += f"{idx}{d},"
-        return index
-
-    def test_non_accessible_user_data(self, client, server_config, pbench_token):
-        """
-        Test behavior when Authorization header does not have access to other user's data
-        """
-        # The pbench_token fixture logs in as user "drb"
-        # Trying to access the data belong to the user "pp"
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list",
-            headers={"Authorization": "Bearer " + pbench_token},
-            json={"user": "pp", "start": "2020-08", "end": "2020-10"},
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        super()._setup(
+            pbench_endpoint="/controllers/list",
+            elastic_endpoint="/_search?ignore_unavailable=true",
+            payload={"user": "drb", "start": "2020-08", "end": "2020-10"},
+            bad_date_payload={"user": "drb", "start": "2020-12", "end": "2020-19"},
+            error_payload={"start": "2020-08", "end": "2020-08"},
+            empty_response_payload={
+                "took": 1,
+                "timed_out": False,
+                "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
+                "hits": {
+                    "total": {"value": 0, "relation": "eq"},
+                    "max_score": None,
+                    "hits": [],
+                },
+            },
         )
-        assert response.status_code == HTTPStatus.FORBIDDEN
-
-    @pytest.mark.parametrize(
-        "user", ("drb", "pp"),
-    )
-    def test_accessing_user_data_with_invalid_token(
-        self, client, server_config, pbench_token, user
-    ):
-        """
-        Test behavior when Authorization header does not have access to other user's data
-        """
-        # valid token logout
-        response = client.post(
-            f"{server_config.rest_uri}/logout",
-            headers=dict(Authorization="Bearer " + pbench_token),
-        )
-        assert response.status_code == HTTPStatus.OK
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list",
-            headers={"Authorization": "Bearer " + pbench_token},
-            json={"user": user, "start": "2020-08", "end": "2020-10"},
-        )
-        assert response.status_code == HTTPStatus.FORBIDDEN
-
-    def test_missing_json_object(self, client, server_config, pbench_token):
-        """
-        Test behavior when no JSON payload is given
-        """
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list",
-            headers={"Authorization": "Bearer " + pbench_token},
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert response.json.get("message") == "Invalid request payload"
 
     @pytest.mark.parametrize(
         "keys",
@@ -91,33 +53,15 @@ class TestControllersList:
         Note that "start", and "end" are required whereas "user" is not mandatory;
         however, Pbench will silently ignore any additional keys that are
         specified.
-        """
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list",
-            headers={"Authorization": "Bearer " + pbench_token},
-            json=keys,
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        missing = [k for k in ("start", "end") if k not in keys]
-        assert (
-            response.json.get("message")
-            == f"Missing required parameters: {','.join(missing)}"
-        )
-
-    def test_bad_dates(self, client, server_config, user_ok, pbench_token):
-        """
-        Test behavior when a bad date string is given
-        """
-        response = client.post(
-            f"{server_config.rest_uri}/controllers/list",
-            headers={"Authorization": "Bearer " + pbench_token},
-            json={"user": "drb", "start": "2020-12", "end": "2020-19"},
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert (
-            response.json.get("message")
-            == "Value '2020-19' (str) cannot be parsed as a date/time string"
-        )
+       """
+        self.required_keys = [
+            key
+            for key, parameter in ControllersList(
+                client.config, client.logger
+            ).schema.parameters.items()
+            if parameter.required
+        ]
+        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(
         "user", ("drb", "badwolf", "no_user"),
@@ -138,7 +82,7 @@ class TestControllersList:
         The test will run once with each parameter supplied from the local parameterization,
         and, for each of those, three times with different values of the build_auth_header fixture.
         """
-        json = {
+        payload = {
             "user": user,
             "access": "private",
             "start": "2020-08",
@@ -146,9 +90,9 @@ class TestControllersList:
         }
         # "no_user" means omitting the "user" parameter entirely.
         if user == "no_user":
-            json.pop("user", None)
+            payload.pop("user", None)
         if user == "no_user" or user is None:
-            json["access"] = "public"
+            payload["access"] = "public"
 
         response_payload = {
             "took": 1,
@@ -204,7 +148,7 @@ class TestControllersList:
         response = query_api(
             "/controllers/list",
             "/_search?ignore_unavailable=true",
-            json,
+            payload,
             index,
             expected_status,
             headers=build_auth_header["header"],
@@ -226,112 +170,3 @@ class TestControllersList:
             assert res_json[1]["results"] == 1
             assert res_json[1]["last_modified_value"] == 1.6
             assert res_json[1]["last_modified_string"] == "2020-09-26T20:19:15.810Z"
-
-    def test_empty_query(
-        self,
-        client,
-        server_config,
-        query_api,
-        user_ok,
-        find_template,
-        build_auth_header,
-        pbench_token,
-    ):
-        """
-        Check proper handling of a query resulting in no Elasticsearch matches.
-        The test will run thrice with different values of the build_auth_header
-        fixture.
-        """
-        json = {
-            "user": "drb",
-            "start": "2020-08",
-            "end": "2020-10",
-        }
-        response_payload = {
-            "took": 1,
-            "timed_out": False,
-            "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
-            "hits": {
-                "total": {"value": 0, "relation": "eq"},
-                "max_score": None,
-                "hits": [],
-            },
-        }
-
-        expected_status = HTTPStatus.OK
-        if build_auth_header["header_param"] != "valid":
-            expected_status = HTTPStatus.FORBIDDEN
-
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
-        response = query_api(
-            "/controllers/list",
-            "/_search?ignore_unavailable=true",
-            json,
-            index,
-            expected_status,
-            headers=build_auth_header["header"],
-            status=HTTPStatus.OK,
-            json=response_payload,
-        )
-        assert response.status_code == expected_status
-        if response.status_code == HTTPStatus.OK:
-            assert response.json == []
-
-    @pytest.mark.parametrize(
-        "exceptions",
-        (
-            {
-                "exception": requests.exceptions.ConnectionError(),
-                "status": HTTPStatus.BAD_GATEWAY,
-            },
-            {
-                "exception": requests.exceptions.Timeout(),
-                "status": HTTPStatus.GATEWAY_TIMEOUT,
-            },
-            {
-                "exception": requests.exceptions.InvalidURL(),
-                "status": HTTPStatus.INTERNAL_SERVER_ERROR,
-            },
-            {"exception": Exception(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
-            {"exception": ValueError(), "status": HTTPStatus.INTERNAL_SERVER_ERROR},
-        ),
-    )
-    def test_http_exception(
-        self, server_config, query_api, exceptions, user_ok, find_template
-    ):
-        """
-        Check that an exception in calling Elasticsearch is reported correctly.
-        """
-        json = {
-            "start": "2020-08",
-            "end": "2020-08",
-        }
-        index = self.build_index(server_config, ("2020-08",))
-        query_api(
-            "/controllers/list",
-            "/_search?ignore_unavailable=true",
-            json,
-            index,
-            exceptions["status"],
-            body=exceptions["exception"],
-        )
-
-    @pytest.mark.parametrize("errors", (400, 500, 409))
-    def test_http_error(self, server_config, query_api, errors, user_ok, find_template):
-        """
-        Check that an Elasticsearch error is reported correctly through the
-        response.raise_for_status() and Pbench handlers.
-        """
-        json = {
-            "start": "2020-08",
-            "end": "2020-08",
-        }
-        index = self.build_index(server_config, ("2020-08",))
-        query_api(
-            "/controllers/list",
-            "/_search?ignore_unavailable=true",
-            json,
-            index,
-            HTTPStatus.BAD_GATEWAY,
-            status=errors,
-        )

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -20,7 +20,7 @@ class TestControllersList(Commons):
             pbench_endpoint="/controllers/list",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={"user": "drb", "start": "2020-08", "end": "2020-10"},
-            empty_es_response_payload=Commons.EMPTY_ES_RESPONSE_PAYLOAD,
+            empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -20,31 +20,8 @@ class TestControllersList(Commons):
             pbench_endpoint="/controllers/list",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={"user": "drb", "start": "2020-08", "end": "2020-10"},
-            empty_es_response_payload=Commons.empty_es_response_payload,
+            empty_es_response_payload=Commons.EMPTY_ES_RESPONSE_PAYLOAD,
         )
-
-    @pytest.mark.parametrize(
-        "keys",
-        (
-            {"user": "x"},
-            {"start": "2020"},
-            {"end": "2020"},
-            {"user": "x", "start": "2020"},
-            {"user": "x", "end": "2020"},
-            {"some_additional_key": "test"},
-        ),
-    )
-    def test_missing_keys(
-        self, client, server_config, keys, find_template, user_ok, pbench_token
-    ):
-        """
-        Test behavior when JSON payload does not contain all required keys.
-
-        Note that "start", and "end" are required whereas "user" is not mandatory;
-        however, Pbench will silently ignore any additional keys that are
-        specified.
-       """
-        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(
         "user", ("drb", "badwolf", "no_user"),
@@ -112,7 +89,9 @@ class TestControllersList(Commons):
             },
         }
 
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        index = self.build_index(
+            server_config, self.date_range(self.payload["start"], self.payload["end"])
+        )
 
         # Determine whether we should expect the request to succeed, or to
         # fail with a permission error. We always authenticate with the

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -14,23 +14,13 @@ class TestControllersList(Commons):
     """
 
     @pytest.fixture(autouse=True)
-    def _setup(self):
+    def _setup(self, client):
         super()._setup(
+            cls_obj=ControllersList(client.config, client.logger),
             pbench_endpoint="/controllers/list",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={"user": "drb", "start": "2020-08", "end": "2020-10"},
-            bad_date_payload={"user": "drb", "start": "2020-12", "end": "2020-19"},
-            error_payload={"start": "2020-08", "end": "2020-08"},
-            empty_response_payload={
-                "took": 1,
-                "timed_out": False,
-                "_shards": {"total": 1, "successful": 1, "skipped": 0, "failed": 0},
-                "hits": {
-                    "total": {"value": 0, "relation": "eq"},
-                    "max_score": None,
-                    "hits": [],
-                },
-            },
+            empty_es_response_payload=Commons.empty_es_response_payload,
         )
 
     @pytest.mark.parametrize(
@@ -54,13 +44,6 @@ class TestControllersList(Commons):
         however, Pbench will silently ignore any additional keys that are
         specified.
        """
-        self.required_keys = [
-            key
-            for key, parameter in ControllersList(
-                client.config, client.logger
-            ).schema.parameters.items()
-            if parameter.required
-        ]
         self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -14,8 +14,9 @@ class TestDatasetsDetail(Commons):
     """
 
     @pytest.fixture(autouse=True)
-    def _setup(self):
+    def _setup(self, client):
         super()._setup(
+            cls_obj=DatasetsDetail(client.config, client.logger),
             pbench_endpoint="/datasets/detail",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={
@@ -24,20 +25,7 @@ class TestDatasetsDetail(Commons):
                 "start": "2020-08",
                 "end": "2020-10",
             },
-            bad_date_payload={
-                "user": "drb",
-                "name": "footest",
-                "start": "2020-12",
-                "end": "2020-19",
-            },
-            error_payload={"name": "foobar", "start": "2020-08", "end": "2020-08"},
-            empty_response_payload={
-                "hits": {
-                    "total": {"value": 0, "relation": "eq"},
-                    "max_score": None,
-                    "hits": [],
-                },
-            },
+            empty_es_response_payload=Commons.empty_es_response_payload,
         )
 
     @pytest.mark.parametrize(
@@ -62,13 +50,6 @@ class TestDatasetsDetail(Commons):
         however, Pbench will silently ignore any additional keys that are
         specified.
        """
-        self.required_keys = [
-            key
-            for key, parameter in DatasetsDetail(
-                client.config, client.logger
-            ).schema.parameters.items()
-            if parameter.required
-        ]
         self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(
@@ -257,7 +238,7 @@ class TestDatasetsDetail(Commons):
             index,
             expected_status,
             headers=build_auth_header["header"],
-            json=self.empty_response_payload,
+            json=self.empty_es_response_payload,
         )
         assert response.status_code == expected_status
         if response.status_code == HTTPStatus.BAD_REQUEST:

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -25,32 +25,8 @@ class TestDatasetsDetail(Commons):
                 "start": "2020-08",
                 "end": "2020-10",
             },
-            empty_es_response_payload=Commons.empty_es_response_payload,
+            empty_es_response_payload=Commons.EMPTY_ES_RESPONSE_PAYLOAD,
         )
-
-    @pytest.mark.parametrize(
-        "keys",
-        (
-            {"user": "x"},
-            {"name": "y"},
-            {"start": "2020"},
-            {"end": "2020"},
-            {"user": "x", "start": "2020"},
-            {"user": "x", "end": "2020"},
-            {"user": "x", "name": "y", "start": "2021"},
-            {"some_additional_key": "test"},
-        ),
-    )
-    def test_missing_keys(self, client, server_config, keys, user_ok, pbench_token):
-        """
-        Test behavior when JSON payload does not contain
-        all required keys.
-
-        Note that "name", "start", and "end" are required whereas "user" is not mandatory;
-        however, Pbench will silently ignore any additional keys that are
-        specified.
-       """
-        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(
         "user", ("drb", "badwolf", "no_user"),
@@ -141,7 +117,9 @@ class TestDatasetsDetail(Commons):
             },
         }
 
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        index = self.build_index(
+            server_config, self.date_range(self.payload["start"], self.payload["end"])
+        )
 
         expected_status = HTTPStatus.OK
 
@@ -230,7 +208,9 @@ class TestDatasetsDetail(Commons):
         if build_auth_header["header_param"] != "valid":
             expected_status = HTTPStatus.FORBIDDEN
 
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        index = self.build_index(
+            server_config, self.date_range(self.payload["start"], self.payload["end"])
+        )
         response = query_api(
             "/datasets/detail",
             "/_search?ignore_unavailable=true",

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -25,7 +25,7 @@ class TestDatasetsDetail(Commons):
                 "start": "2020-08",
                 "end": "2020-10",
             },
-            empty_es_response_payload=Commons.EMPTY_ES_RESPONSE_PAYLOAD,
+            empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
@@ -14,8 +14,9 @@ class TestDatasetsList(Commons):
     """
 
     @pytest.fixture(autouse=True)
-    def _setup(self):
+    def _setup(self, client):
         super()._setup(
+            cls_obj=DatasetsList(client.config, client.logger),
             pbench_endpoint="/datasets/list",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={
@@ -23,17 +24,6 @@ class TestDatasetsList(Commons):
                 "controller": "cpntroller.name",
                 "start": "2020-08",
                 "end": "2020-10",
-            },
-            bad_date_payload={
-                "user": "drb",
-                "controller": "dbutenho.csb",
-                "start": "2020-12",
-                "end": "2020-19",
-            },
-            error_payload={
-                "controller": "foobar",
-                "start": "2020-08",
-                "end": "2020-08",
             },
         )
 
@@ -59,13 +49,6 @@ class TestDatasetsList(Commons):
         however, Pbench will silently ignore any additional keys that are
         specified.
        """
-        self.required_keys = [
-            key
-            for key, parameter in DatasetsList(
-                client.config, client.logger
-            ).schema.parameters.items()
-            if parameter.required
-        ]
         self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_list.py
@@ -28,30 +28,6 @@ class TestDatasetsList(Commons):
         )
 
     @pytest.mark.parametrize(
-        "keys",
-        (
-            {"user": "x"},
-            {"controller": "y"},
-            {"start": "2020"},
-            {"end": "2020"},
-            {"user": "x", "start": "2020"},
-            {"user": "x", "end": "2020"},
-            {"user": "x", "controller": "y", "start": "2021"},
-            {"some_additional_key": "test"},
-        ),
-    )
-    def test_missing_keys(self, client, server_config, user_ok, pbench_token, keys):
-        """
-        Test behavior when JSON payload does not contain
-        all required keys.
-
-        Note that "start", "controller", "end" are required whereas "user" is not mandatory;
-        however, Pbench will silently ignore any additional keys that are
-        specified.
-       """
-        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
-
-    @pytest.mark.parametrize(
         "query_api",
         [{"pbench": "/datasets/list", "elastic": "/_search?ignore_unavailable=true"}],
         indirect=True,
@@ -113,7 +89,9 @@ class TestDatasetsList(Commons):
             },
         }
 
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        index = self.build_index(
+            server_config, self.date_range(self.payload["start"], self.payload["end"])
+        )
 
         # Determine whether we should expect the request to succeed, or to
         # fail with a permission error. We always authenticate with the

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -95,29 +95,6 @@ class TestDatasetsPublish(Commons):
         )
 
     @pytest.mark.parametrize(
-        "keys",
-        (
-            {"controller": "x"},
-            {"name": "y"},
-            {"controller": "foobar", "access": "public"},
-            {"access": "public"},
-            {"controller": "foo", "access": "private", "whatkey": None},
-            {"controller": "one", "name": "mine", "notakey": "none"},
-            {"name": "y", "access": "private"},
-            {"notakey": None},
-        ),
-    )
-    def test_missing_keys(self, client, server_config, keys, user_ok, pbench_token):
-        """
-        Test behavior when JSON payload does not contain all required keys.
-
-        Note that "user", "controller", "name", and "access" are all required;
-        however Pbench will silently ignore any additional keys that are
-        specified.
-        """
-        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
-
-    @pytest.mark.parametrize(
         "owner", ("drb", "test"),
     )
     def test_query(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -86,8 +86,9 @@ class TestDatasetsPublish(Commons):
     """
 
     @pytest.fixture(autouse=True)
-    def _setup(self):
+    def _setup(self, client):
         super()._setup(
+            cls_obj=DatasetsPublish(client.config, client.logger),
             pbench_endpoint="/datasets/publish",
             elastic_endpoint="/_bulk?refresh=true",
             payload={"controller": "node", "name": "drb", "access": "public"},
@@ -114,13 +115,6 @@ class TestDatasetsPublish(Commons):
         however Pbench will silently ignore any additional keys that are
         specified.
         """
-        self.required_keys = [
-            key
-            for key, parameter in DatasetsPublish(
-                client.config, client.logger
-            ).schema.parameters.items()
-            if parameter.required
-        ]
         self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -2,8 +2,10 @@ import json
 import pytest
 import requests
 from http import HTTPStatus
+from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.server.database.models.users import User
+from pbench.test.unit.server.query_apis.commons import Commons
 
 
 @pytest.fixture()
@@ -74,7 +76,7 @@ def get_document_map(monkeypatch, attach_dataset):
         yield map
 
 
-class TestDatasetsPublish:
+class TestDatasetsPublish(Commons):
     """
     Unit testing for DatasetsPublish class.
 
@@ -82,6 +84,14 @@ class TestDatasetsPublish:
     Flask test client rather than trying to directly invoke the class
     constructor and `post` service.
     """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self):
+        super()._setup(
+            pbench_endpoint="/datasets/publish",
+            elastic_endpoint="/_bulk?refresh=true",
+            payload={"controller": "node", "name": "drb", "access": "public"},
+        )
 
     @pytest.mark.parametrize(
         "keys",
@@ -104,17 +114,14 @@ class TestDatasetsPublish:
         however Pbench will silently ignore any additional keys that are
         specified.
         """
-        response = client.post(
-            f"{server_config.rest_uri}/datasets/publish",
-            headers={"Authorization": "Bearer " + pbench_token},
-            json=keys,
-        )
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        missing = [k for k in ("controller", "name", "access") if k not in keys]
-        assert (
-            response.json.get("message")
-            == f"Missing required parameters: {','.join(missing)}"
-        )
+        self.required_keys = [
+            key
+            for key, parameter in DatasetsPublish(
+                client.config, client.logger
+            ).schema.parameters.items()
+            if parameter.required
+        ]
+        self.missing_keys(client, server_config, keys, user_ok, pbench_token)
 
     @pytest.mark.parametrize(
         "owner", ("drb", "test"),
@@ -135,11 +142,7 @@ class TestDatasetsPublish:
         as the "name" key below. The authenticated caller is always "drb", so
         we expect access to the "test" dataset to fail with a permission error.
         """
-        payload = {
-            "controller": "node",
-            "name": owner,
-            "access": "public",
-        }
+        self.payload["name"] = owner
         map = json.loads(get_document_map.value)
         items = []
 
@@ -172,9 +175,9 @@ class TestDatasetsPublish:
             expected_status = HTTPStatus.FORBIDDEN
 
         response = query_api(
-            "/datasets/publish",
-            "/_bulk?refresh=true",
-            payload,
+            self.pbench_endpoint,
+            self.elastic_endpoint,
+            self.payload,
             "",
             expected_status,
             json=response_payload,
@@ -193,12 +196,6 @@ class TestDatasetsPublish:
         """
         Check the handling of a query that doesn't completely succeed.
         """
-        payload = {
-            "controller": "node",
-            "name": "drb",
-            "access": "public",
-        }
-
         items = []
         first = True
         map = json.loads(get_document_map.value)
@@ -238,9 +235,9 @@ class TestDatasetsPublish:
         }
 
         response = query_api(
-            "/datasets/publish",
-            "/_bulk?refresh=true",
-            payload,
+            self.pbench_endpoint,
+            self.elastic_endpoint,
+            self.payload,
             "",
             HTTPStatus.INTERNAL_SERVER_ERROR,
             json=response_payload,
@@ -288,15 +285,10 @@ class TestDatasetsPublish:
         """
         Check that an exception in calling Elasticsearch is reported correctly.
         """
-        payload = {
-            "controller": "node",
-            "name": "drb",
-            "access": "public",
-        }
         query_api(
             "/datasets/publish",
             "/_bulk?refresh=true",
-            payload,
+            self.payload,
             "",
             exceptions["status"],
             body=exceptions["exception"],
@@ -318,15 +310,10 @@ class TestDatasetsPublish:
         Check that an Elasticsearch error is reported correctly through the
         response.raise_for_status() and Pbench handlers.
         """
-        payload = {
-            "controller": "node",
-            "name": "drb",
-            "access": "public",
-        }
         query_api(
             "/datasets/publish",
             "/_bulk?refresh=true",
-            payload,
+            self.payload,
             "",
             HTTPStatus.BAD_GATEWAY,
             status=errors,


### PR DESCRIPTION
This PR tries to remove some of the redundant code in our query API tests