### PR TITLE
Fixes to pbench-list-tools (abandonware)

### DIFF
--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -24,8 +24,9 @@ class ListTools(ToolCommand):
 
     @staticmethod
     def print_results(toolinfo, with_options):
-        for group, rest in toolinfo.items():
-            for host, tools in rest.items():
+        for group in sorted(toolinfo.keys()):
+            for host in sorted(toolinfo[group].keys()):
+                tools = toolinfo[group][host]
                 if not with_options:
                     s = ",".join(tools)
                 else:

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -28,10 +28,10 @@ class ListTools(ToolCommand):
             for host in sorted(toolinfo[group].keys()):
                 tools = toolinfo[group][host]
                 if not with_options:
-                    s = ",".join(tools)
+                    s = ", ".join(tools)
                 else:
-                    s = ",".join(map(lambda x: " ".join(x), tools))
-                print("%s: %s: %s" % (group, host, s))
+                    s = ", ".join(map(lambda x: " ".join(x), tools))
+                print(f"{group}: {host}: {s}")
 
     def execute(self):
         if not self.pbench_run.exists():
@@ -44,7 +44,6 @@ class ListTools(ToolCommand):
         else:
             groups = self.groups
 
-        with_option = False
         if not self.context.name:
             host_tools = {}
             for group in groups:
@@ -53,7 +52,6 @@ class ListTools(ToolCommand):
                     for path in self.gen_tools_group_dir(group).glob("*/**"):
                         host = path.name
                         if self.context.with_option:
-                            with_option = True
                             host_tools[group][host] = [
                                 (p, (path / p).read_text().rstrip("\n"))
                                 for p in self.tools(path)
@@ -64,7 +62,7 @@ class ListTools(ToolCommand):
                     self.logger.error("Tool group does not exist: %s", group)
                     return 1
             if host_tools:
-                self.print_results(host_tools, with_option)
+                self.print_results(host_tools, self.context.with_option)
         else:
             # List the groups which include this tool
             group_list = []
@@ -87,22 +85,19 @@ class ListTools(ToolCommand):
                     if tool in self.tools(path):
                         group_list.append(group)
                         if self.context.with_option:
-                            with_option = True
                             options[group] = (
                                 host,
                                 (path / tool).read_text().rstrip("\n"),
                             )
 
             if group_list:
-                if with_option:
-                    print("tool name: %s" % (tool))
-                    for group, rest in options.items():
+                if self.context.with_option:
+                    print(f"tool name: {tool}")
+                    for group, rest in sorted(options.items()):
                         host, options = rest
-                        print(
-                            "group: %s, host: %s, options: %s" % (group, host, options)
-                        )
+                        print(f"group: {group}, host: {host}, options: {options}")
                 else:
-                    print("tool name: %s groups: %s" % (tool, ", ".join(group_list)))
+                    print(f"tool name: {tool} groups: {', '.join(sorted(group_list))}")
             else:
                 # name does not exist in any group
                 self.logger.error("Tool does not exist in any group: %s", tool)

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -109,7 +109,7 @@ def _group_option(f):
 
     def callback(ctxt, param, value):
         clictxt = ctxt.ensure_object(CliContext)
-        try:
+        try:g
             clictxt.group = value.split()
         except Exception:
             clictxt.group = []
@@ -139,8 +139,7 @@ def _name_option(f):
         callback=callback,
         help=(
             "list the tool groups in which <tool-name> is used.\n"
-            "Not allowed with the --group option"
-        ),
+         ),
     )(f)
 
 

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -23,14 +23,6 @@ class ListTools(ToolCommand):
         super(ListTools, self).__init__(context)
 
     @staticmethod
-    def chomp(s):
-        if len(s) == 0:
-            return s
-        if s[-1] == '\n':
-            return s[0:-1]
-        return s
-
-    @staticmethod
     def print_results(toolinfo, with_options):
         for group, rest in toolinfo.items():
             for host, tools in rest.items():
@@ -62,7 +54,7 @@ class ListTools(ToolCommand):
                         if self.context.with_option:
                             with_option = True
                             host_tools[group][host] = [
-                                (p, self.chomp((path / p).read_text())) for p in self.tools(path)
+                                (p, (path / p).read_text().rstrip("\n")) for p in self.tools(path)
                             ]
                         else:
                             host_tools[group][host] = [p for p in self.tools(path)]
