### PR TITLE
Move index_mappings api to appropriate directory

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -78,7 +78,7 @@ def register_endpoints(api, app, config):
     api.add_resource(
         IndexMappings,
         f"{base_uri}/index/mappings/<string:index_key>",
-        resource_class_args=(logger,),
+        resource_class_args=(config, logger),
     )
     api.add_resource(
         IndexSearch, f"{base_uri}/index/search", resource_class_args=(config, logger),

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -23,7 +23,9 @@ from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetai
 from pbench.server.api.resources.query_apis.datasets_list import DatasetsList
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
-from pbench.server.api.resources.query_apis.index_mappings import IndexMappings
+from pbench.server.api.resources.query_apis.metadata_index.index_mappings import (
+    IndexMappings,
+)
 from pbench.server.api.resources.query_apis.index_search import IndexSearch
 from pbench.server.api.resources.query_apis.metadata_index.namespace_and_rows import (
     SampleNamespace,
@@ -75,7 +77,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         IndexMappings,
-        f"{base_uri}/index/mappings/<string:index_name>",
+        f"{base_uri}/index/mappings/<string:index_key>",
         resource_class_args=(logger,),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/query_apis/metadata_index/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/metadata_index/__init__.py
@@ -60,6 +60,16 @@ class RunIdBase(ElasticBase):
                 "result",
             ],
         },
+        "search": {
+            "index": "run",
+            "whitelist": [
+                "@timestamp",
+                "@metadata",
+                "host_tools_info",
+                "run",
+                "sosreports",
+            ],
+        },
     }
 
     def __init__(self, config: PbenchServerConfig, logger: Logger, schema: Schema):

--- a/lib/pbench/server/api/resources/query_apis/metadata_index/index_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/metadata_index/index_mappings.py
@@ -89,8 +89,7 @@ class IndexMappings(ApiBase):
         request on index/mappings/search. Similarly other index documents can be
         fetched by making a GET request on appropriate index names.
 
-        We fetch the mapping by querying the template database. If the
-        template is not found in the database NOT_FOUND error will be raised.
+        The mappings are retrieved by querying the template database.
         """
         # Normalize and validate the index keys we got via URI string. These
         # don't go through JSON schema validation, so we have

--- a/lib/pbench/server/api/resources/query_apis/metadata_index/index_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/metadata_index/index_mappings.py
@@ -5,17 +5,17 @@ from typing import Any, AnyStr, Dict
 from flask import jsonify
 from flask_restful import Resource, abort
 
+from pbench.server.api.resources.query_apis.metadata_index import RunIdBase
 from pbench.server.database.models.template import Template, TemplateNotFound
 
 
 class IndexMappings(Resource):
     """
-    Get properties of the run-data document type on which the dashboard can search.
-    This API currently only returns mapping properties of run-data documents.
+    Get properties of a document on which the client can search.
+    This API currently only supports mapping properties of documents specified
+    in RunIdBase.ES_INTERNAL_INDEX_NAMES.
 
-    TODO: In future we can tweak this API to take the document type name from the user
-    and query that type name against the template table to return the appropriate mappings
-
+    Example: get /api/v1/index/mappings/search
     :return:
     {
         "@metadata":
@@ -59,16 +59,22 @@ class IndexMappings(Resource):
     def __init__(self, logger: Logger):
         self.logger = logger
 
-    def get(self, index_name: AnyStr) -> Dict[AnyStr, Any]:
+    def get(self, index_key: AnyStr) -> Dict[AnyStr, Any]:
         """
-        Return mapping properties of the document specified by the index name in the URI.
-        For example, user can get the run document properties by making a GET request on
-        index/mappings/run. Similarly other index documents can be fetched by making a GET
-        request on appropriate index names.
-        We fetch the mapping by querying the template database. If the template is not found
-        in the database NOT_FOUND error will be raised.
+        Return mapping properties of the document specified by the index name
+        in the URI. For example, user can get the run document properties by
+        making a GET request on index/mappings/search. Similarly other index
+        documents can be fetched by making a GET request on appropriate index names.
+
+        We fetch the mapping by querying the template database. If the
+        template is not found in the database NOT_FOUND error will be raised.
         """
+        index = RunIdBase.ES_INTERNAL_INDEX_NAMES.get(index_key)
+        if not index:
+            self.logger.debug(f"Document index key is not valid {index_key!r}")
+            abort(HTTPStatus.NOT_FOUND, message="Mapping not found")
         try:
+            index_name = index["index"]
             template = Template.find(index_name)
             mappings = template.mappings
 
@@ -85,4 +91,4 @@ class IndexMappings(Resource):
             self.logger.exception(
                 "Document template {} not found in the database.", index_name
             )
-            abort(HTTPStatus.NOT_FOUND, message="Mapping not found")
+            abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")

--- a/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
@@ -30,7 +30,7 @@ class TestIndexMappings:
         response body.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            response = client.get(f"{server_config.rest_uri}/index/mappings/search")
             assert response.status_code == HTTPStatus.OK
             res_json = response.json
             assert res_json == {
@@ -85,9 +85,7 @@ class TestIndexMappings:
         response body.
         """
         with client:
-            response = client.get(
-                f"{server_config.rest_uri}/index/mappings/result-data-sample"
-            )
+            response = client.get(f"{server_config.rest_uri}/index/mappings/iterations")
             assert response.status_code == HTTPStatus.OK
             res_json = response.json
             assert res_json == {
@@ -110,7 +108,7 @@ class TestIndexMappings:
         present in the database.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            response = client.get(f"{server_config.rest_uri}/index/mappings/test")
             assert response.status_code == HTTPStatus.NOT_FOUND
             assert response.json["message"] == "Mapping not found"
 
@@ -119,6 +117,6 @@ class TestIndexMappings:
         Check the index mappings API if there is an error connecting to sql database.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/index/mappings/run")
+            response = client.get(f"{server_config.rest_uri}/index/mappings/search")
             assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
             assert response.json["message"] == "Internal Server Error"

--- a/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_index_mappings.py
@@ -108,9 +108,14 @@ class TestIndexMappings:
         present in the database.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/index/mappings/test")
-            assert response.status_code == HTTPStatus.NOT_FOUND
-            assert response.json["message"] == "Mapping not found"
+            response = client.get(
+                f"{server_config.rest_uri}/index/mappings/bad_data_object_type"
+            )
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            assert (
+                response.json["message"]
+                == "Unrecognized keyword ['bad_data_object_type'] given for parameter index_key; allowed keywords are ['iterations', 'search', 'timeseries']"
+            )
 
     def test_with_db_error(self, client, server_config, database_error):
         """


### PR DESCRIPTION
- Move index_mappings api under lib/pbench/server/api/resources/query_apis/metadata_index directory.
- Replace index name in the index_mappings get URI where <index> parameter is not a direct Elasticsearch root index name, but a key like search, samples, timeseries.