### PR TITLE
Pbench put shim server

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -4,7 +4,7 @@ pipeline {
         stage('Linting & Unit Tests') {
             steps {
                 echo 'Linting and legacy unit tests'
-                sh 'jenkins/run jenkins/tox -r --current-env -e jenkins-unittests'
+                sh 'jenkins/run jenkins/tox -r --current-env -e jenkins-unittests,py3-server'
             }
         }
     }

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -24,6 +24,5 @@ while read -r _pdir; do
     fi
 done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null)
 $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"
-export PYTHONPATH
 
-python3 setup.py develop --prefix="${_prefix}"
+export PYTHONPATH

--- a/server/Makefile
+++ b/server/Makefile
@@ -50,6 +50,7 @@ binlinks = \
 	pbench-satellite-cleanup\
 	pbench-satellite-state-change\
 	pbench-server-prep-shim-002\
+	pbench-server-put-shim\
 	pbench-sync-package-tarballs\
 	pbench-sync-satellite\
 	pbench-unpack-tarballs\

--- a/server/bin/pbench-server-put-shim
+++ b/server/bin/pbench-server-put-shim
@@ -1,0 +1,1 @@
+pbench-trampoline

--- a/server/bin/pbench-server-put-shim.py
+++ b/server/bin/pbench-server-put-shim.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- mode: python -*-
+
+# Forward tar balls received via SSH from version 002 clients
+# to the configured pbench server using the pbench agent's new
+# PUT API interface.
+
+import os
+import sys
+import tempfile
+
+from pbench import PbenchConfig, BadConfig, get_pbench_logger
+from pbench.process_tb import ProcessTb
+from pbench.report import Report
+
+
+_NAME_ = "pbench-server-put-shim"
+
+
+def main(cfg_name: str) -> int:
+    if not cfg_name:
+        print(
+            f"{_NAME_}: ERROR: No config file specified; set"
+            " _PBENCH_SERVER_CONFIG env variable",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        config = PbenchConfig(cfg_name)
+    except BadConfig as e:
+        print(f"{_NAME_}: {e} (config file {cfg_name})", file=sys.stderr)
+        return 1
+
+    logger = get_pbench_logger(_NAME_, config)
+
+    try:
+        ptb = ProcessTb(config, logger)
+    except Exception as e:
+        logger.error("Error: {}", e)
+        return 2
+
+    counts = ptb.process_tb()
+
+    result_string = (
+        f"{config.TS} Status: Total no. of tarballs {counts.ntotal},"
+        f" Successfully moved {counts.ntbs}, Encountered"
+        f" {counts.nerr} Errors"
+    )
+    logger.info(result_string)
+
+    # prepare and send report
+    try:
+        fd, tmp_file = tempfile.mkstemp(dir=config.TMP, text=True)
+    except Exception as exc:
+        logger.error("Creation of temporary Report file Failed: '{}'", exc)
+        return 1
+
+    try:
+        with os.fdopen(fd, "w+") as reportfp:
+            reportfp.write(f"{counts.nstatus}{result_string}\n")
+
+        report = Report(config, _NAME_)
+        report.init_report_template()
+        report.post_status(config.timestamp(), "status", tmp_file)
+    except Exception as exc:
+        logger.warning("Report post unsuccessful: '{}'", exc)
+    finally:
+        os.remove(tmp_file)
+
+    if counts.nerr > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    cfg_name = os.environ.get("_PBENCH_SERVER_CONFIG")
+    status = main(cfg_name)
+    sys.exit(status)

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -181,6 +181,10 @@ tasks = pbench-backup-tarballs
 # This is a template that is expanded by pbench-server-activate-create-crontab
 crontab =  * * * * *  flock -n %(lock-dir)s/pbench-prep-$SHIM_VERSION.lock %(script-dir)s/pbench-server-prep-shim-$SHIM_VERSION
 
+[pbench-put-shim]
+# This is a template that is expanded by pbench-server-activate-create-crontab
+crontab =  * * * * *  flock -n %(lock-dir)s/pbench-put-shim.lock %(script-dir)s/pbench-server-put-shim
+
 [pbench-dispatch]
 crontab =  * * * * *  flock -n %(lock-dir)s/pbench-dispatch.lock %(script-dir)s/pbench-dispatch
 

--- a/server/lib/pbench/process_tb.py
+++ b/server/lib/pbench/process_tb.py
@@ -1,0 +1,131 @@
+import os
+import subprocess
+
+from collections import namedtuple
+from logging import Logger
+from pathlib import Path
+
+from pbench import PbenchConfig
+
+Results = namedtuple("Results", ["nstatus", "ntotal", "ntbs", "nerr"])
+
+
+class ProcessTb:
+    def __init__(self, config: PbenchConfig, logger: Logger):
+        """ Processes Tar ball, gets the tar ball from receiving directory
+        and copies it to the remote server by creating a subprocess which
+        call Agent's 'pbench-results-push' command.
+
+            Args -
+                config -- PbenchServer config object
+                logger -- logger object to use when emitting log entries during
+                            operation
+
+        """
+        self.config = config
+        self.logger = logger
+        self.token = self.config.get("pbench-server", "put-token")
+        if not self.token:
+            raise ValueError(
+                "No value for config option put-token in section pbench-server"
+            )
+        # receive_dir -- directory where tarballs are received from agent
+        self.receive_dir = self._get_receive_dir()
+
+    def _get_receive_dir(self) -> Path:
+        receive_dir_prefix = self.config.get(
+            "pbench-server", "pbench-receive-dir-prefix"
+        )
+        if not receive_dir_prefix:
+            raise ValueError(
+                "Failed: No value for config option pbench-receive-dir-prefix in section pbench-server"
+            )
+
+        receive_dir = Path(f"{receive_dir_prefix}-002").resolve()
+        if not receive_dir.is_dir():
+            raise NotADirectoryError(
+                f"Failed: {str(receive_dir)!r} does not exist, or is not a directory",
+            )
+
+        return receive_dir
+
+    @staticmethod
+    def _results_push(controller: str, tb: Path, token: str):
+        """Runs Agent's `pbench-results-push` command with controller, tb
+        and token options
+
+        Args -
+            controller -- the name of the controller to be associated with the
+                          tar ball
+            tb -- path of the tar ball
+            token -- generated authorised token for Pbench user
+
+        Importance of this function is while running tests we get the
+        ability to mock this function and test it easily
+        """
+
+        res = subprocess.run(
+            ["pbench-results-push", controller, tb, token], capture_output=True
+        )
+        error = res.stderr
+        if res.returncode > 0:
+            raise RuntimeError(error)
+
+    def process_tb(self) -> Results:
+        """Searches for tarballs in the configured receive directory and
+        uploads them to the Pbench server"""
+
+        # Check for results that are ready for processing: version 002 agents
+        # upload the MD5 file as xxx.md5.check and they rename it to xxx.md5
+        # after they are done with MD5 checking so that's what we look for.
+        self.logger.info("{}", self.config.TS)
+        nstatus = ""
+        ntotal = ntbs = nerr = 0
+
+        for tbmd5 in sorted(self.receive_dir.glob("**/*.tar.xz.md5")):
+            ntotal += 1
+
+            # Extracts full pathname of tarball from the name of hashfile
+            # by trimming .md5 suffix
+            tb = Path(str(tbmd5)[0 : -len(".md5")])
+            tbdir = tb.parent
+            controller = tbdir.name
+
+            try:
+                ProcessTb._results_push(controller, tb, self.token)
+            except Exception as e:
+                self.logger.error(
+                    "{}: Unexpected Error while running Agent's 'pbench-result-push' command: {}",
+                    self.config.TS,
+                    e,
+                )
+                nerr += 1
+                continue
+
+            try:
+                os.remove(tbmd5)
+            except Exception as exc:
+                self.logger.error(
+                    "{}: Cleanup of successful copy operation for MD5 file '{}' failed: '{}'",
+                    self.config.TS,
+                    tbmd5,
+                    exc,
+                )
+                nerr += 1
+
+            try:
+                os.remove(tb)
+            except Exception as exc:
+                self.logger.error(
+                    "{}: Cleanup of successful copy operation for tar ball '{}' failed: '{}'",
+                    self.config.TS,
+                    tb,
+                    exc,
+                )
+                nerr += 1
+
+            ntbs += 1
+            nstatus += f": processed {tb.name}\n"
+            self.logger.info(f"{tb.name}: OK")
+
+        return Results(nstatus, ntotal, ntbs, nerr)

--- a/server/lib/pbench/test/conftest.py
+++ b/server/lib/pbench/test/conftest.py
@@ -1,0 +1,38 @@
+"""This module builts base setup for Server side testing.
+It is implicitly included by PyTest for all unit tests and provides
+test fixtures and other definitions common across the Server unit tests"""
+import logging
+import pytest
+import tempfile
+
+from pathlib import Path
+
+from pbench import _PbenchLogFormatter, _StyleAdapter
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup(request, pytestconfig):
+    """Test package setup for pbench-server"""
+
+    # Create a single temporary directory for the "/srv/pbench" and
+    # "/opt/pbench-server" directories.
+    tmp = tempfile.TemporaryDirectory(suffix=".d", prefix="pbench-server-unit-tests.")
+    tmp_d = Path(tmp.name)
+
+    pytestconfig.cache.set("TMP", str(tmp_d))
+    request.addfinalizer(lambda: tmp.cleanup())
+
+
+@pytest.fixture
+def test_logger(pytestconfig):
+    tmp = Path(pytestconfig.cache.get("TMP", None))
+    logger = logging.getLogger("testing")
+    handler = logging.FileHandler(tmp / "test.log")
+    handler.setLevel(logging.ERROR)
+    logfmt = (
+        "1970-01-01T00:00:42.000000 {levelname} {name}.{module} {funcName} -- {message}"
+    )
+    formatter = _PbenchLogFormatter(fmt=logfmt)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return _StyleAdapter(logger)

--- a/server/lib/pbench/test/unit/test_process_tb.py
+++ b/server/lib/pbench/test/unit/test_process_tb.py
@@ -1,0 +1,270 @@
+import os
+import logging
+import pytest
+
+from pathlib import Path
+from typing import List
+
+from pbench.process_tb import ProcessTb, Results
+
+
+class MockConfig:
+    TS = "run-1970-01-02T00:00:00.000000"
+
+    def __init__(self, mappings: dict):
+        self.mappings = mappings
+
+    def get(self, section: str, option: str) -> str:
+        assert (
+            section in self.mappings and option in self.mappings[section]
+        ), f"Unexpected configuration option, {section!r}/{option!r}, in MockConfig.get()"
+        return self.mappings[section][option]
+
+
+class TestProcessTb:
+
+    receive_dir = "/srv/pbench/pbench-results-receive-dir"
+
+    def test_token(self, test_logger):
+        expected_error_msg = (
+            "No value for config option put-token in section pbench-server"
+        )
+        mappings = {"pbench-server": {"put-token": ""}}
+        with pytest.raises(ValueError) as e:
+            ProcessTb(MockConfig(mappings), test_logger)
+
+        assert expected_error_msg in str(e)
+
+    def test_get_receive_dir_failed(self, monkeypatch, test_logger):
+        def mock_is_dir(self) -> bool:
+            assert False, f"Unexpected call to mocked Path.is_dir()"
+
+        expected_error_msg = "Failed: No value for config option pbench-receive-dir-prefix in section pbench-server"
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": "",
+                "put-token": "Authorization-token",
+            }
+        }
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        with pytest.raises(ValueError) as e:
+            ProcessTb(MockConfig(mappings), test_logger)
+
+        assert expected_error_msg in str(e)
+
+    def test_get_receive_dir_value_failed(self, test_logger):
+        wrong_dir = "/srv/wrong-directory"
+        expected_error_msg = (
+            f"Failed: '{wrong_dir}-002' does not exist, or is not a directory"
+        )
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": wrong_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        with pytest.raises(NotADirectoryError) as e:
+            ProcessTb(MockConfig(mappings), test_logger)
+
+        assert expected_error_msg in str(e)
+
+    def test_process_tb_file_not_found_error(self, monkeypatch, caplog, test_logger):
+        """checks normal processing when tar ball is not present"""
+        receive_path = Path(TestProcessTb.receive_dir + "-002")
+        bad_tarball = "bad_log.tar.xz"
+        bad_tb = receive_path / bad_tarball
+
+        def mock_is_dir(self) -> bool:
+            assert self == receive_path, f"Unexpected Results directory: {str(self)!r}"
+            return True
+
+        def mock_glob(self: Path, pattern: str) -> List[Path]:
+            assert self == receive_path and pattern == "**/*.tar.xz.md5"
+            return [receive_path / (bad_tarball + ".md5")]
+
+        def mock_results_push(ctrl: str, tb: Path, token: str) -> None:
+            assert (
+                tb == bad_tb
+            ), f"Unexpected tar ball, {tb!r} in mocked results_push function"
+            raise FileNotFoundError(f"No such file or directory: '{tb.name}'")
+
+        expected_result = Results(nstatus="", ntotal=1, ntbs=0, nerr=1)
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": TestProcessTb.receive_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        expected_error_msg = f"No such file or directory: '{bad_tarball}'"
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        monkeypatch.setattr(Path, "glob", mock_glob)
+        monkeypatch.setattr(ProcessTb, "_results_push", mock_results_push)
+        ptb = ProcessTb(MockConfig(mappings), test_logger)
+        res = ptb.process_tb()
+
+        assert res == expected_result
+        assert expected_error_msg in caplog.text
+
+    def test_process_tb_connection_error(self, monkeypatch, caplog, test_logger):
+        """checks normal processing when Connection Error is faced"""
+        receive_path = Path(TestProcessTb.receive_dir + "-002")
+        tarball = "log.tar.xz"
+        good_tb = receive_path / tarball
+
+        def mock_is_dir(self) -> bool:
+            assert self == receive_path, f"Unexpected Results directory: {str(self)!r}"
+            return True
+
+        def mock_glob(self: Path, pattern: str) -> List[Path]:
+            assert self == receive_path and pattern == "**/*.tar.xz.md5"
+            return [receive_path / (tarball + ".md5")]
+
+        def mock_results_push(ctrl: str, tb: Path, token: str) -> None:
+            assert (
+                tb == good_tb
+            ), f"Unexpected tar ball, {tb!r} in mocked results_push function"
+            raise RuntimeError(expected_error_msg)
+
+        expected_result = Results(nstatus="", ntotal=1, ntbs=0, nerr=1)
+        expected_error_msg = (
+            f"Cannot connect to 'https://pbench.example.com/v2/1/upload/{tarball}'"
+        )
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": TestProcessTb.receive_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        monkeypatch.setattr(Path, "glob", mock_glob)
+        monkeypatch.setattr(ProcessTb, "_results_push", mock_results_push)
+        ptb = ProcessTb(MockConfig(mappings), test_logger)
+        res = ptb.process_tb()
+
+        assert res == expected_result
+        assert expected_error_msg in caplog.text
+
+    def test_process_tb(self, monkeypatch, test_logger):
+        """verify processing of tar balls without any failure"""
+        receive_path = Path(TestProcessTb.receive_dir + "-002")
+        tarball = "log.tar.xz"
+        good_tb = receive_path / tarball
+
+        def mock_is_dir(self) -> bool:
+            assert self == receive_path, f"Unexpected Results directory: {str(self)!r}"
+            return True
+
+        def mock_glob(self: Path, pattern: str) -> List[Path]:
+            assert self == receive_path and pattern == "**/*.tar.xz.md5"
+            return [receive_path / (tarball + ".md5")]
+
+        def mock_results_push(ctrl: str, tb: Path, token: str) -> None:
+            assert (
+                tb == good_tb
+            ), f"Unexpected tar ball, {tb!r} in mocked results_push function"
+            return
+
+        def mock_remove(path, *, dir_fd=None):
+            assert path in [
+                good_tb,
+                Path(str(good_tb) + ".md5"),
+            ], f"Unexpected tar ball, {path!r} in mocked os.remove()"
+
+        expected_result = Results(
+            nstatus=f": processed {tarball}\n", ntotal=1, ntbs=1, nerr=0
+        )
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": TestProcessTb.receive_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        monkeypatch.setattr(Path, "glob", mock_glob)
+        monkeypatch.setattr(ProcessTb, "_results_push", mock_results_push)
+        monkeypatch.setattr(os, "remove", mock_remove)
+        ptb = ProcessTb(MockConfig(mappings), test_logger)
+        res = ptb.process_tb()
+
+        assert res == expected_result
+
+    def test_process_tb_zero(self, monkeypatch, test_logger):
+        """verify processing if there are no TBs without any failure"""
+        receive_path = Path(TestProcessTb.receive_dir + "-002")
+
+        def mock_is_dir(self) -> bool:
+            assert self == receive_path, f"Unexpected Results directory: {str(self)!r}"
+            return True
+
+        def mock_glob(self: Path, pattern: str) -> List[Path]:
+            assert self == receive_path and pattern == "**/*.tar.xz.md5"
+            return []
+
+        def mock_results_push(ctrl: str, tb: Path, token: str) -> None:
+            assert False, "Unexpected call to mocked result_push function"
+
+        expected_result = Results(nstatus="", ntotal=0, ntbs=0, nerr=0)
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": TestProcessTb.receive_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        monkeypatch.setattr(Path, "glob", mock_glob)
+        monkeypatch.setattr(ProcessTb, "_results_push", mock_results_push)
+        ptb = ProcessTb(MockConfig(mappings), test_logger)
+        res = ptb.process_tb()
+
+        assert res == expected_result
+
+    def test_multiple_process_tb(self, monkeypatch, caplog, test_logger):
+        """verify tar balls processing at the time of Failure as well as success"""
+        receive_path = Path(TestProcessTb.receive_dir + "-002")
+        tarball = "log.tar.xz"
+        bad_tarball = "bad_log.tar.xz"
+        good_tb = receive_path / tarball
+        bad_tb = receive_path / bad_tarball
+
+        def mock_is_dir(self) -> bool:
+            assert self == receive_path, f"Unexpected Results directory: {str(self)!r}"
+            return True
+
+        def mock_glob(self: Path, pattern: str) -> List[Path]:
+            assert self == receive_path and pattern == "**/*.tar.xz.md5"
+            return [
+                receive_path / (bad_tarball + ".md5"),
+                receive_path / (tarball + ".md5"),
+            ]
+
+        def mock_results_push(ctrl: str, tb: Path, token: str) -> None:
+            if tb == bad_tb:
+                raise FileNotFoundError(f"No such file or directory: '{tb.name}'")
+            return
+
+        def mock_remove(path, *, dir_fd=None):
+            assert path in [
+                good_tb,
+                Path(str(good_tb) + ".md5"),
+            ], f"Unexpected tar ball, {path!r} in mocked os.remove()"
+
+        expected_result = Results(
+            nstatus=f": processed {tarball}\n", ntotal=2, ntbs=1, nerr=1
+        )
+        mappings = {
+            "pbench-server": {
+                "pbench-receive-dir-prefix": TestProcessTb.receive_dir,
+                "put-token": "Authorization-token",
+            }
+        }
+        expected_error_msg = f"No such file or directory: '{bad_tarball}'"
+        monkeypatch.setattr(Path, "is_dir", mock_is_dir)
+        monkeypatch.setattr(Path, "glob", mock_glob)
+        monkeypatch.setattr(ProcessTb, "_results_push", mock_results_push)
+        monkeypatch.setattr(os, "remove", mock_remove)
+        caplog.set_level(logging.ERROR, logger=test_logger.name)
+        ptb = ProcessTb(MockConfig(mappings), test_logger)
+        res = ptb.process_tb()
+
+        assert res == expected_result
+        assert expected_error_msg in caplog.text

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -115,6 +115,7 @@ fi
 /%{installdir}/lib/pbench/__init__.py
 /%{installdir}/lib/pbench/indexer.py
 /%{installdir}/lib/pbench/mock.py
