### PR TITLE
Canonicalize the JSON output from trafficgen-postprocess

### DIFF
--- a/agent/bench-scripts/postprocess/trafficgen-postprocess
+++ b/agent/bench-scripts/postprocess/trafficgen-postprocess
@@ -858,7 +858,7 @@ gen_data(\%graph, \%graph_type, \%graph_threshold, $dir, 1);
 
 convert_samples_hash_to_array(\%workload);
 
-$json_text = to_json( \%workload, { ascii => 1, pretty => 1 } );
+$json_text = to_json( \%workload, { ascii => 1, pretty => 1, canonical => 1 } );
 open(JSON, ">$json_file") || die "$script: could not open file $json_file: $!\n";
 print JSON $json_text;
 close(JSON);


### PR DESCRIPTION
This change ensures that the JSON output from `trafficgen-postprocess` is produced in "canonical order", so that it produces consistent results for things like testing.

(I had intended to include this change in #2349, but I forgot.)

Fixes #2451.

(Reviewer invitations:  @ndokos, @dbutenhof, @portante)