### PR TITLE
Require `--user` for `pbench-move/copy-results`

### DIFF
--- a/agent/util-scripts/gold/pbench-copy-results/test-31.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-31.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:ndk:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-31.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-31.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:ndk:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:ndk:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-32.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-32.txt
@@ -1,6 +1,23 @@
 +++ Running test-32 pbench-copy-results --help
 usage:
-pbench-copy-results [--help] [--controller=<controller>] [--user=<user>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
+pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
+
+The '--user' option value is required, and can also be provided
+by the 'PBENCH_USER' environment variable.
+
+The '--controller' option is also required, but defaults to
+the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment
+variable.
+
+The '--prefix' option allows the user to specify an optional
+directory path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+The '--show-server' will not copy any results, but resolve and
+then display the pbench server destination for results.
+
+The '--xz-single-threaded' will force the use of a single
+thread for locally compressing the result tar balls.
 --- Finished test-32 pbench-copy-results (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-copy-results/test-32.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-32.txt
@@ -2,12 +2,14 @@
 usage:
 pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
 
-The '--user' option value is required, and can also be provided
-by the 'PBENCH_USER' environment variable.
-
-The '--controller' option is also required, but defaults to
-the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment
-variable.
+The '--user' option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, the value provided
+on the command line will override any value provided by the
+environment.
+The '--controller' option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
 
 The '--prefix' option allows the user to specify an optional
 directory path hierarchy to be used when displaying the result

--- a/agent/util-scripts/gold/pbench-copy-results/test-34.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-34.txt
@@ -103,7 +103,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-34.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-34.txt
@@ -59,6 +59,7 @@ controller = testhost.example.com
 start_run = 2018-05-23T03:21:32.387628370
 end_run = 2018-05-23T03:22:39.538437410
 controller_orig = alphaville.usersys.redhat.com
+user = unittests
 raw_size = #####
 
 [iterations/1]
@@ -102,7 +103,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-37.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-37.txt
@@ -55,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-37.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-37.txt
@@ -45,6 +45,7 @@ turbostat = --interval=3
 controller = testhost.example.com
 start_run = 2019-09-27T14:21:33.387628370
 end_run = 2019-09-27T14:22:38.538437410
+user = unittests
 raw_size = #####
 
 [iterations/1]
@@ -54,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-38.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-38.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:my-controller.example.com:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/my-controller.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/my-controller.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-38.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-38.txt
@@ -46,6 +46,7 @@ controller = my-controller.example.com
 start_run = 2019-09-27T14:21:33.387628370
 end_run = 2019-09-27T14:22:38.538437410
 controller_orig = testhost.example.com
+user = unittests
 raw_size = #####
 
 [iterations/1]
@@ -55,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/my-controller.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/my-controller.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-39.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-39.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-39.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-39.txt
@@ -45,6 +45,7 @@ turbostat = --interval=3
 controller = testhost.example.com
 start_run = 2019-09-27T14:21:31.387628370
 end_run = 2019-09-27T14:22:38.538437410
+user = unittests
 prefix = goo/tar
 raw_size = #####
 
@@ -55,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.09.27T14.21.31.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-40.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-40.txt
@@ -55,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pap:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:pap:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check && mv pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-40.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-40.txt
@@ -55,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pap:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check && mv pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5.check pbench-user-benchmark_pap-test-1_2019.09.27T14.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-41.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-41.txt
@@ -55,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-41.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-41.txt
@@ -45,6 +45,7 @@ turbostat = --interval=3
 controller = testhost.example.com
 start_run = 2019-09-27T14:21:33.387628370
 end_run = 2019-09-27T14:22:38.538437410
+user = unittests
 raw_size = #####
 
 [iterations/1]
@@ -54,7 +55,7 @@ user_script = sleep
 --- pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check && mv pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5.check pbench-user-benchmark_rht-test-1_2019.09.27T14.21.33.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-49.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-49.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:ndk20%:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-49.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-49.txt
@@ -56,7 +56,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:ndk20%:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:ndk20%:pbench-copy-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-copy-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5.check pbench-user-benchmark_ndk-test30%-1_2018.05.23T03.21.32.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-copy-results/test-50.txt
+++ b/agent/util-scripts/gold/pbench-copy-results/test-50.txt
@@ -1,0 +1,11 @@
++++ Running test-50 pbench-copy-results --prefix=foo/bar3%
+[error][1900-01-01T00:00:00.000000] Missing required 'user' value (provided either by the '--user' option or the 'PBENCH_USER' environment variable)
+--- Finished test-50 pbench-copy-results (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state
++++ pbench.log file contents
+[error][1900-01-01T00:00:00.000000] Missing required 'user' value (provided either by the '--user' option or the 'PBENCH_USER' environment variable)
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-move-results/test-20.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-20.txt
@@ -1,6 +1,23 @@
 +++ Running test-20 pbench-move-results --help
 usage:
-pbench-move-results [--help] [--controller=<controller>] [--user=<user>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
+pbench-move-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
+
+The '--user' option value is required, and can also be provided
+by the 'PBENCH_USER' environment variable.
+
+The '--controller' option is also required, but defaults to
+the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment
+variable.
+
+The '--prefix' option allows the user to specify an optional
+directory path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+The '--show-server' will not move any results, but resolve and
+then display the pbench server destination for results.
+
+The '--xz-single-threaded' will force the use of a single
+thread for locally compressing the result tar balls.
 --- Finished test-20 pbench-move-results (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-move-results/test-20.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-20.txt
@@ -2,12 +2,14 @@
 usage:
 pbench-move-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
 
-The '--user' option value is required, and can also be provided
-by the 'PBENCH_USER' environment variable.
-
-The '--controller' option is also required, but defaults to
-the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment
-variable.
+The '--user' option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, the value provided
+on the command line will override any value provided by the
+environment.
+The '--controller' option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
 
 The '--prefix' option allows the user to specify an optional
 directory path hierarchy to be used when displaying the result

--- a/agent/util-scripts/gold/pbench-move-results/test-33.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-33.txt
@@ -57,7 +57,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-move-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:testhost.example.com:unittests:pbench-move-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-move-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5

--- a/agent/util-scripts/gold/pbench-move-results/test-33.txt
+++ b/agent/util-scripts/gold/pbench-move-results/test-33.txt
@@ -57,7 +57,7 @@ user_script = sleep
 --- pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43/metadata.log file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/yum info installed pbench-agent
-/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:pbench-move-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/curl -s -A pbench-agent-unknown-unknown:testhost.example.com:nobody:unittests:pbench-move-results -L http://pbench.example.com/pbench-results-host-info.versioned/pbench-results-host-info.URL002
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com exit
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/scp -r -o BatchMode=yes -o StrictHostKeyChecking=no -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa /var/tmp/pbench-test-utils/pbench/tmp/pbench-move-results.NNNNN/testhost.example.com pbench@server.com:/foo/bar
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -n -i /var/tmp/pbench-test-utils/opt/pbench-agent/id_rsa -o BatchMode=yes -o StrictHostKeyChecking=no pbench@server.com cd /foo/bar/testhost.example.com; md5sum --check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check && mv pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5.check pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42.tar.xz.md5

--- a/agent/util-scripts/pbench-make-result-tb
+++ b/agent/util-scripts/pbench-make-result-tb
@@ -9,7 +9,7 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 . "$pbench_bin"/base
 
 function usage() {
-    printf -- "usage:\n%s --result-dir=<pbench results dir> --target-dir=<where to put tar ball> [--help] [--user=<user>] [--prefix=<path>] [--xz-single-threaded=<0|1>]\n" "${script_name}"
+    printf -- "usage:\n%s --result-dir=<pbench results dir> --target-dir=<where to put tar ball> [--help] --user=<user> [--prefix=<path>] [--xz-single-threaded=<0|1>]\n" "${script_name}"
 }
 function missing_arg() {
     printf -- "\n%s: %s is missing its argument\n\n" "${script_name}" "${1}" >&2
@@ -91,6 +91,11 @@ while true; do
     esac
 done
 
+if [[ -z "$user" ]] ;then
+    error_log "Missing required '--user' option"
+    exit 1
+fi
+
 if [[ ! -d "${result_dir}" ]]; then
     error_log "Invalid result directory provided: \"${result_dir}\""
     usage >&2
@@ -162,10 +167,8 @@ if [[ -e pbench.log ]]; then
     /bin/cp pbench.log ${pbench_run_name}/
 fi
 
-# if -u|--user was specified, store the specified user in metadata.log
-if [[ ! -z "$user" ]] ;then
-    printf -- "%s" "$user" | pbench-add-metalog-option ${mdlog} run user
-fi
+# Store the specified user in metadata.log
+printf -- "%s" "$user" | pbench-add-metalog-option ${mdlog} run user
 
 # if -p|--prefix was specified, store the specified prefix in metadata.log
 if [[ ! -z "$prefix" ]] ;then

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -8,8 +8,24 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 . "${pbench_bin}"/base
 
 function usage() {
-    printf "usage:\n"
-    printf "${script_name} [--help] [--controller=<controller>] [--user=<user>] [--prefix=<path>] [--xz-single-threaded] [--show-server]\n"
+    printf -- "usage:\n%s [--help] --user=<user> [--controller=<controller>]" "${script_name}"
+    printf -- " [--prefix=<path>] [--xz-single-threaded] [--show-server]\n"
+    printf -- "\nThe '--user' option value is required, and can also be provided\n"
+    printf -- "by the 'PBENCH_USER' environment variable.\n"
+    printf -- "\nThe '--controller' option is also required, but defaults to\n"
+    printf -- "the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment\n"
+    printf -- "variable.\n"
+    printf -- "\nThe '--prefix' option allows the user to specify an optional\n"
+    printf -- "directory path hierarchy to be used when displaying the result\n"
+    printf -- "tar balls on the pbench server.\n"
+    local op="move"
+    if [[ "${script_name}" == "pbench-copy-results" ]]; then
+	op="copy"
+    fi
+    printf -- "\nThe '--show-server' will not ${op} any results, but resolve and\n"
+    printf -- "then display the pbench server destination for results.\n"
+    printf -- "\nThe '--xz-single-threaded' will force the use of a single\n"
+    printf -- "thread for locally compressing the result tar balls.\n"
 }
 
 function missing_arg() {
@@ -83,11 +99,16 @@ done
 if [[ -z "${controller}" ]]; then
     controller=${_pbench_full_hostname}
     if [[ -z "${controller}" ]]; then
-        error_log "Missing controller name (should be \"hostname -f\" value)"
+        error_log "Missing required controller name (should be \"hostname -f\" value)"
         exit 1
     fi
 fi
 validate_hostname "${controller}" "controller"
+
+if [[ -z "${user}" ]]; then
+    error_log "Missing required '--user' option (not found via 'PBENCH_USER' environment variable, either)"
+    exit 1
+fi
 
 # Move into pbench run collection directory
 cd ${pbench_run} >/dev/null
@@ -135,7 +156,7 @@ if [[ -z "${rel}" ]]; then
     rel="unknown"
 fi
 # User-Agent HTTP header: <pbench-agent-ver-rel>:<FQDN>:<$USER>:<full path of this script>""
-user_agent="pbench-agent-${ver}-${rel}:${_pbench_full_hostname}:${USER}:${script_name}"
+user_agent="pbench-agent-${ver}-${rel}:${_pbench_full_hostname}:${USER}:${user}:${script_name}"
 
 results_host_info_url=$(pbench-config host_info_url results)
 results_host_info=$(curl -s -A "${user_agent}" -L "${results_host_info_url}")
@@ -216,11 +237,7 @@ while read -r dir; do
     # contain the tarball and the md5 file (as ${tb}.tar.xz.md5.check); pass
     # that information on to pbench-make-result-tb.
     result_dir=$(basename ${dir})
-    if [[ -n "${user}" ]]; then
-        user_arg="--user ${user}"
-    else
-        user_arg=""
-    fi
+    user_arg="--user ${user}"
     if [[ -n "${prefix}" ]]; then
         prefix_arg="--prefix ${prefix}"
     else
@@ -247,7 +264,7 @@ while read -r dir; do
         continue
     fi
 
-    if [[ "$script_name" == "pbench-move-results" ]]; then
+    if [[ "${script_name}" == "pbench-move-results" ]]; then
         rm -r ${result_dir}
         if [[ ${?} -ne 0 ]]; then
             error_log "UNEXPECTED ERROR: rm failed to remove the ${result_dir} directory hierarchy"

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -10,11 +10,14 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 function usage() {
     printf -- "usage:\n%s [--help] --user=<user> [--controller=<controller>]" "${script_name}"
     printf -- " [--prefix=<path>] [--xz-single-threaded] [--show-server]\n"
-    printf -- "\nThe '--user' option value is required, and can also be provided\n"
-    printf -- "by the 'PBENCH_USER' environment variable.\n"
-    printf -- "\nThe '--controller' option is also required, but defaults to\n"
-    printf -- "the 'hostname -f' value, or the 'PBENCH_CONTROLLER' environment\n"
-    printf -- "variable.\n"
+    printf -- "\nThe '--user' option value is required if not provided by the\n"
+    printf -- "'PBENCH_USER' environment variable; otherwise, the value provided\n"
+    printf -- "on the command line will override any value provided by the\n"
+    printf -- "environment.\n"
+    printf -- "The '--controller' option may be used to override the value\n"
+    printf -- "provided by the 'PBENCH_CONTROLLER' environment variable; if\n"
+    printf -- "neither value is available, the result of 'hostname -f' is used.\n"
+    printf -- "(If no value is available, the command will exit with an error.)\n"
     printf -- "\nThe '--prefix' option allows the user to specify an optional\n"
     printf -- "directory path hierarchy to be used when displaying the result\n"
     printf -- "tar balls on the pbench server.\n"
@@ -237,13 +240,12 @@ while read -r dir; do
     # contain the tarball and the md5 file (as ${tb}.tar.xz.md5.check); pass
     # that information on to pbench-make-result-tb.
     result_dir=$(basename ${dir})
-    user_arg="--user ${user}"
     if [[ -n "${prefix}" ]]; then
-        prefix_arg="--prefix ${prefix}"
+        prefix_arg=" --prefix ${prefix}"
     else
         prefix_arg=""
     fi
-    result_tb_name=$(pbench-make-result-tb --result-dir "${result_dir}" --target-dir "${tmp}/${controller}" ${user_arg} ${prefix_arg} --xz-single-threaded "${xz_single_threaded}")
+    result_tb_name=$(pbench-make-result-tb --result-dir "${result_dir}" --target-dir "${tmp}/${controller}" --user ${user}${prefix_arg} --xz-single-threaded "${xz_single_threaded}")
     if [[ ${?} -ne 0 ]]; then
         # Messaging already handled by pbench-make-result-tb
         continue

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -7,6 +7,13 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 # source the base script
 . "${pbench_bin}"/base
 
+_op=${script_name#pbench-}
+_op=${_op%-results}
+_op_pt="${_op}d"
+if [[ "${_op}" == "copy" ]]; then
+    _op_pt="copied"
+fi
+
 function usage() {
     printf -- "usage:\n%s [--help] --user=<user> [--controller=<controller>]" "${script_name}"
     printf -- " [--prefix=<path>] [--xz-single-threaded] [--show-server]\n"
@@ -21,11 +28,7 @@ function usage() {
     printf -- "\nThe '--prefix' option allows the user to specify an optional\n"
     printf -- "directory path hierarchy to be used when displaying the result\n"
     printf -- "tar balls on the pbench server.\n"
-    local op="move"
-    if [[ "${script_name}" == "pbench-copy-results" ]]; then
-	op="copy"
-    fi
-    printf -- "\nThe '--show-server' will not ${op} any results, but resolve and\n"
+    printf -- "\nThe '--show-server' will not ${_op} any results, but resolve and\n"
     printf -- "then display the pbench server destination for results.\n"
     printf -- "\nThe '--xz-single-threaded' will force the use of a single\n"
     printf -- "thread for locally compressing the result tar balls.\n"
@@ -102,7 +105,7 @@ done
 if [[ -z "${controller}" ]]; then
     controller=${_pbench_full_hostname}
     if [[ -z "${controller}" ]]; then
-        error_log "Missing required controller name (should be \"hostname -f\" value)"
+        error_log "'--controller' is required, because no 'hostname' is configured"
         exit 1
     fi
 fi
@@ -144,7 +147,7 @@ fi
 # ask the server where to send the tarballs
 results_webserver=$(pbench-config webserver results)
 if [[ -z "${results_webserver}" ]]; then
-    error_log "ERROR: No web server host configured from which we can fetch the FQDN of the host to which we copy/move results"
+    error_log "ERROR: No web server host configured from which we can fetch the FQDN of the host to which we ${_op} results"
     debug_log "\"webserver\" variable in \"results\" section not set"
     exit 1
 fi
@@ -158,8 +161,8 @@ rel=$(printf -- "%s" "${_info}" | grep Release | awk '{ print $3 }')
 if [[ -z "${rel}" ]]; then
     rel="unknown"
 fi
-# User-Agent HTTP header: <pbench-agent-ver-rel>:<FQDN>:<$USER>:<full path of this script>""
-user_agent="pbench-agent-${ver}-${rel}:${_pbench_full_hostname}:${USER}:${user}:${script_name}"
+# User-Agent HTTP header: <pbench-agent-ver-rel>:<FQDN>:<${USER}>:${controller}:${user}:<name of this script>""
+user_agent="pbench-agent-${ver}-${rel}:${_pbench_full_hostname}:${USER}:${controller}:${user}:${script_name}"
 
 results_host_info_url=$(pbench-config host_info_url results)
 results_host_info=$(curl -s -A "${user_agent}" -L "${results_host_info_url}")
@@ -266,7 +269,7 @@ while read -r dir; do
         continue
     fi
 
-    if [[ "${script_name}" == "pbench-move-results" ]]; then
+    if [[ "${_op}" == "move" ]]; then
         rm -r ${result_dir}
         if [[ ${?} -ne 0 ]]; then
             error_log "UNEXPECTED ERROR: rm failed to remove the ${result_dir} directory hierarchy"
@@ -284,11 +287,6 @@ done < ${tmp}/results.lis
 
 let anything=runs_copied+failures
 if [[ $anything -gt 0 ]]; then
-    if [[ "$script_name" == "pbench-move-results" ]]; then
-        op="moved"
-    else
-        op="copied"
-    fi
-    debug_log "successfully $op $runs_copied runs, encountered $failures failures"
+    debug_log "successfully ${_op_pt} $runs_copied runs, encountered $failures failures"
 fi
 exit $failures

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -39,7 +39,7 @@ while true; do
         -c|--controller)
             if [[ -n "${1}" ]]; then
                 controller="${1}"
-                shift;
+                shift
             else
                 missing_arg "${opt}"
             fi
@@ -47,7 +47,7 @@ while true; do
         -u|--user)
             if [[ -n "${1}" ]]; then
                 user="${1}"
-                shift;
+                shift
             else
                 missing_arg "${opt}"
             fi
@@ -55,7 +55,7 @@ while true; do
         -p|--prefix)
             if [[ -n "${1}" ]]; then
                 prefix="${1}"
-                shift;
+                shift
             else
                 missing_arg "${opt}"
             fi
@@ -71,7 +71,7 @@ while true; do
             exit 0
             ;;
         --)
-            break;
+            break
             ;;
         *)
             printf "\n${script_name}: you specified an invalid option or an unexpected argument\n\n" >&2

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -38,26 +38,26 @@ while true; do
     case "${opt}" in
         -c|--controller)
             if [[ -n "${1}" ]]; then
-        	controller="${1}"
-        	shift;
+                controller="${1}"
+                shift;
             else
-        	missing_arg "${opt}"
+                missing_arg "${opt}"
             fi
             ;;
         -u|--user)
             if [[ -n "${1}" ]]; then
-        	user="${1}"
-        	shift;
+                user="${1}"
+                shift;
             else
-        	missing_arg "${opt}"
+                missing_arg "${opt}"
             fi
             ;;
         -p|--prefix)
             if [[ -n "${1}" ]]; then
-        	prefix="${1}"
-        	shift;
+                prefix="${1}"
+                shift;
             else
-        	missing_arg "${opt}"
+                missing_arg "${opt}"
             fi
             ;;
         -x|--xz-single-threaded)
@@ -68,7 +68,7 @@ while true; do
             ;;
         -h|--help)
             usage
-   	    exit 0
+            exit 0
             ;;
         --)
             break;

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -106,7 +106,7 @@ fi
 validate_hostname "${controller}" "controller"
 
 if [[ -z "${user}" ]]; then
