### PR TITLE
Ensure fio usage msg sent to stderr as necessary

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -179,143 +179,130 @@ function usage {
 }
 
 function fio_process_options() {
-	opts=$(getopt -q -o b:c:d:hj:r:s:t: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,numjobs:,job-file:,sysinfo:,pre-iteration-script:,histogram-interval-sec:,histogram-interval-msec:,unique-ports" -n "getopt.sh" -- "$@");
+	opts=$(getopt -q -o b:c:d:hj:r:s:t: --longoptions "help,max-stddev:,max-failures:,samples:,direct:,sync:,install,remote-only,clients:,client-file:,iodepth:,ioengine:,config:,jobs-per-dev:,job-mode:,rate-iops:,ramptime:,runtime:,test-types:,block-sizes:,file-size:,targets:,tool-group:,postprocess-only:,run-dir:,numjobs:,job-file:,sysinfo:,pre-iteration-script:,histogram-interval-sec:,histogram-interval-msec:,unique-ports" -n "getopt.sh" -- "$@")
 	if [ $? -ne 0 ]; then
 		printf -- "${script_name} $*\n"
 		printf -- "\n"
 		printf -- "\tunrecognized option specified\n\n"
-		usage
+		usage >&2
 		exit 1
 	fi
-	eval set -- "$opts";
+	eval set -- "$opts"
 	while true; do
-		case "$1" in
+		arg="${1}"
+		shift
+		case "${arg}" in
 		-h|--help)
 			usage
-			exit
+			exit 0
 			;;
 		--install)
-			shift;
 			if [[ "$postprocess_only" != "n" ]]; then
 				printf -- "${script_name} $*\n"
 				printf -- "\n"
 				printf -- "\t--install not compatible with specified \"--postprocess-only ${postprocess_only}\" option\n\n"
-				usage
+				usage >&2
 				exit 1
 			fi
 			install_only="y"
 			;;
 		--remote-only)
-			shift;
 			warn_log "--remote-only is deprecated, ignoring (was non-operational previously)"
 			;;
 		--max-stddev)
-			shift;
 			if [ -n "$1" ]; then
 				maxstddevpct="$1"
-				shift;
+				shift
 			fi
 			;;
 		--max-failures)
-			shift;
 			if [ -n "$1" ]; then
 				max_failures="$1"
-				shift;
+				shift
 			fi
 			;;
 		--samples)
-			shift;
 			if [ -n "$1" ]; then
 				nr_samples="$1"
-				shift;
+				shift
 			fi
 			;;
 		--direct)
-			shift;
 			if [ -n "$1" ]; then
 				direct=$1
-				shift;
+				shift
 			fi
 			;;
 		--sync)
-			shift;
 			if [ -n "$1" ]; then
 				sync=$1
-				shift;
+				shift
 			fi
 			;;
 		-t|--test-types)
-			shift;
 			if [ -n "$1" ]; then
 				test_types="$1"
-				shift;
+				shift
 			fi
 			;;
 		-b|--block-sizes)
-			shift;
 			if [ -n "$1" ]; then
 				block_sizes="$1"
-				shift;
+				shift
 			fi
 			;;
 		-s|--file-size)
-			shift;
 			if [ -n "$1" ]; then
 				file_size="$1"
-				shift;
+				shift
 			fi
 			;;
 		--ramptime)
-			shift;
 			if [ -n "$1" ]; then
 				ramptime="$1"
-				shift;
+				shift
 			fi
 			;;
 		--rate-iops)
-			shift;
 			if [ -n "$1" ]; then
 				rate_iops="$1"
-				shift;
+				shift
 			fi
 			;;
 		-r|--runtime)
-			shift;
 			if [ -n "$1" ]; then
 				runtime="$1"
-				shift;
+				shift
 			fi
 			;;
 		-c|--clients)
-			shift;
 			if [ ! -z "$client_file" ] ;then
 				printf -- "${script_name} $*\n"
 				printf -- "\n"
 				printf -- "\t-c|--clients and --client-file are mutually exclusive\n\n"
-				usage
+				usage >&2
 				exit 1
 			fi
 			if [ -n "$1" ]; then
 				clients="$1"
-				shift;
+				shift
 			fi
 			;;
 		--client-file)
-			shift;
 			if [ ! -z "$clients" ] ;then
 				printf -- "${script_name} $*\n"
 				printf -- "\n"
 				printf -- "\t--client-file and -c|--clients are mutually exclusive\n\n"
-				usage
+				usage >&2
 				exit 1
 			fi
 			client_file=$1