@@ -83,21 +75,18 @@ class ListTools(ToolCommand):
                     self.logger.error("Tool group does not exist: %s", group)
                     return 1
 
-                if not tg_dir.exists():
-                    self.logger.error("bad or missing tool group %s", group)
-                    continue
-
                 for path in tg_dir.iterdir():
-                    host = path.name
                     # skip files like __label__ and __trigger__
                     if not path.is_dir():
                         continue
+
+                    host = path.name
                     # Check to see if the tool is in any of the hosts.
                     if tool in self.tools(path):
                         group_list.append(group)
                         if self.context.with_option:
                             with_option = True
-                            options[group] = (host, self.chomp((path / tool).read_text()))
+                            options[group] = (host, (path / tool).read_text().rstrip("\n"))
 
             if group_list:
                 if with_option:

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -9,7 +9,7 @@ group, or list which groups contain a specific tool
 import sys
 
 import click
-
+113
 from pbench.agent.tool_group import BadToolGroup
 from pbench.cli.agent import CliContext, pass_cli_context
 from pbench.cli.agent.commands.tools.base import ToolCommand
@@ -109,7 +109,7 @@ def _group_option(f):
 
     def callback(ctxt, param, value):
         clictxt = ctxt.ensure_object(CliContext)
-        try:g
+        try:
             clictxt.group = value.split()
         except Exception:
             clictxt.group = []

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -40,7 +40,7 @@ class ListTools(ToolCommand):
                     for path in self.gen_tools_group_dir(group).glob("*/**"):
                         if self.context.with_option:
                             host_tools[group][path.name] = [
-                                p.read_text() for p in self.tools(path)
+                                (p, (path / p).read_text()) for p in self.tools(path)
                             ]
                         else:
                             host_tools[group][path.name] = [p for p in self.tools(path)]

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -9,6 +9,7 @@ group, or list which groups contain a specific tool
 import sys
 
 import click
+
 113
 from pbench.agent.tool_group import BadToolGroup
 from pbench.cli.agent import CliContext, pass_cli_context
@@ -137,9 +138,7 @@ def _name_option(f):
         "--name",
         expose_value=False,
         callback=callback,
-        help=(
-            "list the tool groups in which <tool-name> is used.\n"
-         ),
+        help=("list the tool groups in which <tool-name> is used.\n"),
     )(f)
 
 

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -55,7 +55,8 @@ class ListTools(ToolCommand):
                         if self.context.with_option:
                             with_option = True
                             host_tools[group][host] = [
-                                (p, (path / p).read_text().rstrip("\n")) for p in self.tools(path)
+                                (p, (path / p).read_text().rstrip("\n"))
+                                for p in self.tools(path)
                             ]
                         else:
                             host_tools[group][host] = [p for p in self.tools(path)]
@@ -87,19 +88,21 @@ class ListTools(ToolCommand):
                         group_list.append(group)
                         if self.context.with_option:
                             with_option = True
-                            options[group] = (host, (path / tool).read_text().rstrip("\n"))
+                            options[group] = (
+                                host,
+                                (path / tool).read_text().rstrip("\n"),
+                            )
 
             if group_list:
                 if with_option:
                     print("tool name: %s" % (tool))
                     for group, rest in options.items():
                         host, options = rest
-                        print("group: %s, host: %s, options: %s" % (group, host, options))
+                        print(
+                            "group: %s, host: %s, options: %s" % (group, host, options)
+                        )
                 else:
-                    print(
-                        "tool name: %s groups: %s"
-                        % (tool, ", ".join(group_list))
-                    )
+                    print("tool name: %s groups: %s" % (tool, ", ".join(group_list)))
             else:
                 # name does not exist in any group
                 self.logger.error("Tool does not exist in any group: %s", tool)

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -13,7 +13,7 @@ import click
 from pbench.cli.agent import CliContext, pass_cli_context
 from pbench.cli.agent.commands.tools.base import ToolCommand
 from pbench.cli.agent.options import common_options
