### PR TITLE
Implement DELETE and re-implement PUT to no longer require `pbench-server-prep-shim-002`

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -24,8 +24,9 @@ class CliContext:
 pass_cli_context = click.make_pass_decorator(CliContext, ensure=True)
 
 
-def config_setup(context: object) -> None:
+def config_setup(context: object) -> PbenchServerConfig:
     config = PbenchServerConfig(context.config)
     # We're going to need the Postgres DB to track dataset state, so setup
     # DB access.
     init_db(config, None)
+    return config

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -1,0 +1,119 @@
+"""pbench-show-tree"""
+
+from pathlib import Path
+from typing import List
+
+import click
+
+from pbench.cli.server import config_setup, pass_cli_context
+from pbench.cli.server.options import common_options
+from pbench.common.logger import get_pbench_logger
+from pbench.server import BadConfig
+from pbench.server.api.resources.upload_api import Upload
+from pbench.server.database.models.datasets import Dataset
+from pbench.server.database.models.users import User
+from pbench.server.filetree import FileTree
+
+
+def print_tree(tree: FileTree):
+    print(f"Tree anchored at {tree.archive_root}\n")
+
+    if len(tree.datasets) == 0 and len(tree.controllers) == 0:
+        print("Pbench file tree is empty")
+        return
+
+    print("Tarballs:")
+    for tarball in tree.datasets.values():
+        print(f"  {tarball.name}")
+
+    print("\nControllers:")
+    for controller in tree.controllers.values():
+        print(f"  Controller {controller.name}:")
+        for tarball in controller.tarballs.values():
+            print(f"    Tarball {tarball.name}")
+            if tarball.unpacked:
+                print(f"      Unpacked in {tarball.unpacked}")
+                states: List[str] = []
+                for name, path in controller.state_dirs.items():
+                    for link in path.iterdir():
+                        if tarball.name in link.name:
+                            states.append(name)
+                if states:
+                    states.sort()
+                    print(f"        States: {', '.join(states)}")
+
+
+@click.command()
+@pass_cli_context
+@click.option("--controller", help="Controller name for a created dataset")
+@click.option(
+    "--create",
+    type=click.Path(
+        exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True
+    ),
+    prompt="Tarball path",
+    prompt_required=False,
+    help="Create a dataset from a tarball and MD5 file",
+)
+@click.option(
+    "--display", default=False, is_flag=True, help="Display the full tree on completion"
+)
+@click.option(
+    "--full/--no-full", default=False, help="Discover the full tree on startup"
+)
+@click.option("--user", help="Username to own a created dataset")
+@common_options
+def tree_manage(
+    context: object, controller: str, create: str, display: bool, full: bool, user: str
+):
+    """
+    Discover, display, and manipulate the on-disk representation of controllers
+    and datasets.
+
+    This primarily exposes the FileTree object hierarchy, and provides a simple
+    hierarchical display of controllers and datasets.
+
+    This command can also be used to create a dataset, using the Dataset and
+    FileTree classes to maintain equivalence with the PUT operation (skipping
+    the network upload when the tarball and MD5 file are available locally). We
+    don't implement `--delete` however, as that would require also integrating
+    with the Elasticsearch bulk delete: this has to be done through the API.
+
+    Args:
+        context: Click context (contains shared `--config` value)
+        controller: Controller name (required for `--create`)
+        create: Create a new on-disk dataset from a tarball path
+        display: Print a simplified representation of the hierarchy
+        full: Discover the full Pbench on-disk hierarchy
+        user: Username to own a new dataset
+    """
+    try:
+        config = config_setup(context)
+        logger = get_pbench_logger("filetree", config)
+
+        file_tree = FileTree(config, logger)
+        if full:
+            file_tree.full_discovery()
+
+        if create:
+            if not controller:
+                click.echo("Create requires a controller name", err=True)
+                exit(1)
+            if not user:
+                click.echo("Create requires a username", err=True)
+                exit(1)
+            owner = User.query(username=user)
+            dataset = Dataset.create(controller=controller, owner=owner, path=create)
+            tarball = file_tree.create(controller, Path(create))
+            Upload.finalize_dataset(dataset, tarball, config, logger)
+
+        if display:
+            print_tree(file_tree)
+
+        rv = 0
+    except Exception as exc:
+        logger.exception("Something went awry! {}", exc)
+        click.echo(exc, err=True)
+        rv = 2 if isinstance(exc, BadConfig) else 1
+
+    click.get_current_context().exit(rv)

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -50,12 +50,6 @@ def tree_manage(context: object, display: bool):
 
     This primarily exposes the FileTree object hierarchy, and provides a simple
     hierarchical display of controllers and datasets.
-
-    This command can also be used to create a dataset, using the Dataset and
-    FileTree classes to maintain equivalence with the PUT operation (skipping
-    the network upload when the tarball and MD5 file are available locally). We
-    don't implement `--delete` however, as that would require also integrating
-    with the Elasticsearch bulk delete: this has to be done through the API.
     \f
 
     Args:
@@ -67,13 +61,12 @@ def tree_manage(context: object, display: bool):
         logger = get_pbench_logger("filetree", config)
         file_tree = FileTree(config, logger)
         file_tree.full_discovery()
+        if display:
+            print_tree(file_tree)
         rv = 0
     except Exception as exc:
         logger.exception("An error occurred discovering the file tree: {}", exc)
         click.echo(exc, err=True)
         rv = 2 if isinstance(exc, BadConfig) else 1
-    else:
-        if display:
-            print_tree(file_tree)
 
     click.get_current_context().exit(rv)

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -26,13 +26,14 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleNamespace,
     SampleValues,
 )
+from pbench.server.api.resources.query_apis.datasets_delete import DatasetsDelete
 from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetail
 from pbench.server.api.resources.query_apis.datasets_list import DatasetsList
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
 from pbench.server.api.resources.query_apis.month_indices import MonthIndices
-from pbench.server.api.resources.upload_api import HostInfo, Upload
+from pbench.server.api.resources.upload_api import Upload
 from pbench.server.api.resources.users_api import Login, Logout, RegisterUser, UserAPI
 from pbench.server.database import init_db
 from pbench.server.database.database import Database
