### PR TITLE
Update `push` to change permissions on `quay.io`

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -178,6 +178,12 @@ $(_TAG_TYPES:%=push-%): push-%: $(_DEFAULT_DISTROS:%=%-push-%)
 
 
 #+
+# Ensure repos exist with correct visibility and permissions.
+#-
+repofix: $(_DEFAULT_DISTROS:%=%-repofix)
+
+
+#+
 # Build targets
 #-
 
@@ -254,6 +260,13 @@ $(foreach tagtype,${_TAG_TYPES},$(eval $(call _PUSH_RULE,${tagtype})))  # Define
 
 %-push: %-tags.lis
 	./push ${IMAGE_REPO} $*
+
+#+
+# Invoke quay-repo to force visibility and permission change
+#-
+
+%-repofix:
+	./repo-fix $*
 
 #+
 # Tag local images for the given distribution.

--- a/agent/containers/images/push
+++ b/agent/containers/images/push
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+_dir=$(dirname "${0}")
+
 image_repo="${1}"
 distro="${2}"
 
@@ -28,6 +30,10 @@ function pushit {
 }
 
 for image in base tools tool-meister tool-data-sink workloads all; do
+    if [[ "${image_repo}" == "docker://quay.io/pbench" ]]; then
+        # Ensure quay repository exists, create if missing
+        ${_dir}/quay-repo pbench-agent-${image}-${distro}
+    fi
     pushit pbench-agent-${image}-${distro}:${githash}
     pushit pbench-agent-${image}-${distro}:${ver}
     if [[ ! -z "${other}" ]]; then

--- a/agent/containers/images/quay-repo
+++ b/agent/containers/images/quay-repo
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""quay-repo: idempotent method to ensure a given repository exists in Quay.io
+
+If the repository exists already, no action is taken (we don't want to cause
+unnecessary traffic to Quay.io).
+
+If the repository does not exist, it is created with visibility public, and
+the core team added as admins.
+
+Returns 0 on success
+Returns 1 on failure (
+"""
+
+import json
+import os
+from pathlib import Path
+import requests
+import sys
+
+
+prog = Path(sys.argv[0]).name
+
+home = os.environ.get("HOME", "")
+quay_bearer_token_file = Path(f"{home}/") / ".config" / "pbench" / "quay_bearer.token"
+try:
+    quay_bearer_token = quay_bearer_token_file.read_text()
+except Exception as exc:
+    print(
+        f"[{prog}] ERROR - failure reading Quay.io API bearer token from"
+        f" {quay_bearer_token_file}, {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+else:
+    quay_bearer_token = quay_bearer_token.strip()
+    if not quay_bearer_token:
+        print(
+            f"[{prog}] ERROR - Quay.io API bearer token not found in"
+            f" {quay_bearer_token_file}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+headers = {
+    "User-Agent": "pbench quay-repo",
+    "Authorization": f"Bearer {quay_bearer_token}",
+}
+session = requests.Session()
+session.headers.update(headers)
+
+
+def exists(session, repo):
+    url = f"https://quay.io/api/v1/repository/pbench/{repo}"
+    response = session.get(url, allow_redirects=False)
+    if response.status_code == 404:
+        return False
+    elif response.status_code == 200:
+        return True
+    else:
+        print(
+            f"[{prog}] ERROR - 'GET {url}' failed with {response.status_code},"
+            f" '{response.text}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def create(session, repo):
+    url = "https://quay.io/api/v1/repository"
+    body = {
+        "repository": repo,
+        "visibility": "public",
+        "namespace": "pbench",
+        "description": "",
+        "repo_kind": "image",
+    }
+    payload = json.dumps(body)
+    mod_headers = headers.copy()
+    mod_headers["Content-Type"] = "application/json"
+
+    response = session.post(
+        url, headers=mod_headers, data=payload, allow_redirects=False
+    )
+    if response.status_code != 201:
+        print(
+            f"[{prog}] ERROR - 'POST {url}', with body '{payload}', failed"
+            f" with {response.status_code}, '{response.text}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def add_core(session, repo):
+    url = f"https://quay.io/api/v1/repository/pbench/{repo}/permissions/team/core"
+    body = {"role": "admin"}
+    payload = json.dumps(body)
+    mod_headers = headers.copy()
+    mod_headers["Content-Type"] = "application/json"
+    response = session.put(
+        url, headers=mod_headers, data=payload, allow_redirects=False
+    )
+    if response.status_code != 200:
+        print(
+            f"[{prog}] ERROR - 'PUT {url}', with body '{payload}', failed"
+            f" with {response.status_code}, '{response.text}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+def make_public(session, repo):
+    url = f"https://quay.io/api/v1/repository/pbench/{repo}/changevisibility"
+    body = {"visibility": "public"}
+    payload = json.dumps(body)
+    mod_headers = headers.copy()
+    mod_headers["Content-Type"] = "application/json"
+    response = session.post(
+        url, headers=mod_headers, data=payload, allow_redirects=False
+    )
+    if response.status_code != 200:
+        print(
+            f"[{prog}] ERROR - 'POST {url}', with body '{payload}', failed"
+            f" with {response.status_code}, '{response.text}'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+repo_arg = sys.argv[1]
+if not exists(session, repo_arg):
+    create(session, repo_arg)
+    add_core(session, repo_arg)
+    print(f"{repo_arg} created")
+else:
+    try:
+        force = sys.argv[2]
+    except IndexError:
+        pass
+    else:
+        make_public(session, repo_arg)
+        print(f"{repo_arg} made public")
+        add_core(session, repo_arg)
+        print(f"{repo_arg} core added")

--- a/agent/containers/images/quay-repo
+++ b/agent/containers/images/quay-repo
@@ -51,14 +51,14 @@ session.headers.update(headers)
 
 def exists(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}"
-    response = session.get(url, allow_redirects=False)
+    response = session.head(url, allow_redirects=False)
     if response.status_code == 404:
         return False
     elif response.status_code == 200:
         return True
     else:
         print(
-            f"[{prog}] ERROR - 'GET {url}' failed with {response.status_code},"
+            f"[{prog}] ERROR - 'HEAD {url}' failed with {response.status_code},"
             f" '{response.text}'",
             file=sys.stderr,
         )

--- a/agent/containers/images/quay-repo
+++ b/agent/containers/images/quay-repo
@@ -11,7 +11,6 @@ Returns 0 on success
 Returns 1 on failure (
 """
 
-import json
 import os
 from pathlib import Path
 import requests
@@ -74,16 +73,10 @@ def create(session, repo):
         "description": "",
         "repo_kind": "image",
     }
