### PR TITLE
Add `hiredis` requirement for performance reasons

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,6 +1,7 @@
 bottle
 cffi
 click>=8.0
+hiredis
 jinja2
 python-daemon
 python-pidfile


### PR DESCRIPTION
It also quiets a ridiculous warning message, see: https://github.com/redis/redis-py/commit/16cfcc7fced84d2b53edf95af1c40b230b30fc3d

This happens with version 4.x and later of `redis-py`, which is now live on PyPI at this point.