### PR TITLE
Remove explicit removals from RPM removal

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -81,7 +81,7 @@ if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;f
 # to install the latest Python3 modules, which we need. So we have to fetch
 # our own copy of `pip3`, as described at:
 #   https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py 
-# We then install it separately from the existing verion and set `PATH` and
+# We then install it separately from the existing version and set `PATH` and
 # `PYTHONPATH` so that we use this updated version when we install our module
 # dependencies below.
 curl -X GET -o /%{installdir}/get-pip.py https://bootstrap.pypa.io/get-pip.py > /%{installdir}/pip3-update.log 2>&1

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -63,7 +63,7 @@ mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
 %post
 # Install python dependencies as pbench user into user's site-packages
-(su pbench -c "pip3 --no-cache-dir install --user -r /%{installdir}/requirements.txt") > /%{installdir}/pip3-install.log
+(su pbench -c "pip3 --no-cache-dir install --user --no-warn-script-location -r /%{installdir}/requirements.txt") > /%{installdir}/pip3-install.log
 
 # The `site` package is Python magic; it runs automatically when Python starts,
 # and builds `sys.path`.
@@ -89,6 +89,7 @@ su pbench -c "echo /%{installdir}/lib > \$(python3 -m site --user-site)/pbench.p
 # install node.js modules under /%{installdir}
 cd /%{installdir}
 rm -rf node_modules
+echo 'package-lock=false' >> .npmrc
 npm install
 
 # this only handles v0.3
@@ -112,6 +113,16 @@ chown -R pbench.pbench /%{installdir}
 
 %preun
 
+rm -rf \
+    "$(python3 -m site --user-site)/pbench.pth"       \
+    /%{installdir}/node_modules                       \
+    /%{installdir}/.npmrc                             \
+    /%{installdir}/package-lock.json                  \
+    /%{installdir}/pip3-install.log                   \
+    /%{installdir}/%{static}/js/v0.3/d3.min.js        \
+    /%{installdir}/%{static}/js/v0.3/d3-queue.min.js  \
+    /%{installdir}/%{static}/js/v0.3/saveSvgAsPng.js
+
 %postun
 # if uninstalling, rather than updating, remove everything
 if [ $1 -eq 0 ] ;then
@@ -119,7 +130,6 @@ if [ $1 -eq 0 ] ;then
     if [ -f $crontab ] ;then
         crontab -u pbench -r
     fi
-    rm -rf /%{installdir}
 fi
 
 %posttrans
@@ -127,24 +137,14 @@ fi
 %files
 
 %defattr(644, pbench, pbench, 755)
-/%{installdir}/VERSION
-/%{installdir}/SEQNO
-/%{installdir}/SHA1
-/%{installdir}/package.json
-/%{installdir}/requirements.txt
-
-# pbench-base.sh %attr overrides previous /bin %attr
+/%{installdir}
 %attr(755, pbench, pbench) /%{installdir}/bin
 %attr(644, pbench, pbench) /%{installdir}/bin/pbench-base.sh
-
-# service script %attr overrides %defattr on later /lib
 %attr(755, pbench, pbench) /%{installdir}/lib/systemd/pbench-server.service
-/%{installdir}/lib
-/%{installdir}/%{static}
 
-%doc
-/%{installdir}/lib/pbench/server/s3backup/README
-/%{installdir}/lib/pbench/common/AUTHORS.log_formatter
-/%{installdir}/lib/pbench/common/LICENSE.log_formatter
-/%{installdir}/%{static}/css/v0.3/LICENSE.TXT
-/%{installdir}/%{static}/js/v0.3/LICENSE.TXT
+%doc /%{installdir}/lib/pbench/server/s3backup/README
+%doc /%{installdir}/lib/pbench/common/AUTHORS.log_formatter
+%doc /%{installdir}/lib/pbench/common/LICENSE.log_formatter
+
+%license /%{installdir}/%{static}/css/v0.3/LICENSE.TXT
+%license /%{installdir}/%{static}/js/v0.3/LICENSE.TXT


### PR DESCRIPTION
This change touches up the RPM spec file template for the Server to enable `dnf remove` to work properly.  Previously, we used the "big hammer" approach of simply (manually/explicitly) removing the entire `%{installdir}` during the `%postun` stage, but this has the undesirable side effect of wiping out any user files which might be in `/opt/pbench-server/` (such as `pbench-server.cfg`).  Instead, we now use better discipline, removing during the `%preun` stage the files which we created during the `%post` stage, so that, during the "uninstall" stage, the directory tree looks like what RPM expects it to look like, which means that all of the entries in the `%files` list are removed implicitly for us (but, things like user files are left alone).

This change also declares the entire `%{installdir}` to belong to this package, so, if there are no user files in it, then the entire directory tree is removed on uninstall.  And, that means that a number of files no longer need to be explicitly listed in the `%files` section (because they are already in the tree).  However,  the RPM build now issues more `File listed twice` warnings, because the files from entire `bin` subdirectory are also listed under the top-level directory list (but with different attributes).  (There doesn't seem to be a good way to avoid double listings -- the recommended approach is to dynamically generate the files list, but I concluded that ignoring the warnings was a better way to go.)

This PR also contains several smaller fixes:
- It looked like the `%doc` directive was being mis-used, so I guessed at how we wanted it to be applied.  However, I now cannot find where RPM is putting those files, but maybe that's a feature?  I used the `%license` directive for the license files, and they behave reasonably, so I think RPM may be configured to drop documentation on my test platform.
- I added a file to suppress the NPM message about the `package-lock.json` file.  Since we're not distributing it, and since we're not doing development on this platform or repeated NPM deployments, there's no reason to generate the file or to complain about its absence.
- I added a switch to the `pip` install to suppress the `PATH` warning, since it's not germane in this context.
- And, I fixed a typo in the Agent spec file template.  (I was going to fix it up like I fixed up the Server one, but it took so much effort to do the Server one that I've kind of lost interest....)

Fixes #2042.

Reviewers:  any thoughts about what to do about the two items under the `FIXME` comment?
@portante, @ndokos, @dbutenhof 