### PR TITLE
Stop explicitly manipulating firewalls in `pbench-fio` and `pbench-uperf`

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -603,11 +603,6 @@ function fio_run_job() {
 			ssh ${ssh_opts} ${client} mkdir -p ${benchmark_results_dir} &
 		done
 		wait
-		debug_log "opening client port in firewall on the clients"
-		for client in "${client_names[@]}"; do
-			ssh ${ssh_opts} ${client} "firewall-cmd --add-port=${client_ports[${client}]}/tcp >/dev/null" &
-		done
-		wait
 		debug_log "killing any old fio process on the clients"
 		for client in "${client_names[@]}"; do
 			ssh ${ssh_opts} ${client} "killall fio >/dev/null 2>&1" &

--- a/agent/bench-scripts/pbench-fio.md
+++ b/agent/bench-scripts/pbench-fio.md
@@ -339,3 +339,28 @@ Here are the pbench-fio parameters:
 * **--numjobs=uint** - the total number of "jobs" to run.  This is typically set to the number of clients above.  Typically in the job file, you use numjobs=1.
 * **--pre-iteration-script=path** - this points to a local executable script (doesn't have to be bash) that will execute before each sample is run.  For an example of how this can be useful, see cache-dropping section above.
 * **--max-stddev=uint** - maximum percent deviation (100.0 \* standard deviation / mean) allowed for a successful test.  If you get test failures, consider either lengthening your test, changing test procedure to improve repeatability, or increasing this parameter.  Default is 5%.
+
+
+## firewalls
+
+*You must ensure that the network firewall is not up, or poke holes in the firewall
+for pbench-fio when using remote clients*.  Typically there are two possible
+firewall implementations encountered:
+
+* the **firewalld** service
+* the **iptables** service
+
+To temporarily disable (this may give security folks heartburn):
+
+    # systemctl stop firewalld
+    # systemctl stop iptables
+
+To temporarily enable port under firewalld use:
+
+    # firewall-cmd --add-port=8765/tcp
+
+Where "8765" is the default port pbench-fio will use for the fio clients.
+If you are using multiple clients, without specifying explicit ports, and using
+the `--unique-ports` switch, then starting with port 8765, pbench-fio will use
+sequential ports for each client.  Be sure you open those ports on the remote
+systems ahead of time.

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -471,9 +471,7 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 							if [ "$postprocess_only" != "y" ]; then
 								# prepare the netperf server(s)
 								for server in `echo $servers | sed -e s/,/" "/g`; do
-									ssh $ssh_opts $server killall netperf
-									ssh $ssh_opts $server "systemctl stop firewalld"
-									ssh $ssh_opts $server "screen -dmS netperf-server /usr/bin/netperf -s"
+									ssh $ssh_opts $server "killall netperf; screen -dmS netperf-server /usr/bin/netperf -s"
 								done
 								# prepare test files and dirs if using remote clients
 								if [ ! -z "$clients" ]; then
@@ -483,7 +481,6 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 										xml_file="$benchmark_run_dir/$iteration/netperf-config-$server.xml"
 										ssh $ssh_opts $client mkdir -p $benchmark_results_dir
 										scp $scp_opts $xml_file $client:$xml_file
-										ssh $ssh_opts $client "systemctl stop firewalld"
 										let i=$i+1
 									done
 									wait

--- a/agent/bench-scripts/pbench-uperf
+++ b/agent/bench-scripts/pbench-uperf
@@ -632,7 +632,6 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 										ssh $ssh_opts $client mkdir -p $benchmark_results_dir
 										scp $scp_opts $xml_file $client:$xml_file >/dev/null
 										scp $scp_opts $benchmark_client_cmd_file $client:$benchmark_client_cmd_file >/dev/null
-										ssh $ssh_opts $client "systemctl stop firewalld"
 									fi
 
 									# prepare test files and dirs on servers
@@ -641,7 +640,6 @@ for protocol in `echo $protocols | sed -e s/,/" "/g`; do
 
 									# start the uperf server(s)
 									stop_server $server $server_port 1
-									ssh $ssh_opts $server "systemctl stop firewalld"
 									ssh $ssh_opts $server "screen -dmS uperf-server $benchmark_server_cmd_file"
 
 									((server_nr++))

--- a/agent/bench-scripts/pbench-uperf.md
+++ b/agent/bench-scripts/pbench-uperf.md
@@ -79,15 +79,27 @@ they only have to allow password-less ssh access from the head node.
 
 ## firewalls
 
-*you must ensure that the network firewall or poke holes in the firewall for pbench-uperf*.  Typically there are two possible firewall implementations encountered:
+*You must ensure that the network firewall is not up, or poke holes in the firewall
+for pbench-uperf*.  Typically there are two possible firewall implementations
+encountered:
 
 * the **firewalld** service
 * the **iptables** service
 
-to temporarily disable (this may give security folks heartburn):
+To temporarily disable (this may give security folks heartburn):
 
     # systemctl stop firewalld
     # systemctl stop iptables
+
+To temporarily enable port under firewalld use:
+
+    # firewall-cmd --add-port=20000/tcp
+
+Where "20000" is the default port pbench-uperf will use for the uperf server.
+If you are using multiple servers, then starting with port 20000, pbench-uperf
+will use ports in increments of 10.  E.g. for 3 client / server pairs, ports
+ports 20000, 20010, and 20020 will be used.  Be sure you open those ports on
+the remote systems ahead of time.
 
 ## syntax
 

--- a/agent/bench-scripts/tests/pbench-fio/test-05.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-05.txt
@@ -144,7 +144,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -155,7 +154,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -166,7 +164,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -207,9 +204,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/1-rw-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/2-rw-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/3-rw-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
@@ -220,9 +214,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/1-rw-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/2-rw-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-05_1900.01.01T00.00.00/3-rw-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-06.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-06.txt
@@ -150,7 +150,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="foo,bar,baz")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -162,7 +161,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -174,7 +172,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -216,9 +213,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/1-rw-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/2-rw-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/3-rw-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no bar killall fio >/dev/null 2>&1
@@ -229,9 +223,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/1-rw-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/2-rw-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/3-rw-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no baz killall fio >/dev/null 2>&1
@@ -242,9 +233,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/1-rw-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/2-rw-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-06_1900.01.01T00.00.00/3-rw-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no foo killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-07.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-07.txt
@@ -136,7 +136,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd1 exists on client 192.168.121.112
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd1 exists on client 192.168.121.158
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -148,7 +147,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -160,7 +158,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -172,7 +169,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -184,7 +180,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -238,11 +233,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
@@ -261,11 +251,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
@@ -284,11 +269,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-07_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-08.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-08.txt
@@ -124,7 +124,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/mnt/cephfs", clients="192.168.121.64,192.168.121.112,192.168.121.158")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -136,7 +135,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -148,7 +146,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -160,7 +157,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -172,7 +168,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -226,11 +221,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
@@ -247,11 +237,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
@@ -268,11 +253,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-08_1900.01.01T00.00.00/1-read-4KiB/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-13.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-13.txt
@@ -233,7 +233,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd1 exists on client 192.168.121.112
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/rbd1 exists on client 192.168.121.158
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -245,7 +244,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -257,7 +255,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -269,7 +266,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -281,7 +277,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -293,7 +288,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -305,7 +299,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -317,7 +310,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -329,7 +321,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -341,7 +332,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -431,16 +421,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.112 killall fio >/dev/null 2>&1
@@ -474,16 +454,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.158 killall fio >/dev/null 2>&1
@@ -517,16 +487,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample3 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample4 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-13_1900.01.01T00.00.00/2-read-4KiB-rbd1/sample5 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 if [ -L /dev/rbd0 ]; then dev=/dev/; fi; test -b /dev/rbd0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 if [ -L /dev/rbd1 ]; then dev=/dev/; fi; test -b /dev/rbd1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.121.64 killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-16.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-16.txt
@@ -68,7 +68,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/sda0 exists on client 192.168.1.1
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/sda1 exists on client 192.168.1.1
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -92,7 +91,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n fio
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-16_1900.01.01T00.00.00/1-rw-42KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 if [ -L /dev/sda0 ]; then dev=/dev/; fi; test -b /dev/sda0
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 if [ -L /dev/sda1 ]; then dev=/dev/; fi; test -b /dev/sda1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 192.168.1.1 killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-20.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-20.txt
@@ -174,7 +174,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/bar exists on client def
 [debug][1900-01-01T00:00:00.000000] checking to see if /dev/bar exists on client ghi
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -186,7 +185,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -198,7 +196,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] post-processing tool data
 [debug][1900-01-01T00:00:00.000000] post-processing fio result
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -240,9 +237,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/2-read-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/3-read-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc if [ -L /dev/bar ]; then dev=/dev/; fi; test -b /dev/bar
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc if [ -L /dev/foo ]; then dev=/dev/; fi; test -b /dev/foo
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no abc killall fio >/dev/null 2>&1
@@ -255,9 +249,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/2-read-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/3-read-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def if [ -L /dev/bar ]; then dev=/dev/; fi; test -b /dev/bar
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def if [ -L /dev/foo ]; then dev=/dev/; fi; test -b /dev/foo
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no def killall fio >/dev/null 2>&1
@@ -270,9 +261,6 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/2-read-64KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-20_1900.01.01T00.00.00/3-read-1024KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi firewall-cmd --add-port=8765/tcp >/dev/null
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi if [ -L /dev/bar ]; then dev=/dev/; fi; test -b /dev/bar
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi if [ -L /dev/foo ]; then dev=/dev/; fi; test -b /dev/foo
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no ghi killall fio >/dev/null 2>&1

