### PR TITLE
Ensure `fio` uses full unix timestamps

### DIFF
--- a/agent/bench-scripts/templates/fio-shared-fs.job
+++ b/agent/bench-scripts/templates/fio-shared-fs.job
@@ -23,6 +23,7 @@ log_avg_msec = 1000
 write_hist_log = fio
 log_hist_msec = 10000
 # log_hist_coarseness = 4 # 76 bins
+log_unix_epoch = 1
 
 [TheJob]
 directory = $target

--- a/agent/bench-scripts/templates/fio.job
+++ b/agent/bench-scripts/templates/fio.job
@@ -23,6 +23,7 @@ log_avg_msec = 1000
 write_hist_log = fio
 log_hist_msec = 10000
 # log_hist_coarseness = 4 # 76 bins
+log_unix_epoch = 1
 
 [job-$target]
 filename = $target

--- a/agent/bench-scripts/tests/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.txt
@@ -16,6 +16,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -60,6 +61,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -104,6 +106,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -148,6 +151,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -192,6 +196,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -236,6 +241,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio

--- a/agent/bench-scripts/tests/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-05.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -46,6 +47,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -75,6 +77,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio

--- a/agent/bench-scripts/tests/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-06.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -47,6 +48,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -77,6 +79,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio

--- a/agent/bench-scripts/tests/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-07.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/rbd0]
 filename=/dev/rbd0

--- a/agent/bench-scripts/tests/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-08.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [TheJob]
 directory=/mnt/cephfs

--- a/agent/bench-scripts/tests/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-13.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/rbd0]
 filename=/dev/rbd0
@@ -71,6 +72,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/rbd1]
 filename=/dev/rbd1

--- a/agent/bench-scripts/tests/pbench-fio/test-15.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-15.txt
@@ -16,6 +16,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -44,6 +45,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -72,6 +74,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -100,6 +103,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -128,6 +132,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -156,6 +161,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio

--- a/agent/bench-scripts/tests/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-16.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/sda0]
 filename=/dev/sda0

--- a/agent/bench-scripts/tests/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-20.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/foo]
 filename=/dev/foo
@@ -53,6 +54,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/foo]
 filename=/dev/foo
@@ -89,6 +91,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/dev/foo]
 filename=/dev/foo

--- a/agent/bench-scripts/tests/pbench-fio/test-28.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-28.txt
@@ -16,6 +16,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio

--- a/agent/bench-scripts/tests/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-30.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp]
 filename=/tmp

--- a/agent/bench-scripts/tests/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-31.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [TheJob]
 directory=/tmp

--- a/agent/bench-scripts/tests/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-32.txt
@@ -17,6 +17,7 @@ write_lat_log=fio
 log_avg_msec=1000
 write_hist_log=fio
 log_hist_msec=10000
+log_unix_epoch=1
 
 [job-/tmp/fio]
 filename=/tmp/fio
@@ -25,9 +26,9 @@ size=4096M
 numjobs=1
 
 running fio job: /var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/fio.job (sample1)
-[fio-postprocess-viz.py] Chart Type: xy (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/clients/hist.foo/hist/results.html)
-[fio-postprocess-viz.py] Chart Type: xy (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/clients/hist.bar/hist/results.html)
-[fio-postprocess-viz.py] Chart Type: xy (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/hist/results.html)
+[fio-postprocess-viz.py] Chart Type: timeseries (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/clients/hist.foo/hist/results.html)
+[fio-postprocess-viz.py] Chart Type: timeseries (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/clients/hist.bar/hist/results.html)
+[fio-postprocess-viz.py] Chart Type: timeseries (/var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1/hist/results.html)
 fio job complete
 --- Finished test-32 pbench-fio (status=0)
 +++ pbench tree state
@@ -156,7 +157,7 @@ iteration_name = 1-rw-42KiB
     <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
     <div id='jschart_latency'>
       <script>
-        create_jschart(0, "xy", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
+        create_jschart(0, "timeseries", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
             { plotfiles: [ "min.log", "median.log", "p90.0.log", "p95.0.log", "p99.0.log", "p99.5.log", "max.log" ],
               sort_datasets: false, x_log_scale: false
             });
@@ -179,7 +180,7 @@ iteration_name = 1-rw-42KiB
     <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
     <div id='jschart_latency'>
       <script>
-        create_jschart(0, "xy", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
+        create_jschart(0, "timeseries", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
             { plotfiles: [ "min.log", "median.log", "p90.0.log", "p95.0.log", "p99.0.log", "p99.5.log", "max.log" ],
               sort_datasets: false, x_log_scale: false
             });
@@ -202,7 +203,7 @@ iteration_name = 1-rw-42KiB
     <script src="/static/js/v0.3/saveSvgAsPng.js" charset="utf-8"></script>
     <div id='jschart_latency'>
       <script>
-        create_jschart(0, "xy", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
+        create_jschart(0, "timeseries", "jschart_latency", "Percentiles", "Time (msec)", "Latency (usec)",
             { plotfiles: [ "min.log", "median.log", "p90.0.log", "p95.0.log", "p99.0.log", "p99.5.log", "max.log" ],
               sort_datasets: false, x_log_scale: false
             });


### PR DESCRIPTION
Addresses issuse #913 and fixes issue #1021.

Note that the generated HTML for `tests/pbench-fio/test-32.txt` changes from using an `xy` chart to a `timeseries` chart because the existing code at [line 73](https://github.com/distributed-system-analysis/pbench/blob/main/agent/bench-scripts/postprocess/fio-postprocess-viz.py#L73) of `fio-postprocess-viz.py` uses `timeseries` when it sees `log_unix_epoch` in the `fio.job` file.

Note that our tests do not run `fio` so we only ensure the option is now showing up in `fio.job` files.
