### PR TITLE
Add option to allow chroot specs for COPR builds (b0.69)

### DIFF
--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -8,6 +8,13 @@
 # 7. Optionally generate a local RPM.
 # 8. Clean up the temp directory
 
+# Do not use the RHEL9 chroots - v0.69 does not work on RHEL9
+CHROOTS = --exclude-chroot centos-stream-9-aarch64 \
+	  --exclude-chroot centos-stream-9-x86_64 \
+	  --exclude-chroot epel-9-aarch64 \
+	  --exclude-chroot epel-9-x86_64
+
+
 CWD = $(shell pwd)
 
 # adjust as necessary

--- a/agent/rpm/rpm.mk
+++ b/agent/rpm/rpm.mk
@@ -41,6 +41,6 @@ copr-interim \
 copr-index \
 copr-inotify \
 copr-dashboard:	$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
-	copr-cli build $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
+	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 veryclean:: clean rpm-clean


### PR DESCRIPTION
Add a CHROOTS variable to the agent/rpm/Makefile and an option
to the `copr-cli build' command in rpm.mk, to allow
the specification of chroots to include or exclude in a build.

The default setting for the b0.69 branch excludes all RHEL9 builds:
the 0.69 agent does not work on RHEL9 because of an `scp -r' bug.