-			shift;
+			shift
 			if [ ! -e "${client_file}" ]; then
 				printf -- "${script_name} $*\n"
 				printf -- "\n"
 				printf -- "\tSpecified client file, ${client_file}, does not exist\n\n"
-				usage
+				usage >&2
 				exit 1
 			fi
 			if [[ "$client_file" != /* ]] ;then
@@ -329,125 +316,108 @@ function fio_process_options() {
 			clients=`echo $clients | sed -e 's/^,//'`
 			;;
 		-d|--targets)
-			shift;
 			if [ -n "$1" ]; then
 				targets="$1"
-				shift;
+				shift
 			fi
 			;;
 		-j|--job-mode)
-			shift;
 			if [ -n "$1" ]; then
 				job_mode="$1"
-				shift;
+				shift
 			fi
 			;;
 		--config)
-			shift;
 			if [ -n "$1" ]; then
 				config="$1"
-				shift;
+				shift
 			fi
 			;;
 		--ioengine)
-			shift;
 			if [ -n "$1" ]; then
 				ioengine="$1"
-				shift;
+				shift
 			fi
 			;;
 		--iodepth)
-			shift;
 			if [ -n "$1" ]; then
 				iodepth="$1"
-				shift;
+				shift
 			fi
 			;;
 		--tool-group)
-			shift;
 			if [ -n "$1" ]; then
 				tool_group="$1"
-				shift;
+				shift
 			fi
 			;;
 		--postprocess-only)
-			shift;
 			if [ -n "$1" ]; then
 				postprocess_only="$1"
-				shift;
+				shift
 				if [[ "$postprocess_only" != "n" && "$install_only" == "y" ]]; then
 					printf -- "${script_name} $*\n"
 					printf -- "\n"
 					printf -- "\t\"--postprocess-only ${postprocess_only}\" not compatible with specified --install option\n\n"
-					usage
+					usage >&2
 					exit 1
 				fi
 			fi
 			;;
 		--run-dir)
-			shift;
 			if [ -n "$1" ]; then
 				run_dir="$1"
-				shift;
+				shift
 			fi
 			;;
 		--numjobs)
-			shift;
 			if [ -n "$1" ]; then
 				numjobs="$1"
-				shift;
+				shift
 			fi
 			;;
 		--job-file)
-			shift;
 			if [ -n "$1" ]; then
 				job_file="$1"
-				shift;
+				shift
 
 			fi
 			;;
 		--pre-iteration-script)
-			shift;
 			if [ -n "$1" ]; then
 				pre_iteration_script="$1"
 				if [ ! -x $pre_iteration_script ]; then
 					printf "ERROR: $pre_iteration_script must be executable\n"
 					exit 1
 				fi
-				shift;
+				shift
 			fi
 			;;
 		--histogram-interval-sec)
-			shift;
 			histogram_interval_sec="$1"
 			shift
 			;;
 			# histogram-interval-msec is only kept for backwards compatibility
 			# it is deprecated and is not documented in the --help output
 		--histogram-interval-msec)
-			shift;
 			(( histogram_interval_sec = $1 / 1000 ))
 			shift
 			;;
 		--sysinfo)
-			shift;
 			if [ -n "$1" ]; then
 				sysinfo="$1"
-				shift;
+				shift
 			fi
 			;;
 		--unique-ports)
-			shift;
 			unique_ports=1
 			;;
 		--)
-			shift;
-			break;
+			break
 			;;
 		*)
-			echo "what's this? [$1]"
-			shift;
-			break;
+			usage >&2
+			exit 1
 			;;
 		esac
 	done
@@ -461,7 +431,7 @@ function fio_process_options() {
 
 	if [[ ${job_mode} != "serial" && ${job_mode} != "concurrent" ]]; then
 		error_log "Unsupported --job-mode=${job_mode} encountered"
-		usage
+		usage >&2
 		exit 1
 	fi
 
@@ -472,12 +442,12 @@ function fio_process_options() {
 		for vtt in ${space_sep_vtt}; do
 			if [[ "${tt}" == "${vtt}" ]]; then
 				found=1
-				break;
+				break
 			fi
 		done
 		if [[ ${found} -ne 1 ]]; then
 			error_log "Unsupported --test-types=${test_types} encountered"
-			usage
+			usage >&2
 			exit 1
 		fi
 	done


### PR DESCRIPTION
Originally part of PR #2524, we correct the usage output to be emitted on `stderr` in error conditions, and to `stdout` for the one non-error condition, `--help`.

Further we remove the annoying trailing semi-colons, and remove the extra `shift` statement while processing options.

Lastly, unrecognized parameters now cause an error.