### PR TITLE
Adjust dependencies

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -6,9 +6,20 @@ from pathlib import Path
 from datetime import datetime, tzinfo, timedelta
 from time import time as _time
 from configparser import NoSectionError, NoOptionError
+from typing import Dict, List, Union
 
 from pbench import PbenchConfig, _STD_DATETIME_FMT
 from pbench.common.exceptions import BadConfig
+
+
+# A type defined to conform to the semantic definition of a JSON structure
+# with Python syntax.
+JSONSTRING = str
+JSONNUMBER = Union[int, float]
+JSONVALUE = Union["JSONOBJECT", "JSONARRAY", JSONSTRING, JSONNUMBER, bool, None]
+JSONARRAY = List[JSONVALUE]
+JSONOBJECT = Dict[JSONSTRING, JSONVALUE]
+JSON = JSONVALUE
 
 
 class simple_utc(tzinfo):

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 import json
 from json.decoder import JSONDecodeError
 from logging import Logger
-from typing import Any, AnyStr, Callable, Dict, List, Union
+from typing import Any, AnyStr, Callable, List, Union
 
 from dateutil import parser as date_parser
 from flask import request
@@ -12,7 +12,7 @@ from flask.wrappers import Request, Response
 from flask_restful import Resource, abort
 from sqlalchemy.orm.query import Query
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON, JSONVALUE
 from pbench.server.api.auth import Auth
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -21,15 +21,6 @@ from pbench.server.database.models.datasets import (
     MetadataNotFound,
 )
 from pbench.server.database.models.users import User
-
-# A type defined to conform to the semantic definition of a JSON structure
-# with Python syntax.
-JSONSTRING = str
-JSONNUMBER = Union[int, float]
-JSONVALUE = Union["JSONOBJECT", "JSONARRAY", JSONSTRING, JSONNUMBER, bool, None]
-JSONARRAY = List[JSONVALUE]
-JSONOBJECT = Dict[JSONSTRING, JSONVALUE]
-JSON = JSONVALUE
 
 
 class UnauthorizedAccess(Exception):

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -5,11 +5,10 @@ from flask.json import jsonify
 from flask.wrappers import Request, Response
 from flask_restful import abort
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
     ApiBase,
     API_OPERATION,
-    JSON,
     Parameter,
     ParamType,
     Schema,

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -5,11 +5,10 @@ from flask.json import jsonify
 from flask.wrappers import Request, Response
 from flask_restful import abort
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
     ApiBase,
     API_OPERATION,
