### PR TITLE
Sort all items in the tarball stats report

### DIFF
--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -356,13 +356,13 @@ Summary Statistics for Tar Balls on 1970-01-01 (external data only):
                     1.8 kB size
 
         By Server Origin:
-                         5 main pbench server
                          3 "ONE" pbench satellite server
+                         5 main pbench server
 
         Controller Counts:
                          6 controllers
-                         3 main pbench server
                          3 "ONE" pbench satellite server
+                         3 main pbench server
 
 Tar Ball Counts broken down by weeks for most recent 2 months (with satellite percentages):
 

--- a/server/bin/pbench-tarball-stats.py
+++ b/server/bin/pbench-tarball-stats.py
@@ -173,13 +173,13 @@ report_tmpl = """Summary Statistics for Tar Balls on {{ now.strftime("%Y-%m-%d")
         {{ "{:>18s}".format(good.size|humanize_naturalsize) }} size
 
         By Server Origin:
-        {% for name, value in server_origin.items() %}
+        {% for name, value in server_origin.items()|sort %}
         {{ "{:18n}".format(value) }} {% if name == "main" %}{{ name }} pbench server{% else %}"{{ name }}" pbench satellite server{% endif +%}
         {% endfor %}
 
         Controller Counts:
         {{ "{:18n}".format(good.ctrls.keys()|length) }} controllers
-        {% for name, value in satellites.items() %}
+        {% for name, value in satellites.items()|sort %}
         {{ "{:18n}".format(value) }} {% if name == "main" %}{{ name }} pbench server{% else %}"{{ name }}" pbench satellite server{% endif +%}
         {% endfor %}
         {% endif %}

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 elasticsearch1
-humanize>=3.11
+humanize>=3.11, <4.0.0
 jinja2>=3.0
 jinja2-humanize-extension


### PR DESCRIPTION
Currently, the v0.69 branch testing is failing due to a non-determinism in the `server/bin/pbench-tarball-stats.py` output.  For parts of the report, the lists of servers are sorted; and, for other parts they are not.  This change adds the missing sort directives to the output template.

Fixes #2623.