### PR TITLE
Spec file and ansible fixes for RHEL9

### DIFF
--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
@@ -17,3 +17,8 @@
     dest: "{{ pbench_key_dest }}"
     mode: "0600"
     files: id_rsa
+
+- name: "pbench agent configuration - open firewall ports for tool meister"
+  include_role:
+    name: pbench_firewall_open_ports
+

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/README.md
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/README.md
@@ -1,0 +1,40 @@
+pbench_firewall_open_ports
+===================
+
+This role punches a hole through the firewall for various ports that the tool meister
+processes need to use.
+
+Requirements
+------------
+None.
+
+Role Variables
+--------------
+These are the variables that are defined by default and do not
+generally need to be modified unless there is a conflict:
+
+- pbench_redis_port: 17001
+- pbench_wsgi_port: 8080
+
+Dependencies
+------------
+None
+
+Example Playbook
+----------------
+An example playbook can be obtained from
+
+    https://github.com/distributed-system-analysis/pbench/blob/master/agent/ansible/pbench_agent_install.yml
+
+or you can use the raw link to wget/curl the file:
+
+    https://raw.githubusercontent.com/distributed-system-analysis/pbench/master/agent/ansible/pbench_agent_install.yml
+
+
+License
+-------
+GPL-3.0-or-later.
+
+Author Information
+------------------
+The Pbench team.

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/defaults/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+pbench_redis_port: 17001
+pbench_wsgi_port: 8080

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/meta/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/meta/main.yml
@@ -1,0 +1,25 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: pbench_firewall_open_ports
+  author: The Pbench team
+  description: Role to open firewall ports for tool meister
+  license: "license(GPL-3.0-or-later)"
+  min_ansible_version: 2.4
+  platforms:
+    - name: Fedora
+      versions:
+        - all
+    - name: RHEL
+      versions:
+        - 7
+        - 8
+        - 9
+    - name: CentOS
+      versions:
+        - 7
+        - 8
+        - 9
+  galaxy_tags:
+    - pbench

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# pbench agent configuration
+- name: "pbench agent configuration - open firewall ports for tool meister"
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
+    permanent: yes
+    offline: yes
+    state: enabled
+  with_items:
+    - "{{ pbench_redis_port }}"
+    - "{{ pbench_wsgi_port }}"
+

--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/vars/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/vars/main.yml
@@ -1,5 +1,7 @@
 ---
-distro: "{{ 'epel' if ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
+distro: "{{ 'centos-stream' if ansible_distribution_major_version == '9'
+          else
+            'epel' if ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
           else
             'fedora' if ansible_distribution == 'Fedora'
           else

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -8,6 +8,12 @@ URL:            https://github.com/distributed-system-analysis/pbench
 Source0:        pbench-agent-%{version}.tar.gz
 Buildarch:      noarch
 
+%if 0%{?rhel} < 9
+Requires:  ansible
+%else
+Requires:  ansible-core
+%endif
+
 %if 0%{?rhel} == 7
 Requires:  python3, python3-pip
 # For RHEL boxen we need the python development environment in order for the
@@ -19,6 +25,14 @@ Requires:  gcc python3-devel
 Requires:  python36, python3-pip
 # RPMs for modules in requirements.txt
 Requires:  python3-cffi, python3-click, python3-requests
+# RPMs for module dependencies
+Requires:  python3-docutils, python3-psutil
+%endif
+
+%if 0%{?rhel} == 9
+Requires:  python3-pip
+# RPMs for modules in requirements.txt
+Requires:  python3-cffi, python3-requests
 # RPMs for module dependencies
 Requires:  python3-docutils, python3-psutil
 %endif
@@ -38,7 +52,7 @@ Requires:  python3-psutil
 Requires:  perl, perl-Data-UUID, perl-JSON, %{?prefixjsonxs}perl-JSON-XS
 Requires:  perl-Time-HiRes
 
-Requires:  ansible, bc, bzip2, hostname, iproute, iputils, net-tools
+Requires:  bc, bzip2, hostname, iproute, iputils, net-tools
 Requires:  openssh-clients, openssh-server, procps-ng, psmisc, redis
 Requires:  rpmdevtools, rsync, screen, sos, tar, xz
 


### PR DESCRIPTION
- Replace `ansible` dependency by `ansible-core` (more for documentation
than any other reason: `ansible-core` is installed by default on RHEL9)

- Add some python dependencies similar to RHEL8, although I had to
leave out `python3-click` which is not available (yet?)

- Fix the name of the COPR repo for RHEL9 in the ansible roles.

- The second commit adds an ansible role to punch holes in the firewall
for tool meister use
