### PR TITLE
pbench-register-tool-set: check for bad remotes file

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.08.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.08.txt
@@ -1,5 +1,5 @@
 +++ Running test-11.08 pbench-register-tool-set --remotes=one.example.com,two.example.com --labels=labelOne
-[error][1900-01-01T00:00:00.000000] The number of labels given, " --labels=labelOne", does not match the number of remotes given, " --remotes=one.example.com,two.example.com"
+[error][1900-01-01T00:00:00.000000] The number of labels given, "labelOne", does not match the number of remotes given, "one.example.com,two.example.com"
 usage:
 pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]]
 pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>]
@@ -27,5 +27,5 @@ Available tool sets from /var/tmp/pbench-test-utils/opt/pbench-agent/config/pben
 /var/tmp/pbench-test-utils/pbench/tmp
 --- pbench tree state
 +++ pbench.log file contents
-[error][1900-01-01T00:00:00.000000] The number of labels given, " --labels=labelOne", does not match the number of remotes given, " --remotes=one.example.com,two.example.com"
+[error][1900-01-01T00:00:00.000000] The number of labels given, "labelOne", does not match the number of remotes given, "one.example.com,two.example.com"
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.15.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.15.txt
@@ -1,5 +1,5 @@
-+++ Running test-11.07 pbench-register-tool-set --labels=labelG,labelB
-[error][1900-01-01T00:00:00.000000] The number of labels given, "labelG,labelB", does not match the number of remotes given, "testhost.example.com" (default)
++++ Running test-11.15 pbench-register-tool-set --remotes=@non-existent-file
+[error][1900-01-01T00:00:00.000000] --remotes=@non-existent-file specifies a file that does not exist or is not readable
 usage:
 pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]]
 pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>]
@@ -20,12 +20,12 @@ Available tool sets from /var/tmp/pbench-test-utils/opt/pbench-agent/config/pben
 	legacy
 	light
 	medium
---- Finished test-11.07 pbench-register-tool-set (status=1)
+--- Finished test-11.15 pbench-register-tool-set (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 --- pbench tree state
 +++ pbench.log file contents
-[error][1900-01-01T00:00:00.000000] The number of labels given, "labelG,labelB", does not match the number of remotes given, "testhost.example.com" (default)
+[error][1900-01-01T00:00:00.000000] --remotes=@non-existent-file specifies a file that does not exist or is not readable
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.16.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.16.txt
@@ -1,0 +1,49 @@
++++ Running test-11.16 pbench-register-tool-set --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/good-remote-file
+"vmstat" tool is now registered for host "foo" in group "default"
+"vmstat" tool is now registered for host "bar" in group "default"
+"iostat" tool is now registered for host "foo" in group "default"
+"iostat" tool is now registered for host "bar" in group "default"
+"sar" tool is now registered for host "foo" in group "default"
+"sar" tool is now registered for host "bar" in group "default"
+--- Finished test-11.16 pbench-register-tool-set (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tmp/good-remote-file
+/var/tmp/pbench-test-utils/pbench/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/bar
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/iostat
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/sar
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/vmstat
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/foo
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/iostat
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/sar
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/vmstat
+=== /var/tmp/pbench-test-utils/pbench/tmp/good-remote-file:
+foo
+bar
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/iostat:
+--interval=3
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/sar:
+--interval=3
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/bar/vmstat:
+--interval=3
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/iostat:
+--interval=3
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/sar:
+--interval=3
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/foo/vmstat:
+--interval=3
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "foo" in group "default"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "bar" in group "default"
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "iostat" tool is now registered for host "foo" in group "default"
+[info][1900-01-01T00:00:00.000000] "iostat" tool is now registered for host "bar" in group "default"
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "sar" tool is now registered for host "foo" in group "default"
+[info][1900-01-01T00:00:00.000000] "sar" tool is now registered for host "bar" in group "default"
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-44.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-44.txt
@@ -1,5 +1,5 @@
 +++ Running test-44 pbench-register-tool --name=mpstat --no-install --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/doesntexist.lis
-[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/doesntexist.lis specifies a file that does not exist
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/doesntexist.lis specifies a file that does not exist or is not readable
 usage:
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here]
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=@<remotes-file>] -- [all tool specific options here]
@@ -72,5 +72,5 @@ For a list of tool specific options, run:
 /var/tmp/pbench-test-utils/pbench/tmp
 --- pbench tree state
 +++ pbench.log file contents
-[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/doesntexist.lis specifies a file that does not exist
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/doesntexist.lis specifies a file that does not exist or is not readable
 --- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool/test-46.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-46.txt
@@ -1,5 +1,5 @@
 +++ Running test-46 pbench-register-tool --name=mpstat --no-install --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis
-[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]" at line #4
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis specifies a file with an invalid format, expected "<hostname>[,<label>]" at line #5
 usage:
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here]
 pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=@<remotes-file>] -- [all tool specific options here]
