### PR TITLE
Fix fio's "ramp_time" template handling

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -544,7 +544,7 @@ function fio_create_jobfile() {
 		-direct="${5}" \
 		-sync="${6}" \
 		-runtime="${7}" \
-		-ramptime="${8}" \
+		-ramp_time="${8}" \
 		-size="${9}" \
 		-rate_iops="${10}" \
 		-log_hist_msec="${11}" \

--- a/agent/bench-scripts/templates/make-fio-jobfile.py
+++ b/agent/bench-scripts/templates/make-fio-jobfile.py
@@ -68,7 +68,7 @@ other_args = [
     "direct",
     "sync",
     "runtime",
-    "ramptime",
+    "ramp_time",
     "size",
     "rate_iops",
     "log_hist_msec",

--- a/agent/bench-scripts/tests/pbench-fio/test-04.opts
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.opts
@@ -1,1 +1,1 @@
---test-types=rw,randrw
+--test-types=rw,randrw --ramptime=61

--- a/agent/bench-scripts/tests/pbench-fio/test-04.txt
+++ b/agent/bench-scripts/tests/pbench-fio/test-04.txt
@@ -9,7 +9,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -54,7 +54,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -99,7 +99,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -144,7 +144,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -189,7 +189,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -234,7 +234,7 @@ direct=1
 sync=0
 time_based=1
 clocksource=gettimeofday
-ramp_time=5
+ramp_time=61
 write_bw_log=fio
 write_iops_log=fio
 write_lat_log=fio
@@ -698,7 +698,7 @@ fio job complete
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample3 fio- default
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample4 fio- default
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/fio-postprocess /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/6-randrw-1024KiB/sample5 fio- default
-/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/generate-benchmark-summary fio --config=test-04 --test-types=rw,randrw /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00
+/var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/generate-benchmark-summary fio --config=test-04 --test-types=rw,randrw --ramptime=61 /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/1-rw-4KiB readwrite_IOPS 5 0 6 y y
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/2-rw-64KiB readwrite_IOPS 5 0 6 y y
 /var/tmp/pbench-test-bench/opt/pbench-agent/bench-scripts/postprocess/process-iteration-samples /var/tmp/pbench-test-bench/pbench-agent/fio_test-04_1900.01.01T00.00.00/3-rw-1024KiB readwrite_IOPS 5 0 6 y y


### PR DESCRIPTION
The "ramp_time" option in fio includes the "\_" character, but currently
the "make-fio-jobfile.py" uses ramptime without the "\_" character
resulting in the default being used instead. Add the "\_" character to
the "make-fio-jobfile.py" while preserving the original in "pbench-fio"
to keep the compatibility.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>