### PR TITLE
Increase Prom retention in visualizers

### DIFF
--- a/agent/containers/images/visualizers/run.py
+++ b/agent/containers/images/visualizers/run.py
@@ -64,6 +64,7 @@ elif metric_type == "prom":
         "./prometheus",
         "--config.file=/data/prometheus.yml",
         "--storage.tsdb.path=/data",
+        "--storage.tsdb.retention.time=1y",
     ]
     collector = subprocess.Popen(cmd)
 


### PR DESCRIPTION
Increase Prom retention to 1yr. 

This is especially useful for the "post" PromGrafVisualizer option where you may be looking at older data. Without an increase in retention, when running the visualizer image Prom can delete any original data (provided by the volume mount) older than the default 15d.