### PR TITLE
Check for the `ansible` RPM for the `pprof` tool

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,4 +1,3 @@
-ansible
 bottle
 cffi
 click>=8.0

--- a/agent/test-requirements.txt
+++ b/agent/test-requirements.txt
@@ -1,3 +1,4 @@
+ansible
 coverage
 gitpython
 mock>=3.0.5

--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -591,9 +591,18 @@ install)
 		return ${rc}
 	}
 	case "${tool}" in
-	bpftrace|haproxy-ocp|iostat|kvmtrace|mpstat|oc|perf|pidstat|pprof|prometheus-metrics|sar|turbostat)
+	bpftrace|haproxy-ocp|iostat|kvmtrace|mpstat|oc|perf|pidstat|prometheus-metrics|sar|turbostat)
 		check_required_rpm ${tool_package_name} ${tool_package_ver}
 		rc=${?}
+		;;
+	pprof)
+		check_required_rpm ${tool_package_name} ${tool_package_ver}
+		rc=${?}
+		if [[ ${rc} == 0 ]]; then
+			# For pprof, we also need ansible installed.
+			check_required_rpm "ansible"
+			rc=${?}
+		fi
 		;;
 	systemtap)
 		# We need a number of systemtap and kernel packages for the

--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -152,6 +152,7 @@ sysfs)
 systemtap)
 	script=""
 	longoptions="${longoptions},script:"
+	tool_package_name="systemtap-client"
 	;;
 tcpdump)
 	interface=""
@@ -576,10 +577,10 @@ rc=0
 case "${mode}" in
 install)
 	function check_required_rpm {
-		_tpn="${1}"
-		_tpv="${2}"
-		_installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
-		rc=${?}
+		local _tpn="${1}"
+		local _tpv="${2}"
+		local _installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
+		local rc=${?}
 		if [[ ${rc} != 0 ]]; then
 			if [[ ! -z "${_tpv}" ]]; then
 				_tpv="-${_tpv}"
@@ -590,39 +591,33 @@ install)
 		fi
 		return ${rc}
 	}
-	case "${tool}" in
-	bpftrace|haproxy-ocp|iostat|kvmtrace|mpstat|oc|perf|pidstat|prometheus-metrics|sar|turbostat)
-		check_required_rpm ${tool_package_name} ${tool_package_ver}
-		rc=${?}
-		;;
-	pprof)
+	if [[ ! -z "${tool_package_name}" ]]; then
 		check_required_rpm ${tool_package_name} ${tool_package_ver}
 		rc=${?}
 		if [[ ${rc} == 0 ]]; then
-			# For pprof, we also need ansible installed.
-			check_required_rpm "ansible"
-			rc=${?}
+			case "${tool}" in
+			pprof)
+				# We also need ansible installed.
+				check_required_rpm "ansible"
+				rc=${?}
+				;;
+			systemtap)
+				# We need a number of systemtap and kernel packages for the
+				# systemtap tool to actually work.
+				check_required_rpm "systemtap-devel"
+				rc=${?}
+				if [[ ${rc} == 0 ]]; then
+					check_required_rpm "kernel-devel" "$(uname -r)"
+					rc=${?}
+				fi
+				if [[ ${rc} == 0 ]]; then
+					check_required_rpm "kernel-debuginfo" "$(uname -r)"
+					rc=${?}
+				fi
+				;;
+			esac
 		fi
-		;;
-	systemtap)
-		# We need a number of systemtap and kernel packages for the
-		# systemtap tool to actually work.
-		check_required_rpm "systemtap-client"
-		rc=${?}
-		if [[ ${rc} == 0 ]]; then
-			check_required_rpm "systemtap-devel"
-			rc=${?}
-		fi
-		if [[ ${rc} == 0 ]]; then
-			check_required_rpm "kernel-devel" "$(uname -r)"
-			rc=${?}
-		fi
-		if [[ ${rc} == 0 ]]; then
-			check_required_rpm "kernel-debuginfo" "$(uname -r)"
-			rc=${?}
-		fi
-		;;
-	esac
+	fi
 	;;
 start)
 	case "${tool}" in