--- a/agent/bench-scripts/tests/pbench-fio/test-30.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-30.txt
@@ -62,7 +62,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -87,12 +86,10 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n fio
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-30_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-30_1900.01.01T00.00.00/1-read-4KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-30_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-30_1900.01.01T00.00.00/1-read-4KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done nodeA 8765

--- a/agent/bench-scripts/tests/pbench-fio/test-31.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-31.txt
@@ -62,7 +62,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp", clients="nodeA,nodeB")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -87,12 +86,10 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n fio
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-31_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeA mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-31_1900.01.01T00.00.00/1-read-4KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-31_1900.01.01T00.00.00/1-read-4KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,8765 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB firewall-cmd --add-port=8765/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no nodeB mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-31_1900.01.01T00.00.00/1-read-4KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done nodeA 8765

--- a/agent/bench-scripts/tests/pbench-fio/test-32.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-32.txt
@@ -97,7 +97,6 @@ fio job complete
 [debug][1900-01-01T00:00:00.000000] verifying clients have fio installed
 [debug][1900-01-01T00:00:00.000000] fio_device_check(devs="/tmp/fio", clients="hist.foo,hist.bar")
 [debug][1900-01-01T00:00:00.000000] creating directories on the clients
-[debug][1900-01-01T00:00:00.000000] opening client port in firewall on the clients
 [debug][1900-01-01T00:00:00.000000] killing any old fio process on the clients
 [debug][1900-01-01T00:00:00.000000] starting new fio process on the clients
 [debug][1900-01-01T00:00:00.000000] waiting for fio process(server) to start on clients
