### PR TITLE
Miscellaneous fixes in support of a Containerized Pbench Server

### DIFF
--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -92,6 +92,7 @@ RUN \
         `# using the Server RPM.  Then, if a 'pip3 install -r requirements.txt'` \
         `# shows any missing dependencies they should be added to the RPM spec` \
         `# file and this list should be regenerated.` \
+        cronie \
         npm \
         policycoreutils \
         policycoreutils-python-utils \
@@ -171,6 +172,7 @@ RUN \
         python3-sphinx \
         `#` \
         `# Install utilities for building RPMs, evaluating test results, etc.` \
+        copr-cli \
         diffutils \
         git \
         less \

--- a/server/bin/pbench-server-prep-shim-002.py
+++ b/server/bin/pbench-server-prep-shim-002.py
@@ -241,13 +241,16 @@ def process_tb(config, logger, receive_dir, qdir_md5, duplicates, errors):
             nerrs += 1
             continue
 
-        # Restore the SELinux context properly
-        try:
-            selinux.restorecon(dest / tb.name)
-            selinux.restorecon(dest / tbmd5.name)
-        except Exception as e:
-            # log it but do not abort
-            logger.error("{}: Error: 'restorecon {}', {}", config.TS, dest / tb.name, e)
+        if selinux.is_selinux_enabled():
+            # Restore the SELinux context properly
+            try:
+                selinux.restorecon(dest / tb.name)
+                selinux.restorecon(dest / tbmd5.name)
+            except Exception as e:
+                # log it but do not abort
+                logger.error(
+                    "{}: Error: 'restorecon {}', {}", config.TS, dest / tb.name, e
+                )
 
         # Now that we have successfully moved the tar ball and its .md5 to the
         # destination, we can remove the original .md5 file.

--- a/server/bin/test-lib/selinux.py
+++ b/server/bin/test-lib/selinux.py
@@ -21,3 +21,7 @@ def restorecon(path, recursive=False, verbose=False, force=False):
         )
 
     return 0
+
+
+def is_selinux_enabled():
+    return 1

--- a/server/lib/systemd/pbench-server.service
+++ b/server/lib/systemd/pbench-server.service
@@ -17,7 +17,8 @@ PIDFile = /run/pbench-server/gunicorn.pid
 ExecStart = /opt/pbench-server/bin/pbench-server
 ExecStop = /bin/kill -s TERM $MAINPID
 Restart = always
-StartLimitInterval = 60
+RestartSec = 30
+StartLimitInterval = 600
 StartLimitBurst = 10
 
 [Install]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,5 +19,6 @@ pyesbulk>=2.0.1
 PyJwt
 psycopg2
 requests
+selinux
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -9,7 +9,7 @@ Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
 
-Requires: python3 python3-devel
+Requires: python3 python3-devel cronie
 
 # policycoreutils for semanage and restorecon - used in pbench-server-activate-create-results-dir
 Requires:       policycoreutils

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -181,7 +181,6 @@ fi
 /%{installdir}
 %attr(755, pbench, pbench) /%{installdir}/bin
 %attr(644, pbench, pbench) /%{installdir}/bin/pbench-base.sh
-%attr(755, pbench, pbench) /%{installdir}/lib/systemd/pbench-server.service
 
 %doc /%{installdir}/lib/pbench/server/s3backup/README
 %doc /%{installdir}/lib/pbench/common/AUTHORS.log_formatter


### PR DESCRIPTION
This PR is for a set of miscellaneous fixes which I made leading up to providing a containerized Pbench Server (see #2585).

- The first change works around a bug in the RHEL 8 `libselinux` implementation, which results in a SEGV when the `restorecon` function is invoked with SELinux disabled (as it is, for whatever reason, in the RHEL 8 container).  The fix is simple and of general applicability, which is why it's included in this PR:  only call `restorecon` if SELinux is enabled.  However, it turns out that the Server's functional test suite mocks the `selinux` module, but it does so incompletely, so I had to add `is_selinux_enabled()` to the mock-module.
- The second change is centered on the `pbench-server.service` file which is used by `systemd` to run the Pbench Server.  Part of it is to correct the file permissions to remove the eXecutable bit, which `systemd` complains about.  The more substantive change is to establish a cooldown interval between failures:  if the Pbench Server crashes for some reason, it will wait 30 seconds before being restarted.  And, I've set it to allow 20 retries.  In the case of the containerized Pbench Server, on startup, the Server process attempts to connect to the PostgreSQL database before the database is ready to accept connections, which causes the Pbench Server to crash.  Without increasing the retry interval, the Pbench Server repeatedly crashes, exhausting its retries before the database becomes available, and so it never starts.  With the increased interval, the Pbench Server stabilizes after only a few attempts.  This change should have little impact in other deployment cases -- at the worst, it will increase the downtime for an unexpected failure to half a minute.
- The next change acknowledges the fact that the Pbench Server depends on `cron` by adding the `cronie` package to the list of required packages in the Server's RPM spec file.  Typically, on systems where the Server is installed, `cron` is already available; however, in the containerized environment, this is not the case, so we need to request it explicitly.
- The next change is basically a housekeeping update, adding `cronie` to the Jenkins development container recipe.  The intention is that the container should already include all the Pbench requirements, and this brings it up to date with the previous change in this PR.  This change also adds the `copr-cli` package, to enable building Server RPMs in the container.
- The last change adds `selinux` to the Server `requirements.txt` file since it was missing.

[Review invitations:  @portante, @dbutenhof, @ndokos, and anyone else who would like to chime in]