### PR TITLE
Dynamic `root_index_name`

### DIFF
--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -69,14 +69,16 @@ class Commons:
 
     def build_index_from_metadata(self, root_index_name: str) -> str:
         """
-            Retrieve the list of ES indices from the dataset index map metadata based on a given root index name.
+            Retrieve the list of ES indices from the dataset index
+            map metadata based on a given root index name.
 
             Args:
                 root_index_name: root index name
 
             Returns:
-                An Elasticsearch query URL string listing the set of indices containing documents for the specified
-                root index name.
+                An Elasticsearch query URL string listing the set of
+                indices containing documents for the specified root
+                index name.
         """
         drb = Dataset.attach(controller="node", name="drb")
         index_map = Metadata.getvalue(dataset=drb, key="server.index-map")

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -33,6 +33,7 @@ class Commons:
             "hits": [],
         },
     }
+    RESULT_DATA_SAMPLE = "result-data-sample"
 
     def _setup(
         self,
@@ -66,7 +67,11 @@ class Commons:
 
         return f"/{index}"
 
-    def build_index_from_metadata(self, root_index_name):
+    def build_index_from_metadata(self, root_index_name:str) -> str:
+        """Args
+            - root_index_name: Retrieve the list of ES indices from
+                the metadata table based on a given root_index_name.
+        """
         drb = Dataset.attach(controller="node", name="drb")
         index_map = Metadata.getvalue(dataset=drb, key="server.index-map")
         index_keys = [key for key in index_map if root_index_name in key]
@@ -365,7 +370,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_exception.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata("result-data-sample")
+            index = self.build_index_from_metadata(Commons.RESULT_DATA_SAMPLE)
         else:
             index = self.build_index(
                 server_config,
@@ -400,7 +405,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_error.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata("result-data-sample")
+            index = self.build_index_from_metadata(Commons.RESULT_DATA_SAMPLE)
         else:
             index = self.build_index(
                 server_config,

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -66,10 +66,10 @@ class Commons:
 
         return f"/{index}"
 
-    def build_index_from_metadata(self):
+    def build_index_from_metadata(self, root_index_name):
         drb = Dataset.attach(controller="node", name="drb")
         index_map = Metadata.getvalue(dataset=drb, key="server.index-map")
-        index_keys = [key for key in index_map if "result-data-sample" in key]
+        index_keys = [key for key in index_map if root_index_name in key]
         return "/" + ",".join(index_keys)
 
     def date_range(self, start: AnyStr, end: AnyStr) -> list:
@@ -365,7 +365,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_exception.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata()
+            index = self.build_index_from_metadata("result-data-sample")
         else:
             index = self.build_index(
                 server_config,
@@ -400,7 +400,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_error.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata()
+            index = self.build_index_from_metadata("result-data-sample")
         else:
             index = self.build_index(
                 server_config,

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -67,7 +67,7 @@ class Commons:
 
         return f"/{index}"
 
-    def build_index_from_metadata(self, root_index_name:str) -> str:
+    def build_index_from_metadata(self, root_index_name: str) -> str:
         """Args
             - root_index_name: Retrieve the list of ES indices from
                 the metadata table based on a given root_index_name.

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -68,9 +68,15 @@ class Commons:
         return f"/{index}"
 
     def build_index_from_metadata(self, root_index_name: str) -> str:
-        """Args
-            - root_index_name: Retrieve the list of ES indices from
-                the metadata table based on a given root_index_name.
+        """
+            Retrieve the list of ES indices from the dataset index map metadata based on a given root index name.
+
+            Args:
+                root_index_name: root index name
+
+            Returns:
+                An Elasticsearch query URL string listing the set of indices containing documents for the specified
+                root index name.
         """
         drb = Dataset.attach(controller="node", name="drb")
         index_map = Metadata.getvalue(dataset=drb, key="server.index-map")
@@ -370,7 +376,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_exception.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata(Commons.RESULT_DATA_SAMPLE)
+            index = self.build_index_from_metadata(self.RESULT_DATA_SAMPLE)
         else:
             index = self.build_index(
                 server_config,
@@ -405,7 +411,7 @@ class Commons:
             pytest.skip("skipping " + self.test_http_error.__name__)
 
         if self.use_index_from_metadata:
-            index = self.build_index_from_metadata(Commons.RESULT_DATA_SAMPLE)
+            index = self.build_index_from_metadata(self.RESULT_DATA_SAMPLE)
         else:
             index = self.build_index(
                 server_config,

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -327,7 +327,7 @@ class TestSamplesNamespace(Commons):
                 },
             },
         }
-        index = self.build_index_from_metadata("result-data-sample")
+        index = self.build_index_from_metadata(self.RESULT_DATA_SAMPLE)
 
         # get_expected_status() expects to read username and access from the
         # JSON client payload, however this API acquires that information
@@ -397,7 +397,6 @@ class TestSampleValues(Commons):
     """
 
     SCROLL_ID = "random_scroll_id_string_1=="
-    RESULT_DATA_SAMPLE = "result-data-sample"
 
     @pytest.fixture(autouse=True)
     def _setup(self, client):
@@ -558,7 +557,7 @@ class TestSampleValues(Commons):
                 ],
             },
         }
-        index = self.build_index_from_metadata(TestSampleValues.RESULT_DATA_SAMPLE)
+        index = self.build_index_from_metadata(self.RESULT_DATA_SAMPLE)
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(
@@ -624,7 +623,7 @@ class TestSampleValues(Commons):
                 ),
             },
         }
-        index = self.build_index_from_metadata(TestSampleValues.RESULT_DATA_SAMPLE)
+        index = self.build_index_from_metadata(self.RESULT_DATA_SAMPLE)
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(
@@ -758,7 +757,7 @@ class TestSampleValues(Commons):
 
     def test_get_index(self, attach_dataset, provide_metadata):
         drb = Dataset.attach(controller="node", name="drb")
-        indices = self.cls_obj.get_index(drb, TestSampleValues.RESULT_DATA_SAMPLE)
+        indices = self.cls_obj.get_index(drb, self.RESULT_DATA_SAMPLE)
         assert indices == "unit-test.v5.result-data-sample.2020-08"
 
     def test_exceptions_on_get_index(self, attach_dataset):
@@ -766,7 +765,7 @@ class TestSampleValues(Commons):
 
         # When server index_map is None we expect 500
         with pytest.raises(InternalServerError) as exc:
-            self.cls_obj.get_index(test, TestSampleValues.RESULT_DATA_SAMPLE)
+            self.cls_obj.get_index(test, self.RESULT_DATA_SAMPLE)
         assert exc.value.code == HTTPStatus.INTERNAL_SERVER_ERROR
 
         Metadata.setvalue(
@@ -777,4 +776,4 @@ class TestSampleValues(Commons):
 
         # When server index_map doesn't have mappings for result-data-sample
         # documents we expect the indices to an empty string
-        assert self.cls_obj.get_index(test, TestSampleValues.RESULT_DATA_SAMPLE) == ""
+        assert self.cls_obj.get_index(test, self.RESULT_DATA_SAMPLE) == ""

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -397,6 +397,7 @@ class TestSampleValues(Commons):
     """
 
     SCROLL_ID = "random_scroll_id_string_1=="
+    RESULT_DATA_SAMPLE = "result-data-sample"
 
     @pytest.fixture(autouse=True)
     def _setup(self, client):
@@ -557,7 +558,7 @@ class TestSampleValues(Commons):
                 ],
             },
         }
-        index = self.build_index_from_metadata("result-data-sample")
+        index = self.build_index_from_metadata(TestSampleValues.RESULT_DATA_SAMPLE)
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(
@@ -623,7 +624,7 @@ class TestSampleValues(Commons):
                 ),
             },
         }
