### PR TITLE
Add option to allow chroot specs for COPR builds

### DIFF
--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -1,6 +1,25 @@
 # Makefile for generating a source RPM and optional local RPM
 # for the Pbench agent.
 
+# To limit the builds to certain chroots or exclude certain chroots
+# from building, add entries of the form
+#    "--chroot centos-stream-9-x86_64"
+# or
+#    "--exclude-chroot centos-stream-9-x86_64"
+# to the CHROOTS variable below.
+# Multiple such entries can be added to be passed as options to
+# `copr-cli build'.  By default, we build every chroot configured for
+# the repo.
+# N.B. `copr-cli' flags an error if the value of a `--chroot' or
+# `--exclude-chroot' option is not configured in the repo.
+# E.g. to build the RHEL9 chroots only:
+# CHROOTS = --chroot centos-stream-9-x86_64 \
+#           --chroot centos-stream-9-aarch64 \
+#           --chroot epel-9-x86_64 \
+#           --chroot epel-9-aarch64
+# By default, we build every chroot enabled in the repo.
+CHROOTS =
+
 component = agent
 subcomps = agent
 

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -78,7 +78,7 @@ endif
 COPR_TARGETS = copr copr-test
 .PHONY: ${COPR_TARGETS}
 ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
-	copr-cli build $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
+	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 .PHONY: distclean
 distclean:


### PR DESCRIPTION
Add a CHROOTS variable to the agent/rpm/Makefile and an option
to the `copr-cli build' command in ../../utils/rpm.mk, to allow
the specification of chroots to include or exclude in a build.

The default setting for the main branch builds all chroots configured
in the COPR repo.