-    payload = json.dumps(body)
-    mod_headers = headers.copy()
-    mod_headers["Content-Type"] = "application/json"
-
-    response = session.post(
-        url, headers=mod_headers, data=payload, allow_redirects=False
-    )
+    response = session.post(url, json=body, allow_redirects=False)
     if response.status_code != 201:
         print(
-            f"[{prog}] ERROR - 'POST {url}', with body '{payload}', failed"
+            f"[{prog}] ERROR - 'POST {url}', with body {body!r}, failed"
             f" with {response.status_code}, '{response.text}'",
             file=sys.stderr,
         )
@@ -93,15 +86,10 @@ def create(session, repo):
 def add_core(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}/permissions/team/core"
     body = {"role": "admin"}
-    payload = json.dumps(body)
-    mod_headers = headers.copy()
-    mod_headers["Content-Type"] = "application/json"
-    response = session.put(
-        url, headers=mod_headers, data=payload, allow_redirects=False
-    )
+    response = session.put(url, json=body, allow_redirects=False)
     if response.status_code != 200:
         print(
-            f"[{prog}] ERROR - 'PUT {url}', with body '{payload}', failed"
+            f"[{prog}] ERROR - 'PUT {url}', with body {body!r}, failed"
             f" with {response.status_code}, '{response.text}'",
             file=sys.stderr,
         )
@@ -111,15 +99,10 @@ def add_core(session, repo):
 def make_public(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}/changevisibility"
     body = {"visibility": "public"}
-    payload = json.dumps(body)
-    mod_headers = headers.copy()
-    mod_headers["Content-Type"] = "application/json"
-    response = session.post(
-        url, headers=mod_headers, data=payload, allow_redirects=False
-    )
+    response = session.post(url, json=body, allow_redirects=False)
     if response.status_code != 200:
         print(
-            f"[{prog}] ERROR - 'POST {url}', with body '{payload}', failed"
+            f"[{prog}] ERROR - 'POST {url}', with body {body!r}, failed"
             f" with {response.status_code}, '{response.text}'",
             file=sys.stderr,
         )

--- a/agent/containers/images/quay-repo
+++ b/agent/containers/images/quay-repo
@@ -8,7 +8,7 @@ If the repository does not exist, it is created with visibility public, and
 the core team added as admins.
 
 Returns 0 on success
-Returns 1 on failure (
+Returns 1 on failure
 """
 
 import os
@@ -50,7 +50,7 @@ session.headers.update(headers)
 
 def exists(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}"
-    response = session.head(url, allow_redirects=False)
+    response = session.head(url)
     if response.status_code == 404:
         return False
     elif response.status_code == 200:
@@ -73,7 +73,7 @@ def create(session, repo):
         "description": "",
         "repo_kind": "image",
     }
-    response = session.post(url, json=body, allow_redirects=False)
+    response = session.post(url, json=body)
     if response.status_code != 201:
         print(
             f"[{prog}] ERROR - 'POST {url}', with body {body!r}, failed"
@@ -86,7 +86,7 @@ def create(session, repo):
 def add_core(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}/permissions/team/core"
     body = {"role": "admin"}
-    response = session.put(url, json=body, allow_redirects=False)
+    response = session.put(url, json=body)
     if response.status_code != 200:
         print(
             f"[{prog}] ERROR - 'PUT {url}', with body {body!r}, failed"
@@ -99,7 +99,7 @@ def add_core(session, repo):
 def make_public(session, repo):
     url = f"https://quay.io/api/v1/repository/pbench/{repo}/changevisibility"
     body = {"visibility": "public"}
-    response = session.post(url, json=body, allow_redirects=False)
+    response = session.post(url, json=body)
     if response.status_code != 200:
         print(
             f"[{prog}] ERROR - 'POST {url}', with body {body!r}, failed"

--- a/agent/containers/images/repo-fix
+++ b/agent/containers/images/repo-fix
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+_dir=$(dirname "${0}")
+
+distro="${1}"
+
+for image in base tools tool-meister tool-data-sink workloads all; do
+    ${_dir}/quay-repo pbench-agent-${image}-${distro} force
+done


### PR DESCRIPTION
PBENCH-703

When we are pushing images to https://quay.io, we ensure that the target repository is created ahead of time, if it does not already exist, as a publicly visible repository, with the `core` team is added as an administrator.

The new `make` target, `repofix`, uses the default distro targets to ensure all the existing repositories have the appropriate visibility and permissions.