### PR TITLE
Cleanup in JSON parameter handling

### DIFF
--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -154,6 +154,21 @@ class Commons:
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == "Invalid request payload"
 
+    def test_malformed_payload(self, client, server_config, pbench_token):
+        """
+        Test behavior when payload is not valid JSON
+        """
+        response = client.post(
+            server_config.rest_uri + self.pbench_endpoint,
+            headers={
+                "Authorization": "Bearer " + pbench_token,
+                "Content-Type": "application/json",
+            },
+            data='{"x":0]',
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json.get("message") == "Invalid request payload"
+
     def test_missing_keys(self, client, server_config, user_ok, pbench_token):
         """
         Test behavior when JSON payload does not contain all required keys.


### PR DESCRIPTION
While attempting to debug a Postman problem with @riya-17 I experimentally removed the "silent=True" option in our JSON payload processing hoping for some insight into the problem, which was that the request from Postman was resulting in no JSON payload. (With `silent=True`, on any parsing problem `get_json` simply returns `None`.) This change exposed a problem in `GET` handling, in that we were still attempting to process a JSON payload when there is none and we won't use it anyway.

I moved payload processing *after* the `GET` shortcut; and I added a `try`/`except` to catch and report any errors here, and to abort with BAD_REQUEST. I also added a new unit test with deliberately malformed JSON.

None of this unfortunately helped to make progress on the original problem, but it seems like a useful cleanup.

@webbnh @npalaska @portante 