### PR TITLE
Server installation cleanup

### DIFF
--- a/server/ansible/roles/pbench-server-activate-create-crontab/tasks/main.yml
+++ b/server/ansible/roles/pbench-server-activate-create-crontab/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 - name: create crontab
+  become: yes
+  become_user: pbench
   command: "pbench-server-activate-create-crontab {{ pbench_server_install_dir }}/lib/crontab"
   environment:
      _PBENCH_SERVER_CONFIG: "{{ pbench_server_install_dir }}/lib/config/pbench-server.cfg"

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,6 +1,9 @@
+alembic>=1.6.4
+aniso8601>=9.0.1
 boto3
+click
 python-dateutil
-elasticsearch
+elasticsearch==7.13.1
 email-validator
 flask
 flask-bcrypt
@@ -14,7 +17,7 @@ gunicorn
 humanize
 pyesbulk>=2.0.1
 PyJwt
-psycopg2-binary
+psycopg2
 requests
-sqlalchemy
-sqlalchemy_utils
+sqlalchemy>=1.4.23
+sqlalchemy_utils>=0.37.6

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -65,7 +65,9 @@ mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 # Install python dependencies for pbench user
 (su pbench -c "pip3 --no-cache-dir install --user -r /%{installdir}/requirements.txt") > /%{installdir}/pip3-install.log
 
-# Add install directory into the pbench user default PYTHONPATH
+# Create a `pbench.pth` file under the `pbench` account site library: the
+# `site` package will automatically add directories referenced in `*.pth`
+# files to the default `sys.path` when Python starts.
 su pbench -c "echo /%{installdir}/lib > \$(python3 -m site --user-site)/pbench.pth"
 
 # install node.js modules under /%{installdir}

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -62,12 +62,28 @@ cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
 %post
-# Install python dependencies for pbench user
+# Install python dependencies as pbench user into user's site-packages
 (su pbench -c "pip3 --no-cache-dir install --user -r /%{installdir}/requirements.txt") > /%{installdir}/pip3-install.log
 
-# Create a `pbench.pth` file under the `pbench` account site library: the
-# `site` package will automatically add directories referenced in `*.pth`
-# files to the default `sys.path` when Python starts.
+# The `site` package is Python magic; it runs automatically when Python starts,
+# and builds `sys.path`.
+#
+# For our purposes, this includes looking in the per-user site library and
+# adding the site-packages paths plus adding directories captured in *.pth
+# files it finds in the "user site" directory.
+#
+# The following line captures our install path `/${installdir}/lib` in our own
+# pbench.pth file for `site` to find when the pbench user runs Python.
+#
+# That `pbench.pth` file needs to be in the right place, and the command
+# 'python3 -m site --user-site` gives us the proper location. The `su pbench`
+# ensures that this is run as "pbench" and therefore gives us the proper
+# path where `pbench.pth` will be found, without making arbitrary assumptions
+# about `site` package behavior.
+#
+# Now, when the pbench user runs Python, without any PYTHONPATH environment
+# variable, the normal Python startup will include both the pbench user's
+# site-library paths, and /opt/pbench-server/lib.
 su pbench -c "echo /%{installdir}/lib > \$(python3 -m site --user-site)/pbench.pth"
 
 # install node.js modules under /%{installdir}

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -45,6 +45,10 @@ The pbench server scripts.
 
 %build
 
+%pre
+getent group pbench > /dev/null || groupadd pbench
+getent passwd pbench > /dev/null || useradd -g pbench -d /home/pbench -c "Pbench user" pbench
+
 %install
 rm -rf %{buildroot}
 
@@ -58,8 +62,11 @@ cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
 %post
-# Install python dependencies
-pip3 --no-cache-dir install -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
+# Install python dependencies for pbench user
+(su pbench -c "pip3 --no-cache-dir install --user -r /%{installdir}/requirements.txt") > /%{installdir}/pip3-install.log
+
+# Add install directory into the pbench user default PYTHONPATH
+su pbench -c "echo /%{installdir}/lib > \$(python3 -m site --user-site)/pbench.pth"
 
 # install node.js modules under /%{installdir}
 cd /%{installdir}

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -59,7 +59,7 @@ mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
 %post
 # Install python dependencies
-pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
+pip3 --no-cache-dir install -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
 
 # install node.js modules under /%{installdir}
 cd /%{installdir}


### PR DESCRIPTION
1. Add missing dependencies to requirements.txt
2. Lock elasticsearch module dependency to workaround bug
3. Limit module versions to eliminate pip version matrix thrashing
4. Remove the /opt/pbench-server prefix on pip install in order to simplify PYTHONPATH (after discussion with Pete this looked like a better alternative than computing an inclusive path later).

Tested by re-installing on our new staging server.

This is a fix for some problems called out in #2422 but not sufficient to close the issue.