-
+from pbench.agent.tool_group import BadToolGroup
 
 class ListTools(ToolCommand):
     """ List registered Tools """
@@ -36,13 +36,17 @@ class ListTools(ToolCommand):
             host_tools = {}
             for group in groups:
                 host_tools[group] = {}
-                for path in self.gen_tools_group_dir(group).glob("*/**"):
-                    if self.context.with_option:
-                        host_tools[group][path.name] = [
-                            p.read_text() for p in self.tools(path)
-                        ]
-                    else:
-                        host_tools[group][path.name] = [p for p in self.tools(path)]
+                try:
+                    for path in self.gen_tools_group_dir(group).glob("*/**"):
+                        if self.context.with_option:
+                            host_tools[group][path.name] = [
+                                p.read_text() for p in self.tools(path)
+                            ]
+                        else:
+                            host_tools[group][path.name] = [p for p in self.tools(path)]
+                except BadToolGroup:
+                    self.logger.error("Bad tool group: %s", group)
+                    return 1
             if host_tools:
                 for k, v in host_tools.items():
                     for h, t in v.items():

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -10,7 +10,6 @@ import sys
 
 import click
 
-113
 from pbench.agent.tool_group import BadToolGroup
 from pbench.cli.agent import CliContext, pass_cli_context
 from pbench.cli.agent.commands.tools.base import ToolCommand

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -23,7 +23,7 @@ class ListTools(ToolCommand):
         super(ListTools, self).__init__(context)
 
     @staticmethod
-    def print_results(toolinfo, with_options):
+    def print_results(toolinfo: dict, with_options: bool):
         for group in sorted(toolinfo.keys()):
             for host in sorted(toolinfo[group].keys()):
                 tools = toolinfo[group][host]

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -15,6 +15,7 @@ from pbench.cli.agent.commands.tools.base import ToolCommand
 from pbench.cli.agent.options import common_options
 from pbench.agent.tool_group import BadToolGroup
 
+
 class ListTools(ToolCommand):
     """ List registered Tools """
 
@@ -61,6 +62,9 @@ class ListTools(ToolCommand):
                     continue
 
                 for path in tg_dir.iterdir():
+                    # skip files like __label__ and __trigger__
+                    if not path.is_dir():
+                        continue
                     # Check to see if the tool is in any of the hosts.
                     if self.context.name in self.tools(path):
                         group_list.append(group)

--- a/lib/pbench/test/functional/agent/cli/commands/conftest.py
+++ b/lib/pbench/test/functional/agent/cli/commands/conftest.py
@@ -30,7 +30,7 @@ def pbench_run(tmp_path):
 
 
 @pytest.fixture
-def agent_config(tmp_path, opt_pbench, pbench_cfg, pbench_run):
+def agent_config(monkeypatch, tmp_path, opt_pbench, pbench_cfg, pbench_run):
     shutil.copyfile("./agent/config/pbench-agent-default.cfg", pbench_cfg)
 
     config = configparser.ConfigParser()
@@ -39,3 +39,4 @@ def agent_config(tmp_path, opt_pbench, pbench_cfg, pbench_run):
     config["pbench-agent"]["pbench_run"] = str(pbench_run)
     with open(pbench_cfg, "w") as f:
         config.write(f)
+    monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -1,5 +1,9 @@
 import pytest
 
+group_err = b"Tool group does not exist: "
+tool_err = b"Tool does not exist in any group: "
+usage_msg = b"Usage: pbench-list-tools [OPTIONS]"
+
 
 class Test_list_tool_no_tools_registered:
     def test_help(self):
