### PR TITLE
Tweaks for Jenkins

### DIFF
--- a/agent/tool-scripts/postprocess/unittests
+++ b/agent/tool-scripts/postprocess/unittests
@@ -2,7 +2,7 @@
 export LANG=C.UTF-8
 export LC_ALL=C.UTF-8
 export PERL_HASH_SEED=0
-let MAX_PERFTEST_SECONDS=300  # 5 minutes
+let MAX_PERFTEST_SECONDS=600  # 10 minutes
 
 export _tdir=$(dirname $(readlink -f $0))
 cd $_tdir

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -11,7 +11,7 @@ pipeline {
         stage('Linting & Unit Tests') {
             steps {
                 echo 'Linting, pytest-based unit tests, and legacy unit tests'
-                sh 'jenkins/run "source jenkins/python-setup.sh; jenkins/run-pytests; jenkins/run-unittests"'
+                sh 'jenkins/run "source jenkins/python-setup.sh && jenkins/run-pytests && jenkins/run-unittests"'
             }
         }
     }


### PR DESCRIPTION
- Correct the Jenkins pipeline to avoid losing failure statuses (fixes #2498).
- Raise the time limit on Agent postprocessing performance tests to accommodate occasional resource crunches on the executors (fixes #2500).