-        index = self.build_index_from_metadata("result-data-sample")
+        index = self.build_index_from_metadata(TestSampleValues.RESULT_DATA_SAMPLE)
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(
@@ -757,7 +758,7 @@ class TestSampleValues(Commons):
 
     def test_get_index(self, attach_dataset, provide_metadata):
         drb = Dataset.attach(controller="node", name="drb")
-        indices = self.cls_obj.get_index(drb, "result-data-sample")
+        indices = self.cls_obj.get_index(drb, TestSampleValues.RESULT_DATA_SAMPLE)
         assert indices == "unit-test.v5.result-data-sample.2020-08"
 
     def test_exceptions_on_get_index(self, attach_dataset):
@@ -765,7 +766,7 @@ class TestSampleValues(Commons):
 
         # When server index_map is None we expect 500
         with pytest.raises(InternalServerError) as exc:
-            self.cls_obj.get_index(test, "result-data-sample")
+            self.cls_obj.get_index(test, TestSampleValues.RESULT_DATA_SAMPLE)
         assert exc.value.code == HTTPStatus.INTERNAL_SERVER_ERROR
 
         Metadata.setvalue(
@@ -776,4 +777,4 @@ class TestSampleValues(Commons):
 
         # When server index_map doesn't have mappings for result-data-sample
         # documents we expect the indices to an empty string
-        assert self.cls_obj.get_index(test, "result-data-sample") == ""
+        assert self.cls_obj.get_index(test, TestSampleValues.RESULT_DATA_SAMPLE) == ""

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -327,7 +327,7 @@ class TestSamplesNamespace(Commons):
                 },
             },
         }
-        index = self.build_index_from_metadata()
+        index = self.build_index_from_metadata("result-data-sample")
 
         # get_expected_status() expects to read username and access from the
         # JSON client payload, however this API acquires that information
@@ -557,7 +557,7 @@ class TestSampleValues(Commons):
                 ],
             },
         }
-        index = self.build_index_from_metadata()
+        index = self.build_index_from_metadata("result-data-sample")
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(
@@ -623,7 +623,7 @@ class TestSampleValues(Commons):
                 ),
             },
         }
-        index = self.build_index_from_metadata()
+        index = self.build_index_from_metadata("result-data-sample")
 
         auth_json = {"user": "drb", "access": "private"}
         expected_status = self.get_expected_status(


### PR DESCRIPTION
`root_index_name` in the `commons.py` file is hard coded to `result-data-sample` where it needs to be script-based. Like for `namespaces_and_rows` PR we need `result-data-sample` as a `root_index_name` for finding the appropriate indices, while we need `run-toc` as `root_index_name` for finding indices related to that