### PR TITLE
Cleanup of agent ansible roles

### DIFF
--- a/agent/ansible/Makefile
+++ b/agent/ansible/Makefile
@@ -18,6 +18,7 @@ test:   build
 	ansible-galaxy collection install ${tb} -p ./collections
 	git submodule update --init --recursive
 	cd ${colldir}; ansible-test sanity
+	# test for README.md in *every* role
 
 publish: clean build
 	ansible-galaxy collection publish -vvv -s "${apiserver}"  --api-key "${apikey}" ${tb}

--- a/agent/ansible/pbench/agent/galaxy.yml
+++ b/agent/ansible/pbench/agent/galaxy.yml
@@ -9,7 +9,7 @@ namespace: pbench
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.4
+version: 1.0.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/agent/ansible/pbench/agent/meta/runtime.yml
+++ b/agent/ansible/pbench/agent/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.5"

--- a/agent/ansible/pbench/agent/roles/epel_repo_install/README.md
+++ b/agent/ansible/pbench/agent/roles/epel_repo_install/README.md
@@ -1,24 +1,16 @@
-pbench_firewall_open_ports
-==========================
+epel_repo_install
+=================
 
-This role punches a hole through the firewall for various ports that the tool meister
-processes need to use.
+This role installs a repo file for EPEL.
 
 Requirements
 ------------
-None.
 
 Role Variables
 --------------
-These are the variables that are defined by default and do not
-generally need to be modified unless there is a conflict:
-
-- pbench_redis_port: 17001
-- pbench_wsgi_port: 8080
 
 Dependencies
 ------------
-None
 
 Example Playbook
 ----------------
@@ -33,8 +25,10 @@ or you can use the raw link to wget/curl the file:
 
 License
 -------
+
 GPL-3.0-or-later.
 
 Author Information
 ------------------
+
 The Pbench team.

--- a/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
@@ -4,4 +4,3 @@
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
     state: latest
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS"
-  

--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
@@ -21,4 +21,3 @@
 - name: "pbench agent configuration - open firewall ports for tool meister"
   include_role:
     name: pbench_firewall_open_ports
-

--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
@@ -17,7 +17,3 @@
     dest: "{{ pbench_key_dest }}"
     mode: "0600"
     files: id_rsa
-
-- name: "pbench agent configuration - open firewall ports for tool meister"
-  include_role:
-    name: pbench_firewall_open_ports

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
@@ -9,4 +9,3 @@
   with_items:
     - "{{ pbench_redis_port }}"
     - "{{ pbench_wsgi_port }}"
-


### PR DESCRIPTION
Two commits:

- the first one deals with a couple of changes that are needed to satisfy Galaxy: some whitespace changes, a missing role README and a `requires_ansible` directive.
- the second one decouples the firewall role from the `pbench_agent_config` role and makes it standalone.

New version of the pbench.agent collection has been uploaded to Galaxy and tested with RHEL9.