@@ -122,12 +121,10 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n fio
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.bar /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.bar cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,42 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.bar firewall-cmd --add-port=42/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.bar killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.bar mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.foo /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/pbench-fio --install
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.foo cd /var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1 && screen -dmS fio-server bash -c '/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/bm --server=,42 2>&1 >client-result.txt'
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.foo firewall-cmd --add-port=42/tcp >/dev/null
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.foo killall fio >/dev/null 2>&1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no hist.foo mkdir -p /var/tmp/pbench-test-bench/pbench-agent/fio_test-32_1900.01.01T00.00.00/1-rw-42KiB/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/timeout --kill-after=1 60 bash -c until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done hist.bar 42

--- a/agent/bench-scripts/tests/pbench-uperf/test-00.txt
+++ b/agent/bench-scripts/tests/pbench-uperf/test-00.txt
@@ -133,10 +133,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no 127.0.0.1 systemctl stop firewalld
 --- test-execution.log file contents
 +++ uperf_test-00_1900.01.01T00.00.00/metadata.log file contents
 [pbench]

--- a/agent/bench-scripts/tests/pbench-uperf/test-01.txt
+++ b/agent/bench-scripts/tests/pbench-uperf/test-01.txt
@@ -214,10 +214,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/client::c1-server::s1:20010--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c1-server::s1:20010--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c1-server::s1:20010--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1
@@ -227,10 +223,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/client::c2-server::s2:20020--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c2-server::s2:20020--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c2-server::s2:20020--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1
@@ -240,10 +232,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/client::c3-server::s3:20030--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c3-server::s3:20030--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/client::c3-server::s3:20030--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1
@@ -261,10 +249,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1
@@ -282,10 +266,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/1-tcp_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-01_1900.01.01T00.00.00/2-tcp_stream-64B-1i/sample1
@@ -303,10 +283,6 @@ Iteration 2-tcp_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
 --- test-execution.log file contents
 +++ uperf_test-01_1900.01.01T00.00.00/metadata.log file contents
 [pbench]

--- a/agent/bench-scripts/tests/pbench-uperf/test-52.txt
+++ b/agent/bench-scripts/tests/pbench-uperf/test-52.txt
@@ -214,10 +214,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/client::c1-server::s1:20010--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c1-server::s1:20010--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c1-server::s1:20010--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c1 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/sample1
@@ -227,10 +223,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/client::c2-server::s2:20020--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c2-server::s2:20020--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c2-server::s2:20020--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c2 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/sample1
@@ -240,10 +232,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/client::c3-server::s3:20030--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c3-server::s3:20030--client_start.sh
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 screen -dmS uperf-client /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/client::c3-server::s3:20030--client_start.sh
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no c3 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/sample1
@@ -261,10 +249,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s1 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/sample1
@@ -282,10 +266,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s2 systemctl stop firewalld
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample1
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/1-vsock_rr-64B-1i/sample2
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 mkdir -p /var/tmp/pbench-test-bench/pbench-agent/uperf_test-52_1900.01.01T00.00.00/2-vsock_stream-64B-1i/sample1
@@ -303,10 +283,6 @@ Iteration 2-vsock_stream-64B-1i complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
 /var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 ss -tlnp --vsock
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
-/var/tmp/pbench-test-bench/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no s3 systemctl stop firewalld
 --- test-execution.log file contents
 +++ uperf_test-52_1900.01.01T00.00.00/metadata.log file contents
 [pbench]


### PR DESCRIPTION
All three existing benchmark scripts which manipulate network firewalls have been changed to ignore firewalls entirely.

For `pbench-fio`, this means it no longer attempts to add open ports when clients are used.

For `pbench-uperf` and `pbench-netperf`, those scripts no longer disable `firewalld` explicitly.

Any one using `pbench-fio` in client mode, or either `pbench-uperf` or `pbench-netperf`, must be responsible for properly enabling access on the expected ports.

The documentation for `pbench-uperf` and `pbench-fio` have been updated to reflect this new behavior.

Fixed #1217.