--- a/agent/tool-scripts/tests/blktrace/gold/stdout
+++ b/agent/tool-scripts/tests/blktrace/gold/stdout
@@ -1,3 +1,4 @@
+blktrace: blktrace is installed
 blktrace: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/blktrace-datalog /dev/sda42 /dev/sdb42 /dev/sdc42"
 blktrace: stopping
 blktrace: post-processing following stop

--- a/agent/tool-scripts/tests/numastat/gold/stdout
+++ b/agent/tool-scripts/tests/numastat/gold/stdout
@@ -1,3 +1,4 @@
+numastat: numactl is installed
 numastat: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/numastat-datalog 10 "pig42""
 numastat: stopping
 numastat: no post-processing available following stop

--- a/agent/tool-scripts/tests/pprof/gold/stdout
+++ b/agent/tool-scripts/tests/pprof/gold/stdout
@@ -1,4 +1,5 @@
 pprof: golang is installed
+pprof: ansible is installed
 pprof: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/pprof-datalog /var/tmp/pbench-test-tool-scripts/pprof/tools-group/pprof 42 tests/pprof/inventory-hosts.lis"
 pprof: stopping
 pprof: no post-processing available following stop

--- a/agent/tool-scripts/tests/qemu-migrate/gold/stdout
+++ b/agent/tool-scripts/tests/qemu-migrate/gold/stdout
@@ -1,3 +1,4 @@
+qemu-migrate: nmap-ncat is installed
 qemu-migrate: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/qemu-migrate-datalog 10 qemu-vm-42"
 qemu-migrate: stopping
 qemu-migrate: no post-processing available following stop

--- a/agent/tool-scripts/tests/strace/gold/stdout
+++ b/agent/tool-scripts/tests/strace/gold/stdout
@@ -1,3 +1,4 @@
+strace: strace is installed
 strace: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/strace-datalog /var/tmp/pbench-test-tool-scripts/strace/tools-group/strace 42 "forty-two""
 strace: stopping
 strace: no post-processing available following stop

--- a/agent/tool-scripts/tests/tcpdump/gold/stdout
+++ b/agent/tool-scripts/tests/tcpdump/gold/stdout
@@ -1,3 +1,4 @@
+tcpdump: tcpdump is installed
 tcpdump: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/tcpdump-datalog 42 en42"
 tcpdump: stopping
 tcpdump: no post-processing available following stop

--- a/agent/tool-scripts/tests/virsh-migrate/gold/stdout
+++ b/agent/tool-scripts/tests/virsh-migrate/gold/stdout
@@ -1,3 +1,4 @@
+virsh-migrate: libvirt-client is installed
 virsh-migrate: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/virsh-migrate-datalog 42 vm42"
 virsh-migrate: stopping
 virsh-migrate: no post-processing available following stop

--- a/agent/tool-scripts/tests/vmstat/gold/stdout
+++ b/agent/tool-scripts/tests/vmstat/gold/stdout
@@ -1,3 +1,4 @@
+vmstat: procps-ng is installed
 vmstat: running "/var/tmp/pbench-test-tool-scripts/opt/pbench-agent/tool-scripts/datalog/vmstat-datalog 10"
 vmstat: stopping
 vmstat: no post-processing available following stop


### PR DESCRIPTION
The `pprof` tool requires both `golang` and `ansible` RPMs, but the tool was only checking for `golang`.  We add an explicit check for both now.

In principle the `pbench-agent` should not have any explicit RPM dependencies for RPMs needed by tools.  But, the `pbench-run-bencmark` interface requires the `ansible` RPM, so we happen to satisfy the `pprof` requirement indirectly.

However, we don't want to have the `ansible` Python3 module explicitly listed in the `agent/requirements.txt` file since it is not a direct dependency for any Python3 code of the agent.  So for testing purposes we move the `ansible` module requirement to `test-requirements.txt`.