@@ -59,6 +60,11 @@ def register_endpoints(api, app, config):
     api.add_resource(
         MonthIndices,
         f"{base_uri}/controllers/months",
+        resource_class_args=(config, logger),
+    )
+    api.add_resource(
+        DatasetsDelete,
+        f"{base_uri}/datasets/delete",
         resource_class_args=(config, logger),
     )
     api.add_resource(
@@ -110,10 +116,6 @@ def register_endpoints(api, app, config):
 
     api.add_resource(
         GraphQL, f"{base_uri}/graphql", resource_class_args=(config, logger),
-    )
-
-    api.add_resource(
-        HostInfo, f"{base_uri}/host_info", resource_class_args=(config, logger),
     )
 
     api.add_resource(

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -91,7 +91,14 @@ class EndpointConfig(Resource):
         implementations. The entire "indices" section can be removed once that is
         resolved.
         """
-        self.logger.debug("Received these headers: {!r}", request.headers)
+        self.logger.debug(
+            "Received headers: {!r}, access_route {!r}, base_url {!r}, host {!r}, host_url {!r}",
+            request.headers,
+            request.access_route,
+            request.base_url,
+            request.host,
+            request.host_url,
+        )
         origin = None
         host_source = "request"
         host_value = request.host

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -11,7 +11,7 @@ from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
     Metadata,
-    MetadataError
+    MetadataError,
 )
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -7,7 +7,12 @@ from flask_restful import abort
 from pbench.server import PbenchServerConfig
 from pbench.server.api.resources import JSON, Schema, SchemaError
 from pbench.server.api.resources.query_apis import CONTEXT, ElasticBase
-from pbench.server.database.models.datasets import Dataset, Metadata, MetadataError
+from pbench.server.database.models.datasets import (
+    Dataset,
+    DatasetNotFound,
+    Metadata,
+    MetadataError
+)
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
 
@@ -90,8 +95,9 @@ class RunIdBase(ElasticBase):
         run_id = client_json["run_id"]
 
         # Query the dataset using the given run id
-        dataset = Dataset.query(md5=run_id)
-        if not dataset:
+        try:
+            dataset = Dataset.query(md5=run_id)
+        except DatasetNotFound:
             self.logger.debug(f"Dataset with Run ID {run_id!r} not found")
             abort(HTTPStatus.NOT_FOUND, message="Dataset not found")
 

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -1,0 +1,68 @@
+from logging import Logger
+from typing import Iterator
+
+from pbench.server import PbenchServerConfig
+from pbench.server.filetree import FileTree
+from pbench.server.api.resources import (
+    API_OPERATION,
+    JSON,
+    Schema,
+    Parameter,
+    ParamType,
+)
+from pbench.server.api.resources.query_apis import ElasticBulkBase
+from pbench.server.database.models.datasets import Dataset, Metadata
+
+
+class DatasetsDelete(ElasticBulkBase):
+    """
+    Delete the specified dataset.
+
+    This includes all Elasticsearch documents associated with the dataset, plus
+    the PostgreSQL representation, the tarball and MD5 file in the ARCHIVE file
+    system tree, the unpacked tarball from the INCOMING file system tree, and the
+    reference link in the RESULTS file system tree. If there is a BACKUP of the
+    tarball file (which there should be, if configured), this will not touch the
+    backup.
+    """
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            Schema(Parameter("name", ParamType.STRING, required=True)),
+            action="delete",
+            role=API_OPERATION.DELETE,
+        )
+
+    def generate_actions(self, json_data: JSON, dataset: Dataset) -> Iterator[dict]:
+        """
+        Generate a series of Elasticsearch bulk delete actions driven by the
+        dataset document map.
+
+        Args:
+            dataset: the Dataset object
+
+        Returns:
+            A sequence of Elasticsearch bulk actions
+        """
+        map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
+
+        self.logger.info("Starting delete operation for dataset {}", dataset)
+
+        # Generate a series of bulk delete documents, which will be passed to
+        # the Elasticsearch bulk helper.
+
+        for index, ids in map.items():
+            for id in ids:
+                yield {"_op_type": self.action, "_index": index, "_id": id}
+
+    def complete(self, dataset: Dataset, json_data: JSON, summary: JSON) -> None:
+        # Only on total success we update the Dataset's registered access
+        # column; a "partial success" will remain in the previous state.
+        if summary["failure"] == 0:
+            self.logger.info("Deleting dataset {} file system representation", dataset)
+            file_tree = FileTree(self.config, self.logger)
+            file_tree.delete(dataset.name)
+            self.logger.info("Deleting dataset {} PostgreSQL representation", dataset)
+            dataset.delete()

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -44,7 +44,7 @@ class DatasetsPublish(ElasticBulkBase):
             dataset: the Dataset object
 
         Returns:
-            A sequence of Elasticsearch bulk actions
+            A generator for Elasticsearch bulk update actions
         """
         access = json_data["access"]
         map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
@@ -68,8 +68,20 @@ class DatasetsPublish(ElasticBulkBase):
                 }
 
     def complete(self, dataset: Dataset, json_data: JSON, summary: JSON) -> None:
-        # Only on total success we update the Dataset's registered access
-        # column; a "partial success" will remain in the previous state.
+        """
+        Complete the delete operation by updating the access of the Dataset
+        object.
+
+        Note that an exception will be caught outside this class; the Dataset
+        object will remain in the previous state to allow a retry.
+
+        Args:
+            dataset: Dataset object
+            json_data: client JSON payload
+            summary: summary of the bulk operation
+                ok: count of successful updates
+                failure: count of failures
+        """
         if summary["failure"] == 0:
             dataset.access = json_data["access"]
             dataset.update()

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -25,7 +25,6 @@ class DatasetsPublish(ElasticBulkBase):
             config,
             logger,
             Schema(
-                Parameter("controller", ParamType.STRING, required=True),
                 Parameter("name", ParamType.STRING, required=True),
                 Parameter("access", ParamType.ACCESS, required=True),
             ),
@@ -69,7 +68,7 @@ class DatasetsPublish(ElasticBulkBase):
 
     def complete(self, dataset: Dataset, json_data: JSON, summary: JSON) -> None:
         """
-        Complete the delete operation by updating the access of the Dataset
+        Complete the publish operation by updating the access of the Dataset
         object.
 
         Note that an exception will be caught outside this class; the Dataset
@@ -78,6 +77,7 @@ class DatasetsPublish(ElasticBulkBase):
         Args:
             dataset: Dataset object
             json_data: client JSON payload
+                access: new dataset access setting
             summary: summary of the bulk operation
                 ok: count of successful updates
                 failure: count of failures

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -183,7 +183,7 @@ class Upload(Resource):
                     HTTPStatus.BAD_REQUEST, "Filename must not contain a path"
                 )
 
-            if not Tarball.has_suffix(filename):
+            if not Tarball.is_tarball(filename):
                 raise CleanupTime(
                     HTTPStatus.BAD_REQUEST,
                     f"File extension not supported, must be {Tarball.TARBALL_SUFFIX}",

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -1,16 +1,21 @@
+from collections import deque
 import datetime
+from enum import Enum
 import errno
 import hashlib
+from logging import Logger
 import os
-import tempfile
 from http import HTTPStatus
 from pathlib import Path
+from typing import Any, Deque
 
 import humanize
 from flask import jsonify, request
 from flask_restful import Resource, abort
 
 from pbench.common.utils import validate_hostname
+from pbench.server import PbenchServerConfig
+from pbench.server.filetree import FileTree, Tarball
 from pbench.server.api.auth import Auth
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -22,29 +27,174 @@ from pbench.server.utils import filesize_bytes
 
 
 class HostInfo(Resource):
+    """
+    Show the status of the server.
+
+    This code will read a standard file and return a stock 200 / OK status if
+    the content doesn't start with `MESSAGE==`; and, if it does, fail with
+    503 / Service Unavailable and the remaining text of the file as a
+    `"message"` response key.
+
+    TODO: This is an artifact of the old ssh-based mechanism, where a fixed
+    symlink on disk points either to a templated file with the scp target
+    directory or a status string prefixed with `MESSAGE===` intended to be
+    reported to the user as an explanation that the server is not currently
+    taking calls -- e.g. (in standard boilerplate) because it's "in
+    maintenance mode". We should get away from the fixed files, and we have no
+    need for the templated scp directory as we no longer support ssh uploads.
+    We should create a new ADMIN-only server status API to specify whether the
+    server should be active or not, with an optional message that will be
+    reported by this API. This could become part of a "server state"
+    PostgreSQL table.
+
+    NOTE: `PUT` should check the status and fail with 503 if the server is not
+    in service, rather than relying on a separate API call.
+    """
+
+    STATUS_LINK = Path(
+        "/var/www/html/pbench-results-host-info.versioned/pbench-results-host-info.URL002"
+    )
+
     def __init__(self, config, logger):
         self.logger = logger
-        self.user = config.get_conf(__name__, "pbench-server", "user", self.logger)
-        self.host = config.get_conf(__name__, "pbench-server", "host", self.logger)
-        self.prdp = config.get_conf(
-            __name__, "pbench-server", "pbench-receive-dir-prefix", self.logger
-        )
 
     def get(self):
         try:
-            response = jsonify(
-                dict(message=f"{self.user}@{self.host}" f":{self.prdp}-002")
+            status = HostInfo.STATUS_LINK.read_text()
+            self.logger.info(
+                "Read status {!r} from {}", status, str(HostInfo.STATUS_LINK)
             )
         except Exception as exc:
             self.logger.error(
                 "There was something wrong constructing the host info: '{}'", exc
             )
             abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-        response.status_code = HTTPStatus.OK
-        return response
+        if status.startswith("MESSAGE==="):
+            msg = status[len("MESSAGE===") :]
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, message=msg)
+        return HTTPStatus.OK
+
+
+class CleanupTime(Exception):
+    """
+    Used to support handling errors during PUT without constantly testing the
+    current status and additional indentation. This will be raised to an outer
+    try block when an error occurs.
+    """
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+
+
+class Step(Enum):
+    """
+    Define the persistent changes caused during the PUT upload, which need to
+    be undone if the upload ultimately fails.
+    """
+
+    DATASET = 1  # Dataset was created
+    UPLOAD = 2  # Uploaded tar file was created
+    MD5 = 3  # MD5 file was created
+
+
+class CleanupAction:
+    """
+    Define a single cleanup action necessary to reverse persistent steps in the
+    upload procedure, based on the Step ENUM associated with the action.
+    """
+
+    def __init__(self, step: Step, logger: Logger, parameter: Any):
+        """
+        Define a cleanup action
+
+        Args:
+            step: The persistent step taken
+            logger: The active Pbench Logger object
+            parameter: The object (type varies depending on step) on which the
+                cleanup action is performed.
+        """
+        self.step = step
+        self.parameter = parameter
+        self.logger = logger
+
+    def cleanup(self):
+        """
+        Perform a cleanup action depending on the associated Step value.
+
+        This handles errors and reports them, but doesn't propagate failure to
+        ensure that cleanup continues as best we can.
+        """
+        if self.step is Step.DATASET:
+            try:
+                self.parameter.delete()
+            except Exception as e:
+                self.logger.error("Unable to remove dataset {}: {}", self.parameter, e)
+        elif self.step is Step.MD5:
+            try:
+                self.parameter.unlink()
+            except FileNotFoundError:
+                pass  # Note: Python 3.8 avoids this with `missing_ok=True`
+            except Exception as e:
+                self.logger.error(
+                    "Unable to remove temporary MD5 file {}: {}", self.parameter, e
+                )
+        elif self.step is Step.UPLOAD:
+            try:
+                self.parameter.unlink()
+            except FileNotFoundError:
+                pass  # Note: Python 3.8 avoids this with `missing_ok=True`
+            except Exception as e:
+                self.logger.error(
+                    "Unable to remove temporary TAR file {}: {}", self.parameter, e
+                )
+
+
+class Cleanup:
+    """
+    Maintain and process a deque of cleanup actions accumulated during the
+    upload procedure. Cleanup actions will be processed in reverse of the
+    order they were registered.
+    """
+
+    def __init__(self, logger: Logger):
+        """
+        Define a deque on which cleanup actions will be recorded, and attach
+        a Pbench Logger object to report errors.
+
+        Args:
+            logger: Pbench Logger
+        """
+        self.logger = logger
+        self.actions: Deque[CleanupAction] = deque()
+
+    def add(self, step: Step, parameter: Any) -> None:
+        """
+        Add a new cleanup action to the front of the deque
+
+        Args:
+            step: Step ENUM value describing the cleanup action
+            parameter: A parameter for the cleanup action
+        """
+        self.actions.appendleft(CleanupAction(step, self.logger, parameter))
+
+    def cleanup(self):
+        """
+        Perform queued cleanup actions in order from most recent to oldest.
+        """
+        for action in self.actions:
+            action.cleanup()
 
 
 class Upload(Resource):
+    """
+    Upload a dataset from an agent. This API accepts a tarball, controller
+    name, and MD5 value from a client. After validation, it creates a new
+    Dataset DB row describing the dataset, along with some metadata, and it
+    creates a pair of files (tarball and MD5 file) within the designated
+    controller directory under the configured ARCHIVE file tree.
+    """
+
     ALLOWED_EXTENSION = ".tar.xz"
     CHUNK_SIZE = 65536
 
@@ -56,276 +206,277 @@ class Upload(Resource):
                 __name__, "pbench-server", "rest_max_content_length", self.logger
             )
         )
+        self.temporary = config.ARCHIVE / FileTree.TEMPORARY
+        self.temporary.mkdir(mode=0o755, parents=True, exist_ok=True)
+        self.logger.info("Configured PUT temporary directory as {}", self.temporary)
 
     @Auth.token_auth.login_required()
     def put(self, filename: str):
+
+        # Used to record what steps have been completed during the upload, and
+        # need to be undone on failure
+        recovery = Cleanup(self.logger)
+
         try:
-            username = Auth.token_auth.current_user().username
-        except Exception as exc:
-            self.logger.error("Error verifying the username: '{}'", exc)
+            try:
+                username = Auth.token_auth.current_user().username
+            except Exception:
+                username = None
+                raise CleanupTime(
+                    HTTPStatus.INTERNAL_SERVER_ERROR, "Error verifying username"
+                )
+
+            controller = None
+            self.logger.info("Entertaining PUT request for {}...", filename)
+
+            if os.path.basename(filename) != filename:
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST, "Filename must not contain a path"
+                )
+
+            if not self.supported_file_extension(filename):
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST,
+                    f"File extension not supported, must be {self.ALLOWED_EXTENSION}",
+                )
+
+            controller = request.headers.get("controller")
+            if not controller:
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST, "Missing required controller header"
+                )
+
+            if validate_hostname(controller) != 0:
+                raise CleanupTime(HTTPStatus.BAD_REQUEST, "Invalid controller header")
+
+            md5sum = request.headers.get("Content-MD5")
+            if not md5sum:
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST, "Missing required Content-MD5 header"
+                )
+
+            try:
+                length_string = request.headers["Content-Length"]
+                content_length = int(length_string)
+            except KeyError:
+                raise CleanupTime(
+                    HTTPStatus.LENGTH_REQUIRED, "Missing required Content-Length header"
+                )
+            except ValueError:
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST,
+                    f"Invalid Content-Length header, not an integer ({length_string})",
+                )
+            else:
+                if content_length <= 0:
+                    raise CleanupTime(
+                        HTTPStatus.BAD_REQUEST,
+                        f"Content-Length {content_length} must be greater than 0",
+                    )
+                elif content_length > self.max_content_length:
+                    raise CleanupTime(
+                        HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                        f"Content-Length {content_length} must be no greater than than {humanize.naturalsize(self.max_content_length)}",
+                    )
+
+            try:
+                file_tree = FileTree(self.config, self.logger)
+            except Exception:
+                raise CleanupTime(
+                    HTTPStatus.INTERNAL_SERVER_ERROR, "Unable to map the file tree"
+                )
+
+            tar_full_path = self.temporary / filename
+            md5_full_path = self.temporary / f"{filename}.md5"
+            bytes_received = 0
+
+            self.logger.info(
+                "PUT uploading {}:{} to {}, {}",
+                controller,
+                filename,
+                tar_full_path,
+                md5_full_path,
+            )
+
+            # Create a tracking dataset object; it'll begin in UPLOADING state
+            try:
+                dataset = Dataset(
+                    owner=username,
+                    controller=controller,
+                    path=tar_full_path,
+                    md5=md5sum,
+                )
+                dataset.add()
+            except DatasetDuplicate:
+                self.logger.info(
+                    "Dataset already exists, user = {}, ctrl = {!a}, file = {!a}",
+                    username,
+                    controller,
+                    filename,
+                )
+                response = jsonify(dict(message="Dataset already exists"))
+                response.status_code = HTTPStatus.OK
+                return response
+            except Exception:
+                raise CleanupTime(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message="Unable to create dataset",
+                )
+
+            recovery.add(Step.DATASET, dataset)
+
+            # NOTE: Let the Dataset path filter extract the dataset name rather
+            # repeat that logic here. If we hit this case it means that the dataset
+            # file exists in the file system but no Dataset was created: which
+            # would be odd and certainly qualifies as an internal error.
+            if dataset.name in file_tree:
+                tarball = file_tree[dataset.name]
+                raise CleanupTime(
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    message="File tree dataset already exists",
+                )
+
+            self.logger.info(
+                "Uploading file {!a} (user = {}, ctrl = {!a}) to {}",
+                filename,
+                username,
+                controller,
+                dataset,
+            )
+
+            # An exception from this point on MAY leave an uploaded tar file
+            # (possibly partial, or corrupted); remove it if possible on
+            # error recovery.
+            recovery.add(Step.UPLOAD, tar_full_path)
+
+            with tar_full_path.open(mode="wb") as ofp:
+                hash_md5 = hashlib.md5()
+
+                try:
+                    while True:
+                        chunk = request.stream.read(self.CHUNK_SIZE)
+                        bytes_received += len(chunk)
+                        if len(chunk) == 0 or bytes_received > content_length:
+                            break
+
+                        ofp.write(chunk)
+                        hash_md5.update(chunk)
+                except OSError as exc:
+                    if exc.errno == errno.ENOSPC:
+                        raise CleanupTime(
+                            HTTPStatus.INSUFFICIENT_STORAGE,
+                            f"Out of space on {tar_full_path.root}",
+                        )
+                    else:
+                        raise CleanupTime(
+                            HTTPStatus.INTERNAL_SERVER_ERROR,
+                            "Unexpected error encountered during file upload",
+                        )
+                except Exception:
+                    raise CleanupTime(
+                        HTTPStatus.INTERNAL_SERVER_ERROR,
+                        "Unexpected error encountered during file upload",
+                    )
+
+                if bytes_received != content_length:
+                    raise CleanupTime(
+                        HTTPStatus.BAD_REQUEST,
+                        f"Expected {content_length} bytes but received {bytes_received} bytes",
+                    )
+                elif hash_md5.hexdigest() != md5sum:
+                    raise CleanupTime(
+                        HTTPStatus.BAD_REQUEST,
+                        f"MD5 checksum {hash_md5.hexdigest()} does not match expected {md5sum}",
+                    )
+
+                # First write the .md5
+                self.logger.info("Creating MD5 file {}: {}", md5_full_path, md5sum)
+
+                # From this point attempt to remove the MD5 file on error exit
+                recovery.add(Step.MD5, md5_full_path)
+                try:
+                    md5_full_path.write_text(f"{md5sum} {filename}\n")
+                except Exception:
+                    raise CleanupTime(
+                        HTTPStatus.INTERNAL_SERVER_ERROR,
+                        f"Failed to write .md5 file '{md5_full_path}'",
+                    )
+
+                # Move the files to their official location
+                try:
+                    tarball = file_tree.create(controller, tar_full_path)
+                except Exception:
+                    raise CleanupTime(
+                        HTTPStatus.INTERNAL_SERVER_ERROR,
+                        "Unable to create dataset in file system",
+                    )
+        except CleanupTime as c:
+            cause = c.__cause__ if c.__cause__ else c.__context__
+            if c.status == HTTPStatus.INTERNAL_SERVER_ERROR:
+                abort_msg = "INTERNAL ERROR"
+                if cause:
+                    self.logger.exception(
+                        "{}:{}:{} error {}", username, controller, filename, c.message
+                    )
+                else:
+                    self.logger.error(
+                        "{}:{}:{} error {}", username, controller, filename, c.message
+                    )
+            else:
+                self.logger.warning(
+                    "{}:{}:{} error {} ({})",
+                    username,
+                    controller,
+                    filename,
+                    c.message,
+                    cause,
+                )
+                abort_msg = c.message
+            recovery.cleanup()
+            abort(c.status, message=abort_msg)
+        except Exception:
+            self.logger.exception("Unexpected exception in outer try")
+            recovery.cleanup()
             abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
 
-        if os.path.basename(filename) != filename:
-            msg = "File must not contain a path"
-            self.logger.warning(
-                "{} for user = {}, file = {!a}", msg, username, filename,
-            )
-            abort(HTTPStatus.BAD_REQUEST, message=msg)
-
-        if not self.supported_file_extension(filename):
-            msg = f"File extension not supported, must be {self.ALLOWED_EXTENSION}"
-            self.logger.warning(
-                "{} for user = {}, file = {!a}", msg, username, filename,
-            )
-            abort(HTTPStatus.BAD_REQUEST, message=msg)
-
-        controller = request.headers.get("controller")
-        if not controller:
-            msg = "Missing required controller header"
-            self.logger.warning(
-                "{} for user = {}, file = {!a}", msg, username, filename
-            )
-            abort(HTTPStatus.BAD_REQUEST, message=msg)
-        if validate_hostname(controller) != 0:
-            msg = "Invalid controller header"
-            self.logger.warning(
-                "{} for user = {}, ctrl = {!a}, file = {!a}",
-                msg,
-                username,
-                controller,
-                filename,
-            )
-            abort(HTTPStatus.BAD_REQUEST, message=msg)
-
-        md5sum = request.headers.get("Content-MD5")
-        if not md5sum:
-            msg = "Missing required Content-MD5 header"
-            self.logger.warning(
-                "{} for user = {}, ctrl = {!a}, file = {!a}",
-                msg,
-                username,
-                controller,
-                filename,
-            )
-            abort(HTTPStatus.BAD_REQUEST, message=msg)
-
-        status = HTTPStatus.OK
         try:
-            content_length = int(request.headers["Content-Length"])
-        except KeyError:
-            msg = "Missing required Content-Length header"
-            status = HTTPStatus.LENGTH_REQUIRED
-        except ValueError:
-            msg = f"Invalid Content-Length header, not an integer ({content_length})"
-            status = HTTPStatus.BAD_REQUEST
-        else:
-            if not (0 < content_length <= self.max_content_length):
-                msg = "Content-Length ({}) must be greater than 0 and no greater than {}".format(
-                    content_length, humanize.naturalsize(self.max_content_length)
-                )
-                status = (
-                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE
-                    if 0 < content_length
-                    else HTTPStatus.BAD_REQUEST
-                )
-        if status != HTTPStatus.OK:
-            self.logger.warning(
-                "{} for user = {}, ctrl = {!a}, file = {!a}",
-                msg,
-                username,
-                controller,
-                filename,
-            )
-            abort(status, message=msg)
+            self.finalize_dataset(dataset, tarball, self.config, self.logger)
+        except Exception:
+            abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
+        response = jsonify(dict(message="File successfully uploaded"))
+        response.status_code = HTTPStatus.CREATED
+        return response
 
-        path = self.upload_directory / controller
-        path.mkdir(exist_ok=True)
-        tar_full_path = Path(path, filename)
-        md5_full_path = Path(path, f"{filename}.md5")
-        bytes_received = 0
-
-        # Create a tracking dataset object; it'll begin in UPLOADING state
-        try:
-            dataset = Dataset(
-                owner=username, controller=controller, path=tar_full_path, md5=md5sum
-            )
-            dataset.add()
-        except DatasetDuplicate:
-            self.logger.info(
-                "Dataset already exists, user = {}, ctrl = {!a}, file = {!a}",
-                username,
-                controller,
-                filename,
-            )
-            response = jsonify(dict(message="Dataset already exists"))
-            response.status_code = HTTPStatus.OK
-            return response
-        except Exception as exc:
-            self.logger.error(
-                "unable to create dataset, '{}', for user = {}, ctrl = {!a}, file = {!a}",
-                exc,
-                username,
-                controller,
-                filename,
-            )
-            abort(
-                HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR",
-            )
-
-        if tar_full_path.is_file() or md5_full_path.is_file():
-            self.logger.error(
-                "Dataset, or corresponding md5 file, already present; tar {} ({}), md5 {} ({})",
-                tar_full_path,
-                "present" if tar_full_path.is_file() else "missing",
-                md5_full_path,
-                "present" if md5_full_path.is_file() else "missing",
-            )
-            abort(
-                HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR",
-            )
-
-        self.logger.info(
-            "Uploading file {!a} (user = {}, ctrl = {!a}) to {}",
-            filename,
-            username,
-            controller,
-            dataset,
-        )
-
-        with tempfile.NamedTemporaryFile(mode="wb", dir=path) as ofp:
-            hash_md5 = hashlib.md5()
-
-            try:
-                while True:
-                    chunk = request.stream.read(self.CHUNK_SIZE)
-                    bytes_received += len(chunk)
-                    if len(chunk) == 0 or bytes_received > content_length:
-                        break
-
-                    ofp.write(chunk)
-                    hash_md5.update(chunk)
-            except OSError as exc:
-                if exc.errno == errno.ENOSPC:
-                    self.logger.error(
-                        "Not enough space on volume, {}, for upload:"
-                        " user = {}, ctrl = {!a}, file = {!a}",
-                        path,
-                        username,
-                        controller,
-                        filename,
-                    )
-                    abort(HTTPStatus.INSUFFICIENT_STORAGE)
-                else:
-                    msg = "Unexpected error encountered during file upload"
-                    self.logger.error(
-                        "{}, {}, for user = {}, ctrl = {!a}, file = {!a}",
-                        msg,
-                        exc,
-                        username,
-                        controller,
-                        filename,
-                    )
-                    abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-            except Exception as exc:
-                msg = "Unexpected error encountered during file upload"
-                self.logger.error(
-                    "{}, {}, for user = {}, ctrl = {!a}, file = {!a}",
-                    msg,
-                    exc,
-                    username,
-                    controller,
-                    filename,
-                )
-                abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-
-            if bytes_received != content_length:
-                msg = (
-                    "Bytes received do not match Content-Length header"
-                    f" (expected {content_length}; received {bytes_received})"
-                )
-                self.logger.warning(
-                    "{} for user = {}, ctrl = {!a}, file = {!a}",
-                    msg,
-                    username,
-                    controller,
-                    filename,
-                )
-                abort(HTTPStatus.BAD_REQUEST, message=msg)
-            elif hash_md5.hexdigest() != md5sum:
-                msg = (
-                    "MD5 checksum does not match Content-MD5 header"
-                    f" ({hash_md5.hexdigest()} != {md5sum})"
-                )
-                self.logger.warning(
-                    "{} for user = {}, ctrl = {!a}, file = {!a}",
-                    msg,
-                    username,
-                    controller,
-                    filename,
-                )
-                abort(HTTPStatus.BAD_REQUEST, message=msg)
-
-            # First write the .md5
-            try:
-                md5_full_path.write_text(f"{md5sum} {filename}\n")
-            except Exception as exc:
-                try:
-                    md5_full_path.unlink(missing_ok=True)
-                except Exception as md5_exc:
-                    self.logger.error(
-                        "Failed to remove .md5 {} when trying to clean up: '{}'",
-                        md5_full_path,
-                        md5_exc,
-                    )
-                self.logger.error(
-                    "Failed to write .md5 file, '{}': '{}'", md5_full_path, exc
-                )
-                abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-
-            # Then create the final filename link to the temporary file.
-            try:
-                os.link(ofp.name, tar_full_path)
-            except Exception as exc:
-                try:
-                    md5_full_path.unlink()
-                except Exception as md5_exc:
-                    self.logger.error(
-                        "Failed to remove .md5 {} when trying to clean up: {}",
-                        md5_full_path,
-                        md5_exc,
-                    )
-                self.logger.error(
-                    "Failed to rename tar ball '{}' to '{}': '{}'",
-                    ofp.name,
-                    md5_full_path,
-                    exc,
-                )
-                abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-
+    @staticmethod
+    def finalize_dataset(
+        dataset: Dataset, tarball: Tarball, config: PbenchServerConfig, logger: Logger
+    ):
         try:
             dataset.advance(States.UPLOADED)
 
             # TODO: Implement per-user override of default (requires PR #2049)
             try:
                 retention_days = int(
-                    self.config.get_conf(
+                    config.get_conf(
                         __name__, "pbench-server", "default-dataset-retention-days", 90
                     )
                 )
             except Exception as e:
-                self.logger.error("Unable to get integer retention days: {}", str(e))
+                logger.error("Unable to get integer retention days: {}", str(e))
                 raise
             retention = datetime.timedelta(days=retention_days)
             deletion = datetime.datetime.now() + retention
             Metadata.setvalue(
+                dataset=dataset,
+                key=Metadata.TARBALL_PATH,
+                value=str(tarball.tarball_path),
+            )
+            Metadata.setvalue(
                 dataset=dataset, key=Metadata.DELETION, value=f"{deletion:%Y-%m-%d}"
             )
         except Exception as exc:
-            self.logger.error("Unable to finalize {}, '{}'", dataset, exc)
-            abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
-        response = jsonify(dict(message="File successfully uploaded"))
-        response.status_code = HTTPStatus.CREATED
-        return response
+            logger.error("Unable to finalize {}, '{}'", dataset, exc)
+            raise
 
     @staticmethod
     def supported_file_extension(filename: str) -> bool:
@@ -334,25 +485,3 @@ class Upload(Resource):
         Return True if the allowed extension is found, False otherwise.
         """
         return filename.endswith(Upload.ALLOWED_EXTENSION)
-
-    @property
-    def upload_directory(self):
-        prdp = self.config.get_conf(
-            __name__, "pbench-server", "pbench-receive-dir-prefix", self.logger
-        )
-        try:
-            return Path(f"{prdp}-002").resolve(strict=True)
-        except FileNotFoundError:
-            self.logger.exception(
-                "pbench-receive-dir-prefix does not exist on the host"
-            )
-            raise FileNotFoundError(
-                "pbench-receive-dir-prefix does not exist on the host"
-            )
-        except Exception:
-            self.logger.exception(
-                "Exception occurred during setting up the upload directory on the host"
-            )
-            raise Exception(
-                "Some Exception occurred during setting up the upload directory on the host"
-            )

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -589,14 +589,14 @@ class Dataset(Database.Base):
         """
         try:
             dataset = Database.db_session.query(Dataset).filter_by(**kwargs).first()
-
-            if dataset is None:
-                raise DatasetNotFound(**kwargs)
-
-            return dataset
         except SQLAlchemyError as e:
             Dataset.logger.warning("Error querying {}: {}", kwargs, str(e))
             raise DatasetSqlError("querying", **kwargs)
+
+        if dataset is None:
+            raise DatasetNotFound(**kwargs)
+
+        return dataset
 
     def __str__(self) -> str:
         """

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -649,10 +649,11 @@ class Dataset(Database.Base):
             Database.db_session.add(self)
             Database.db_session.commit()
         except IntegrityError as e:
-            Dataset.logger.exception(
-                "Duplicate dataset {}|{}", self.controller, self.name
+            Dataset.logger.warning(
+                "Duplicate dataset {}|{}: {}", self.controller, self.name, e
             )
-            raise DatasetDuplicate(self.controller, self.name) from e
+            Database.db_session.rollback()
+            raise DatasetDuplicate(self.controller, self.name) from None
         except Exception:
             self.logger.exception("Can't add {} to DB", str(self))
             Database.db_session.rollback()

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -67,7 +67,7 @@ class Tarball:
     TARBALL_SUFFIX = ".tar.xz"
 
     @staticmethod
-    def has_suffix(path: Union[Path, str]) -> bool:
+    def is_tarball(path: Union[Path, str]) -> bool:
         """
         Determine whether a path has the expected suffix to qualify as a Pbench
         tarball.
@@ -99,8 +99,8 @@ class Tarball:
         Returns:
             The stripped "stem" of the dataset
         """
-        if Tarball.has_suffix(path):
-            return path.name[:-7]
+        if Tarball.is_tarball(path):
+            return path.name[:-len(Tarball.TARBALL_SUFFIX)]
         else:
             raise BadFilename(path)
 
@@ -176,9 +176,9 @@ class Tarball:
         md5_source = tarball.with_suffix(".xz.md5")
 
         # If either expected destination file exists, something is wrong
-        if (controller.path / tarball.name).exists() or (
-            controller.path / md5_source.name
-        ).exists():
+        if (controller.path / tarball.name).exists():
+            raise DuplicateDataset(name)
+        if (controller.path / md5_source.name).exists():
             raise DuplicateDataset(name)
 
         # Copy the MD5 file first; only if that succeeds, copy the tarball

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -1,0 +1,778 @@
+from logging import Logger
+from pathlib import Path
+import re
+import selinux
+import shutil
+from typing import Dict, List
+
+from pbench.server import PbenchServerConfig
+from pbench.server.database.models.datasets import Dataset
+
+
+class FiletreeError(Exception):
+    """
+    Base class for exceptions raised from this code.
+    """
+
+    def __str__(self) -> str:
+        return "Generic file tree exception"
+
+
+class BadFilename(FiletreeError):
+    """
+    A bad path is given for a tarball.
+    """
+
+    def __init__(self, path: str):
+        self.path = str(path)
+
+    def __str__(self) -> str:
+        return f"The file path {self.path} is not a tarball"
+
+
+class DatasetNotFound(FiletreeError):
+    """
+    The on-disk representation of a dataset (tarball and MD5 companion) were
+    not found in the ARCHIVE tree.
+    """
+
+    def __init__(self, dataset: str):
+        self.dataset = dataset
+
+    def __str__(self) -> str:
+        return f"The dataset named {self.dataset!r} is not present in the file tree"
+
+
+class DuplicateDataset(FiletreeError):
+    """
+    A duplicate dataset name was detected.
+    """
+
+    def __init__(self, dataset: str):
+        self.dataset = dataset
+
+    def __str__(self) -> str:
+        return f"A dataset named {self.dataset!r} is already present in the file tree"
+
+
+class ControllerNotFound(FiletreeError):
+    """
+    A specified controller name does not exist in the ARCHIVE tree.
+    """
+
+    def __init__(self, controller: str):
+        self.controller = controller
+
+    def __str__(self) -> str:
+        return (
+            f"The controller name {self.controller!r} is not present in the file tree"
+        )
+
+
+class Tarball:
+    """
+    This class corresponds to the physical representation of a Dataset: the
+    tarball, the MD5 file, and the unpacked data.
+
+    It provides discovery and management methods related to a specific
+    dataset.
+    """
+
+    @staticmethod
+    def stem(path: Path) -> str:
+        """
+        The Path.stem() removes a single suffix, so our standard "a.tar.xz"
+        returns "a.tar" instead of "a". We could double-stem, but instead
+        this just checks for the expected 7 character suffix and strips it.
+
+        If the path does not end in ".tar.xz" then the full path.name is
+        returned.
+
+        Args:
+            path: A file path that might be a Pbench tarball
+
+        Returns:
+            The stripped "stem" of the dataset
+        """
+        name = path.name
+        return name[:-7] if name[-7:] == ".tar.xz" else name
+
+    def __init__(self, path: Path, controller: "Controller"):
+        """
+        Construct a `Tarball` object instance representing a tarball found on
+        disk.
+
+        Args:
+            path: The file path to a discovered tarball (.tar.xz file) in the
+                configured ARCHIVE directory for a controller.
+            controller: The associated Controller object
+        """
+        self.name = Tarball.stem(path)
+        self.controller = controller
+        self.logger = controller.logger
+        self.tarball_path = path
+        self.unpacked: Path = None
+        self.results_link: Path = None
+        self.md5_path = path.with_suffix(".xz.md5")
+        self.controller_name = path.parent.name
+
+    def record_unpacked(self, directory: Path):
+        """
+        Record that an unpacked tarball directory was found for this dataset.
+
+        Args:
+            directory: The unpacked INCOMING tree directory for the dataset
+        """
+        self.unpacked = directory
+
+    def record_results(self, link: Path):
+        """
+        Record that a results directory link was found for this dataset.
+
+        Args:
+            link: The symlink in the results tree to the incoming directory
+        """
+        self.results_link = link
+
+    # Most of the "operational" methods below this point should be coordinated
+    # through Controller and/or FileTree methods, which are aware of higher
+    # level file tree structure, including the parallel INCOMING and RESULTS
+    # trees.
+    #
+    # create
+    #   Alternate constructor to create a Tarball object and move an incoming
+    #   tarball and md5 into the proper controller directory.
+    #
+    # unpack
+    #   Unpack the ARCHIVE tarball file into a new directory under the
+    #   controller directory in the INCOMING directory tree.
+    #
+    # uncache
+    #   Remove the unpacked directory tree under INCOMING when no longer needed.
+    #
+    # delete
+    #   Remove the tarball and MD5 file from ARCHIVE after uncaching the
+    #   unpacked directory tree.
+
+    @staticmethod
+    def create(tarball: Path, controller: "Controller") -> "Tarball":
+        """
+        This is an alternate constructor to move an incoming tarball into the
+        proper place along with the md5 companion file. It returns the new
+        Tarball object.
+        """
+        destination = controller.path / tarball.name
+
+        # NOTE: with_suffix replaces only the final suffix, .xz, not the full
+        # standard .tar.xz
+        md5_source = tarball.with_suffix(".xz.md5")
+        md5_destination = controller.path / md5_source.name
+
+        # Copy the MD5 file first; only if that succeeds, copy the tarball
+        # itself.
+        try:
+            shutil.copy2(md5_source, md5_destination)
+        except Exception as e:
+            controller.logger.error("ERROR copying dataset {} MD5: {}", tarball, e)
+            raise
+
+        try:
+            moved = shutil.copy2(tarball, destination)
+        except Exception as e:
+            try:
+                md5_destination.unlink()
+            except Exception as e:
+                controller.logger.error(
+                    "Unable to recover by removing MD5 after tarball copy failure: {}",
+                    e,
+                )
+            controller.logger.error("ERROR copying dataset {}: {}", tarball, e)
+            raise
+
+        # Restore the SELinux context properly
+        try:
+            selinux.restorecon(destination)
+            selinux.restorecon(md5_destination)
+        except Exception as e:
+            # log it but do not abort
+            controller.logger.error("Unable to 'restorecon {}', {}", destination, e)
+
+        # To get the new tarball into the server pipeline, we start with a
+        # symlink in the TODO state directory.
+        try:
+            controller.link(destination, "TODO")
+        except Exception as e:
+            controller.logger.error(
+                "Failed to link dataset {} into TODO state directory: {}",
+                destination,
+                e,
+            )
+
+        # If we were able to copy both files, remove the originals
+        try:
+            tarball.unlink()
+            md5_source.unlink()
+        except Exception as e:
+            controller.logger.error(
+                "WARNING removing incoming dataset {}: {}", tarball, e
+            )
+
+        return Tarball(moved, controller)
+
+    def unpack(self, incoming: Path, results: Path):
+        """
+        Unpack a tarball into the INCOMING directory tree; this assumes that
+        the INCOMING controller directory already exists, which should be
+        ensured by calling this indirectly through the Controller class unpack
+        method.
+
+        TODO: This is a prototype for testing, and doesn't actually unpack
+        the tarball as we're going to be relying on the current unpack pipeline
+        command for some time.
+
+        Args:
+            incoming: Controller's directory in the INCOMING tree
+            results: Controller's directory in the RESULTS tree
+        """
+        self.logger.warning("Tarball unpack is not yet implemented")
+        unpacked = incoming / self.name
+        unpacked.mkdir()  # Just create an empty directory for now
+        self.unpacked = unpacked
+        results_link = results / self.name
+        results_link.symlink_to(unpacked)
+        self.results_link = results_link
+
+    def uncache(self):
+        """
+        Remove the unpacked tarball directory and all contents. The Tarball
+        object isn't directly aware of the RESULTS tree at all, so the caller
+        is responsible for managing that along with the controller directories
+        in each tree.
+        """
+        if self.unpacked:
+            try:
+                shutil.rmtree(self.unpacked)
+                self.unpacked = None
+            except Exception as e:
+                self.logger.error("{}", e)
+        if self.results_link:
+            try:
+                self.results_link.unlink()
+                self.results_link = None
+            except Exception as e:
+                self.logger.error("{}", e)
+
+    def delete(self):
+        """
+        Delete the tarball and MD5 file
+        """
+        self.uncache()
+        if self.md5_path:
+            # NOTE: it's actually an error if there's no MD5 companion, but
+            # since Tarball object creation is driven by presence of the
+            # .tar.xz file we won't assume it's there to delete.
+            self.md5_path.unlink()
+            self.md5_path = None
+        self.tarball_path.unlink()
+        self.tarball_path = None
+
+
+class Controller:
+    """
+    Record the existence of a "controller" in the file store: this simply means
+    a directory that was found within the root ARCHIVE directory. A controller
+    with no data may be ignored in most contexts, but will trigger an audit.
+    """
+
+    # List of the state directories under controller in which we record the
+    # "state" of tarballs via symlinks. The FileTree package can discover,
+    # validate, and report on these.
+    STATE_DIRS = [
+        "BACKED-UP",
+        "BACKUP-FAILED",
+        "BAD-MD5",
+        "COPIED-SOS",
+        "INDEXED",
+        "TO-BACKUP",
+        "TO-COPY-SOS",
+        "TO-DELETE",
+        "TODO",
+        "TO-INDEX",
+        "TO-INDEX-TOOL",
+        "TO-LINK",
+        "TO-RE-INDEX",
+        "TO-UNPACK",
+        "TO-SYNC",
+        "SYNCED",
+        "UNPACKED",
+        r"WONT-INDEX(\.\d+)",
+        "WONT-UNPACK",
+    ]
+
+    @staticmethod
+    def is_statedir(directory: Path) -> bool:
+        """
+        Determine whether the path's name matches a known state directory
+        pattern. Most of the standard Pbench state directories are fixed
+        strings, but `WONT-INDEX` can be suffixed with ".n" where "n" is
+        a pbench_index error exit code.
+
+        Args:
+            directory: A directory path
+
+        Returns:
+            True if the path's name matches a state directory pattern
+        """
+        name = directory.name
+        for state in Controller.STATE_DIRS:
+            if re.fullmatch(state, name):
+                return True
+        return False
+
+    def __init__(self, path: Path, incoming: Path, results: Path, logger: Logger):
+        """
+        Manage the representation of a controller on disk, which is a set of
+        directories; one each in the ARCHIVE, INCOMING, and RESULTS tree.
+
+        Args:
+            path: Controller directory path
+            incoming: The root of the INCOMING tree
+            results: The root of the RESULTS tree
+            logger: Logger object
+        """
+        self.logger = logger
+        self.name = path.name
+        self.path = path
+        self.errors: List[str] = []
+        self.state_dirs = {}
+        self.tarballs: Dict[str, Tarball] = {}
+        self.incoming: Path = incoming / self.name
+        self.results: Path = results / self.name
+        self._discover_tarballs()
+
+    def _discover_tarballs(self):
+        """
+        Discover the tarballs and state directories within the ARCHIVE tree's
+        controller directory.
+        """
+        for file in self.path.iterdir():
+            if file.is_dir():
+                if Controller.is_statedir(file):
+                    self.state_dirs[file.name] = file
+            elif file.name[-7:] == ".tar.xz":
+                tarball = Tarball(file, self)
+                self.tarballs[tarball.name] = tarball
+
+    def check_incoming(self):
+        """
+        Discover whether the INCOMING directory tree has an unpacked copy of
+        the dataset's tarball.
+        """
+        for file in self.incoming.iterdir():
+            if file.is_dir():
+                dataset = file.name
+                if dataset in self.tarballs:
+                    self.tarballs[dataset].record_unpacked(file)
+
+    def check_results(self):
+        """
+        Discover whether the RESULTS directory tree has a link to the unpacked
+        INCOMING directory.
+        """
+        for file in self.results.iterdir():
+            if file.is_symlink():
+                dataset = file.name
+                if dataset in self.tarballs:
+                    tarball = self.tarballs[dataset]
+                    tarball.record_results(file)
+
+    @staticmethod
+    def create(name: str, options: PbenchServerConfig, logger: Logger) -> "Controller":
+        """
+        Create a new controller directory under the ARCHIVE tree if one doesn't
+        already exist, and return a Controller object.
+
+        Returns:
+            Controller object
+        """
+        controller_dir = options.ARCHIVE / name
+        if not controller_dir.exists():
+            controller_dir.mkdir(exist_ok=True, mode=0o755)
+        (controller_dir / "TODO").mkdir(exist_ok=True)
+        return Controller(controller_dir, options.INCOMING, options.RESULTS, logger)
+
+    def create_tarball(self, dataset: Path) -> Tarball:
+        """
+        Create a new dataset under the controller, link it to the controller,
+        and return the new Tarball object.
+
+        Args:
+            dataset: Path to source tarball file
+
+        Returns:
+            Tarball object
+        """
+        tarball = Tarball.create(dataset, self)
+        self.tarballs[tarball.name] = tarball
+        return tarball
+
+    def link(self, dataset: Path, state: str):
+        """
+        Create a state link within the controller sub-tree.
+
+        Args:
+            dataset: Tarball path
+            state: State directory name (e.g., "TODO")
+        """
+        (self.state_dirs[state] / dataset.name).symlink_to(dataset)
+
+    def unpack(self, dataset: str):
+        """
+        Unpack a tarball into the INCOMING tree. Create the INCOMING controller
+        directory if necessary, along with the RESULTS tree link.
+
+        NOTE: This does not look at tarball metadata.log, and therefore cannot
+        consider the `prefix` and `user` metadata which, in 0.69, affect
+        (respectively) the directory path of the RESULTS tree link, and whether
+        an entry is added under a different USERS tree. It's unclear we want
+        to preserve either behavior for 0.72 (especially USERS, which we've
+        replaced with true users and ownership).
+
+        Args:
+            dataset: Name of the dataset to unpack
+        """
+        tarball = self.tarballs[dataset]
+        self.incoming.mkdir(exist_ok=True)
+        self.results.mkdir(exist_ok=True)
+        tarball.unpack(self.incoming, self.results)
+
+    def uncache(self, dataset: str):
+        """
+        The reverse of `unpack`, removing the RESULTS tree link and the
+        unpacked tarball contents from INCOMING.
+
+        Args:
+            dataset: Name of dataset to remove
+        """
+        tarball = self.tarballs[dataset]
+        results_link = self.results / tarball.name
+        if results_link.exists():
+            results_link.unlink()
+        if self.results.exists() and not list(self.results.iterdir()):
+            self.results.rmdir()
+        incoming_dir = self.incoming / tarball.name
+        if incoming_dir.is_dir():
+            shutil.rmtree(incoming_dir, ignore_errors=True)
+        if self.incoming.exists() and not list(self.incoming.iterdir()):
+            self.incoming.rmdir()
+
+    def delete(self, dataset: str):
+        """
+        Delete a dataset and remove it from the controller. This will also
+        remove any links to the dataset tarball from the controller's state
+        directories.
+
+        NOTE: This relies on FileTree.delete() having already called the
+        controller uncache; we can't completely clean up within the controller
+        scope.
+
+        Args:
+            dataset: Name of dataset to delete
+        """
+        self.logger.info("LOOKING for {} in {}", dataset, self.tarballs)
+        tarball = self.tarballs[dataset]
+        for file in self.path.iterdir():
+            if file.is_dir() and Controller.is_statedir(file):
+                for link in file.iterdir():
+                    if link.samefile(tarball.tarball_path):
+                        link.unlink()
+        tarball.delete()
+        del self.tarballs[dataset]
+
+
+class FileTree:
+    """
+    A hierarchical representation of the Pbench on-disk file structure,
+    including the ARCHIVE, INCOMING, and RESULTS directory subtrees.
+    """
+
+    # The FileTree class owns the definition of the "controller" level
+    # directory where PUT will store uploading files. Co-locating this
+    # with the ARCHIVE tree ensures that we can move files without an
+    # additional copy, and the upload will already fail if the file
+    # system has insufficient space. Defining the directory here allows
+    # FileTree discovery to ignore it.
+    TEMPORARY = "UPLOAD"
+
+    def __init__(self, options: PbenchServerConfig, logger: Logger):
+        """
+        Construct a FileTree object. We don't do any discovery here, because
+        the mutation operations allow dynamic minimal discovery to save on
+        some time. The `full_discovery` method allows full discovery when
+        desired.
+
+        Args:
+            options: PbenchServerConfig configuration object
+            logger: A Pbench python Logger
+        """
+        self.options = options
+        self.archive_root = self.options.ARCHIVE
+        self.incoming_root = self.options.INCOMING
+        self.results_root = self.options.RESULTS
+        self.logger = logger
+        self.controllers: Dict[str, Controller] = {}
+        self.datasets: Dict[str, Tarball] = {}
+
+    def full_discovery(self):
+        """
+        Discover and diagnose the state of the entire file tree, including the
+        ARCHIVE, INCOMING, and RESULTS subtrees.
+
+        This is useful for standalone reporting, including to enable an audit
+        check. Generally it's overkill for specific operations such as adding
+        or removing a dataset. This setup is sufficient but not necessary for
+        mutation operations.
+        """
+        self._discover_filesystem()
+
+    def __contains__(self, dataset: str) -> bool:
+        """
+        Allow asking whether a FileTree contains an entry for a specific
+        dataset.
+
+        Args:
+            dataset: Dataset name
+
+        Returns:
+            True if the dataset is present
+        """
+        return dataset in self.datasets
+
+    def __getitem__(self, dataset: str) -> Dataset:
+        """
+        Direct access to a dataset Tarball object by name.
+
+        Args:
+            dataset: Dataset name
+
+        Returns:
+            Tarball object
+        """
+        try:
+            return self.datasets[dataset]
+        except KeyError:
+            raise DatasetNotFound(dataset)
+
+    def _clean_empties(self, controller: str):
+        """
+        Remove empty controller directories from the RESULTS and INCOMING
+        trees. If there are no remaining tarballs in the ARCHIVE controller
+        directory, remove all empty state subdirectories; and, if the
+        controller directory is now empty remove it as well.
+
+        Args:
+            controller: Name of the controller to clean up
+        """
+        results = self.options.RESULTS / controller
+        if results.exists() and not list(results.iterdir()):
+            results.rmdir()
+        incoming = self.options.INCOMING / controller
+        if incoming.exists() and not list(incoming.iterdir()):
+            incoming.rmdir()
+        archive = self.options.ARCHIVE / controller
+        if archive.exists() and not list(archive.glob("*.tar.xz")):
+            for file in archive.iterdir():
+                if file.is_dir() and Controller.is_statedir(file):
+                    if not list(file.iterdir()):
+                        file.rmdir()
+            if not list(archive.iterdir()):
+                archive.rmdir()
+            del self.controllers[controller]
+
+    def _discover_filesystem(self):
+        """
+        Update the FileTree object with the structure of the Pbench server file
+        tree representation.
+
+        We discover the ARCHIVE, INCOMING, and RESULTS trees as defined by the
+        pbench-server.cfg file. We do not support the 0.69 USERS directory,
+        which is completely superseded by dataset user ownership in 0.72. We
+        also do not support the `prefix` mechanism that allowed inserting a
+        directory prefix or directory sub-tree in front of the RESULTS link
+        which exposes the unpacked tarball data. Both of these may become
+        accessible through dataset metadata.
+        """
+        self._discover_archive()
+        self._discover_unpacked()
+        self._discover_results()
+
+    def _discover_archive(self):
+        """
+        Build a representation of the ARCHIVE tree, recording controllers (top
+        level directories), the tarballs and MD5 files that represent datasets,
+        and the server chain "state" directories.
+        """
+        if not self.archive_root.exists():
+            return
+        for file in self.archive_root.iterdir():
+            if file.is_dir() and file.name != FileTree.TEMPORARY:
+                controller = Controller(
+                    file, self.options.INCOMING, self.options.RESULTS, self.logger
+                )
+                self.controllers[controller.name] = controller
+                self.datasets.update(controller.tarballs)
+
+    def _discover_unpacked(self):
+        """
+        Build a representation of the "INCOMING" unpacked dataset tree,
+        recording controllers (top level directories), the unpacked trees that
+        represent datasets, and the expected links back to the ARCHIVE tree.
+        """
+        if not self.incoming_root.exists():
+            return
+        for file in self.incoming_root.iterdir():
+            if file.is_dir():
+                name = file.name
+                if name in self.controllers:
+                    self.controllers[name].check_incoming()
+
+    def _discover_results(self):
+        """
+        Build a representation of the "RESULTS" dataset tree, recording the
+        controllers (top level directories), and the expected links back into
+        the INCOMING tree.
+
+        NOTE: subclass and remove for block store? I don't think this has any
+        real meaning in our block store model...
+        """
+        if not self.results_root.exists():
+            return
+        for file in self.results_root.iterdir():
+            if file.is_dir():
+                name = file.name
+                if name in self.controllers:
+                    self.controllers[name].check_results()
+
+    def find_dataset(self, dataset: str) -> Tarball:
+        """
+        Given the name of a dataset, search the ARCHIVE tree for a controller
+        with that dataset name. This will build the Controller and Tarball
+        object for that dataset if they do not already exist.
+
+        FIXME: This builds the entire Controller, which will discover all
+        datasets within the controller. This could be streamlined... however
+        for create and delete, we need to know the state link directories.
+
+        This allows a targeted minimal entry for mutation without discovering
+        the entire tree.
+
+        Args:
+            dataset: The name of a dataset that might exist somewhere in the
+                file tree
+
+        Raises:
+            DatasetNotFound: the ARCHIVE tree does not contain a tarball that
+                corresponds to the dataset name
+
+        Returns:
+            Either None if the dataset is not found or the Tarball object
+            representing the dataset that was found.
+        """
+        if dataset in self.datasets:
+            return self.datasets[dataset]
+
+        # If we haven't already discovered the dataset, search for it, and
+        # discover just the controller containing that dataset name.
+        for dir in self.archive_root.iterdir():
+            self.logger.info("Checking controller {}", str(dir))
+            if dir.is_dir():
+                for file in dir.glob("*.tar.xz"):
+                    name = Tarball.stem(file)
+                    self.logger.info("Checking tarball {} [{}]", str(file), name)
+                    if name == dataset:
+                        controller = Controller(
+                            dir,
+                            self.options.INCOMING,
+                            self.options.RESULTS,
+                            self.logger,
+                        )
+                        self.controllers[controller.name] = controller
+                        self.datasets.update(controller.tarballs)
+                        return self.datasets[dataset]
+        raise DatasetNotFound(dataset)
+
+    # These are wrappers for controller and tarball operations which need to be
+    # aware of higher-level constructs in the Pbench artifact tree such as the
+    # ARCHIVE, INCOMING, and RESULTS directory branches. These will manage that
+    # higher level environment surrounding the encapsulated class methods.
+    #
+    # create
+    #   Alternate constructor to create a Tarball object and move an incoming
+    #   tarball and md5 into the proper controller directory.
+    #
+    # unpack
+    #   Unpack the ARCHIVE tarball file into a new directory under the
+    #   controller directory in the INCOMING directory tree.
+    #
+    # uncache
+    #   Remove the unpacked directory tree under INCOMING when no longer needed.
+    #
+    # delete
+    #   Remove the tarball and MD5 file from ARCHIVE after uncaching the
+    #   unpacked directory tree.
+
+    def create(self, controller_name: str, dataset: Path) -> Tarball:
+        """
+        Move a dataset tarball and companion MD5 file into the specified
+        controller directory. The controller directory and links will be
+        created if necessary.
+
+        Args:
+            controller: associated controller name
+            dataset: dataset tarball path
+
+        Returns
+            Tarball object
+        """
+        if dataset in self.datasets:
+            raise DuplicateDataset(dataset)
+        if controller_name in self.controllers:
+            controller = self.controllers[controller_name]
+        else:
+            controller = Controller.create(controller_name, self.options, self.logger)
+            self.controllers[controller_name] = controller
+        tarball = controller.create_tarball(dataset)
+        self.datasets[tarball.name] = tarball
+        return tarball
+
+    def unpack(self, dataset: str):
+        """
+        Unpack a tarball into the INCOMING tree, creating the INCOMING
+        controller directory if necessary.
+        """
+        tarball = self.find_dataset(dataset)
+        tarball.controller.unpack(dataset)
+
+    def uncache(self, dataset: str):
+        """
+        Remove the unpacked INCOMING tree.
+
+        Args:
+            dataset: Dataset name to "uncache"
+        """
+        tarball = self.find_dataset(dataset)
+        controller = tarball.controller
+        controller.uncache(dataset)
+        self._clean_empties(controller.name)
+
+    def delete(self, dataset: str):
+        """
+        Delete the tarball and MD5 file as well as all unpacked artifacts
+
+        Args:
+            dataset: Dataset name to delete
+        """
+        tarball = self.find_dataset(dataset)
+        tarball.controller.delete(dataset)
+        del self.datasets[dataset]
+        self._clean_empties(tarball.controller_name)

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -100,7 +100,7 @@ class Tarball:
             The stripped "stem" of the dataset
         """
         if Tarball.is_tarball(path):
-            return path.name[:-len(Tarball.TARBALL_SUFFIX)]
+            return path.name[: -len(Tarball.TARBALL_SUFFIX)]
         else:
             raise BadFilename(path)
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -664,6 +664,14 @@ def current_user_none(monkeypatch):
 
 @pytest.fixture
 def tarball(pytestconfig):
+    """
+    Create a test tarball and MD5 file; the tarball is empty, but has a real
+    MD5.
+
+    This intentionally uses a weird and ugly file name that should be
+    maintained through all the marshalling and unmarshalling on the wire until
+    it lands on disk and in the Dataset.
+    """
     filename = "pbench-user-benchmark_some + config_2021.05.01T12.42.42.tar.xz"
     tmp_d = pytestconfig.cache.get("TMP", None)
     datafile = Path(tmp_d, filename)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 from http import HTTPStatus
 import os
 import pytest
@@ -659,3 +660,25 @@ def current_user_none(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(Auth, "token_auth", FakeHTTPTokenAuth())
         yield None
+
+
+@pytest.fixture
+def tarball(pytestconfig):
+    filename = "pbench-user-benchmark_some + config_2021.05.01T12.42.42.tar.xz"
+    tmp_d = pytestconfig.cache.get("TMP", None)
+    datafile = Path(tmp_d, filename)
+    file_contents = b"something\n"
+    md5 = hashlib.md5()
+    md5.update(file_contents)
+    datafile.write_bytes(file_contents)
+    md5file = Path(tmp_d) / (filename + ".md5")
+    md5file.write_text(md5.hexdigest())
+
+    yield datafile, md5file, md5.hexdigest()
+
+    # Clean up after the test case
+
+    if md5file.exists():
+        md5file.unlink()
+    if datafile.exists():
+        datafile.unlink()

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -126,6 +126,25 @@ class TestDatasets:
         assert ds2.md5 is ds1.md5
         assert ds2.id is ds1.id
 
+    def test_query_name(self, db_session, create_user):
+        """ Test that we can find a dataset by name alone
+        """
+        ds1 = Dataset(
+            owner=create_user.username,
+            controller="frodo",
+            name="fio",
+            state=States.INDEXING,
+        )
+        ds1.add()
+
+        ds2 = Dataset.query(name="fio")
+        assert ds2.owner == ds1.owner
+        assert ds2.controller == ds1.controller
+        assert ds2.name == ds1.name
+        assert ds2.state == ds1.state
+        assert ds2.md5 is ds1.md5
+        assert ds2.id is ds1.id
+
     def test_advanced_good(self, db_session, create_user):
         """ Test advancing the state of a dataset
         """
@@ -189,3 +208,23 @@ class TestDatasets:
             lifecycle
             == "UPLOADING,UPLOADED,UNPACKING,UNPACKED,INDEXING,INDEXED,EXPIRING,EXPIRED"
         )
+
+    def test_delete(self, db_session, create_user):
+        """ Test that we can attach to a dataset
+        """
+        ds1 = Dataset(
+            owner=create_user.username,
+            controller="frodo",
+            name="foobar",
+            state=States.INDEXING,
+        )
+        ds1.add()
+
+        # we can find it
+        ds2 = Dataset.attach(controller="frodo", name="foobar", state=States.INDEXED)
+        assert ds2.name == ds1.name
+
+        ds2.delete()
+
+        with pytest.raises(DatasetNotFound):
+            Dataset.query(name="foobar")

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -139,8 +139,6 @@ class TestDatasets:
 
         ds2 = Dataset.query(name="fio")
         assert ds2.name == "fio"
-        ds2.name = "abc"
-        assert ds1.name == "abc"
         assert ds2.owner == ds1.owner
         assert ds2.controller == ds1.controller
         assert ds2.name == ds1.name

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -138,12 +138,15 @@ class TestDatasets:
         ds1.add()
 
         ds2 = Dataset.query(name="fio")
+        assert ds2.name == "fio"
+        ds2.name = "abc"
+        assert ds1.name == "abc"
         assert ds2.owner == ds1.owner
         assert ds2.controller == ds1.controller
         assert ds2.name == ds1.name
         assert ds2.state == ds1.state
-        assert ds2.md5 is ds1.md5
-        assert ds2.id is ds1.id
+        assert ds2.md5 == ds1.md5
+        assert ds2.id == ds1.id
 
     def test_advanced_good(self, db_session, create_user):
         """ Test advancing the state of a dataset
@@ -210,7 +213,7 @@ class TestDatasets:
         )
 
     def test_delete(self, db_session, create_user):
-        """ Test that we can attach to a dataset
+        """ Test that we can delete a dataset
         """
         ds1 = Dataset(
             owner=create_user.username,

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -1,4 +1,5 @@
 import pytest
+from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
@@ -201,7 +202,14 @@ class TestMetadataNamespace:
             "first": "My",
             "last": "Name",
         }
+        id = ds.id
         ds.delete()
 
+        # Test that the dataset is gone by searching for it
         with pytest.raises(DatasetNotFound):
             Dataset.query(name="fio")
+
+        # Peek under the carpet to look for orphaned metadata objects linked
+        # to the deleted Dataset
+        metadata = Database.db_session.query(Metadata).filter_by(dataset_ref=id).first()
+        assert metadata is None

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -6,9 +6,9 @@ import elasticsearch
 import pytest
 
 from pbench.server import PbenchServerConfig
-from pbench.server.filetree import FileTree
 from pbench.server.api.resources import JSON
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
+from pbench.server.filetree import FileTree
 from pbench.test.unit.server.headertypes import HeaderTypes
 
 
@@ -61,8 +61,7 @@ class TestDatasetsDelete:
                     delete["error"] = {"reason": "Just kidding", "type": "KIDDING"}
                 else:
                     status = True
-                item = {"delete": delete}
-                expected_results.append((status, item))
+                expected_results.append((status, {"delete": delete}))
                 expected_ids.append(docid)
 
         def fake_bulk(
@@ -108,9 +107,7 @@ class TestDatasetsDelete:
         monkeypatch.setattr(FileTree, "__init__", fake_constructor)
         monkeypatch.setattr(FileTree, "delete", fake_delete)
 
-    @pytest.mark.parametrize(
-        "owner", ("drb", "test"),
-    )
+    @pytest.mark.parametrize("owner", ("drb", "test"))
     def test_query(
         self,
         attach_dataset,
@@ -122,7 +119,7 @@ class TestDatasetsDelete:
         server_config,
     ):
         """
-        Check behavior of the publish API with various combinations of dataset
+        Check behavior of the delete API with various combinations of dataset
         owner (managed by the "owner" parametrization here) and authenticated
         user (managed by the build_auth_header fixture).
         """
@@ -168,7 +165,7 @@ class TestDatasetsDelete:
         server_config,
     ):
         """
-        Check the publish API when some document updates fail. We expect an
+        Check the delete API when some document updates fail. We expect an
         internal error with a report of success and failure counts.
         """
         self.fake_elastic(monkeypatch, get_document_map, True)
@@ -200,7 +197,7 @@ class TestDatasetsDelete:
         self, client, get_document_map, monkeypatch, pbench_token, server_config
     ):
         """
-        Check the publish API if the dataset doesn't exist.
+        Check the delete API if the dataset doesn't exist.
         """
         payload = self.PAYLOAD.copy()
         payload["name"] = "badwolf"
@@ -219,7 +216,7 @@ class TestDatasetsDelete:
         self, attach_dataset, client, monkeypatch, pbench_token, server_config
     ):
         """
-        Check the publish API response if the bulk helper throws an exception.
+        Check the delete API response if the bulk helper throws an exception.
 
         (It shouldn't do this as we've set raise_on_exception=False, but we
         check the code path anyway.)

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from logging import Logger
+from logging import Logger, ERROR
 from typing import Iterator
 
 import elasticsearch
@@ -180,15 +180,11 @@ class TestDatasetsDelete:
         # Verify the report and status
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         assert response.json["data"] == {"ok": 28, "failure": 3}
-        for record in caplog.records:
-            if (
-                record.levelname == "ERROR"
-                and record.name == "pbench.server.api:__init__.py"
-            ):
-                assert (
-                    record.message
-                    == "DatasetsDelete:dataset drb(1)|node|drb: 28 successful document updates and 3 failures: defaultdict(<class 'collections.Counter'>, {'Just kidding': Counter({'unit-test.v6.run-data.2021-06': 1, 'unit-test.v6.run-toc.2021-06': 1, 'unit-test.v5.result-data-sample.2021-06': 1}), 'ok': Counter({'unit-test.v5.result-data-sample.2021-06': 19, 'unit-test.v6.run-toc.2021-06': 9})})"
-                )
+        assert (
+            "pbench.server.api",
+            ERROR,
+            'DatasetsDelete:dataset drb(1)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+        ) in caplog.record_tuples
 
         # Verify that the Dataset still exists
         Dataset.query(controller="node", name="drb")

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -57,8 +57,7 @@ class TestDatasetsPublish:
                     update["error"] = {"reason": "Just kidding", "type": "KIDDING"}
                 else:
                     status = True
-                item = {"update": update}
-                expected_results.append((status, item))
+                expected_results.append((status, {"update": update}))
                 expected_ids.append(docid)
 
         def fake_bulk(

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from logging import ERROR
 from typing import Iterator
 
 import elasticsearch
@@ -158,15 +159,11 @@ class TestDatasetsPublish:
         # Verify the report and status
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         assert response.json["data"] == {"ok": 28, "failure": 3}
-        for record in caplog.records:
-            if (
-                record.levelname == "ERROR"
-                and record.name == "pbench.server.api:__init__.py"
-            ):
-                assert (
-                    record.message
-                    == "DatasetsPublish:dataset drb(1)|node|drb: 28 successful document updates and 3 failures: defaultdict(<class 'collections.Counter'>, {'Just kidding': Counter({'unit-test.v6.run-data.2021-06': 1, 'unit-test.v6.run-toc.2021-06': 1, 'unit-test.v5.result-data-sample.2021-06': 1}), 'ok': Counter({'unit-test.v5.result-data-sample.2021-06': 19, 'unit-test.v6.run-toc.2021-06': 9})})"
-                )
+        assert (
+            "pbench.server.api",
+            ERROR,
+            'DatasetsPublish:dataset drb(1)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+        ) in caplog.record_tuples
 
         # Verify that the Dataset access didn't change
         dataset = Dataset.query(controller="node", name="drb")

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -48,6 +48,10 @@ class TestEndpointConfig:
                 "result_data_index": f"{prefix}.v5.result-data.",
             },
             "api": {
+                # API endpoints with trailing Flask parameters are marked with
+                # a trailing "/" here; for example, /datasets/mappings/
+                # corresponds to /datasets/mappings/<string:dataset_view>";
+                # see endpoint_configure.py for more detail.
                 "controllers_list": f"{uri}/controllers/list",
                 "controllers_months": f"{uri}/controllers/months",
                 "datasets_delete": f"{uri}/datasets/delete",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -62,7 +62,6 @@ class TestEndpointConfig:
                 "elasticsearch": f"{uri}/elasticsearch",
                 "endpoints": f"{uri}/endpoints",
                 "graphql": f"{uri}/graphql",
-                "host_info": f"{uri}/host_info",
                 "login": f"{uri}/login",
                 "logout": f"{uri}/logout",
                 "register": f"{uri}/register",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -50,6 +50,7 @@ class TestEndpointConfig:
             "api": {
                 "controllers_list": f"{uri}/controllers/list",
                 "controllers_months": f"{uri}/controllers/months",
+                "datasets_delete": f"{uri}/datasets/delete",
                 "datasets_detail": f"{uri}/datasets/detail",
                 "datasets_list": f"{uri}/datasets/list",
                 "datasets_mappings": f"{uri}/datasets/mappings/",

--- a/lib/pbench/test/unit/server/test_file_tree.py
+++ b/lib/pbench/test/unit/server/test_file_tree.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+import re
+
+import hashlib
+
+import pytest
+import shutil
+
+from pbench.common.logger import get_pbench_logger
+from pbench.server.filetree import FileTree
+
+
+@pytest.fixture
+def make_logger(server_config):
+    return get_pbench_logger("TEST", server_config)
+
+
+def clean_subtree(tree: Path):
+    if not tree.exists():
+        return
+    for d in tree.iterdir():
+        if d.is_dir():
+            shutil.rmtree(d, ignore_errors=True)
+        else:
+            d.unlink()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def file_sweeper(server_config):
+    yield
+
+    # After each test case:
+
+    clean_subtree(server_config.ARCHIVE)
+    clean_subtree(server_config.INCOMING)
+    clean_subtree(server_config.RESULTS)
+
+
+class TestFileTree:
+    def test_create(self, server_config, make_logger):
+        tree = FileTree(server_config, make_logger)
+        assert tree is not None
+        assert not tree.datasets  # No datasets expected
+        assert not tree.controllers  # No controllers expected
+
+        temp = re.compile(r"^(.*)/srv/pbench")
+        match = temp.match(str(tree.archive_root))
+        root = match.group(1)
+        assert str(tree.archive_root) == root + "/srv/pbench/archive/fs-version-001"
+        assert str(tree.incoming_root) == root + "/srv/pbench/public_html/incoming"
+        assert str(tree.results_root) == root + "/srv/pbench/public_html/results"
+
+    def test_discover_empties(self, server_config, make_logger):
+        tree = FileTree(server_config, make_logger)
+        tree.full_discovery()
+        assert not tree.datasets  # No datasets expected
+        assert not tree.controllers  # No controllers expected
+
+    def test_empty_controller(self, server_config, make_logger):
+        tree = FileTree(server_config, make_logger)
+        test_controller = tree.archive_root / "TEST"
+        test_controller.mkdir()
+        tree.full_discovery()
+        assert not tree.datasets  # No datasets expected
+        assert list(tree.controllers.keys()) == ["TEST"]
+
+    def test_clean_emptys(self, server_config, make_logger):
+        tree = FileTree(server_config, make_logger)
+        controllers = ["PLUGH", "XYZZY"]
+        roots = [tree.archive_root, tree.incoming_root, tree.results_root]
+        for c in controllers:
+            for r in roots:
+                d = r / c
+                d.mkdir(parents=True)
+        tree.full_discovery()
+        ctrls = sorted(list(tree.controllers.keys()))
+        assert ctrls == controllers
+
+        for c in controllers:
+            tree._clean_empties(c)
+        assert not tree.controllers
+        for c in controllers:
+            for r in roots:
+                assert not (r / c).exists()
+
+    def test_lifecycle(self, monkeypatch, server_config, make_logger, tarball):
+
+        # Calling restorecon() gives warning messages about "no default label"
+        monkeypatch.setattr("selinux.restorecon", lambda a: None)
+
+        source_tarball, source_md5, md5 = tarball
+        tree = FileTree(server_config, make_logger)
+        tree.create("ABC", source_tarball)
+
+        archive = tree.archive_root / "ABC"
+        incoming = tree.incoming_root / "ABC"
+        results = tree.results_root / "ABC"
+
+        # Expect the archive directory was created, but we haven't unpacked so
+        # incoming and results should not exist.
+        assert archive.is_dir()
+        assert not incoming.exists()
+        assert not results.exists()
+
+        # The original files should have been removed
+        assert not source_tarball.exists()
+        assert not source_md5.exists()
+
+        tarfile = archive / source_tarball.name
+        md5file = archive / source_md5.name
+        assert tarfile.exists()
+        assert md5file.exists()
+
+        todo_state = archive / "TODO" / tarfile.name
+        assert todo_state.is_symlink()
+        assert todo_state.samefile(tarfile)
+
+        assert md5 == md5file.read_text()
+        hash = hashlib.md5()
+        hash.update(tarfile.read_bytes())
+        assert md5 == hash.hexdigest()
+
+        assert list(tree.controllers.keys()) == ["ABC"]
+        dataset_name = source_tarball.name[:-7]
+        assert list(tree.datasets.keys()) == [dataset_name]
+
+        # Now "unpack" the tarball and check that the incoming directory and
+        # results link are set up.
+        incoming_dir = incoming / dataset_name
+        results_link = results / dataset_name
+        tree.unpack(dataset_name)
+        assert incoming_dir.is_dir()
+        assert results_link.is_symlink()
+        assert results_link.samefile(incoming_dir)
+
+        # Re-discover, with all the files in place, and compare
+        newtree = FileTree(server_config, make_logger)
+        newtree.full_discovery()
+
+        # Is it worth writing __eql__ for the classes?
+        assert newtree.archive_root == tree.archive_root
+        assert newtree.incoming_root == tree.incoming_root
+        assert newtree.results_root == tree.results_root
+        assert sorted(list(newtree.controllers.keys())) == sorted(
+            list(tree.controllers.keys())
+        )
+        assert sorted(list(newtree.datasets.keys())) == sorted(
+            list(tree.datasets.keys())
+        )
+        for controller in tree.controllers.values():
+            other = newtree.controllers[controller.name]
+            assert controller.name == other.name
+            assert controller.path == other.path
+            assert sorted(list(controller.tarballs.keys())) == sorted(
+                list(other.tarballs.keys())
+            )
+        for tarball in tree.datasets.values():
+            other = newtree.datasets[tarball.name]
+            assert tarball.name == other.name
+            assert tarball.controller_name == other.controller_name
+            assert tarball.tarball_path == other.tarball_path
+            assert tarball.md5_path == other.md5_path
+            assert tarball.unpacked == other.unpacked
+            assert tarball.results_link == other.results_link
+
+        # Remove the unpacked tarball, and confirm that the directory and link
+        # are removed.
+        tree.uncache(dataset_name)
+        assert not results_link.exists()
+        assert not incoming_dir.exists()
+
+        # Now that we have all that setup, delete the dataset
+        tree.delete(dataset_name)
+
+        assert not archive.exists()
+        assert not tree.controllers
+        assert not tree.datasets

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -34,21 +34,6 @@ def get_pbench_token(client, server_config):
     return data["auth_token"]
 
 
-class TestHostInfo:
-    @staticmethod
-    def test_host_info_ok(client, monkeypatch, server_config):
-        monkeypatch.setattr(Path, "read_text", lambda self: "address")
-        response = client.get(f"{server_config.rest_uri}/host_info")
-        assert response.status_code == HTTPStatus.OK
-
-    @staticmethod
-    def test_host_info_not_ready(client, monkeypatch, server_config):
-        monkeypatch.setattr(Path, "read_text", lambda self: "MESSAGE===not now")
-        response = client.get(f"{server_config.rest_uri}/host_info")
-        assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
-        assert response.json.get("message") == "not now"
-
-
 class TestElasticsearch:
     @staticmethod
     def test_missing_json_object(client, caplog, server_config, pbench_token):
@@ -163,7 +148,7 @@ class TestUpload:
     def test_missing_controller_header_upload(
         self, client, caplog, server_config, pbench_token
     ):
-        expected_message = "Missing required controller header"
+        expected_message = "Missing required 'controller' header"
         response = client.put(
             self.gen_uri(server_config),
             headers={"Authorization": "Bearer " + pbench_token},
@@ -175,7 +160,7 @@ class TestUpload:
     def test_missing_md5sum_header_upload(
         self, client, caplog, server_config, setup_ctrl, pbench_token
     ):
-        expected_message = "Missing required Content-MD5 header"
+        expected_message = "Missing required 'Content-MD5' header"
         response = client.put(
             self.gen_uri(server_config),
             headers={
@@ -190,7 +175,7 @@ class TestUpload:
     def test_missing_length_header_upload(
         self, client, caplog, server_config, setup_ctrl, pbench_token
     ):
-        expected_message = "Missing required Content-Length header"
+        expected_message = "Missing required 'Content-Length' header"
         response = client.put(
             self.gen_uri(server_config),
             headers={
@@ -287,7 +272,9 @@ class TestUpload:
                 ),
             )
         assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert response.json.get("message") == "Content-Length 0 must be greater than 0"
+        assert (
+            response.json.get("message") == "'Content-Length' 0 must be greater than 0"
+        )
         self.verify_logs(caplog)
 
     def test_upload(

--- a/server/Makefile
+++ b/server/Makefile
@@ -20,6 +20,7 @@ INSTALL = install
 INSTALLOPTS = --directory
 
 click-scripts = \
+	pbench-tree-manage \
 	pbench-user-create \
 	pbench-user-update \
 	pbench-user-list \

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -104,7 +104,7 @@ python3 -m pip install --upgrade pip 2>&1 > /%{installdir}/pip3-install.log
 # The newly installed pip3 should be able to deal with the following.
 # N.B. We redirect both stdout and stderr into the log here but append the output to
 # the already existing file.
-(su pbench -c "pip3 --no-cache-dir install --user --no-warn-script-location -r /%{installdir}/requirements.txt" 2>&1) >> /%{installdir}/pip3-install.log
+(su pbench -c "python3 -m pip --no-cache-dir install --user --no-warn-script-location -r /%{installdir}/requirements.txt" 2>&1) >> /%{installdir}/pip3-install.log
 
 # The `site` package is Python magic; it runs automatically when Python starts,
 # and builds `sys.path`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ console_scripts =
    pbench-clear-results = pbench.cli.agent.commands.results.clear:main
    pbench-clear-tools = pbench.cli.agent.commands.tools.clear:main
    pbench-config = pbench.cli.getconf:main
+   pbench-tree-manage = pbench.cli.server.tree_manage:tree_manage
    pbench-generate-token = pbench.cli.agent.commands.generate_token:main
    pbench-list-tools = pbench.cli.agent.commands.tools.list:main
    pbench-list-triggers = pbench.cli.agent.commands.triggers.list:main


### PR DESCRIPTION
The *delete* operation builds on the *publish* operation, but the bulk Elastic operation to delete all of the indexed Elastic documents is only the first stage; we also need to delete the `Dataset` DB row itself and the on-disk file structure representing the dataset (`ARCHIVE` tarball and MD5 file, the unpacked `INCOMING` tarball if any, and the `RESULTS` link).

To accomplish that, this PR adds a new module with a set of related classes to discover and manipulate the on-disk file structure, including the ability to create and delete datasets.

The create operation subsumes the operation of `pbench-server-prep-shim-002` so that it's no longer needed. (NOTE: this PR doesn't actually remove it, as the impact on the legacy test system felt like more churn than really necessary here, however my server is running fine without it.) The PUT API has been refactored extensively to utilize the `FileTree` to create a dataset, and no longer stores the temporary file in the `pbench-server-prep-shim-002` intake directory.