### PR TITLE
pbench-register-tool: treat an empty remotes file as an error

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.17.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.17.txt
@@ -1,0 +1,33 @@
++++ Running test-11.17 pbench-register-tool-set --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/empty-remote-file
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/empty-remote-file specifies an empty file
+usage:
+pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]]
+pbench-register-tool-set --toolset=<tool-set> [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>]
+
+	Where the list of labels must match the list of remotes.
+
+	One can specify as the argument to the "--remotes" option a single
+	remote host, a list of remote hosts (comma-separated, no spaces) or an
+	"at" sign ("@") followed by a filename.  In this last case, the file
+	should contain a list of hosts and their (optional) labels.  Each line
+	of the file should contain a host name, optionally followed by a label
+	separated by a comma (","); empty lines are ignored, and comments are
+	denoted by a leading hash, or pound ("#"), character.
+
+Available tool sets from /var/tmp/pbench-test-utils/opt/pbench-agent/config/pbench-agent.cfg:
+	default
+	heavy
+	legacy
+	light
+	medium
+--- Finished test-11.17 pbench-register-tool-set (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tmp/empty-remote-file
+=== /var/tmp/pbench-test-utils/pbench/tmp/empty-remote-file:
+--- pbench tree state
++++ pbench.log file contents
+[error][1900-01-01T00:00:00.000000] --remotes=@/var/tmp/pbench-test-utils/pbench/tmp/empty-remote-file specifies an empty file
+--- pbench.log file contents

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -250,6 +250,12 @@ if [[ ${remotes_arg::1} == "@" ]]; then
 		exit 1
 	fi
 
+	if [[ ! -s ${remotes_file} ]]; then
+		error_log "--remotes=@${remotes_file} specifies an empty file"
+		usage >&2
+		exit 1
+	fi
+
 	declare -a remotes_A
 	declare -A labels_A
 	idx=0

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -371,6 +371,7 @@ declare -A tools=(
     [test-11.14]="pbench-register-tool-set"
     [test-11.15]="pbench-register-tool-set"
     [test-11.16]="pbench-register-tool-set"
+    [test-11.17]="pbench-register-tool-set"
     [test-17]="test-tm-start-bad-group"
     [test-18]="test-tm-stop-bad-group"
     [test-19]="test-tool-trigger"
@@ -454,6 +455,7 @@ declare -A options=(
     [test-11.13]="--help"
     [test-11.15]="--remotes=@non-existent-file"
     [test-11.16]="--remotes=@${_testdir}/tmp/good-remote-file"
+    [test-11.17]="--remotes=@${_testdir}/tmp/empty-remote-file"
 
     # pbench-move-results
     [test-20]="--help"
@@ -512,6 +514,7 @@ declare -A expected_status=(
     [test-11.08]=1
     [test-11.11]=1
     [test-11.15]=1
+    [test-11.17]=1
     [test-17]=1
     [test-18]=1
     [test-22]=1
@@ -531,6 +534,7 @@ declare -A pre_hooks=(
     [test-06]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client; mkdir -p ${_testdir}/42-iter/sample42/tools-default/testhost.example.com/iostat; touch ${_testdir}/42-iter/sample42/tools-default/testhost.example.com/iostat/iostat-stdout.txt'
     [test-07]='mkdir -p ${_testdir}/42-iter/sample42/tools-foobar/testhost.example.com/iostat; touch ${_testdir}/42-iter/sample42/tools-foobar/testhost.example.com/iostat/iostat-stdout.txt'
     [test-11.16]='mkdir -p ${_testdir}/tmp; (echo foo; echo bar) > ${_testdir}/tmp/good-remote-file'
+    [test-11.17]='mkdir -p ${_testdir}/tmp; touch  ${_testdir}/tmp/empty-remote-file'
     [test-19]='ln -s mock-pbench-tool-meister-client ${_testopt}/unittest-scripts/pbench-tool-meister-client'
     [test-33]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; touch --date="2019-01-01 12:00:44" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44; echo "--- setup pbench results dir time stamps") >> ${_testout}'
     [test-34]='(echo "+++ setup pbench results dir time stamps"; touch --date="2019-01-01 12:00:42" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.42; touch --date="2019-01-01 12:00:43" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.43; touch --date="2019-01-01 12:00:44" ${_testdir}/pbench-user-benchmark_ndk-test-1_2019.01.01T12.00.44; echo "--- setup pbench results dir time stamps") >> ${_testout}'


### PR DESCRIPTION
Fixes #2538

An empty remotes file specified with `--remotes=@/path/to/file` now
makes `pbench-register-tool` (and also `pbench-register-tool-set`) log
an error message and exit with an error status.