@@ -12,27 +16,35 @@ class Test_list_tool_no_tools_registered:
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"" == out
+        assert b"" == out
         assert exitcode == 0
 
     def test_name(self, agent_config):
         command = ["pbench-list-tools", "--name", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
-        # XXX 0.69.9 backward compatibility: non-existent names do no return errors
-        assert exitcode == 0
+        assert b"" == out
+        assert tool_err in err
+        assert exitcode == 1
 
     def test_group(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_group_name(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo", "--name", "iostat"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_group_options(self, agent_config):
         command = ["pbench-list-tools", "--group", "foo", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_group_name_options(self, agent_config):
@@ -45,12 +57,15 @@ class Test_list_tool_no_tools_registered:
             "--with-option",
         ]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_option(self, agent_config):
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"" == out
+        assert b"" == err
         assert exitcode == 0
 
 
@@ -61,58 +76,90 @@ class Test_list_tool_tools_registered:
         p.mkdir(parents=True)
         tool = p / "perf"
         tool.touch()
-        return tool
+
+    @pytest.fixture
+    def tools_on_multiple_hosts(self, pbench_run):
+        p = pbench_run / "tools-v1-default" / "testhost.example.com"
+        p.mkdir(parents=True)
+        for tool in ["perf", "mpstat"]:
+            ( p / tool).touch()
+        p = pbench_run / "tools-v1-default" / "testhost2.example.com"
+        p.mkdir(parents=True)
+        for tool in ["iostat", "sar"]:
+            ( p / tool).touch()
 
     def test_help(self, tool, agent_config):
         command = ["pbench-list-tools", "--help"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert usage_msg in out
+        assert b"" == err
         assert exitcode == 0
 
     def test_no_args(self, tool, agent_config):
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert b"default: testhost.example.com ['perf']\n" == out
+        assert b"default: testhost.example.com: perf\n" == out
         assert exitcode == 0
 
     def test_group_existing(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert b"default: testhost.example.com ['perf']\n" == out
+        assert b"default: testhost.example.com: perf\n" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_name_existing(self, tool, agent_config):
         command = ["pbench-list-tools", "-n", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"tool name: perf groups: default\n" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_non_existent_group(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_non_existent_name(self, tool, agent_config):
         command = ["pbench-list-tools", "-n", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
-        # XXX 0.69.9 backward compatibility: non-existent names do not return errors
-        assert exitcode == 0
+        assert b"" == out
+        assert tool_err in err
+        assert exitcode == 1
 
     def test_existing_group_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"tool name: perf groups: default\n" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_existing_group_non_existent_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--name", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert exitcode == 0
+        assert b"" == out
+        assert tool_err in err
+        assert exitcode == 1
 
     def test_non_existent_group_existing_name(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown", "--name", "perf"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
+
+    def test_multiple_hosts(self, tools_on_multiple_hosts, agent_config):
+        command = ["pbench-list-tools"]
+        out, err, exitcode = pytest.helpers.capture(command)
+ 
+        assert (
+            b"default: testhost2.example.com: iostat,sar\ndefault: testhost.example.com: mpstat,perf\n"
+            == out
+        )
+        assert b"" == err
+        assert exitcode == 0
 
 
 class Test_list_tool_tools_registered_with_options:
@@ -127,19 +174,33 @@ class Test_list_tool_tools_registered_with_options:
             tool.write_text("--interval=300")
         return
 
+    @pytest.fixture
+    def tools_on_multiple_hosts(self, pbench_run):
+        for group in ["default", "test"]:
+            for host in ["th1.example.com", "th2.example.com"]:
+                p = pbench_run / f"tools-v1-{group}" / host 
+                p.mkdir(parents=True)
+                tool = p / "iostat"
+                tool.write_text("--interval=30")
+                tool = p / "mpstat"
+                tool.write_text("--interval=300")
+
     def test_existing_group_options(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
-        # XXX this is the current output - pretty ugly
+        # This is (apart from the hostname) the 0.69.9 output.
         assert (
-            b"default: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\n"
+            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300\n"
             == out
         )
+        assert b"" == err
         assert exitcode == 0
 
     def test_non_existent_group_options(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "unknown", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert group_err in err
         assert exitcode == 1
 
     def test_existing_group_name_options(self, tool, agent_config):
@@ -152,16 +213,30 @@ class Test_list_tool_tools_registered_with_options:
             "--with-option",
         ]
         out, err, exitcode = pytest.helpers.capture(command)
-        # XXX this is the current output - obviously wrong
-        assert b"tool name: mpstat groups: default\n" == out
+        assert b"tool name: mpstat\ngroup: default, host: testhost.example.com, options: --interval=300\n" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_option(self, tool, agent_config):
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
-        # XXX this is the current output - pretty ugly
+        # This is the 0.69.9 output with hostname mods
         assert (
-            b"default: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\ntest: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\n"
+            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300\ntest: testhost.example.com: iostat --interval=30,mpstat --interval=300\n"
             == out
         )
+        assert b"" == err
         assert exitcode == 0
+
+    def test_multiple_hosts_with_options(self, tools_on_multiple_hosts, agent_config):
+        command = ["pbench-list-tools", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+
+        # This is the 0.69.9 output with hostname mods
+        assert (
+            b"default: th2.example.com: iostat --interval=30,mpstat --interval=300\ndefault: th1.example.com: iostat --interval=30,mpstat --interval=300\ntest: th2.example.com: iostat --interval=30,mpstat --interval=300\ntest: th1.example.com: iostat --interval=30,mpstat --interval=300\n"
+            == out
+        )
+        assert b"" == err
+        assert exitcode == 0
+

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -1,31 +1,167 @@
 import pytest
 
 
-def test_pbench_list_tools_help():
-    command = ["pbench-list-tools", "--help"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert b"Usage: pbench-list-tools [OPTIONS]" in out
-    assert exitcode == 0
+class Test_list_tool_no_tools_registered:
+    def test_help(self):
+        command = ["pbench-list-tools", "--help"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert exitcode == 0
+
+    def test_no_args(self, agent_config):
+        command = ["pbench-list-tools"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert exitcode == 0
+
+    def test_name(self, agent_config):
+        command = ["pbench-list-tools", "--name", "foo"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        # XXX 0.69.9 backward compatibility: non-existent names do no return errors
+        assert exitcode == 0
+
+    def test_group(self, agent_config):
+        command = ["pbench-list-tools", "--group", "foo"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_group_name(self, agent_config):
+        command = ["pbench-list-tools", "--group", "foo", "--name", "iostat"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_group_options(self, agent_config):
+        command = ["pbench-list-tools", "--group", "foo", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_group_name_options(self, agent_config):
+        command = [
+            "pbench-list-tools",
+            "--group",
+            "foo",
+            "--name",
+            "iostat",
+            "--with-option",
+        ]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_option(self, agent_config):
+        command = ["pbench-list-tools", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"" == out
+        assert exitcode == 0
 
 
-def test_list_tool(monkeypatch, agent_config, pbench_run, pbench_cfg):
-    monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-    p = pbench_run / "tools-v1-default" / "testhost.example.com"
-    p.mkdir(parents=True)
-    tool = p / "perf"
-    tool.touch()
+class Test_list_tool_tools_registered:
+    @pytest.fixture
+    def tool(self, pbench_run):
+        p = pbench_run / "tools-v1-default" / "testhost.example.com"
+        p.mkdir(parents=True)
+        tool = p / "perf"
+        tool.touch()
+        return tool
 
-    command = ["pbench-list-tools"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"default: testhost.example.com ['perf']" in out
+    def test_help(self, tool, agent_config):
+        command = ["pbench-list-tools", "--help"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert exitcode == 0
 
-    command = ["pbench-list-tools", "--group", "default"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"default: testhost.example.com ['perf']" in out
+    def test_no_args(self, tool, agent_config):
+        command = ["pbench-list-tools"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"default: testhost.example.com ['perf']\n" == out
+        assert exitcode == 0
 
-    command = ["pbench-list-tools", "-n", "perf"]
-    out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
-    assert b"tool name: perf groups: default" in out
+    def test_group_existing(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "default"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"default: testhost.example.com ['perf']\n" == out
+        assert exitcode == 0
+
+    def test_name_existing(self, tool, agent_config):
+        command = ["pbench-list-tools", "-n", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"tool name: perf groups: default\n" == out
+        assert exitcode == 0
+
+    def test_non_existent_group(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_non_existent_name(self, tool, agent_config):
+        command = ["pbench-list-tools", "-n", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        # XXX 0.69.9 backward compatibility: non-existent names do not return errors
+        assert exitcode == 0
+
+    def test_existing_group_name(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "default", "--name", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert b"tool name: perf groups: default\n" == out
+        assert exitcode == 0
+
+    def test_existing_group_non_existent_name(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "default", "--name", "unknown"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 0
+
+    def test_non_existent_group_existing_name(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "unknown", "--name", "perf"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+
+class Test_list_tool_tools_registered_with_options:
+    @pytest.fixture
+    def tool(self, pbench_run):
+        for group in ["default", "test"]:
+            p = pbench_run / f"tools-v1-{group}" / "testhost.example.com"
+            p.mkdir(parents=True)
+            tool = p / "iostat"
+            tool.write_text("--interval=30")
+            tool = p / "mpstat"
+            tool.write_text("--interval=300")
+        return
+
+    def test_existing_group_options(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "default", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        # XXX this is the current output - pretty ugly
+        assert (
+            b"default: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\n"
+            == out
+        )
+        assert exitcode == 0
+
+    def test_non_existent_group_options(self, tool, agent_config):
+        command = ["pbench-list-tools", "--group", "unknown", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        assert exitcode == 1
+
+    def test_existing_group_name_options(self, tool, agent_config):
+        command = [
+            "pbench-list-tools",
+            "--group",
+            "default",
+            "--name",
+            "mpstat",
+            "--with-option",
+        ]
+        out, err, exitcode = pytest.helpers.capture(command)
+        # XXX this is the current output - obviously wrong
+        assert b"tool name: mpstat groups: default\n" == out
+        assert exitcode == 0
+
+    def test_option(self, tool, agent_config):
+        command = ["pbench-list-tools", "--with-option"]
+        out, err, exitcode = pytest.helpers.capture(command)
+        # XXX this is the current output - pretty ugly
+        assert (
+            b"default: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\ntest: testhost.example.com [('iostat', '--interval=30'), ('mpstat', '--interval=300')]\n"
+            == out
+        )
+        assert exitcode == 0

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -16,7 +16,7 @@ class Test_list_tool_no_tools_registered:
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"" == out
-        assert b"" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_name(self, agent_config):
@@ -99,6 +99,7 @@ class Test_list_tool_tools_registered:
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert b"default: testhost.example.com: perf\n" == out
+        assert b"" == err
         assert exitcode == 0
 
     def test_group_existing(self, tool, agent_config):
@@ -155,7 +156,7 @@ class Test_list_tool_tools_registered:
         out, err, exitcode = pytest.helpers.capture(command)
 
         assert (
-            b"default: testhost.example.com: mpstat,perf\ndefault: testhost2.example.com: iostat,sar\n"
+            b"default: testhost.example.com: mpstat, perf\ndefault: testhost2.example.com: iostat, sar\n"
             == out
         )
         assert b"" == err
@@ -201,7 +202,7 @@ class Test_list_tool_tools_registered_with_options:
         out, err, exitcode = pytest.helpers.capture(command)
         # This is (apart from the hostname) the 0.69.9 output.
         assert (
-            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\n"
+            b"default: testhost.example.com: iostat --interval=30, mpstat --interval=300, sar --interval=10\n"
             == out
         )
         assert b"" == err
@@ -236,7 +237,7 @@ class Test_list_tool_tools_registered_with_options:
         out, err, exitcode = pytest.helpers.capture(command)
         # This is the 0.69.9 output with hostname mods
         assert (
-            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\ntest: testhost.example.com: iostat --interval=30,mpstat --interval=300,perf --record-opts='-a --freq=100'\n"
+            b"default: testhost.example.com: iostat --interval=30, mpstat --interval=300, sar --interval=10\ntest: testhost.example.com: iostat --interval=30, mpstat --interval=300, perf --record-opts='-a --freq=100'\n"
             == out
         )
         assert b"" == err
@@ -246,12 +247,9 @@ class Test_list_tool_tools_registered_with_options:
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
 
-        import sys
-
-        print(out, file=sys.stderr)
         # This is the 0.69.9 output with hostname mods
         assert (
-            b"default: th1.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\ndefault: th2.example.com: iostat --interval=30,mpstat --interval=300,perf --record-opts='-a --freq=100'\ntest: th1.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\ntest: th2.example.com: iostat --interval=30,mpstat --interval=300,perf --record-opts='-a --freq=100'\n"
+            b"default: th1.example.com: iostat --interval=30, mpstat --interval=300, sar --interval=10\ndefault: th2.example.com: iostat --interval=30, mpstat --interval=300, perf --record-opts='-a --freq=100'\ntest: th1.example.com: iostat --interval=30, mpstat --interval=300, sar --interval=10\ntest: th2.example.com: iostat --interval=30, mpstat --interval=300, perf --record-opts='-a --freq=100'\n"
             == out
         )
         assert b"" == err

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -172,7 +172,13 @@ class Test_list_tool_tools_registered_with_options:
             tool.write_text("--interval=30")
             tool = p / "mpstat"
             tool.write_text("--interval=300")
-        return
+            if group == "default":
+                tool = p / "sar"
+                tool.write_text("--interval=10")
+            else:
+                tool = p / "perf"
+                tool.write_text("--record-opts='-a --freq=100'")
+
 
     @pytest.fixture
     def tools_on_multiple_hosts(self, pbench_run):
@@ -190,7 +196,7 @@ class Test_list_tool_tools_registered_with_options:
         out, err, exitcode = pytest.helpers.capture(command)
         # This is (apart from the hostname) the 0.69.9 output.
         assert (
-            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300\n"
+            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\n"
             == out
         )
         assert b"" == err
@@ -222,7 +228,7 @@ class Test_list_tool_tools_registered_with_options:
         out, err, exitcode = pytest.helpers.capture(command)
         # This is the 0.69.9 output with hostname mods
         assert (
-            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300\ntest: testhost.example.com: iostat --interval=30,mpstat --interval=300\n"
+            b"default: testhost.example.com: iostat --interval=30,mpstat --interval=300,sar --interval=10\ntest: testhost.example.com: iostat --interval=30,mpstat --interval=300,perf --record-opts='-a --freq=100'\n"
             == out
         )
         assert b"" == err

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -9,7 +9,7 @@ class Test_list_tool_no_tools_registered:
     def test_help(self):
         command = ["pbench-list-tools", "--help"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert usage_msg ==  out
+        assert usage_msg == out
         assert b"" == err
         assert exitcode == 0
 

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -82,11 +82,11 @@ class Test_list_tool_tools_registered:
         p = pbench_run / "tools-v1-default" / "testhost.example.com"
         p.mkdir(parents=True)
         for tool in ["perf", "mpstat"]:
-            ( p / tool).touch()
+            (p / tool).touch()
         p = pbench_run / "tools-v1-default" / "testhost2.example.com"
         p.mkdir(parents=True)
         for tool in ["iostat", "sar"]:
-            ( p / tool).touch()
+            (p / tool).touch()
 
     def test_help(self, tool, agent_config):
         command = ["pbench-list-tools", "--help"]
@@ -179,7 +179,6 @@ class Test_list_tool_tools_registered_with_options:
                 tool = p / "perf"
                 tool.write_text("--record-opts='-a --freq=100'")
 
-
     @pytest.fixture
     def tools_on_multiple_hosts(self, pbench_run):
         for group in ["default", "test"]:
@@ -196,7 +195,6 @@ class Test_list_tool_tools_registered_with_options:
                 else:
                     tool = p / "perf"
                     tool.write_text("--record-opts='-a --freq=100'")
-
 
     def test_existing_group_options(self, tool, agent_config):
         command = ["pbench-list-tools", "--group", "default", "--with-option"]
@@ -226,7 +224,10 @@ class Test_list_tool_tools_registered_with_options:
             "--with-option",
         ]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert b"tool name: mpstat\ngroup: default, host: testhost.example.com, options: --interval=300\n" == out
+        assert (
+            b"tool name: mpstat\ngroup: default, host: testhost.example.com, options: --interval=300\n"
+            == out
+        )
         assert b"" == err
         assert exitcode == 0
 
@@ -246,6 +247,7 @@ class Test_list_tool_tools_registered_with_options:
         out, err, exitcode = pytest.helpers.capture(command)
 
         import sys
+
         print(out, file=sys.stderr)
         # This is the 0.69.9 output with hostname mods
         assert (
@@ -254,4 +256,3 @@ class Test_list_tool_tools_registered_with_options:
         )
         assert b"" == err
         assert exitcode == 0
-

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -2,14 +2,15 @@ import pytest
 
 group_err = b"Tool group does not exist: "
 tool_err = b"Tool does not exist in any group: "
-usage_msg = b"Usage: pbench-list-tools [OPTIONS]"
+usage_msg = b"Usage: pbench-list-tools [OPTIONS]\n\nOptions:\n  -C, --config PATH  Path to a pbench-agent configuration file (defaults to\n                     the '_PBENCH_AGENT_CONFIG' environment variable, if\n                     defined)  [required]\n  -n, --name TEXT    list the tool groups in which <tool-name> is used.\n  -g, --group TEXT   list the tools used in this <group-name>\n  -o, --with-option  list the options with each tool\n  --help             Show this message and exit.\n"
 
 
 class Test_list_tool_no_tools_registered:
     def test_help(self):
         command = ["pbench-list-tools", "--help"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert b"Usage: pbench-list-tools [OPTIONS]" in out
+        assert usage_msg ==  out
+        assert b"" == err
         assert exitcode == 0
 
     def test_no_args(self, agent_config):
@@ -91,7 +92,7 @@ class Test_list_tool_tools_registered:
     def test_help(self, tool, agent_config):
         command = ["pbench-list-tools", "--help"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert usage_msg in out
+        assert usage_msg == out
         assert b"" == err
         assert exitcode == 0
 


### PR DESCRIPTION
First commit:
----------------
Catch BadToolGroup exception and return error
 
Fixes #2302
    
Running `pbench-init-tools -g foo`, where `foo` is an unknown group,
 results in an exception.
    
 Modify the ListTools().execute() function to catch the exception,
 log an error and return an error status.

Second commit:
---------------------
Fix type confusion that led to an uncaught exception
    
Fixes #2346
    
`pbench-list-tools -o' got an exception because a tool name (a string)
was used as a Path, trying to read the file that contains the options
for the tool. We convert the tool name into a Path in order to read
the file.
    
The output of the command was just the options without the name of
the associated tool, so we now store the name of the tool as well.
The output contains the same information as the 0.69.9 version, but
the format is different.
    
The 0.69 version produces output like this:
```
default: iostat --interval=3,mpstat --interval=3,perf --record-opts='record -a --freq=100', ...
```
whereas the current version's output is straight print() output
from python:
    
```
default: alphaville.usersys.redhat.com [('iostat',  '--interval=3\n'), ('mpstat', '--interval=3\n'), ('perf',  "--record-opts='-a --freq=100'\n"), ...
```

Third commit:
-----------------
Skip files when looking for hosts under a tool group
    
Fixes #2345
    
When listing tools for a given host under a given tool group,
skip non-directory files (e.g. `__label__` and `__trigger__`).


Fourth commit:
-------------------
Add functional tests for pbench-list-tools
    
Although all the tests pass currently, they certainly should not.
There are three classes of tests that IMO should not pass:
    
- `--name <unknown name>` exits with status 0, the same
   as the 0.69.9 version. OTOH, `--group <unknown group>` exits with status 1.
    
- `--with-option` output is ugly (and different from 0.69.9 which is
   also pretty ugly).
    
- `--name <known name>  --group <known-group> --with-option` gives
   wrong output: it does not produce the options. 0.69.9 signals an
   error here, complaining that having both name *and* group specified
   cannot be done: that seems specious to me.
    
The question is what to fix in this PR and what to defer to a future one.

Fifth commit
----------------
Address review comments

Fix the tests:
- Change the exit status in all cases where an unknown tool or an
unknown group was asked for to 1.
- Add asserts, checking stdout and stderr in all cases.

Fix the code:
- Fix one more unhandled exception.
- Fix up the output of options to get rid of pythonisms. In all cases
the output is now (almost) like the 0.69.9 output, except for the
hostname handling.
- Add code to handle '-o -g group -n tool'.

Later commits:
-------------------
- Address review comments
- Change the fixture to create overlapping but distinct sets of
tools for the two groups.
- Sort the output by group and hostname.
-  Fix black failures
-  Rebase
