### PR TITLE
Fix Mr. Jenkins's Cobertura report creation

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -1,7 +1,7 @@
 pipeline {
     agent { label 'pbench' }
     environment {
-        COV_REPORT_LOC="${WORKSPACE_TMP}/${BUILD_NUMBER}/cov/cov.xml"
+        COV_REPORT_LOC="cov.${BUILD_NUMBER}.xml"
         EXTRA_PODMAN_SWITCHES='--user=root'
         NO_COLORS=0
         PY_COLORS=0
@@ -17,15 +17,15 @@ pipeline {
     }
     post {
         success {
-            // Unfortunately, the Cobertura Publisher plugin considers the
-            // report file to be a relative-to-WORKSPACE-only file. So we
-            // have to hack the separate report file into the local workspace
-            // with a symlink.
-            sh 'ln -s ${COV_REPORT_LOC} ${WORKSPACE}/cov.xml'
+            // Note that jenkins/run-pytests is executed inside the container
+            // while the Cobertura plug-in is executed natively, so this poses
+            // a challenge in terms of finding the coverage report file; we
+            // finesse this by assuming that it will be in the current
+            // directory in both environments.
             step([$class: 'CoberturaPublisher',
                 autoUpdateHealth: false,
                 autoUpdateStability: false,
-                coberturaReportFile: 'cov.xml',
+                coberturaReportFile: "${COV_REPORT_LOC}",
                 failNoReports: false,
                 failUnhealthy: false,
                 failUnstable: false,
@@ -33,7 +33,7 @@ pipeline {
                 onlyStable: false,
                 sourceEncoding: 'ASCII',
                 zoomCoverageChart: false])
-            sh 'rm ${WORKSPACE}/cov.xml'
+            sh 'rm ${COV_REPORT_LOC}'
         }
     }
 }


### PR DESCRIPTION
Starting with the 30 September 2021 build ([#110](http://jenkins.perf.lab.eng.bos.redhat.com/job/pbench-ci-multi/job/main/110/)), Mr. Jenkins is no longer finding the Cobertura coverage report which the PyTest run creates.  (This corresponds to Git hash a53ddebd7b320177aa0635ce1be494ea86fbd600, which I believe is PR #2349.)  What's more, while the file seems to be created properly by the PyTest run in the container, when the `post` section of the pipeline is executed, the file is gone!

The previously-merged PR #2424 made changes which are relevant to this functionality.  (Its build, [#109](http://jenkins.perf.lab.eng.bos.redhat.com/job/pbench-ci-multi/job/main/109/), _failed_ due to non-deterministic behavior of one of the tests; otherwise, I believe it would have shown this behavior as well.)

The answer turns out to be that, while the file is created inside the container, the execution of  the `post` section is outside the container, and so the file systems are different, and the file exists but is not where we expect to find it.  Prior to PR #2424, `jenkins/run` was mapping the Jenkins temporary directory into the container as `/tmp`, which allowed the `post` section to find the file.  PR #2424 simplified the invocation of the container, and this detail was lost.

This PR changes the location of the coverage report to place it back into a mapped file system, and it puts it in a location which is easily accessible both inside and outside the container...and now things work again.  (And, it replaces the slightly confusing comment in the `Pipeline.gy` file with a new slightly less confusing comment.)