### PR TITLE
Add a warning message when no tools are registered

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -209,8 +209,8 @@ function verify_tool_group {
         printf -- "\t${script_name}: invalid ${param_name} option (\"${group}\"), directory not found: ${tools_group_dir}\n" >&2
         return 1
     fi
-    if [[ -z "$(ls -A ${tools_group_dir})" ]]; then
-        printf -- "\tWARNING: No tools are registered\n" >&2
+    if [[ -z "$(ls ${tools_group_dir})" ]]; then
+        printf -- "${script_name}: WARNING: No tools are registered\n" >&2
     fi
     printf -- "${tools_group_dir}"
     return 0

--- a/agent/base
+++ b/agent/base
@@ -209,6 +209,9 @@ function verify_tool_group {
         printf -- "\t${script_name}: invalid ${param_name} option (\"${group}\"), directory not found: ${tools_group_dir}\n" >&2
         return 1
     fi
+    if [[ -z "$(ls -A ${tools_group_dir})" ]]; then
+        printf -- "\tWARNING: No tools are registered\n" >&2
+    fi
     printf -- "${tools_group_dir}"
     return 0
 }


### PR DESCRIPTION
When no tools are registered on the host, we can at least put a warning about it for the user to consider. 