-    error_log "Missing required '--user' option (not found via 'PBENCH_USER' environment variable, either)"
+    error_log "Missing required 'user' value (provided either by the '--user' option or the 'PBENCH_USER' environment variable)"
     exit 1
 fi
 

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -116,7 +116,7 @@ function _run {
     echo "+++ Running ${tname} ${tscrpt} ${opts}" >> ${_testout}
 
     _runout=${_testroot}/run.out
-    PBENCH_USER="unittests" eval ${tscrpt} ${opts} > ${_runout} 2>&1
+    eval ${tscrpt} ${opts} > ${_runout} 2>&1
     sts=${?}
 
     popd > /dev/null
@@ -293,6 +293,8 @@ function _setup_state {
     printf -- "\n[pbench-agent]\npbench_run = %s\n" "${_testdir}" >> ${_testopt}/config/pbench-agent.cfg
     export _PBENCH_AGENT_CONFIG=${_testopt}/config/pbench-agent.cfg
 
+    export PBENCH_USER="unittests"
+
     mkdir ${_testdir}
     if [[ ${?} -ne 0 ]]; then
         echo "ERROR: failed to create test pbench directory, \"${_testdir}\"" >&2
@@ -404,6 +406,7 @@ declare -A tools=(
     [test-47]="pbench-register-tool"
     [test-48]="test-add-metalog-%-option"
     [test-49]="pbench-copy-results"
+    [test-50]="pbench-copy-results"
     [test-51]="test-start-stop-tool-meister"
     [test-52]="test-start-stop-tool-meister"
     [test-53]="test-client-tool-meister"
@@ -494,6 +497,7 @@ declare -A options=(
     [test-47]="--name=mpstat --no-install --remotes=@${_testdir}/tmp/remotes.lis --labels=labelOne,labelTwo"
     # pbench-copy-results - verify handling of "%"
     [test-49]="--prefix=foo/bar3% --user=ndk20%"
+    [test-50]="--prefix=foo/bar3%"
     [test-52]="mygroup"
     [test-54]="--help"
     [test-55]="--help"
@@ -521,6 +525,7 @@ declare -A expected_status=(
     [test-44]=1
     [test-46]=1
     [test-47]=1
+    [test-50]=1
     [test-58]=1
     [test-59]=1
     [test-60]=1
@@ -538,6 +543,7 @@ declare -A pre_hooks=(
     [test-46]='mkdir ${_testdir}/tmp; printf -- "# bad list\none.example.com\ntwo.example.com,labelTwo\n\nthree.example.com,labelThree,junk\n" > ${_testdir}/tmp/remotes.lis'
     [test-47]='mkdir ${_testdir}/tmp; printf -- "# good list with no labels\none.example.com\ntwo.example.com\nthree.example.com\n" > ${_testdir}/tmp/remotes.lis'
     [test-48]='mkdir ${_testdir}/tmp; printf -- "%s\n" "30%" > ${_testdir}/tmp/foo.txt'
+    [test-50]='unset PBENCH_USER'
 )
 
 function sort_testlog {

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -116,7 +116,7 @@ function _run {
     echo "+++ Running ${tname} ${tscrpt} ${opts}" >> ${_testout}
 
     _runout=${_testroot}/run.out
-    eval ${tscrpt} ${opts} > ${_runout} 2>&1
+    PBENCH_USER="unittests" eval ${tscrpt} ${opts} > ${_runout} 2>&1
     sts=${?}
 
     popd > /dev/null


### PR DESCRIPTION
Ahead of the work coming for the pbench server being endowed with the notion of a user, we require results being moved to provide the `--user` option for `pbench-move-results`.