### PR TITLE
pbench-list-tools and pbench-register-tools inconsistency with env and config values

### DIFF
--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -21,12 +21,17 @@ class BaseCommand(metaclass=abc.ABCMeta):
         self.config = PbenchAgentConfig(self.context.config)
         self.name = os.path.basename(sys.argv[0])
 
-        self.pbench_run = self.config.pbench_run
+        env_pbench_run = os.environ.get("pbench_run")
+        self.pbench_run = pathlib.Path(
+            env_pbench_run if env_pbench_run else self.config.pbench_run
+        )
+
         if not self.pbench_run.exists():
-            click.secho(
-                f"[ERROR] the provided pbench run directory, {self.pbench_run}, does not exist"
+            click.echo(
+                f"[ERROR] pbench run directory does not exist, {self.pbench_run}",
+                err=True,
             )
-            sys.exit(1)
+            click.get_current_context().exit(1)
 
         # the pbench temporary directory is always relative to the $pbench_run
         # directory

--- a/lib/pbench/test/functional/agent/cli/commands/conftest.py
+++ b/lib/pbench/test/functional/agent/cli/commands/conftest.py
@@ -22,15 +22,6 @@ def pbench_cfg(tmp_path, opt_pbench):
 
 
 @pytest.fixture
-def pbench_run(monkeypatch, tmp_path):
-    monkeypatch.delenv("pbench_run")
-    pbench_agent_d = tmp_path / "var" / "lib" / "pbench-agent"
-    pbench_agent_d.mkdir(parents=True, exist_ok=True)
-
-    yield pbench_agent_d
-
-
-@pytest.fixture
 def agent_config(monkeypatch, tmp_path, opt_pbench, pbench_cfg, pbench_run):
     shutil.copyfile("./agent/config/pbench-agent-default.cfg", pbench_cfg)
 

--- a/lib/pbench/test/functional/agent/cli/commands/conftest.py
+++ b/lib/pbench/test/functional/agent/cli/commands/conftest.py
@@ -22,7 +22,8 @@ def pbench_cfg(tmp_path, opt_pbench):
 
 
 @pytest.fixture
-def pbench_run(tmp_path):
+def pbench_run(monkeypatch, tmp_path):
+    monkeypatch.delenv("pbench_run")
     pbench_agent_d = tmp_path / "var" / "lib" / "pbench-agent"
     pbench_agent_d.mkdir(parents=True, exist_ok=True)
 

--- a/lib/pbench/test/functional/agent/cli/commands/test_config.py
+++ b/lib/pbench/test/functional/agent/cli/commands/test_config.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+
+
+def test_pbench_run(monkeypatch, tmpdir, agent_config, pbench_run):  # noqa F811
+    """Use pbench_run value from pbench-agent.cfg file"""
+    assert os.environ.get("pbench_run") is None
+    command = ["pbench-list-tools"]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert exitcode == 0
+
+
+def test_pbench_run_dir_existence(monkeypatch, agent_config, pbench_run):
+    """Verify that pbench_list_tools fail when pbench_run is defined
+    to a directory that doesn't exist"""
+    monkeypatch.setenv("pbench_run", f"{pbench_run}/test")
+    command = ["pbench-list-tools"]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert exitcode == 1
+    assert b"" == out
+    assert b"[ERROR] pbench run directory does not exist," in err
+
+
+def test_pbench_dir_existence(monkeypatch, pbench_run, agent_config):
+    """Verify the existence of existing pbench_run directory
+    and successful completion of command"""
+    pbench_run_d = pbench_run / "test_dir"
+    pbench_run_d.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("pbench_run", str(pbench_run_d))
+    p = pbench_run_d / "tools-v1-default" / "th1.example.com"
+    p.mkdir(parents=True)
+    tool = p / "iostat"
+    tool.write_text("--interval=30")
+    tool = p / "mpstat"
+    tool.write_text("--interval=300")
+    command = ["pbench-list-tools"]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert exitcode == 0
+    assert b"group: default; host: th1.example.com; tools: iostat, mpstat\n" in out
+    assert b"" == err

--- a/lib/pbench/test/functional/conftest.py
+++ b/lib/pbench/test/functional/conftest.py
@@ -1,7 +1,5 @@
-import os
-import subprocess
-
 import pytest
+import subprocess
 
 from pbench.test.unit.agent.conftest import base_setup
 
@@ -19,7 +17,9 @@ def capture(command):
 
 
 @pytest.fixture
-def pbench_run(tmpdir):
-    pbench_run = tmpdir / "test/var/lib/pbench-agent"
-    os.makedirs(pbench_run)
-    yield pbench_run
+def pbench_run(monkeypatch, tmp_path):
+    monkeypatch.delenv("pbench_run")
+    pbench_agent_d = tmp_path / "var" / "lib" / "pbench-agent"
+    pbench_agent_d.mkdir(parents=True, exist_ok=True)
+
+    yield pbench_agent_d


### PR DESCRIPTION
Fixes Issue #2473 

Checking and adding environment value before config file value for pbench-list-tools.

If an environment value for `pbench_run` is present then `pbench-register tool` considers env value and doesn't care about config file value, `pbench-list-tool` on-the-other hand only considers environment value of `pbench_run` if `pbench_run`'s value is None and take config file's value as default.