### PR TITLE
Fixes for pbench-clear-tools potholes

### DIFF
--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -32,11 +32,12 @@ class ClearTools(ToolCommand):
         for group in groups:
             if self.verify_tool_group(group) != 0:
                 self.logger.warn(f'No such group "{group}".')
-                errors += 1
+                errors = 1
                 continue
 
             error, tools_not_found = self._clear_remotes(group)
-            errors += error
+            if error:
+                errors = 1
 
             if tools_not_found:
                 self.logger.warn(
@@ -52,9 +53,9 @@ class ClearTools(ToolCommand):
                     self.logger.error(
                         "Failed to remove group directory %s", self.tool_group_dir
                     )
-                    errors += 1
+                    errors = 1
 
-        return 1 if errors else 0
+        return errors
 
     def _clear_remotes(self, group: str) -> Tuple[int, List[str]]:
         """
@@ -74,8 +75,7 @@ class ClearTools(ToolCommand):
                 and group != "default"
                 and self.is_empty(self.tool_group_dir)
             ):
-                # Unless it is not a default group we will remove any
-                # empty tool group directories.
+                # Remove non-default empty tool directories
                 try:
                     shutil.rmtree(self.tool_group_dir)
                 except OSError as e:

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -26,7 +26,7 @@ class ClearTools(ToolCommand):
     def execute(self) -> int:
         errors = 0
 
-        groups = self.context.group.split(",")
+        groups = [group for group in self.context.group.split(",") if group]
         # groups is never empty and if the user doesn't specify a --group,
         # then it has the value "default"
         for group in groups:
@@ -66,7 +66,7 @@ class ClearTools(ToolCommand):
         errors = 0
         tools_not_found_group = {}
         if self.context.remote:
-            remotes = self.context.remote.split(",")
+            remotes = [remote for remote in self.context.remote.split(",") if remote]
         else:
             # We were not given any remotes on the command line, build the list
             # from the tools group directory.
@@ -96,7 +96,7 @@ class ClearTools(ToolCommand):
                 continue
 
             if self.context.name:
-                names = self.context.name.split(",")
+                names = [name for name in self.context.name.split(",") if name]
             else:
                 # Discover all the tools registered for this remote
                 names = self.tools(tg_dir_r)

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -45,7 +45,7 @@ class ClearTools(ToolCommand):
 
             # Remove a custom (non-default) tool group directory if there are
             # no tools registered anymore under this group
-            if group != "default" and not any(self.tool_group_dir.iterdir()):
+            if group != "default" and self.is_empty(self.tool_group_dir):
                 try:
                     shutil.rmtree(self.tool_group_dir)
                 except OSError:

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -177,7 +177,7 @@ class ClearTools(ToolCommand):
 
 def contains_empty(items: str) -> bool:
     """Determine if the comma separated string contains en empty element"""
-    return bool([name for name in items.split(",") if not name])
+    return not all(items.split(","))
 
 
 def _group_option(f):
@@ -185,7 +185,7 @@ def _group_option(f):
 
     def callback(ctxt, _param, value):
         if value and contains_empty(value):
-            raise click.BadParameter(message="Blank group name specified; terminating.")
+            raise click.BadParameter(message="Blank group name specified.")
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.group = value
         return value
@@ -209,7 +209,7 @@ def _name_option(f):
 
     def callback(ctxt, _param, value):
         if value and contains_empty(value):
-            raise click.BadParameter(message="Blank tool name specified; terminating.")
+            raise click.BadParameter(message="Blank tool name specified.")
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.name = None
         if value:
@@ -231,9 +231,7 @@ def _remote_option(f):
 
     def callback(ctxt, _param, value):
         if value and contains_empty(value):
-            raise click.BadParameter(
-                message="Blank remote name specified; terminating."
-            )
+            raise click.BadParameter(message="Blank remote name specified.")
         clictxt = ctxt.ensure_object(CliContext)
         clictxt.remote = value
         return value

--- a/lib/pbench/cli/agent/commands/tools/clear.py
+++ b/lib/pbench/cli/agent/commands/tools/clear.py
@@ -31,7 +31,7 @@ class ClearTools(ToolCommand):
         # then it has the value "default"
         for group in groups:
             if not group:
-                self.logger.warn("Tool group name can not be empty")
+                self.logger.warn("Blank group name specified; skipping.")
                 errors = 1
                 continue
             elif self.verify_tool_group(group) != 0:
@@ -90,7 +90,7 @@ class ClearTools(ToolCommand):
 
         for remote in remotes:
             if not remote:
-                self.logger.warn("Remote host name can not be empty if specified")
+                self.logger.warn("Blank remote host name specified; skipping.")
                 errors = 1
                 continue
             tools_not_found_remote = []
@@ -115,7 +115,7 @@ class ClearTools(ToolCommand):
 
             for name in names:
                 if not name:
-                    self.logger.warn("Tool name can not be empty if specified")
+                    self.logger.warn("Blank tool name specified; skipping.")
                     errors = 1
                     continue
                 status = self._clear_tools(name, remote, group)

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -55,6 +55,10 @@ def test_clear_tools_test13(monkeypatch, agent_config, pbench_run, pbench_cfg):
 def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     """ Remove all tools from group good, leave default alone """
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
+    default_group = pbench_run / "tools-v1-default"
+    fubar_default_group = default_group / "fubar2.example.com"
+    fubar_default_group.mkdir(parents=True)
+
     good_group = pbench_run / "tools-v1-good"
     for host in ["fubar2", "fubar", "testhost.example.com"]:
         (good_group / host).mkdir(parents=True)
@@ -78,6 +82,7 @@ def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert turbostat_tool.exists() is False
     assert mpstat_tool.exists() is False
     assert good_group.exists() is False
+    assert fubar_default_group.exists() is True
 
 
 def test_clear_tools_test66(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -206,7 +211,7 @@ def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
     command = ["pbench-clear-tools", "--name=vmstat"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
-    assert b"Tools ['vmstat'] not found\n" in err
+    assert b"Tools ['vmstat'] not found in group default\n" in err
     assert exitcode == 0
 
 
@@ -231,9 +236,7 @@ def test_clear_tools_test71(monkeypatch, agent_config, pbench_run, pbench_cfg):
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
     assert default_group.exists() is True
-    assert fubar_default_host.exists() is False
     assert another_group.exists() is False
-    assert fubar_another_host.exists() is False
 
 
 def test_clear_tools_test72(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -253,11 +256,10 @@ def test_clear_tools_test72(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert b"" == out
     assert (
         b'Removed "pidstat" from host "fubar7.example.com" in tools group '
-        b'"another' in err
+        b'"another"' in err
     )
     assert b'pbench-clear-tools: invalid --group option "wrong"' in err
     assert another_group.exists() is False
-    assert fubar_another_host.exists() is False
 
 
 def test_clear_tools_test73(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -281,7 +283,6 @@ def test_clear_tools_test73(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert pidstat6_tool.exists() is False
     assert mpstat6_tool.exists() is False
     assert iostat6_tool.exists() is True
-    assert fubar6_host.exists() is True
 
 
 def test_clear_tools_test74(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -324,9 +325,6 @@ def test_clear_tools_test75(monkeypatch, agent_config, pbench_run, pbench_cfg):
     command = ["pbench-clear-tools", "--group=another", "--name=pidstat,mpstat"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
-    assert pidstat7_tool.exists() is False
-    assert mpstat7_tool.exists() is False
-    assert fubar7_host.exists() is False
     assert another_group.exists() is False
 
 
@@ -350,7 +348,4 @@ def test_clear_tools_test76(monkeypatch, agent_config, pbench_run, pbench_cfg):
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
     assert pidstat7_1_tool.exists() is True
-    assert pidstat7_2_tool.exists() is False
-    assert fubar7_1_host.exists() is True
     assert fubar7_2_host.exists() is False
-    assert another_group.exists() is True

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -261,7 +261,7 @@ def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
     "tools",
     ["", "pidstat", "pidstat,mpstat", "pidstat,mpstat,iostat", "mpstat,vmstat"],
 )
-def test_clear_tools_test85(tmp_path, tools_configuration, groups, remotes, tools):
+def test_clear_tools_test85(pbench_run, tools_configuration, groups, remotes, tools):
     """ Attempt to clear tools with various combinations of groups, remotes
     and tools against fixed tools configuration"""
     tools_existence = tools_configuration
@@ -280,7 +280,7 @@ def test_clear_tools_test85(tmp_path, tools_configuration, groups, remotes, tool
 
     assert b"" == out
     for tool in tools_existence:
-        tool_str = str(tool).replace(str(tmp_path), "")
+        tool_str = str(tool).replace(str(pbench_run), "")
         remote_check = True
         tool_check = True
         if groups:

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -362,9 +362,9 @@ def test_clear_tools_test86(tools_configuration, groups, remotes, tools):
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
 
-    empty_group_err_msg = "Tool group name can not be empty"
-    empty_remote_err_msg = "Remote host name can not be empty if specified"
-    empty_tool_err_msg = "Tool name can not be empty if specified"
+    empty_group_err_msg = "Blank group name specified; skipping."
+    empty_remote_err_msg = "Blank remote host name specified; skipping."
+    empty_tool_err_msg = "Blank tool name specified; skipping."
 
     if not groups:
         groups = "default"

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -306,11 +306,20 @@ def test_clear_tools_test85(pbench_run, tools_configuration, groups, remotes, to
         remote_check = True
         tool_check = True
         if groups:
-            group_check = any(x in tool_str for x in groups.split(",") if x)
+            groups_list = groups.split(",")
+            group_check = not bool(
+                [group for group in groups_list if not group]
+            ) and any(x in tool_str for x in groups_list if x)
         if remotes:
-            remote_check = any(x in tool_str for x in remotes.split(",") if x)
+            remotes_list = remotes.split(",")
+            remote_check = not bool(
+                [remote for remote in remotes_list if not remote]
+            ) and any(x in tool_str for x in remotes_list if x)
         if tools:
-            tool_check = any(x in tool_str for x in tools.split(",") if x)
+            tools_list = tools.split(",")
+            tool_check = not bool([tool for tool in tools_list if not tool]) and any(
+                x in tool_str for x in tools_list if x
+            )
 
         if tool_check and remote_check and group_check:
             assert not tool.exists()
@@ -362,54 +371,70 @@ def test_clear_tools_test86(tools_configuration, groups, remotes, tools):
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
 
-    empty_group_err_msg = "Blank group name specified; skipping."
-    empty_remote_err_msg = "Blank remote host name specified; skipping."
-    empty_tool_err_msg = "Blank tool name specified; skipping."
+    empty_group_err_msg = (
+        "Error: Invalid value for '-g' / '--group' / '--groups': "
+        "Blank group name specified; terminating.\n"
+    )
+    empty_remote_err_msg = (
+        "Error: Invalid value for '-r' / '--remote' / '--remotes': "
+        "Blank remote name specified; terminating.\n"
+    )
+    empty_tool_err_msg = (
+        "Error: Invalid value for '-n' / '--name' / '--names': "
+        "Blank tool name specified; terminating.\n"
+    )
 
     if not groups:
         groups = "default"
 
-    empty_group_seq = 0
-    empty_remote_seq = 0
-    empty_tool_seq = 0
-    for group in groups.split(","):
-        invalid_group_err_msg = f'pbench-clear-tools: invalid --group option "{group}"'
-        if not group:
-            empty_group_seq += 1
-        elif group not in tools_tree.keys():
-            assert invalid_group_err_msg.encode() in err
+    groups_list = groups.split(",")
+    remotes_list = remotes.split(",")
+    tools_list = tools.split(",")
+
+    # Check for the blank group name
+    if [group for group in groups_list if not group]:
+        assert empty_group_err_msg.encode() in err
+    else:
+        # Check for the blank remote host name
+        if remotes and [remote for remote in remotes_list if not remote]:
+            assert empty_remote_err_msg.encode() in err
         else:
-            assert invalid_group_err_msg.encode() not in err
-
-            remotes_list = remotes.split(",")
-            if not remotes:
-                remotes_list = tools_tree[group].keys()
-            for remote in remotes_list:
-                invalid_remote_err_msg = f'No remote host "{remote}.example.com"'
-                if not remote:
-                    empty_remote_seq += 1
-                elif remote not in tools_tree[group]:
-                    assert invalid_remote_err_msg.encode() in err
-                else:
-                    assert invalid_remote_err_msg.encode() not in err
-                    wrong_tools = []
-                    all_tools_removed = f'All tools removed from group "{group}" on host "{remote}.example.com"'
-                    if not tools:
-                        assert all_tools_removed.encode() in err
+            # Check for the blank tool name
+            if tools and [tool for tool in tools_list if not tool]:
+                assert empty_tool_err_msg.encode() in err
+            else:
+                # If none of the options have any blank value specified
+                for group in groups_list:
+                    invalid_group_err_msg = (
+                        f'pbench-clear-tools: invalid --group option "{group}"'
+                    )
+                    if group not in tools_tree.keys():
+                        assert invalid_group_err_msg.encode() in err
                     else:
-                        tools_list = tools.split(",")
-                        for tool in tools_list:
-                            if not tool:
-                                empty_tool_seq += 1
-                            elif tool not in tools_tree[group][remote]:
-                                wrong_tools.append(tool)
-                    if wrong_tools:
-                        wrong_tools = sorted(wrong_tools)
-                        wrong_tools_err_msg = f"Tools {wrong_tools} not found in remote"
-                        assert wrong_tools_err_msg.encode() in err
-                    else:
-                        assert all_tools_removed.encode() in err
-
-    assert err.count(empty_group_err_msg.encode()) == empty_group_seq
-    assert err.count(empty_remote_err_msg.encode()) == empty_remote_seq
-    assert err.count(empty_tool_err_msg.encode()) == empty_tool_seq
+                        assert invalid_group_err_msg.encode() not in err
+                        if not remotes:
+                            remotes_list = tools_tree[group].keys()
+                        for remote in remotes_list:
+                            invalid_remote_err_msg = (
+                                f'No remote host "{remote}.example.com"'
+                            )
+                            if remote not in tools_tree[group]:
+                                assert invalid_remote_err_msg.encode() in err
+                            else:
+                                assert invalid_remote_err_msg.encode() not in err
+                                wrong_tools = []
+                                all_tools_removed = f'All tools removed from group "{group}" on host "{remote}.example.com"'
+                                if not tools:
+                                    assert all_tools_removed.encode() in err
+                                else:
+                                    for tool in tools_list:
+                                        if tool not in tools_tree[group][remote]:
+                                            wrong_tools.append(tool)
+                                    if wrong_tools:
+                                        wrong_tools = sorted(wrong_tools)
+                                        wrong_tools_err_msg = (
+                                            f"Tools {wrong_tools} not found in remote"
+                                        )
+                                        assert wrong_tools_err_msg.encode() in err
+                                    else:
+                                        assert all_tools_removed.encode() in err

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -58,6 +58,8 @@ def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     default_group = pbench_run / "tools-v1-default"
     fubar_default_group = default_group / "fubar2.example.com"
     fubar_default_group.mkdir(parents=True)
+    iostat_default_tool = fubar_default_group / "iostat"
+    iostat_default_tool.touch()
 
     good_group = pbench_run / "tools-v1-good"
     for host in ["fubar2", "fubar", "testhost.example.com"]:
@@ -82,7 +84,7 @@ def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert turbostat_tool.exists() is False
     assert mpstat_tool.exists() is False
     assert good_group.exists() is False
-    assert fubar_default_group.exists() is True
+    assert iostat_default_tool.exists() is True
 
 
 def test_clear_tools_test66(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -101,23 +103,23 @@ def test_clear_tools_test67(monkeypatch, agent_config, pbench_run, pbench_cfg):
     default_group = pbench_run / "tools-v1-default"
     default_group.mkdir(parents=True)
 
-    fubar3_group = default_group / "fubar3.example.com"
-    fubar3_group.mkdir(parents=True)
-    iostat_tool = fubar3_group / "iostat"
+    fubar1_group = default_group / "fubar1.example.com"
+    fubar1_group.mkdir(parents=True)
+    iostat_tool = fubar1_group / "iostat"
     iostat_tool.touch()
-    vmstat_tool = fubar3_group / "vmstat"
+    vmstat_tool = fubar1_group / "vmstat"
     vmstat_tool.touch()
 
-    fubar4_group = default_group / "fubar4.example.com"
-    fubar4_group.mkdir(parents=True)
-    pidstat_tool = fubar4_group / "pidstat"
+    fubar2_group = default_group / "fubar2.example.com"
+    fubar2_group.mkdir(parents=True)
+    pidstat_tool = fubar2_group / "pidstat"
     pidstat_tool.touch()
-    turbostat_tool = fubar4_group / "turbostat"
+    turbostat_tool = fubar2_group / "turbostat"
     turbostat_tool.touch()
 
     command = [
         "pbench-clear-tools",
-        "--remotes=fubar3.example.com,doesnotexist.example.com,fubar4.example.com",
+        "--remotes=fubar1.example.com,doesnotexist.example.com," "fubar2.example.com",
     ]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
@@ -135,29 +137,29 @@ def test_clear_tools_test68(monkeypatch, agent_config, pbench_run, pbench_cfg):
     default_group = pbench_run / "tools-v1-default"
     default_group.mkdir(parents=True)
 
-    fubar5_group = default_group / "fubar5.example.com"
-    fubar5_group.mkdir(parents=True, exist_ok=True)
-    vmstat5_tool = fubar5_group / "vmstat"
-    vmstat5_tool.touch()
+    fubar1_group = default_group / "fubar1.example.com"
+    fubar1_group.mkdir(parents=True, exist_ok=True)
+    vmstat1_tool = fubar1_group / "vmstat"
+    vmstat1_tool.touch()
 
-    fubar6_group = default_group / "fubar6.example.com"
-    fubar6_group.mkdir(parents=True)
-    vmstat6_tool = fubar6_group / "vmstat"
-    vmstat6_tool.touch()
-    pidstat_tool = fubar6_group / "pidstat"
+    fubar2_group = default_group / "fubar2.example.com"
+    fubar2_group.mkdir(parents=True)
+    vmstat2_tool = fubar2_group / "vmstat"
+    vmstat2_tool.touch()
+    pidstat_tool = fubar2_group / "pidstat"
     pidstat_tool.touch()
-    turbostat_tool = fubar6_group / "turbostat"
+    turbostat_tool = fubar2_group / "turbostat"
     turbostat_tool.touch()
 
     command = [
         "pbench-clear-tools",
         "--name=vmstat",
-        "--remotes=fubar5.example.com,fubar6.example.com",
+        "--remotes=fubar1.example.com,fubar2.example.com",
     ]
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 0
-    assert vmstat6_tool.exists() is False
-    assert vmstat5_tool.exists() is False
+    assert vmstat2_tool.exists() is False
+    assert vmstat1_tool.exists() is False
     assert turbostat_tool.exists() is True
     assert pidstat_tool.exists() is True
 
@@ -168,34 +170,34 @@ def test_clear_tools_test69(monkeypatch, agent_config, pbench_run, pbench_cfg):
     default_group = pbench_run / "tools-v1-default"
     default_group.mkdir(parents=True)
 
-    fubar5_group = default_group / "fubar5.example.com"
-    fubar5_group.mkdir(parents=True, exist_ok=True)
-    pidstat5_tool = fubar5_group / "pidstat"
-    pidstat5_tool.touch()
+    fubar1_group = default_group / "fubar1.example.com"
+    fubar1_group.mkdir(parents=True, exist_ok=True)
+    pidstat1_tool = fubar1_group / "pidstat"
+    pidstat1_tool.touch()
 
-    fubar6_group = default_group / "fubar6.example.com"
-    fubar6_group.mkdir(parents=True, exist_ok=True)
-    pidstat6_tool = fubar6_group / "pidstat"
-    pidstat6_tool.touch()
+    fubar2_group = default_group / "fubar2.example.com"
+    fubar2_group.mkdir(parents=True, exist_ok=True)
+    pidstat2_tool = fubar2_group / "pidstat"
+    pidstat2_tool.touch()
 
-    fubar7_group = default_group / "fubar7.example.com"
-    fubar7_group.mkdir(parents=True, exist_ok=True)
-    pidstat7_tool = fubar7_group / "pidstat"
-    pidstat7_tool.touch()
-    turbostat_tool = fubar7_group / "turbostat"
+    fubar3_group = default_group / "fubar3.example.com"
+    fubar3_group.mkdir(parents=True, exist_ok=True)
+    pidstat3_tool = fubar3_group / "pidstat"
+    pidstat3_tool.touch()
+    turbostat_tool = fubar3_group / "turbostat"
     turbostat_tool.touch()
 
     command = [
         "pbench-clear-tools",
         "--name=pidstat",
-        "--remotes=fubar5.example.com,fubar6.example.com,fubar7.example.com",
+        "--remotes=fubar1.example.com,fubar2.example.com,fubar3.example.com",
     ]
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 0
     assert turbostat_tool.exists() is True
-    assert pidstat5_tool.exists() is False
-    assert pidstat6_tool.exists() is False
-    assert pidstat7_tool.exists() is False
+    assert pidstat1_tool.exists() is False
+    assert pidstat2_tool.exists() is False
+    assert pidstat3_tool.exists() is False
 
 
 def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
@@ -203,10 +205,10 @@ def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
     default_group = pbench_run / "tools-v1-default"
     default_group.mkdir(parents=True)
-    fubar5_host = default_group / "fubar5.example.com"
-    fubar5_host.mkdir(parents=True, exist_ok=True)
-    pidstat5_tool = fubar5_host / "pidstat"
-    pidstat5_tool.touch()
+    fubar_host = default_group / "fubar.example.com"
+    fubar_host.mkdir(parents=True, exist_ok=True)
+    pidstat_tool = fubar_host / "pidstat"
+    pidstat_tool.touch()
 
     command = ["pbench-clear-tools", "--name=vmstat"]
     out, err, exitcode = pytest.helpers.capture(command)
@@ -232,7 +234,7 @@ def test_clear_tools_test71(monkeypatch, agent_config, pbench_run, pbench_cfg):
     pidstat_another_tool = fubar_another_host / "pidstat"
     pidstat_another_tool.touch()
 
-    command = ["pbench-clear-tools", "--group=default,another"]
+    command = ["pbench-clear-tools", "--groups=default,another"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
     assert default_group.exists() is True
@@ -246,106 +248,207 @@ def test_clear_tools_test72(monkeypatch, agent_config, pbench_run, pbench_cfg):
 
     another_group = pbench_run / "tools-v1-another"
     another_group.mkdir(parents=True)
-    fubar_another_host = another_group / "fubar7.example.com"
+    fubar_another_host = another_group / "fubar.example.com"
     fubar_another_host.mkdir(parents=True, exist_ok=True)
     pidstat_another_tool = fubar_another_host / "pidstat"
     pidstat_another_tool.touch()
 
-    command = ["pbench-clear-tools", "--group=another,wrong"]
+    command = ["pbench-clear-tools", "--groups=another,wrong"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
     assert (
-        b'Removed "pidstat" from host "fubar7.example.com" in tools group '
+        b'Removed "pidstat" from host "fubar.example.com" in tools group '
         b'"another"' in err
     )
     assert b'pbench-clear-tools: invalid --group option "wrong"' in err
     assert another_group.exists() is False
 
 
-def test_clear_tools_test73(monkeypatch, agent_config, pbench_run, pbench_cfg):
+@pytest.mark.parametrize(
+    "groups", ["default", "default,custom1", "default,custom1,custom2"]
+)
+@pytest.mark.parametrize(
+    "remotes",
+    ["remote1", "remote1,remote2", "remote1,remote2,remote3", "remote2,remote4"],
+)
+@pytest.mark.parametrize(
+    "tools", ["pidstat", "pidstat,mpstat", "pidstat,mpstat,iostat", "mpstat," "vmstat"]
+)
+def test_clear_tools_test73(
+    monkeypatch, tmp_path, agent_config, pbench_run, pbench_cfg, groups, remotes, tools
+):
     """ Attempt to clear the tools, by name, separated by comma"""
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
-    default_group = pbench_run / "tools-v1-default"
-    default_group.mkdir(parents=True)
-    fubar6_host = default_group / "fubar6.example.com"
-    fubar6_host.mkdir(parents=True, exist_ok=True)
-    pidstat6_tool = fubar6_host / "pidstat"
-    pidstat6_tool.touch()
-    mpstat6_tool = fubar6_host / "mpstat"
-    mpstat6_tool.touch()
-    iostat6_tool = fubar6_host / "iostat"
-    iostat6_tool.touch()
+    tools_existence = []
+    for group in groups.split(","):
+        custom_group = pbench_run / f"tools-v1-{group}"
+        custom_group.mkdir(parents=True)
+        for remote in remotes.split(","):
+            remote_host = custom_group / f"{remote}.example.com"
+            remote_host.mkdir(parents=True, exist_ok=True)
+            for tool in tools.split(","):
+                tool_file = remote_host / tool
+                tool_file.touch()
+                tools_existence.append(tool_file)
 
     command = ["pbench-clear-tools", "--name=pidstat,mpstat"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
     assert b"" in err
-    assert pidstat6_tool.exists() is False
-    assert mpstat6_tool.exists() is False
-    assert iostat6_tool.exists() is True
+    for tool in tools_existence:
+        tool_str = str(tool).replace(str(tmp_path), "")
+        if any(x in tool_str for x in ["pidstat", "mpstat"]) and "default" in tool_str:
+            assert tool.exists() is False
+        else:
+            assert tool.exists() is True
+
+    command = [
+        "pbench-clear-tools",
+        "--groups=custom1,custom2",
+        "--name=pidstat,mpstat",
+    ]
+    # By this point pidstat and mpstat tools in all groups should be cleared
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert b"" == out
+    assert b"" in err
+    for tool in tools_existence:
+        tool_str = str(tool).replace(str(tmp_path), "")
+        if any(x in tool_str for x in ["pidstat", "mpstat"]):
+            assert tool.exists() is False
+        else:
+            assert tool.exists() is True
 
 
-def test_clear_tools_test74(monkeypatch, agent_config, pbench_run, pbench_cfg):
+@pytest.mark.parametrize(
+    "remotes",
+    [
+        "remote1",
+        "remote1,remote2",
+        "remote1,remote2,remote3",
+        "remote2,remote4",
+        "remote4,remote2,remote5",
+    ],
+)
+def test_clear_tools_test74(monkeypatch, agent_config, pbench_run, pbench_cfg, remotes):
     """ Attempt to clear all tools in default group, by name, separated by
     comma"""
     monkeypatch.setenv("_PBENCH_AGENT_CONFIG", str(pbench_cfg))
     default_group = pbench_run / "tools-v1-default"
     default_group.mkdir(parents=True)
-    fubar6_host = default_group / "fubar6.example.com"
-    fubar6_host.mkdir(parents=True, exist_ok=True)
-    pidstat6_tool = fubar6_host / "pidstat"
-    pidstat6_tool.touch()
-    mpstat6_tool = fubar6_host / "mpstat"
-    mpstat6_tool.touch()
-    iostat6_tool = fubar6_host / "iostat"
-    iostat6_tool.touch()
+    tools_existence = []
+    for remote in remotes.split(","):
+        remote_host = default_group / f"{remote}.example.com"
+        remote_host.mkdir(parents=True, exist_ok=True)
+        pidstat_tool = remote_host / "pidstat"
+        pidstat_tool.touch()
+        tools_existence.append(pidstat_tool)
+        mpstat_tool = remote_host / "mpstat"
+        mpstat_tool.touch()
+        tools_existence.append(mpstat_tool)
+        iostat_tool = remote_host / "iostat"
+        iostat_tool.touch()
+        tools_existence.append(iostat_tool)
+
+    command = [
+        "pbench-clear-tools",
+        "--remote=remote1.example.com",
+        "--name=pidstat,mpstat,iostat",
+    ]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert b"" == out
+    for tool in tools_existence:
+        if any(x in str(tool) for x in ["remote1.example.com"]):
+            assert tool.exists() is False
+        else:
+            assert tool.exists() is True
+
+    command = [
+        "pbench-clear-tools",
+        "--remotes=remote2.example.com,remote3.example.com",
+        "--name=pidstat,mpstat,iostat",
+    ]
+    out, err, exitcode = pytest.helpers.capture(command)
+    assert b"" == out
+    for tool in tools_existence:
+        if any(
+            x in str(tool)
+            for x in [
+                "remote1.example.com",
+                "remote2.example.com",
+                "remote3.example.com",
+            ]
+        ):
+            assert tool.exists() is False
+        else:
+            assert tool.exists() is True
 
     command = ["pbench-clear-tools", "--name=pidstat,mpstat,iostat"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
-    assert pidstat6_tool.exists() is False
-    assert mpstat6_tool.exists() is False
-    assert iostat6_tool.exists() is False
-    assert fubar6_host.exists() is False
-    assert default_group.exists() is True
+    for tool in tools_existence:
+        assert tool.exists() is False
 
 
-def test_clear_tools_test75(monkeypatch, agent_config, pbench_run, pbench_cfg):
-    """ Attempt to clear all tools in non-default group, by name, separated by
+@pytest.mark.parametrize("groups", ["custom1", "custom1,custom2"])
+@pytest.mark.parametrize("remotes", ["remote1", "remote1,remote2"])
+def test_clear_tools_test75(
+    monkeypatch, agent_config, pbench_run, pbench_cfg, groups, remotes
+):
+    """ Attempt to clear all tools in non-default groups, by name, separated by
         comma"""
-    another_group = pbench_run / "tools-v1-another"
-    another_group.mkdir(parents=True)
-    fubar7_host = another_group / "fubar7.example.com"
-    fubar7_host.mkdir(parents=True, exist_ok=True)
-    pidstat7_tool = fubar7_host / "pidstat"
-    pidstat7_tool.touch()
-    mpstat7_tool = fubar7_host / "mpstat"
-    mpstat7_tool.touch()
+    groups_shouldnt_exists = []
+    for group in groups.split(","):
+        another_group = pbench_run / f"tools-v1-{group}"
+        another_group.mkdir(parents=True)
+        groups_shouldnt_exists.append(another_group)
+        for remote in remotes:
+            remote_host = another_group / f"{remote}.example.com"
+            remote_host.mkdir(parents=True, exist_ok=True)
+            pidstat7_tool = remote_host / "pidstat"
+            pidstat7_tool.touch()
+            mpstat7_tool = remote_host / "mpstat"
+            mpstat7_tool.touch()
 
-    command = ["pbench-clear-tools", "--group=another", "--name=pidstat,mpstat"]
+    command = ["pbench-clear-tools", f"--group={groups}", "--name=pidstat,mpstat"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
-    assert another_group.exists() is False
+    for group in groups_shouldnt_exists:
+        assert group.exists() is False
 
 
-def test_clear_tools_test76(monkeypatch, agent_config, pbench_run, pbench_cfg):
-    """ Attempt to clear a group, by name, registered on multiple
+@pytest.mark.parametrize(
+    "groups", ["default", "default,custom1", "default,custom1,custom2"]
+)
+@pytest.mark.parametrize(
+    "remotes",
+    ["remote1", "remote1,remote2", "remote1,remote2,remote3", "remote2,remote4"],
+)
+def test_clear_tools_test76(
+    monkeypatch, agent_config, pbench_run, pbench_cfg, groups, remotes
+):
+    """ Attempt to clear groups, by name, registered on multiple
     hosts"""
-    another_group = pbench_run / "tools-v1-another"
-    another_group.mkdir(parents=True)
+    tools_existence = []
+    for group in groups.split(","):
+        another_group = pbench_run / f"tools-v1-{group}"
+        another_group.mkdir(parents=True)
 
-    fubar7_1_host = another_group / "fubar7_1.example.com"
-    fubar7_1_host.mkdir(parents=True, exist_ok=True)
-    pidstat7_1_tool = fubar7_1_host / "pidstat"
-    pidstat7_1_tool.touch()
+        for remote in remotes.split(","):
+            fubar7_1_host = another_group / f"{remote}.example.com"
+            fubar7_1_host.mkdir(parents=True, exist_ok=True)
+            pidstat7_1_tool = fubar7_1_host / "pidstat"
+            pidstat7_1_tool.touch()
+            tools_existence.append(pidstat7_1_tool)
 
-    fubar7_2_host = another_group / "fubar7_2.example.com"
-    fubar7_2_host.mkdir(parents=True, exist_ok=True)
-    pidstat7_2_tool = fubar7_2_host / "pidstat"
-    pidstat7_2_tool.touch()
-
-    command = ["pbench-clear-tools", "--group=another", "--remote=fubar7_2.example.com"]
+    command = [
+        "pbench-clear-tools",
+        f"--group={groups}",
+        "--remote=remote2.example.com,remote3.example.com",
+    ]
     out, err, exitcode = pytest.helpers.capture(command)
     assert b"" == out
-    assert pidstat7_1_tool.exists() is True
-    assert fubar7_2_host.exists() is False
+    for tool in tools_existence:
+        if any(x in str(tool) for x in ["remote2.example.com", "remote3.example.com"]):
+            assert tool.exists() is False
+        else:
+            assert tool.exists() is True

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -275,7 +275,7 @@ def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
 
 @pytest.mark.parametrize(
     "groups",
-    ["", "default", "default,group1", "default,group1,group2", "group1,group2,group3",],
+    ["", "default", "default,group1", "default,group1,group2", "group1,group2,group3"],
 )
 @pytest.mark.parametrize(
     "remotes",
@@ -291,17 +291,7 @@ def test_clear_tools_test70(monkeypatch, agent_config, pbench_run, pbench_cfg):
     "tools",
     ["", "pidstat", "pidstat,mpstat", "pidstat,mpstat,iostat", "mpstat,vmstat"],
 )
-def test_clear_tools_test85(
-    monkeypatch,
-    tmp_path,
-    agent_config,
-    pbench_run,
-    pbench_cfg,
-    tools_configuration,
-    groups,
-    remotes,
-    tools,
-):
+def test_clear_tools_test85(tmp_path, tools_configuration, groups, remotes, tools):
     """ Attempt to clear tools with various combinations of groups, remotes
     and tools against fixed tools configuration"""
     tools_existence = tools_configuration
@@ -351,17 +341,7 @@ def test_clear_tools_test85(
 @pytest.mark.parametrize(
     "tools", ["pidstat,mpstat,iostat", "mpstat,vmstat"],
 )
-def test_clear_tools_test86(
-    monkeypatch,
-    tmp_path,
-    agent_config,
-    pbench_run,
-    pbench_cfg,
-    tools_configuration,
-    groups,
-    remotes,
-    tools,
-):
+def test_clear_tools_test86(tools_configuration, groups, remotes, tools):
     """ Attempt to clear tools at various group-remote-tool locations where the
     combination may not present on the hosts"""
     command = [

--- a/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
+++ b/lib/pbench/test/functional/agent/cli/commands/tools/test_clear_tools.py
@@ -77,8 +77,6 @@ def test_clear_tools_test65(monkeypatch, agent_config, pbench_run, pbench_cfg):
     assert pidstat_tool.exists() is False
     assert turbostat_tool.exists() is False
     assert mpstat_tool.exists() is False
-    # FIXME:  Why do we want to retain the group directory after deleting everything out of it??
-    # FIXME:  Contrary to the test docstring, this test doesn't create or assert that the default group is unmolested.
     assert good_group.exists() is False
 
 


### PR DESCRIPTION
Fixes issue #2337 

- Added support for comma-separated lists of `--name` and `--group` option on `pbench-clear-tools` command.
- Removes the tool group directory after a user clears all the tools from the group