+/%{installdir}/lib/pbench/process_tb.py
 /%{installdir}/lib/pbench/report.py
 /%{installdir}/lib/s3backup/__init__.py
 
@@ -124,6 +125,7 @@ fi
 /%{installdir}/bin/getconf.py
 /%{installdir}/bin/pbench-server-activate-create-crontab
 /%{installdir}/bin/pbench-server-prep-shim-002
+/%{installdir}/bin/pbench-server-put-shim
 /%{installdir}/bin/pbench-audit-server
 /%{installdir}/bin/pbench-backup-tarballs
 /%{installdir}/bin/pbench-verify-backup-tarballs
@@ -154,6 +156,7 @@ fi
 /%{installdir}/bin/pbench-satellite-cleanup.sh
 /%{installdir}/bin/pbench-satellite-state-change.py
 /%{installdir}/bin/pbench-server-prep-shim-002.sh
+/%{installdir}/bin/pbench-server-put-shim.py
 /%{installdir}/bin/pbench-sync-package-tarballs.sh
 /%{installdir}/bin/pbench-sync-satellite.sh
 /%{installdir}/bin/pbench-trampoline

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 skip_missing_interpreters = True
 isolated_build = True
 toxworkdir = {env:TOXWORKDIR:/tmp/{env:USER}/tox}