@@ -79,5 +79,5 @@ two.example.com,labelTwo
 three.example.com,labelThree,junk
 --- pbench tree state
 +++ pbench.log file contents
-[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis contains an invalid file format, expected lines with "<hostname>[,<label>]" at line #4
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/remotes.lis specifies a file with an invalid format, expected "<hostname>[,<label>]" at line #5
 --- pbench.log file contents

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -88,13 +88,23 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 #-
 
 # Defaults
-remotes_arg="localhost"
+name=""
+remotes_arg=""
+remotes_def="localhost"
+labels_arg=""
 group="default"
+tool_type="transient"
 options=""
 do_install=1
-_do_test_labels=0
+_do_test_args=0
 
 function usage() {
+	if [[ ${_do_test_args} -eq 1 ]]; then
+		# Since we are working on behalf of pbench-register-tool-set,
+		# skip printing the usage message here -- it will issue its own
+		# usage message on failure.
+		return 0
+	fi
 	# Usage is formatted for a 80 column width screen.
 	printf -- "usage:\n"
 	printf -- "${script_name} --name=<tool-name> [--group=<group-name>]"
@@ -126,7 +136,7 @@ function usage() {
 }
 
 # Process options and arguments
-opts=$(getopt -q -o hn:g:r:l: --longoptions "help,name:,group:,no-install,remote:,remotes:,label:,labels:,test-labels, persistent, transient" -n "getopt.sh" -- "${@}")
+opts=$(getopt -q -o hn:g:r:l: --longoptions "help,name:,group:,no-install,remote:,remotes:,label:,labels:,test-args,persistent,transient" -n "getopt.sh" -- "${@}")
 if [[ ${?} -ne 0 ]]; then
 	printf -- "\n${*}\n" >&2
 	printf -- "${script_name}: you specified an invalid option\n\n" >&2
@@ -172,9 +182,9 @@ while true; do
 		shift
 		do_install=0
 		;;
-	--test-labels)
+	--test-args)
 		shift
-		_do_test_labels=1
+		_do_test_args=1
 		;;
 	--persistent)
 		shift
@@ -183,7 +193,7 @@ while true; do
 		if [[ -z "${name}" ]]; then
 			name="internal-tool-not-found"
 		fi
-		type="persistent"
+		tool_type="persistent"
 		;;
 	--transient)
 		shift
@@ -192,7 +202,7 @@ while true; do
 		if [[ -z "${name}" ]]; then
 			name="internal-tool-not-found"
 		fi
-		type="transient"
+		tool_type="transient"
 		;;
 	-h|--help)
 		usage
@@ -205,14 +215,18 @@ while true; do
 	esac
 done
 
-if [[ -z ${name} ]]; then
+# Normally --name is required but, when called with --test-args, we allow an
+# exception: that allows pbench-register-tool-set to call us without having to
+# specify a (meaningless in that case) --name.
+if [[ -z "${name}" && "${_do_test_args}" != 1 ]]; then
 	error_log "Missing required parameter --name=<tool-name>"
 	usage >&2
 	exit 1
 fi
+
 if [[ ! -x "${pbench_bin}/tool-scripts/${name}" ]]; then
 	if [[ ${name} == "internal-tool-not-found" ]]; then
-		error_log "Could not find ${display_name} with type ${type} in ${pbench_bin}/tool-scripts/: has the right type been specified?"
+		error_log "Could not find ${display_name} with type ${tool_type} in ${pbench_bin}/tool-scripts/: has the right type been specified?"
 	else
 		error_log "Could not find ${name} in ${pbench_bin}/tool-scripts/: has this tool been integrated into the pbench-agent?"
 	fi
@@ -222,54 +236,52 @@ fi
 
 if [[ ${remotes_arg::1} == "@" ]]; then
 	# We are dealing with a file containing the list of remotes.
+	remotes_file=${remotes_arg:1}
 
 	if [[ -n ${labels_arg} ]]; then
 		error_log "--labels=${labels_arg} not allowed with remotes file (${remotes_arg})"
 		usage >&2
 		exit 1
 	fi
