### PR TITLE
Fix `/api/v1/endpoints` in container environment

### DIFF
--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -12,10 +12,11 @@ class TestEndpointConfig:
 
     def test_query(self, client, server_config):
         """
-        test_query Check that endpoint data matches the config file.
+        test_query Check that endpoint data matches the config file. In the
+        local Flask mocked environment, `request.host` will always be
+        "localhost".
         """
-        host = server_config.get("pbench-server", "host")
-        self.check_config(client, server_config, host)
+        self.check_config(client, server_config, "localhost")
 
     def test_proxy_query(self, client, server_config):
         host = "proxy.example.com:8901"


### PR DESCRIPTION
It may be that we need to ensure that `pbench-server.cfg` has a valid `host` value for other reasons, but `/api/v1/endpoints` is all about making sure an API client (A) knows about all the endpoints we support and (B) can call them reliably using the recommended path (e.g., through an NGINX reverse proxy).

We had advertised endpoints (in the absence of reverse proxy forwarding headers) relative to the static `pbench-server.cfg`
`host` value; this however is unnecessary as the incoming HTTP Requests object includes the actual access path, which makes a much better fallback. This PR changes the endpoints API to use that value, which has the advantage of working within a container regardless of the pod virtual networking configuration.