### PR TITLE
Use --all-ip-addresses instead of --ip-address

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -119,7 +119,7 @@ fi
 validate_hostname "${_pbench_full_hostname}" "_pbench_full_hostname"
 
 if [[ -z "${_pbench_hostname_ip}" ]]; then
-    export _pbench_hostname_ip=$(hostname --ip-address)
+    export _pbench_hostname_ip=$(hostname --all-ip-addresses)
 fi
 for _ip in ${_pbench_hostname_ip}; do
     validate-ipaddress "${_ip}"


### PR DESCRIPTION
The `hostname --ip-addresses` returns loopback and link-local addresses, which are not useful for agent communication and break the `ipaddress.ip_address()` parser. Instead, use `--all-ip-addresses` which provides similar results but corrects these weaknesses and does not depend on name resolution.

```
       -i, --ip-address
              Display  the  network  address(es)  of the host name. Note that this works only if the host name can be resolved. Avoid using this option; use
              hostname --all-ip-addresses instead.

       -I, --all-ip-addresses
              Display all network addresses of the host. This option enumerates all configured addresses on all network interfaces. The  loopback  interface
              and  IPv6 link-local addresses are omitted. Contrary to option -i, this option does not depend on name resolution. Do not make any assumptions
              about the order of the output.
```

Resolves #2608 