-envlist = lint,server,agent
+envlist = lint,server,agent,py3-server
 
 [testenv]
 usedevelop = True
@@ -19,7 +19,6 @@ setenv =
     XDG_CACHE_HOME = {envdir}
     SKIP_GENERATE_AUTHORS = 1
     SKIP_WRITE_GIT_CHANGELOG = 1
-    PATH = {env:PATH}:{toxinidir}/bin
 commands_pre =
     {toxinidir}/utils/detox {envdir}
 whitelist_externals =
@@ -44,6 +43,16 @@ deps =
     -r{toxinidir}/agent/test-requirements.txt
 commands =
     bash -c "./agent/run-unittests"
+
+[testenv:py3-server]
+description = Runs all Python3-based server unit and functional tests
+setenv =
+    PYTHONPATH = {env:PYTHONPATH:}:{toxinidir}/server/lib:{toxinidir}/lib
+deps =
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/server/requirements.txt
+commands =
+    pytest {posargs} ./server/lib/pbench/test/unit
 
 [testenv:lint]
 description = Runs all linting tasks


### PR DESCRIPTION
Fixes #2100

put-shim server will act as an interface between v0.69 pbench-agents and v0.72 pbench-server. It will receive the tarballs using ssh transfer method from the 0.69 agents and will forward them to the 0.72 servers using the Agent's `pbench-results-push` command.

**Note**: This change includes adding a dependency in the 0.69 Server on a 0.71+ Agent. This dependency will include using the `pbench-results-push` command of 0.71+ Agent.

More Details and Discussions about this PR are available on PR #2340. This PR deals with basing the put-shim server on branch b0.69 and structural changes according to that.