### PR TITLE
Fixes footer content overlap issue

### DIFF
--- a/doc.html
+++ b/doc.html
@@ -1012,5 +1012,8 @@
                 $(".searchBtn").show();
             }
         }
+
+        // add margin between body content and footer to avoid overlap
+        $('.section_card').css('margin-bottom', $('.footer').height());
     </script>
 </html>


### PR DESCRIPTION
Footer text content is overlapping the documentation text content.
To resolve it, just add margin-bottom equivalent to footer height

Old rendering:
![Screenshot from 2022-02-08 09-15-09](https://user-images.githubusercontent.com/20382324/152916131-f7894e4a-883a-4372-af6a-c6322162efb3.png)


New rendering:
![Screenshot from 2022-02-08 09-15-37](https://user-images.githubusercontent.com/20382324/152916141-eae206fc-354e-4302-87a4-5860434d8614.png)
.