-    JSON,
     Parameter,
     ParamType,
     Schema,

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -14,12 +14,11 @@ from flask.wrappers import Response
 from flask_restful import abort
 import requests
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.auth import Auth
 from pbench.server.api.resources import (
     API_OPERATION,
     ApiBase,
-    JSON,
     Schema,
     SchemaError,
     UnauthorizedAccess,

--- a/lib/pbench/server/api/resources/query_apis/controllers_list.py
+++ b/lib/pbench/server/api/resources/query_apis/controllers_list.py
@@ -2,8 +2,8 @@ from http import HTTPStatus
 from flask import jsonify
 from logging import Logger
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, Schema, Parameter, ParamType
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Schema, Parameter, ParamType
 from pbench.server.api.resources.query_apis import (
     CONTEXT,
     ElasticBase,

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -4,8 +4,8 @@ from typing import AnyStr, Union, List
 
 from flask_restful import abort
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, Schema, SchemaError
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Schema, SchemaError
 from pbench.server.api.resources.query_apis import CONTEXT, ElasticBase
 from pbench.server.database.models.datasets import (
     Dataset,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -5,10 +5,9 @@ from flask import jsonify
 from flask.wrappers import Request, Response
 from flask_restful import abort
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
     ApiBase,
-    JSON,
     Schema,
     Parameter,
     ParamType,

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -4,13 +4,8 @@ from logging import Logger
 from flask import Response, jsonify
 from flask_restful import abort
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import (
-    JSON,
-    Parameter,
-    ParamType,
-    Schema,
-)
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Parameter, ParamType, Schema
 from pbench.server.api.resources.query_apis import CONTEXT, PostprocessError
 from pbench.server.api.resources.query_apis.datasets import RunIdBase
 from pbench.server.database.models.template import TemplateNotFound

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -1,10 +1,9 @@
 from logging import Logger
 from typing import Iterator
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
     API_OPERATION,
-    JSON,
     Schema,
     Parameter,
     ParamType,

--- a/lib/pbench/server/api/resources/query_apis/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_detail.py
@@ -3,8 +3,8 @@ from flask import jsonify
 from flask_restful import abort
 from logging import Logger
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, Schema, Parameter, ParamType
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Schema, Parameter, ParamType
 from pbench.server.api.resources.query_apis import (
     CONTEXT,
     ElasticBase,

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -1,10 +1,9 @@
 from logging import Logger
 from typing import Iterator
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
     API_OPERATION,
-    JSON,
     Schema,
     Parameter,
     ParamType,

--- a/lib/pbench/server/api/resources/query_apis/datasets_search.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_search.py
@@ -3,9 +3,8 @@ from logging import Logger
 
 from flask import jsonify
 
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
-    JSON,
     Parameter,
     ParamType,
     Schema,

--- a/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
+++ b/lib/pbench/server/api/resources/query_apis/elasticsearch_api.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, Schema, Parameter, ParamType
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Schema, Parameter, ParamType
 from pbench.server.api.resources.query_apis import CONTEXT, ElasticBase
 
 

--- a/lib/pbench/server/api/resources/query_apis/month_indices.py
+++ b/lib/pbench/server/api/resources/query_apis/month_indices.py
@@ -1,8 +1,8 @@
 from flask import jsonify
 from logging import Logger
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, Schema
+from pbench.server import PbenchServerConfig, JSON
+from pbench.server.api.resources import Schema
 from pbench.server.api.resources.query_apis import CONTEXT, ElasticBase
 from pbench.server.database.models.template import Template
 

--- a/lib/pbench/server/database/models/active_tokens.py
+++ b/lib/pbench/server/database/models/active_tokens.py
@@ -1,5 +1,6 @@
 import datetime
 from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+
 from pbench.server.database.database import Database
 
 

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -5,7 +5,7 @@ import re
 import shutil
 from typing import Dict, List, Union
 
-import dateutil
+from dateutil import parser as date_parser
 import selinux
 import tarfile
 
@@ -278,7 +278,7 @@ class Tarball:
             "controller": {"hostname": metadata.get("controller", "hostname")},
             "pbench": {
                 "config": metadata.get("pbench", "config"),
-                "date": dateutil.parser.parse(metadata.get("pbench", "date"), None),
+                "date": date_parser.parse(metadata.get("pbench", "date"), None),
                 "script": metadata.get("pbench", "script"),
                 "version": metadata.get("pbench", "rpm-version"),
             },

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -5,11 +5,11 @@ import re
 import shutil
 from typing import Dict, List, Union
 
+import dateutil
 import selinux
 import tarfile
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON, convert_date
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.database.models.datasets import Dataset
 
 
@@ -278,7 +278,7 @@ class Tarball:
             "controller": {"hostname": metadata.get("controller", "hostname")},
             "pbench": {
                 "config": metadata.get("pbench", "config"),
-                "date": convert_date(metadata.get("pbench", "date"), None),
+                "date": dateutil.parser.parse(metadata.get("pbench", "date"), None),
                 "script": metadata.get("pbench", "script"),
                 "version": metadata.get("pbench", "rpm-version"),
             },

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -4,7 +4,6 @@ import hashlib
 from freezegun import freeze_time
 from http import HTTPStatus
 import os
-import pytest
 import shutil
 import tempfile
 import uuid
@@ -12,6 +11,8 @@ from pathlib import Path
 from posix import stat_result
 from stat import ST_MTIME
 import tarfile
+
+import pytest
 
 from pbench.server.api import create_app, get_server_config
 from pbench.server.api.auth import Auth

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -1,13 +1,14 @@
 import itertools
-import pytest
 import requests
 
 from dateutil import parser as date_parser, rrule
 from dateutil.relativedelta import relativedelta
 from http import HTTPStatus
+import pytest
 from typing import AnyStr, Type
 
-from pbench.server.api.resources import JSON, ParamType, SchemaError
+from pbench.server import JSON
+from pbench.server.api.resources import ParamType, SchemaError
 from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.test.unit.server.headertypes import HeaderTypes

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -1,8 +1,9 @@
 from http import HTTPStatus
-from typing import Any, Dict
-import pytest
 import requests
 import responses
+from typing import Any, Dict
+
+import pytest
 
 
 @pytest.fixture

--- a/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
+++ b/lib/pbench/test/unit/server/query_apis/test_controllers_list.py
@@ -1,5 +1,7 @@
-import pytest
 from http import HTTPStatus
+
+import pytest
+
 from pbench.server.api.resources.query_apis.controllers_list import ControllersList
 from pbench.test.unit.server.query_apis.commons import Commons
 

--- a/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
+++ b/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
@@ -1,5 +1,7 @@
-import pytest
 from http import HTTPStatus
+
+import pytest
+
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
 from pbench.test.unit.server.query_apis.commons import Commons
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -5,8 +5,7 @@ from typing import Iterator
 import elasticsearch
 import pytest
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 from pbench.server.filetree import FileTree
 from pbench.test.unit.server.headertypes import HeaderTypes

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -1,5 +1,7 @@
-import pytest
 from http import HTTPStatus
+
+import pytest
+
 from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetail
 from pbench.test.unit.server.query_apis.commons import Commons
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
@@ -1,5 +1,6 @@
-import pytest
 from http import HTTPStatus
+
+import pytest
 from sqlalchemy.exc import DatabaseError
 
 from pbench.server.database.models.template import Template

--- a/lib/pbench/test/unit/server/query_apis/test_month_indices.py
+++ b/lib/pbench/test/unit/server/query_apis/test_month_indices.py
@@ -1,7 +1,8 @@
-import pytest
+from http import HTTPStatus
 import requests
 import responses
-from http import HTTPStatus
+
+import pytest
 
 
 @responses.activate

--- a/lib/pbench/test/unit/server/query_apis/test_month_indices.py
+++ b/lib/pbench/test/unit/server/query_apis/test_month_indices.py
@@ -1,8 +1,8 @@
 from http import HTTPStatus
-import requests
-import responses
 
 import pytest
+import requests
+import responses
 
 
 @responses.activate

--- a/lib/pbench/test/unit/server/query_apis/test_query_builder.py
+++ b/lib/pbench/test/unit/server/query_apis/test_query_builder.py
@@ -1,8 +1,9 @@
 import pytest
 
-from pbench.server.api.resources import Schema
+from pbench.server import JSON
 from pbench.server.api.auth import Auth
-from pbench.server.api.resources.query_apis import ElasticBase, JSON
+from pbench.server.api.resources import Schema
+from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.database.models.users import User
 
 

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -1,13 +1,12 @@
 import datetime
 from http import HTTPStatus
-import pytest
 import requests
 from typing import List
 
 from freezegun.api import freeze_time
+import pytest
 
-from pbench.server import PbenchServerConfig
-from pbench.server.api.resources import JSON
+from pbench.server import PbenchServerConfig, JSON
 from pbench.server.database.models.datasets import Dataset
 
 

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -2,11 +2,11 @@ import dateutil
 from http import HTTPStatus
 from logging import Logger
 from pathlib import Path
-import pytest
 import socket
 from typing import Any
 
 from freezegun.api import freeze_time
+import pytest
 
 from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import (

--- a/lib/pbench/test/unit/server/test_templates.py
+++ b/lib/pbench/test/unit/server/test_templates.py
@@ -1,6 +1,7 @@
 import datetime
 import io
 from pathlib import Path
+
 import pytest
 
 from pbench.server.templates import JsonFile, JsonToolFile

--- a/lib/pbench/test/unit/server/test_user_management_cli.py
+++ b/lib/pbench/test/unit/server/test_user_management_cli.py
@@ -1,7 +1,7 @@
 import datetime
 
-import pytest
 from click.testing import CliRunner
+import pytest
 
 import pbench.cli.server.user_management as cli
 from pbench.server.database.models.users import User

--- a/lib/pbench/test/unit/server/test_utils.py
+++ b/lib/pbench/test/unit/server/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pbench.server.utils import filesize_bytes
 
 


### PR DESCRIPTION
I've run into a weird problem in a VM deployment showing what appears to be a circular `import` dependency. The `filetree` module imports `JSON` and `convert_date` from `pbench.server.api.resources`, and (judging from the stack trace) Python is somehow importing `pbench.server.api`, which imports `datasets_delete`, which imports `filetree`. I don't understand the linkage from `pbench.server.api.resources` to `bench.server.api` that seems to be represented in the stack trace; however in thinking about this I decided that I'd prefer to push the `JSON` type definitions outside the "API resources" tree anyway, so I'm experimentally pushing this PR as a cleanup.

Along the way, I also replaced the reference to `convert_date` with a direct call to `dateutil.parser.parse` (which is basically what `convert_date` does anyway, without requiring a reference to another Pbench module).

Both are minor changes, although the first touches a fair number of files.

These are the only "functional" changes in this PR, although I also tried to improve the sorting of import statements in a few of the modules, where I happened to notice bad ordering.