-	remotes_file=${remotes_arg#*@}
-	if [[ ! -e ${remotes_file} ]]; then
-		error_log "--remotes=@${remotes_file} specifies a file that does not exist"
+
+	if [[ ! -r ${remotes_file} ]]; then
+		error_log "--remotes=@${remotes_file} specifies a file that does not exist or is not readable"
 		usage >&2
 		exit 1
 	fi
+
 	declare -a remotes_A
 	declare -A labels_A
 	idx=0
 	lineno=0
 	while read line; do
-		if [[ ${line::1} == "#" ]]; then
+		(( lineno++ ))
+		# a comment starts with '#' (optionally preceded by spaces or tabs) and ends at the end of the line
+		if [[ ${line} == *([[:blank:]])#* ]]; then
 			# Ignore comments
-			(( lineno++ ))
 			continue
 		fi
 		IFS=',' read -ra parts <<< "${line}"
-		if [[ ${#parts[@]} == 0 ]]; then
+		# we need arithmetic evaluation of the conditionals
+		if (( ${#parts[@]} == 0 )); then
 			# Ignore empty lines
-			(( lineno++ ))
 			continue
-		elif [[ ${#parts[@]} == 1 ]]; then
-			# Assume the only part is a remote host name.
-			remotes_A[${idx}]=${parts[0]}
-			labels_A[${parts[0]}]=""
-		elif [[ ${#parts[@]} == 2 ]]; then
+		elif (( ${#parts[@]} <= 2 )); then
 			# Assume the first part is the remote host name, and
-			# the second part is the label for that host name.
+			# the second part (if present) is the label for that host name.
 			remotes_A[${idx}]=${parts[0]}
 			labels_A[${parts[0]}]=${parts[1]}
 		else
-			error_log "--remotes=@${remotes_file} contains an invalid file format, expected lines with \"<hostname>[,<label>]\" at line #${lineno}"
+			error_log "--remotes=@${remotes_file} specifies a file with an invalid format, expected \"<hostname>[,<label>]\" at line #${lineno}"
 			usage >&2
 			exit 1
 		fi
-		(( lineno++ ))
 		(( idx++ ))
 	done < ${remotes_file}
 else
 	# First create the array of remotes and their labels, "remotes_A"
 	# "labels_A", from the "remotes_arg" and "labels_arg".
-	IFS=',' read -ra remotes_A <<< "${remotes_arg}"
+	IFS=',' read -ra remotes_A <<< "${remotes_arg:-${remotes_def}}"
 	if [[ -z "${remotes_A}" ]]; then
 		error_log "INTERNAL: missing -r|--remote|--remotes=<remote-host>[,<remote-host>] argument for some unknown reason (should not happen)"
 		usage >&2
@@ -281,15 +293,13 @@ else
 		IFS=',' read -ra labels_A0 <<< "${labels_arg}"
 		if [[ -n "${labels_A0}" ]]; then
 			if [[ ${#remotes_A[@]} -ne ${#labels_A0[@]} ]]; then
-				if [[ ${_do_test_labels} -eq 0 ]]; then
-					# We emit an error message now if we
-					# are not working on behalf of
-					# pbench-register-tool-set, since it
-					# will handle its own error message on
-					# failure.
-					error_log "The number of labels given, \"${labels_arg}\", does not match the number of remotes given, \"${remotes_arg}\""
-					usage >&2
+				if [[ -z "${remotes_arg}" ]]; then
+					remotes="\"${_pbench_full_hostname}\" (default)"
+				else
+					remotes="\"${remotes_arg}\""
 				fi
+				error_log "The number of labels given, \"${labels_arg}\", does not match the number of remotes given, ${remotes}"
+				usage >&2
 				exit 1
 			fi
 			# Now create an array for labels, where the index is
@@ -314,7 +324,7 @@ if [[ ${invalids} -gt 0 ]]; then
 	exit 1
 fi
 
-if [[ ${_do_test_labels} -ne 0 ]]; then
+if [[ ${_do_test_args} -ne 0 ]]; then
 	# Used by pbench-register-tool-set to avoid duplicating logic, we
 	# have been asked to exit early successfully if all argument
 	# processing has been successful so far.
@@ -354,13 +364,13 @@ for (( i=0; ${i} < ${#remotes_A[@]}; i++ )); do
 	for local_interface in ${local_interfaces}; do
 		if [[ "${remote}" == "${local_interface}" ]]; then
 			if [[ -z "${local_hostname}" ]]; then
-				if [[ "${remotes_arg}" != "localhost" ]]; then
+				if [[ -n "${remotes_arg}" ]]; then
 					debug_log "The remote host you have provided, ${remote}, matches a local interface, so we will register this tool locally only"
 				fi
 				local_hostname="${_pbench_full_hostname}"
 				local_label="${labels_A[${remote}]}"
 			else
-				if [[ "${remotes_arg}" != "localhost" ]]; then
+				if [[ -n "${remotes_arg}" ]]; then
 					debug_log "The remote host you have provided, ${remote}, matches a local interface, and has already been registered locally"
 				fi
 			fi

--- a/agent/util-scripts/pbench-register-tool-set
+++ b/agent/util-scripts/pbench-register-tool-set
@@ -34,7 +34,7 @@ function usage() {
 	printf -- "${script_name} --toolset=<tool-set> [--group=<group-name>]"
 	printf -- " [--interval=<interval>] [--no-install]"
 	printf -- " [--remotes=@<remotes-file>]\n\n"
-        #             1         2         3         4         5         6         7         8
+	#             1         2         3         4         5         6         7         8
 	# (tab)    1 901234567890123456789012345678901234567890123456789012345678901234567890
 	printf -- "\tWhere the list of labels must match the list of remotes.\n\n"
 	printf -- "\tOne can specify as the argument to the \"--remotes\" option a single\n"
@@ -129,16 +129,10 @@ if [[ -z ${the_tool_set} ]]; then
 	exit 1
 fi
 
-if [[ -n "${labels_arg}" ]]; then
-	pbench-register-tool --name=perf --test-labels ${remotes_arg}${labels_arg}
-	if [[ ${?} -ne 0 ]]; then
-		if [[ -z "${remotes_arg}" ]]; then
-			remotes_arg="(default) --remotes=${_pbench_full_hostname}"
-		fi
-		error_log "The number of labels given, \"${labels_arg}\", does not match the number of remotes given, \"${remotes_arg}\""
-		usage >&2
-		exit 1
-	fi
+pbench-register-tool --test-args ${remotes_arg}${labels_arg}
+if [[ ${?} -ne 0 ]]; then
+	usage >&2
+	exit 1
 fi
 
 typeset -i nerrs=0

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -369,6 +369,8 @@ declare -A tools=(
     [test-11.12]="pbench-register-tool-set"
     [test-11.13]="pbench-register-tool-set"
     [test-11.14]="pbench-register-tool-set"
+    [test-11.15]="pbench-register-tool-set"
+    [test-11.16]="pbench-register-tool-set"
     [test-17]="test-tm-start-bad-group"
     [test-18]="test-tm-stop-bad-group"
     [test-19]="test-tool-trigger"
@@ -450,6 +452,9 @@ declare -A options=(
     # verify --group option works along side --no-install
     [test-11.12]="--group=other --no-install"
     [test-11.13]="--help"
+    [test-11.15]="--remotes=@non-existent-file"
+    [test-11.16]="--remotes=@${_testdir}/tmp/good-remote-file"
+
     # pbench-move-results
     [test-20]="--help"
     # pbench-move-results - no args, nothing to do
@@ -506,6 +511,7 @@ declare -A expected_status=(
     [test-11.07]=1
     [test-11.08]=1
     [test-11.11]=1
+    [test-11.15]=1
     [test-17]=1
     [test-18]=1
     [test-22]=1
@@ -524,6 +530,7 @@ declare -A pre_hooks=(
     [test-05]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client'
     [test-06]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client; mkdir -p ${_testdir}/42-iter/sample42/tools-default/testhost.example.com/iostat; touch ${_testdir}/42-iter/sample42/tools-default/testhost.example.com/iostat/iostat-stdout.txt'
     [test-07]='mkdir -p ${_testdir}/42-iter/sample42/tools-foobar/testhost.example.com/iostat; touch ${_testdir}/42-iter/sample42/tools-foobar/testhost.example.com/iostat/iostat-stdout.txt'
+    [test-11.16]='mkdir -p ${_testdir}/tmp; (echo foo; echo bar) > ${_testdir}/tmp/good-remote-file'
     [test-19]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client'
     [test-33]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; touch --date="2019-01-01 12:00:44" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44; echo "--- setup pbench results dir time stamps") >> ${_testout}'
     [test-34]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; touch --date="2019-01-01 12:00:44" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44; echo "--- setup pbench results dir time stamps") >> ${_testout}'


### PR DESCRIPTION
Fixes #2463.
    
Passing a non-existent remotes files with `--remotes=@somefile` causes  multiple usage messages from `pbench-register-tool`: one per tool in the set. The problem is that `pbench-register-tool-set` does not check  the remote file at all: it just blindly passes it to  `pbench-register-tool` which does detect the error, but since it is called multiple times, it detects and reports the error multiple times. `pbench-register-tool-set` needs to check the file itself and quit if the file is bad (non-existent or ill-formed).
    
To that end, we add a `--test-arg` option to `pbench-register-tool`  so that it can be used as a checking tool. `pbench-register-tool-set` calls it once with that option and if that call fails, we get the error message(s) from that failed call, `pbench-register-tool-set` produces its usage message *once* and we are done.
    
A couple of test cases are added to the unit tests to test the two cases.
    
A bunch of cleanups to `pbench-register-tool` were added during review and some gold files were amended to conform to these changes.
