### PR TITLE
Add variable for the pbench repo name

### DIFF
--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
- 
+pbench_repo_name: pbench
+
 repos:
-  - tag: pbench
+  - tag: "{{ pbench_repo_name }}"
     user: "{{ fedoraproject_username }}"
-    baseurl: "{{ pbench_repo_url_prefix }}/pbench/{{ distrodir }}"
-    gpgkey: "{{ pbench_repo_url_prefix }}/pbench/pubkey.gpg"
+    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
+    gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1

--- a/server/ansible/roles/pbench-repo-install/defaults/main.yml
+++ b/server/ansible/roles/pbench-repo-install/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
+pbench_repo_name: pbench
 
 repos:
-  - tag: pbench
+  - tag: "{{ pbench_repo_name }}"
     user: "{{ fedoraproject_username }}"
-    baseurl: "{{ pbench_repo_url_prefix }}/pbench/{{ distrodir }}"
-    gpgkey: "{{ pbench_repo_url_prefix }}/pbench/pubkey.gpg"
+    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
+    gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1
-


### PR DESCRIPTION
Fixes #2288.

Add an ansible variable to the defaults so that the pbench repo can be
customized by the user. The variable is named `pbench_repo_name` and
its default value is `pbench`. Together with the existing variable
`fedoraproject_username` and its default value, the two specify the
standard pbench repo.  But just as `fedoraproject_username` can be
changed in the inventory file to point to a user-specific CORP repo,
the `pbench_repo_name` can now be changed to point to a different repo
under that user, e.g. `pbench-test` which is commonly used for test
builds.