### PR TITLE
Remove implicit use of "quarantiner" user

### DIFF
--- a/server/bin/pbench-base.sh
+++ b/server/bin/pbench-base.sh
@@ -137,9 +137,7 @@ function quarantine () {
         fi
         # Create/update state record if we're not moving a .md5 file
         if [ ${afile} != ${afile%.tar.xz} ] ;then
-            # TODO: When we drop ssh intake, we'll always have a user
-            # by now.
-            pbench-state-manager --create=quarantiner --path="${afile}" --state=quarantined
+            pbench-state-manager --path="${afile}" --state=quarantined
             sts=${?}
             if [[ ${sts} -ne 0 ]]; then
                 log_error "$TS: quarantine $afile: \"set state\" failed with status $sts"

--- a/server/bin/state/test-5.2.db
+++ b/server/bin/state/test-5.2.db
@@ -1,0 +1,3 @@
+controller-d-duplicate DUPLICATE__NAME.tarball-duplicate_1970.01.01T00.42.00 uploaded quarantiner
+controller-d-duplicate tarball-that-does-not-exist_1970.01.01T00.42.00 uploaded quarantiner
+controller-h-bad-md5 tarball-bad-md5_1970.01.01T00.42.00 uploaded quarantiner

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -477,10 +477,9 @@ function _setup_state {
 
     # Determine which users the test needs and create them. We discover
     # users dynamically from the database state ".db" files, but also
-    # always allow use of the quarantiner and satellite users for the
-    # pre-shim and satellite intake tests, as well as "pbench" for
-    # un-owned prep-shim intake success.
-    local users="pbench quarantiner satellite"
+    # always allow use of the satellite user for the satellite intake tests,
+    # as well as "pbench" for un-owned prep-shim intake.
+    local users="pbench satellite"
     if [ -f ${_state_db} ]; then
         users="$(cat ${_state_db} | cut --d ' ' -f 4 | sort -u) ${users}"
     fi
@@ -946,7 +945,7 @@ done
 if [[ $count -eq 0 ]]; then
     printf "No tests run!\n" >&2
     let failures=1
-elif [[ $mode == "parallel" ]]; then
+elif [[ ${mode} == "parallel" ]]; then
     for testname in $tests ;do
         wait ${pids[${testname}]} > /dev/null 2>&1
         report_test_result ${testname}


### PR DESCRIPTION
The original "light dataset" implementation provided for dynamically creating datasets. While most of that was removed, it remained in the bash base utilities `quarantine` function because that could be called from `pbench-server-prep-shim-002` before a dataset was created. However, in normal use the "quarantiner" user doesn't exist anyway.

This removes that code, so that `quarantine` depends on the dataset already existing. This includes an adjustment to test-5.2 (which is the only legacy test case exercising this code through pbench-dispatch) to pre-create the expected datasets. (Using the same "quarantiner" user, so that the gold file doesn't change!) Because we collect the usernames specified in the `.db` file, we no longer need to hardcode `quarantiner` in the list of users to create.