### PR TITLE
Small improvements to `pbench-list-tools` and `pbench-clear-tools`

### DIFF
--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -112,7 +112,9 @@ class BaseCommand(metaclass=abc.ABCMeta):
         try:
             self.tool_group_dir = self.gen_tools_group_dir(group)
         except BadToolGroup as exc:
-            click.echo(f'{self.name}: invalid --group option "{group}" ({exc})')
+            click.echo(
+                f'{self.name}: invalid --group option "{group}" ({exc})', err=True
+            )
             ret_code = 1
         else:
             ret_code = 0

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -112,9 +112,7 @@ class BaseCommand(metaclass=abc.ABCMeta):
         try:
             self.tool_group_dir = self.gen_tools_group_dir(group)
         except BadToolGroup as exc:
-            click.echo(f'\t{self.name}: invalid --group option ("{group}"), {exc}')
-            ctxt = click.get_current_context()
-            click.echo(ctxt.get_help())
+            click.echo(f'{self.name}: invalid --group option "{group}" ({exc})')
             ret_code = 1
         else:
             ret_code = 0

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -44,7 +44,7 @@ class ClearTools(ToolCommand):
                 self.logger.error(f'No such group "{self.context.group}".')
                 return 1
 
-        tool_not_found = bool(self.context.name)  # Can't not find if not specified
+        tool_not_found = True  # Not found, yet
         for remote in remotes:
             tg_dir_r = self.tool_group_dir / remote
             if not tg_dir_r.exists():
@@ -96,7 +96,7 @@ class ClearTools(ToolCommand):
                     self.logger.error("Failed to remove remote directory %s", tg_dir_r)
                     errors = 1
 
-        if tool_not_found:
+        if self.context.name and tool_not_found:
             self.logger.warn(f'Tool "{self.context.name}" not found')
 
         return 0 if errors == 0 else 1

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -35,6 +35,12 @@ class ClearTools(ToolCommand):
             # from the tools group directory.
             remotes = self.remote(self.tool_group_dir)
             if not remotes:
+                # FIXME:  This is a weird case -- the group directory exists,
+                #  but contains no remotes. This is the result of clearing the
+                #  tools from a group which has already been cleared, because
+                #  the first clear does not remove the group directory.  This
+                #  behavior might be desirable for the `default` directory, but
+                #  it seems wrong for custom groups.
                 self.logger.error(f'No such group "{self.context.group}".')
                 return 1
 
@@ -53,6 +59,8 @@ class ClearTools(ToolCommand):
                 # Discover all the tools registered for this remote
                 names = self.tools(tg_dir_r)
                 if not names:
+                    # FIXME:  this is another odd case -- the remote subdirectory
+                    #  exists, but it's empty.  (We'll remove it below.)
                     self.logger.warn(
                         'No tools in group "%s" on host "%s".',
                         self.context.group,

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -8,7 +8,6 @@ Specifying a tool name and/or remote host will limit the scope of the removal.
 
 import pathlib
 import shutil
-import sys
 
 import click
 
@@ -23,7 +22,7 @@ class ClearTools(ToolCommand):
     def __init__(self, context):
         super().__init__(context)
 
-    def execute(self):
+    def execute(self) -> int:
         errors = 0
 
         if self.verify_tool_group(self.context.group) != 0:
@@ -35,27 +34,37 @@ class ClearTools(ToolCommand):
             # We were not given any remotes on the command line, build the list
             # from the tools group directory.
             remotes = self.remote(self.tool_group_dir)
+            if not remotes:
+                self.logger.error(f'No such group "{self.context.group}".')
+                return 1
 
+        tool_not_found = bool(self.context.name)  # Can't not find if not specified
         for remote in remotes:
             tg_dir_r = self.tool_group_dir / remote
             if not tg_dir_r.exists():
                 self.logger.warn(
-                    'The given remote host, "%s", is not a directory in %s.',
-                    remote,
-                    self.tool_group_dir,
+                    'No remote host "%s" in group %s.', remote, self.context.group,
                 )
                 continue
 
             if self.context.name:
-                names = self.context.name
+                names = [self.context.name]
             else:
                 # Discover all the tools registered for this remote
                 names = self.tools(tg_dir_r)
+                if not names:
+                    self.logger.warn(
+                        'No tools in group "%s" on host "%s".',
+                        self.context.group,
+                        remote,
+                    )
 
             for name in names:
                 status = self._clear_tools(name, remote)
-                if status != 0:
-                    errors += 1
+                if status > 0:
+                    errors = 1
+                elif status == 0:
+                    tool_not_found = False
 
             tool_files = [p.name for p in tg_dir_r.iterdir()]
 
@@ -65,26 +74,37 @@ class ClearTools(ToolCommand):
                     label.unlink()
                 except Exception:
                     self.logger.error("Failed to remove label for remote %s", tg_dir_r)
-                    errors += 1
+                    errors = 1
 
             if self.is_empty(tg_dir_r):
-                self.logger.info('All tools removed from host, "%s"', tg_dir_r.name)
+                self.logger.info(
+                    'All tools removed from group "%s" on host "%s"',
+                    self.context.group,
+                    tg_dir_r.name,
+                )
                 try:
                     shutil.rmtree(tg_dir_r)
                 except OSError:
                     self.logger.error("Failed to remove remote directory %s", tg_dir_r)
-                    errors += 1
+                    errors = 1
 
-        return errors
+        if tool_not_found:
+            self.logger.warn(f'Tool "{self.context.name}" not found')
 
-    def _clear_tools(self, name, remote):
-        """Remove specified tool and associated files"""
+        return 0 if errors == 0 else 1
+
+    def _clear_tools(self, name, remote) -> int:
+        """
+        Remove specified tool and associated files
+
+        Returns zero for success, -1 for name-not-found, and 1 for failure.
+        """
         tpath = self.tool_group_dir / remote / name
         try:
             tpath.unlink()
         except FileNotFoundError:
             self.logger.debug('Tool "%s" not registered for remote "%s"', name, remote)
-            return 0
+            return -1
         except Exception as exc:
             self.logger.error("Failed to remove %s: %s", tpath, exc)
             ret_val = 1
@@ -102,18 +122,17 @@ class ClearTools(ToolCommand):
 
         if ret_val == 0:
             self.logger.info(
-                'Removed "%s" from host, "%s", in tools group, "%s"',
+                'Removed "%s" from host "%s" in tools group "%s"',
                 name,
                 remote,
                 self.context.group,
             )
         return ret_val
 
-    def is_empty(self, path):
-        """Determine if directory is empty or not"""
-        for dirent in path.iterdir():
-            return False
-        return True
+    @staticmethod
+    def is_empty(path):
+        """Determine if directory is empty"""
+        return not any(path.iterdir())
 
 
 def _group_option(f):
@@ -128,10 +147,12 @@ def _group_option(f):
         "-g",
         "--group",
         default="default",
-        required=True,
         expose_value=False,
         callback=callback,
-        help="list the tools used in this <group-name>",
+        help=(
+            "Clear the tools in the <group-name> group.  "
+            "If no group is specified, the 'default' group is assumed."
+        ),
     )(f)
 
 
@@ -140,9 +161,9 @@ def _name_option(f):
 
     def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
-        clictxt.name = []
+        clictxt.name = None
         if value:
-            clictxt.name.append(value)
+            clictxt.name = value
         return value
 
     return click.option(
@@ -150,10 +171,7 @@ def _name_option(f):
         "--name",
         expose_value=False,
         callback=callback,
-        help=(
-            "list the tool groups in which <tool-name> is used.\n"
-            "Not allowed with the --group option"
-        ),
+        help="Clear only the <tool-name> tool.",
     )(f)
 
 
@@ -172,8 +190,9 @@ def _remote_option(f):
         expose_value=False,
         callback=callback,
         help=(
-            "a specific remote on which tools needs to be cleared.\n"
-            "If no remote is specified, all the tools on all remotes are removed"
+            "Clear the tool(s) only on the specified remote(s).  "
+            "Multiple remotes may be specified as a comma-separated list.  "
+            "If no remote is specified, all remotes are cleared."
         ),
     )(f)
 
@@ -186,4 +205,4 @@ def _remote_option(f):
 @pass_cli_context
 def main(ctxt):
     status = ClearTools(ctxt).execute()
-    sys.exit(status)
+    click.get_current_context().exit(status)

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -1,15 +1,14 @@
 """
 pbench-clear-tools
 
-This script will remove tools that have been registered.  If no options are
-used, then all tools from the "default" tool group are removed.  Specifying
-a tool name and/or remote host will limit the scope of the removal.
-
-
+This script will remove tools that have been registered for a particular group.
+If no options are used, then all tools from the "default" tool group are removed.
+Specifying a tool name and/or remote host will limit the scope of the removal.
 """
+
+import pathlib
 import shutil
 import sys
