### PR TITLE
Post deprecation notice for unsupported benchmark scripts

### DIFF
--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -114,6 +114,8 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 ## Ensure the right version of the benchmark is installed
 check_install_rpm "${benchmark_rpm}" "${ver}"
 

--- a/agent/bench-scripts/pbench-cyclictest
+++ b/agent/bench-scripts/pbench-cyclictest
@@ -12,6 +12,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 export benchmark="cyclictest"
 benchmark_rpm=rt-tests
 ver=0.87
@@ -113,8 +115,6 @@ while true; do
 	esac
 done
 verify_common_bench_script_options $tool_group $sysinfo
-
-warn_log "${script_name} is deprecated and will be removed in the next release"
 
 ## Ensure the right version of the benchmark is installed
 check_install_rpm "${benchmark_rpm}" "${ver}"

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -257,6 +257,8 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
 	benchmark_fullname="${benchmark}_${config}_${date_suffix}"

--- a/agent/bench-scripts/pbench-dbench
+++ b/agent/bench-scripts/pbench-dbench
@@ -19,6 +19,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 benchmark_rpm=$script_name
 export benchmark="dbench"
 if [[ -z "${benchmark_bin}" ]]; then
@@ -256,8 +258,6 @@ while true; do
 	esac
 done
 verify_common_bench_script_options $tool_group $sysinfo
-
-warn_log "${script_name} is deprecated and will be removed in the next release"
 
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -175,6 +175,8 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 ## Ensure the right version of the benchmark is installed
 check_install_rpm "${benchmark_rpm}" "${ver}" "${match}"
 

--- a/agent/bench-scripts/pbench-iozone
+++ b/agent/bench-scripts/pbench-iozone
@@ -20,6 +20,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 benchmark_rpm=$script_name
 export benchmark="iozone"
 if [[ -z "${benchmark_bin}" ]]; then
@@ -174,8 +176,6 @@ while true; do
 	esac
 done
 verify_common_bench_script_options $tool_group $sysinfo
-
-warn_log "${script_name} is deprecated and will be removed in the next release"
 
 ## Ensure the right version of the benchmark is installed
 check_install_rpm "${benchmark_rpm}" "${ver}" "${match}"

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -23,6 +23,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 benchmark_rpm=$script_name
 export benchmark="migrate"
 ver=1.0
@@ -224,8 +226,6 @@ while true; do
 	esac
 done
 verify_common_bench_script_options $tool_group $sysinfo
