### PR TITLE
Add psycopg2 RPM to Jenkins container

### DIFF
--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -79,6 +79,7 @@ RUN \
         python3-mock \
         python3-pip \
         python3-psutil \
+        python3-psycopg2 \
         python3-pytest \
         python3-pytest-cov \
         python3-pytest-helpers-namespace \


### PR DESCRIPTION
This adds the `psycopg2` RPM to the Jenkins container, which is needed in order to test the changes in #2423.