-import pathlib
 
 import click
 
@@ -41,7 +40,7 @@ class ClearTools(ToolCommand):
             tg_dir_r = self.tool_group_dir / remote
             if not tg_dir_r.exists():
                 self.logger.warn(
-                    'The given remote host, "%s", is not a directory in' " %s.",
+                    'The given remote host, "%s", is not a directory in %s.',
                     remote,
                     self.tool_group_dir,
                 )
@@ -120,7 +119,7 @@ class ClearTools(ToolCommand):
 def _group_option(f):
     """Group name option"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.group = value
         return value
@@ -139,7 +138,7 @@ def _group_option(f):
 def _name_option(f):
     """Tool name to use"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.name = []
         if value:
@@ -161,7 +160,7 @@ def _name_option(f):
 def _remote_option(f):
     """Remote hostname"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.remote = value
         return value

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -119,9 +119,9 @@ class ListTools(ToolCommand):
                 self.print_results(tool_info, self.context.with_option)
                 return 0
             else:
-                self.logger.error(
-                    "Tool does not exist in any group: %s", self.context.name
-                )
+                msg = f'Tool "{self.context.name}" not found in '
+                msg += self.context.group[0] if self.context.group else "any group"
+                self.logger.error(msg)
                 return 1
 
 

--- a/lib/pbench/cli/agent/commands/tools/list.py
+++ b/lib/pbench/cli/agent/commands/tools/list.py
@@ -1,8 +1,8 @@
 """
 pbench-list-tools
 
-This script can list all tools from all groups, list tools from a specific
-group, or list which groups contain a specific tool
+This script lists all tools from all groups, all tools from a specific group,
+or all groups which contain a specific tool.
 
 """
 
@@ -10,10 +10,10 @@ import sys
 
 import click
 
+from pbench.agent.tool_group import BadToolGroup
 from pbench.cli.agent import CliContext, pass_cli_context
 from pbench.cli.agent.commands.tools.base import ToolCommand
 from pbench.cli.agent.options import common_options
-from pbench.agent.tool_group import BadToolGroup
 
 
 class ListTools(ToolCommand):
@@ -23,7 +23,7 @@ class ListTools(ToolCommand):
         super(ListTools, self).__init__(context)
 
     @staticmethod
-    def print_results(toolinfo: dict, tool: str, with_option: bool):
+    def print_results(toolinfo: dict, with_option: bool):
         for group, gval in sorted(toolinfo.items()):
             for host, tools in sorted(gval.items()):
                 if tools:
@@ -70,7 +70,7 @@ class ListTools(ToolCommand):
                         )
 
             if tool_info:
-                self.print_results(tool_info, None, self.context.with_option)
+                self.print_results(tool_info, self.context.with_option)
         else:
             # List the groups which include this tool
             tool = self.context.name
@@ -99,7 +99,7 @@ class ListTools(ToolCommand):
                         )
                         found = True
             if found:
-                self.print_results(tool_info, tool, self.context.with_option)
+                self.print_results(tool_info, self.context.with_option)
                 return 0
             else:
                 self.logger.error(
@@ -111,7 +111,7 @@ class ListTools(ToolCommand):
 def _group_option(f):
     """Group name option"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         try:
             clictxt.group = value.split()
