### PR TITLE
pbench-copy-result-tb issue #2437

### DIFF
--- a/agent/util-scripts/pbench-copy-result-tb
+++ b/agent/util-scripts/pbench-copy-result-tb
@@ -9,8 +9,22 @@ pbench_bin="$(realpath -e ${script_path}/..)"
 . "${pbench_bin}"/base
 
 function usage() {
-    printf "usage:\n"
-    printf "${script_name} [--help] <full path to tar ball> <results host> <results path prefix>\n"
+    printf -- "usage:\n%s [--help] <tarball> <host> <prefix>\n" "${script_name}"
+    printf -- "\ntarball:\n"
+    printf -- " The tarball must be in a controller directory along with the matching MD5 file;\n"
+    printf -- " The tarball file name must end in '.tar.xz';\n"
+    printf -- " The tarball must be accompanied by a matching MD5 file with a name ending\n"
+    printf -- "  in '.tar.xz.md5.check';\n"
+    printf -- " For example, '%s /var/tmp/pbench-agent/tmp/hostname/tarball.tar.xz'\n" "${script_name}"
+    printf -- "\nhost:\n"
+    printf -- " The Pbench 0.69 server hostname to which the tarball will be copied; it should\n"
+    printf -- " be the FQDN for the server host configured in the Pbench agent config file, as\n"
+    printf -- " reported by 'pbench-config webserver results'\n"
+    printf -- "\nprefix:\n"
+    printf -- " The Pbench server path where incoming tarballs are stored, as reported by\n"
+    printf -- " 'pbench-config host_info_url results'\n"
+    printf -- "\n\nThis command requires a 0.69 Pbench server id_rsa file in /opt/pbench-agent;\n"
+    printf -- "do not use this command with a Pbench server more recent than 0.69.\n"
 }
 
 # Process options and arguments
@@ -47,12 +61,21 @@ fi
 controller_dir=$(dirname ${tarball})
 cnt=$(find ${controller_dir} -type f 2> /dev/null | wc -l 2> /dev/null)
 if [[ ${cnt} != 2 ]]; then
-    error_log "ERROR (internal): unexpected file count, ${cnt}, associated with tar ball, ${tarball}"
+    error_log "ERROR: expected only two files (found ${cnt}), in controller directory $(basename ${controller_dir}) for tarball $(basename ${tarball})"
     exit 1
 fi
 
 results_repo=${2}
+if [[ -z ${results_repo} ]]; then
+    error_log "ERROR: missing results host parameter."
+    exit 2
+fi
+
 results_path_prefix=${3}
+if [[ -z ${results_path_prefix} ]]; then
+    error_log "ERROR: missing results host path prefix."
+    exit 2
+fi
 
 if [[ ! -f "${pbench_bin}/id_rsa" ]]; then
     error_log "ERROR: ${pbench_bin}/id_rsa required for moving results to archive host"


### PR DESCRIPTION
This is a documentation issue, as the pbench-copy-result-tb neither documents its parameters well, nor diagnoses missing
or inappropriate parameters.

This is ultimately a minor issue as (first off) this is a utility command normally run indirectly by pbench-move-results or
pbench-copy-results and (secondly) it's specific to 0.69 and will be retired when we move to a 0.72 production server.

Nevertheless, the behavior can be somewhat improved both by expanding the `--help` message and by improving the diagnostics when we find missing parameters or unexpected data in the temporary tarball staging area.

Resolves #2437