-
-warn_log "${script_name} is deprecated and will be removed in the next release"
 
 function do_migrate() {
 	local src_host=$1

--- a/agent/bench-scripts/pbench-migrate
+++ b/agent/bench-scripts/pbench-migrate
@@ -225,6 +225,8 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 function do_migrate() {
 	local src_host=$1
 	local dest_host=$2

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -34,6 +34,8 @@ pbench_bin="`cd ${script_path}/..; /bin/pwd`"
 # source the base script
 . "$pbench_bin"/base
 
+warn_log "${script_name} is deprecated and will be removed in the next release"
+
 benchmark_rpm=$script_name
 export benchmark="netperf"
 if [[ -z "${benchmark_bin}" ]]; then
@@ -345,8 +347,6 @@ while true; do
 	esac
 done
 verify_common_bench_script_options $tool_group $sysinfo
-
-warn_log "${script_name} is deprecated and will be removed in the next release."
 
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one

--- a/agent/bench-scripts/pbench-netperf
+++ b/agent/bench-scripts/pbench-netperf
@@ -346,6 +346,8 @@ while true; do
 done
 verify_common_bench_script_options $tool_group $sysinfo
 
+warn_log "${script_name} is deprecated and will be removed in the next release."
+
 if [[ -z "$benchmark_run_dir" ]]; then
 	# We don't have an explicit run directory, construct one
 	benchmark_fullname="${benchmark}_${config}_${date_suffix}"

--- a/agent/bench-scripts/pbench-run-benchmark.pl
+++ b/agent/bench-scripts/pbench-run-benchmark.pl
@@ -59,7 +59,7 @@ if (! exists($benchmarks_hash{$benchmark})) {
     exit 1;
 }
 
-print "WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.\n";
+print "WARNING: pbench-run-benchmark is deprecated and will be removed in the next release\n";
 
 # The rest of the parameters are --arg=val, most of which we just pass to other scripts,
 my %params = get_params(@ARGV);

--- a/agent/bench-scripts/pbench-run-benchmark.pl
+++ b/agent/bench-scripts/pbench-run-benchmark.pl
@@ -59,6 +59,8 @@ if (! exists($benchmarks_hash{$benchmark})) {
     exit 1;
 }
 
+print "WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.\n";
+
 # The rest of the parameters are --arg=val, most of which we just pass to other scripts,
 my %params = get_params(@ARGV);
 

--- a/agent/bench-scripts/tests/pbench-dbench/test-02.txt
+++ b/agent/bench-scripts/tests/pbench-dbench/test-02.txt
@@ -1,4 +1,5 @@
 +++ Running test-02 pbench-dbench
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 Starting iteration 1-24thread (1 of 2)
 test sample 1 of 5
 client[1-127.0.0.1]node[0]threads[24]
@@ -133,6 +134,7 @@ Iteration 2-48thread complete (2 of 2), with 1 pass and 0 failures
 /var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/testhost.example.com/sar
 --- pbench tree state
 +++ pbench.log file contents
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 [debug][1900-01-01T00:00:00.000000] checking for dbench on client 127.0.0.1
 [debug][1900-01-01T00:00:00.000000] checking for dbench on client 127.0.0.1
 [info][1900-01-01T00:00:00.000000] Starting iteration 1-24thread (1 of 2)

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-43.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-43.txt
@@ -1,5 +1,5 @@
 +++ Running test-43 pbench-run-benchmark
-WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release
 You must specify at least 1 client with --clients
 --- Finished test-43 pbench-run-benchmark (status=1)
 +++ pbench tree state

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-43.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-43.txt
@@ -1,4 +1,5 @@
 +++ Running test-43 pbench-run-benchmark
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
 You must specify at least 1 client with --clients
 --- Finished test-43 pbench-run-benchmark (status=1)
 +++ pbench tree state

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-44.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-44.txt
@@ -1,4 +1,5 @@
 +++ Running test-44 pbench-run-benchmark
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
 
 ***** it is highly recommended you do one of the following:
 - export this variable before calling this script USER_NAME

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-44.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-44.txt
@@ -1,5 +1,5 @@
 +++ Running test-44 pbench-run-benchmark
-WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release
 
 ***** it is highly recommended you do one of the following:
 - export this variable before calling this script USER_NAME

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-45.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-45.txt
@@ -1,5 +1,5 @@
 +++ Running test-45 pbench-run-benchmark
-WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/fio_test-45-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations fio --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-45.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-45.txt
@@ -1,4 +1,5 @@
 +++ Running test-45 pbench-run-benchmark
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/fio_test-45-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations fio --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-46.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-46.txt
@@ -1,4 +1,5 @@
 +++ Running test-46 pbench-run-benchmark
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/linpack_test-46-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations linpack --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-46.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-46.txt
@@ -1,5 +1,5 @@
 +++ Running test-46 pbench-run-benchmark
-WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/linpack_test-46-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations linpack --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-47.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-47.txt
@@ -1,4 +1,5 @@
 +++ Running test-47 pbench-run-benchmark
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/trafficgen_test-47-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations trafficgen --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/pbench-run-benchmark/test-47.txt
+++ b/agent/bench-scripts/tests/pbench-run-benchmark/test-47.txt
@@ -1,5 +1,5 @@
 +++ Running test-47 pbench-run-benchmark
-WARNING: pbench-run-benchmark is deprecated and will be removed in the next release.
+WARNING: pbench-run-benchmark is deprecated and will be removed in the next release
 cmdfile: /var/tmp/pbench-test-bench/pbench-agent/trafficgen_test-47-tags_1900.01.01T00.00.00/pbench-run-benchmark.cmd
 Generating all benchmark iterations
 resolving default first with pbench-gen-iterations trafficgen --defaults-only --clients=testhost.example.com

--- a/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
+++ b/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
@@ -2,6 +2,7 @@
 
 Bench Script: pbench-cyclictest --help
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
 	The following options are available:
 
 		-c str --config=str name of the test config
@@ -14,6 +15,7 @@ Bench Script: pbench-cyclictest --help
 
 Bench Script: pbench-cyclictest --tool-group=bad --sysinfo=bad
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
 	pbench-cyclictest: invalid --tool-group option ("bad"), directory not found: /var/tmp/pbench-test-bench/pbench-agent/tools-v1-bad
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 	pbench-cyclictest: invalid --sysinfo option ("bad")
@@ -30,6 +32,7 @@ Bench Script: pbench-cyclictest --tool-group=bad --sysinfo=bad
 
 Bench Script: pbench-cyclictest --bad-to-the-bone
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
 pbench-cyclictest --bad-to-the-bone
 
 	unrecognized option specified
@@ -46,6 +49,7 @@ pbench-cyclictest --bad-to-the-bone
 
 Bench Script: pbench-dbench --help
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 	The following options are available:
 
 		             --tool-group=str
@@ -81,6 +85,7 @@ Bench Script: pbench-dbench --help
 
 Bench Script: pbench-dbench --tool-group=bad --sysinfo=bad
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 	pbench-dbench: invalid --tool-group option ("bad"), directory not found: /var/tmp/pbench-test-bench/pbench-agent/tools-v1-bad
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 	pbench-dbench: invalid --sysinfo option ("bad")
@@ -120,6 +125,7 @@ Bench Script: pbench-dbench --tool-group=bad --sysinfo=bad
 
 Bench Script: pbench-dbench --bad-to-the-bone
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 pbench-dbench --bad-to-the-bone
 
 	unrecognized option specified
@@ -437,6 +443,7 @@ The following options are available:
 
 Bench Script: pbench-iozone --help
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
 	The following options are available:
 
 		-C str --config=str name of the test config
@@ -454,6 +461,7 @@ Bench Script: pbench-iozone --help
 
 Bench Script: pbench-iozone --tool-group=bad --sysinfo=bad
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
 	pbench-iozone: invalid --tool-group option ("bad"), directory not found: /var/tmp/pbench-test-bench/pbench-agent/tools-v1-bad
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 	pbench-iozone: invalid --sysinfo option ("bad")
@@ -475,6 +483,7 @@ Bench Script: pbench-iozone --tool-group=bad --sysinfo=bad
 
 Bench Script: pbench-iozone --bad-to-the-bone
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
 pbench-iozone --bad-to-the-bone
 
 	unrecognized option specified
@@ -534,6 +543,7 @@ pbench-linpack --bad-to-the-bone
 
 Bench Script: pbench-migrate --help
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
 	The following options are available:
 
 		--tool-group=str
@@ -558,6 +568,7 @@ Bench Script: pbench-migrate --help
 
 Bench Script: pbench-migrate --tool-group=bad --sysinfo=bad
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
 	pbench-migrate: invalid --tool-group option ("bad"), directory not found: /var/tmp/pbench-test-bench/pbench-agent/tools-v1-bad
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 	pbench-migrate: invalid --sysinfo option ("bad")
@@ -586,6 +597,7 @@ Bench Script: pbench-migrate --tool-group=bad --sysinfo=bad
 
 Bench Script: pbench-migrate --bad-to-the-bone
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
 pbench-migrate --bad-to-the-bone
 
 	unrecognized option specified
@@ -614,6 +626,7 @@ pbench-migrate --bad-to-the-bone
 
 Bench Script: pbench-netperf --help
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
 	The following options are available:
 
 		             --tool-group=str
@@ -651,6 +664,7 @@ Bench Script: pbench-netperf --help
 
 Bench Script: pbench-netperf --tool-group=bad --sysinfo=bad
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
 	pbench-netperf: invalid --tool-group option ("bad"), directory not found: /var/tmp/pbench-test-bench/pbench-agent/tools-v1-bad
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 	pbench-netperf: invalid --sysinfo option ("bad")
@@ -692,6 +706,7 @@ Bench Script: pbench-netperf --tool-group=bad --sysinfo=bad
 
 Bench Script: pbench-netperf --bad-to-the-bone
 ------------
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
 pbench-netperf --bad-to-the-bone
 
 	unrecognized option specified
@@ -1779,13 +1794,28 @@ Usage: pbench-user-benchmark [options] -- <script to run>
 /var/tmp/pbench-test-bench/pbench-agent/tools-v1-default/testhost.example.com/sar
 --- pbench tree state
 +++ pbench.log file contents
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-cyclictest is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-dbench is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-iozone is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-migrate is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
+[warn][1900-01-01T00:00:00.000000] pbench-netperf is deprecated and will be removed in the next release
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"
 [error][1900-01-01T00:00:00.000000] invalid sysinfo option, "bad"

--- a/docs/guides/UserGuide.rst
+++ b/docs/guides/UserGuide.rst
@@ -112,11 +112,9 @@ Pbench provides a set of pre-packaged scripts to run some common benchmarks usin
 pbench provides. These are found in the bench-scripts directory of the Pbench installation (``/opt/pbench-agent/bench-scripts`` by 
 default). The current set includes:
 
-* pbench-dbench
 * pbench fio
 * pbench-linpack
-* pbench-migrate
-* pbench-tpcc
+* pbench-specjbb2005
 * pbench-uperf
 * pbench-user-benchmark (see :ref:`Running Pbench collection tools with an arbitrary benchmark` below for more on this)
 
@@ -165,13 +163,6 @@ Benchmark-specific options are called out in the following sections for each ben
 Note that in some of these scripts the default tool group is hard-wired: if you want them to run a different tool group, you need 
 to edit the script.
 
-pbench-dbench
-==============
-
-+-----------+
-| --threads |
-+-----------+
-
 pbench-fio
 ===========
 
@@ -217,15 +208,8 @@ pbench-linpack
 
      TBD
 
-pbench-migrate
+pbench-specjbb2005
 ================
-
-.. note::
-
-     TBD
-
-pbench-tpcc
-==============
 
 .. note::
 
@@ -560,26 +544,3 @@ pbench-tool-trigger               | this is a Perl script that looks for the sta
                                   | markers in the benchmark's output, starting and stopping the appropriate 
                                   | group of tools when it finds the corresponding marker.
 ================================= ===================================================================================
-
-As an example, pbench-dbench uses three groups of tools: warmup, measurement and cleanup. It registers these groups as triggers using
-
-.. sourcecode:: bash
-
- pbench-register-tool-trigger --group=warmup --start-trigger="warmup" --stop-trigger="execute"
- pbench-register-tool-trigger --group=measurement --start-trigger="execute" --stop-trigger="cleanup"
- pbench-register-tool-trigger --group=cleanup --start-trigger="cleanup" --stop-trigger="Operation"
-
-It then pipes the output of the benchmark into pbench-tool-trigger:
-
-.. sourcecode:: bash
-
- $benchmark_bin --machine-readable --directory=$dir --timelimit=$runtime
-        --warmup=$warmup --loadfile $loadfile $client |
-         tee $benchmark_results_dir/result.txt |
-         pbench-tool-trigger "$iteration" "$benchmark_results_dir" no
-
-pbench-tool-trigger will then start the warmup group when it encounters the string "warmup" in the benchmark's output and stop 
-it when it encounters "execute". It will also start the measurement group when it encounters "execute" and stop it when it 
-encounters "cleanup" - and so on.
-
-Obviously, the start/stop conditions will have to be chosen with some care to ensure correct actions.


### PR DESCRIPTION
There are six benchmark scripts languishing in the pbench-agent with little or no support for them:

 1. `pbench-cyclictest`
 2. `pbench-dbench`
 3. `pbench-iozone`
 4. `pbench-migrate`
 5. `pbench-netperf`
 6. `pbench-run-benchmark`

The goal is to have these deprecated in the `v0.71` release so that we can remove them entirely in the `v0.72` release.