@@ -131,7 +131,7 @@ def _group_option(f):
 def _name_option(f):
     """Name of the tool option"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.name = value
         return value
@@ -151,7 +151,7 @@ def _name_option(f):
 def _with_option(f):
     """display options with tools"""
 
-    def callback(ctxt, param, value):
+    def callback(ctxt, _param, value):
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.with_option = value
         return value
@@ -162,7 +162,7 @@ def _with_option(f):
         is_flag=True,
         expose_value=False,
         callback=callback,
-        help=("list the options with each tool"),
+        help="list the options with each tool",
     )(f)
 
 

--- a/lib/pbench/cli/agent/options.py
+++ b/lib/pbench/cli/agent/options.py
@@ -11,7 +11,7 @@ def common_options(f):
 def _pbench_agent_config(f):
     """Option for agent configuration"""
 
-    def callback(ctx, param, value):
+    def callback(ctx, _param, value):
         clictx = ctx.ensure_object(CliContext)
         clictx.config = value
         return value

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -20,7 +20,9 @@ def test_clear_tools_test12(monkeypatch, agent_config, pbench_run, pbench_cfg):
 
     command = ["pbench-clear-tools"]
     out, err, exitcode = pytest.helpers.capture(command)
-    assert b'All tools removed from host, "testhost.example.com"' in err
+    assert (
+        b'All tools removed from group "default" on host "testhost.example.com"' in err
+    )
     assert exitcode == 0
     assert mpstat.exists() is False
     assert default_group.exists() is False
@@ -79,7 +81,7 @@ def test_clear_tools_test66(monkeypatch, agent_config, pbench_run, pbench_cfg):
     command = ["pbench-clear-tools", "--group=bad"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 1
-    assert b"\tpbench-clear-tools: invalid" in out
+    assert b"pbench-clear-tools: invalid" in err
 
 
 def test_clear_tools_test67(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -108,10 +110,7 @@ def test_clear_tools_test67(monkeypatch, agent_config, pbench_run, pbench_cfg):
     ]
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 0
-    assert (
-        b'The given remote host, "doesnotexist.example.com", is not a directory in'
-        in err
-    )
+    assert b'No remote host "doesnotexist.example.com" in group default' in err
     assert iostat_tool.exists() is False
     assert vmstat_tool.exists() is False
     assert pidstat_tool.exists() is False

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -43,6 +43,7 @@ def test_clear_tools_test13(monkeypatch, agent_config, pbench_run, pbench_cfg):
 
     command = ["pbench-clear-tools", "--remote=fubar2"]
     out, err, exitcode = pytest.helpers.capture(command)
+    assert b'Removed "mpstat" from host "fubar2" in tools group "default"' in err
     assert exitcode == 0
     assert default_mpstat.exists() is True
     assert foo_mpstat.exists() is False
@@ -81,8 +82,8 @@ def test_clear_tools_test66(monkeypatch, agent_config, pbench_run, pbench_cfg):
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
     command = ["pbench-clear-tools", "--group=bad"]
     out, err, exitcode = pytest.helpers.capture(command)
+    assert b'pbench-clear-tools: invalid --group option "bad"' in err
     assert exitcode == 1
-    assert b"pbench-clear-tools: invalid" in err
 
 
 def test_clear_tools_test67(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -185,3 +186,20 @@ def test_clear_tools_test69(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert pidstat5_tool.exists() is False
     assert pidstat6_tool.exists() is False
     assert pidstat7_tool.exists() is False
+
+
+def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
+    """ Attempt to clear the wrong tool, by name """
+    monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+    default_group = pbench_run / "tools-v1-default"
+    default_group.mkdir(parents=True)
+    fubar5_host = default_group / "fubar5.example.com"
+    fubar5_host.mkdir(parents=True, exist_ok=True)
+    pidstat5_tool = fubar5_host / "pidstat"
+    pidstat5_tool.touch()
+
+    command = ["pbench-clear-tools", "--name=vmstat"]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert b"" == out
+    assert b'Tool "vmstat" not found' in err
+    assert exitcode == 0

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -77,6 +77,8 @@ def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert pidstat_tool.exists() is False
     assert turbostat_tool.exists() is False
     assert mpstat_tool.exists() is False
+    # FIXME:  Why do we want to retain the group directory after deleting everything out of it??
+    # FIXME:  Contrary to the test docstring, this test doesn't create or assert that the default group is unmolested.
     assert good_group.exists() is True
 
 

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -39,6 +39,7 @@ def test_clear_tools_test13(monkeypatch, agent_config, pbench_run, pbench_cfg):
     foo_group = pbench_run / "tools-v1-default" / "fubar2"
     foo_group.mkdir(parents=True)
     foo_mpstat = foo_group / "mpstat"
+    foo_mpstat.touch()
 
     command = ["pbench-clear-tools", "--remote=fubar2"]
     out, err, exitcode = pytest.helpers.capture(command)

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -5,6 +5,7 @@ def test_pbench_clear_tools_help():
     command = ["pbench-clear-tools", "--help"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"Usage: pbench-clear-tools [OPTIONS]" in out
+    assert b"" == err
     assert exitcode == 0
 
 
@@ -23,6 +24,7 @@ def test_clear_tools_test12(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert (
         b'All tools removed from group "default" on host "testhost.example.com"' in err
     )
+    assert b"" == out
     assert exitcode == 0
     assert mpstat.exists() is False
     assert default_group.exists() is False
@@ -44,6 +46,7 @@ def test_clear_tools_test13(monkeypatch, agent_config, pbench_run, pbench_cfg):
     command = ["pbench-clear-tools", "--remote=fubar2"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b'Removed "mpstat" from host "fubar2" in tools group "default"' in err
+    assert b"" == out
     assert exitcode == 0
     assert default_mpstat.exists() is True
     assert foo_mpstat.exists() is False
@@ -82,6 +85,7 @@ def test_clear_tools_test66(monkeypatch, agent_config, pbench_run, pbench_cfg):
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
     command = ["pbench-clear-tools", "--group=bad"]
     out, err, exitcode = pytest.helpers.capture(command)
+    assert b"" == out
     assert b'pbench-clear-tools: invalid --group option "bad"' in err
     assert exitcode == 1
 
@@ -111,8 +115,9 @@ def test_clear_tools_test67(monkeypatch, agent_config, pbench_run, pbench_cfg):
         "--remotes=fubar3.example.com,doesnotexist.example.com,fubar4.example.com",
     ]
     out, err, exitcode = pytest.helpers.capture(command)
-    assert exitcode == 0
+    assert b"" == out
     assert b'No remote host "doesnotexist.example.com" in group default' in err
+    assert exitcode == 0
     assert iostat_tool.exists() is False
     assert vmstat_tool.exists() is False
     assert pidstat_tool.exists() is False
@@ -145,11 +150,11 @@ def test_clear_tools_test68(monkeypatch, agent_config, pbench_run, pbench_cfg):
         "--remotes=fubar5.example.com,fubar6.example.com",
     ]
     out, err, exitcode = pytest.helpers.capture(command)
+    assert exitcode == 0
     assert vmstat6_tool.exists() is False
     assert vmstat5_tool.exists() is False
     assert turbostat_tool.exists() is True
     assert pidstat_tool.exists() is True
-    assert exitcode == 0
 
 
 def test_clear_tools_test69(monkeypatch, agent_config, pbench_run, pbench_cfg):

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -7,6 +7,7 @@ TRACEBACK = b"Traceback (most recent call last):\n"
 
 BAD_GROUP_ERR = b"Bad tool group: "
 TOOL_ERR = b"Tool does not exist in any group: "
+NO_TOOL_GROUP = b"No tool groups found"
 
 
 class Test_list_tools_no_tools_registered:
@@ -22,7 +23,7 @@ class Test_list_tools_no_tools_registered:
         command = ["pbench-list-tools"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert TRACEBACK not in err
-        assert EMPTY == err
+        assert NO_TOOL_GROUP in err
         assert EMPTY == out
         assert exitcode == 0
 
@@ -71,7 +72,7 @@ class Test_list_tools_no_tools_registered:
     def test_option(self, agent_config):
         command = ["pbench-list-tools", "--with-option"]
         out, err, exitcode = pytest.helpers.capture(command)
-        assert EMPTY == err
+        assert NO_TOOL_GROUP in err
         assert EMPTY == out
         assert exitcode == 0
 

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_tools_list.py
@@ -6,7 +6,7 @@ USAGE = b"Usage: pbench-list-tools [OPTIONS]"
 TRACEBACK = b"Traceback (most recent call last):\n"
 
 BAD_GROUP_ERR = b"Bad tool group: "
-TOOL_ERR = b"Tool does not exist in any group: "
+TOOL_ERR = b'Tool "unknown" not found'
 NO_TOOL_GROUP = b"No tool groups found"
 
 
@@ -28,7 +28,7 @@ class Test_list_tools_no_tools_registered:
         assert exitcode == 0
 
     def test_name(self, agent_config):
-        command = ["pbench-list-tools", "--name", "foo"]
+        command = ["pbench-list-tools", "--name", "unknown"]
         out, err, exitcode = pytest.helpers.capture(command)
         assert TOOL_ERR in err
         assert EMPTY == out


### PR DESCRIPTION
This PR is a once-over on `pbench-list-tools` and `pbench-clear-tools`:
- Fixed up docstrings.
- Tweaked and corrected the help text to match the actual functionality.
- Finish by calling the Click `exit()` function instead of `sys.exit()` (and fixed up the `import`'s accordingly).
- Picked lint (fixed import ordering, added an underscore prefix to unused parameters, added type hints).
- If a bad tool group is specified (e.g., to `pbench-clear-tools`, we print a message (with a slightly different formatting) and we no longer print the usage information.
- Added diagnostic messages to most cases where the tools previously exited silently; changed some of the existing messages to make them more useful to end-users.
- Reworked the `is_empty()` function.
- Only changed the unit tests to reflect the changes to the messages.

Fixes #2458.