### PR TITLE
add bug report issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -35,7 +35,7 @@ body:
     id: expected-result
     attributes:
       label: Expected Results
-      description: what is your excepted result?
+      description: what is your expected result?
     validations:
       required: false
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,8 +1,7 @@
-
 name: 🐞 Bug
 description: Report an issue to help improve the project.
-title: "[BUG] <title>"
-labels: ["bug"]
+title: "[BUG]"
+labels: ["needs-triage"]
 body:
   - type: checkboxes
     attributes:
@@ -26,35 +25,23 @@ body:
     validations:
       required: true
   - type: textarea
-    id: screenshots
+    id: actual-result
     attributes:
-      label: Screenshots
-      description: Please add screenshots if applicable
+      label: Actual Results
+      description: Add your observations/output/log/screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: Expected Results
+      description: what is your excepted result?
     validations:
       required: false
   - type: textarea
     id: extrainfo
     attributes:
       label: Additional information
-      description: Is there anything else we should know about this bug? (like linux distribution(version + arch), python version and etc)   
+      description: Is there anything else we should know about this bug? (like Version-Release number of selected component, linux distribution and etc)   
     validations:
       required: false
-  - type: dropdown
-    id: component
-    attributes:
-      label: Where did you see this issue?
-      description: In which pbench component this issue was found?
-      options:
-        - Agent
-        - Server
-        - Other
-    validations:
-      required: true
-  - type: input
-    id: component-version
-    attributes:
-      label: In which version? 
-      description: In which version this issue was found?
-      placeholder: v0.71
-    validations:
-      required: true

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -30,18 +30,19 @@ body:
       label: Actual Results
       description: Add your observations/output/log/screenshots if applicable
     validations:
-      required: false
+      required: true
   - type: textarea
     id: expected-result
     attributes:
       label: Expected Results
-      description: what is your expected result?
+      description: What is your expected result?
     validations:
-      required: false
+      required: true
   - type: textarea
     id: extrainfo
     attributes:
       label: Additional information
-      description: Is there anything else we should know about this bug? (like Version-Release number of selected component, linux distribution and etc)   
+      description: Is there anything else we should know about this bug? (Like version or release number of selected component, Linux distribution, etc.)   
     validations:
       required: false
+

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,60 @@
+
+name: 🐞 Bug
+description: Report an issue to help improve the project.
+title: "[BUG] <title>"
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: Reproduce
+    attributes:
+      label: To Reproduce
+      description: Steps to reproduce this bug
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this bug? (like linux distribution(version + arch), python version and etc)   
+    validations:
+      required: false
+  - type: dropdown
+    id: component
+    attributes:
+      label: Where did you see this issue?
+      description: In which pbench component this issue was found?
+      options:
+        - Agent
+        - Server
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: component-version
+    attributes:
+      label: In which version? 
+      description: In which version this issue was found?
+      placeholder: v0.71
+    validations:
+      required: true


### PR DESCRIPTION
This is an effort to standardize bug reporting.
Now onward while filing a bug one has to answer set of questions, which will avoid vague(unclear) bug reports.
This change will help us understand bug easily without having lot of Q&A in the thread.

Note:
- If you want to try out working page of this PR, visit [link](https://github.com/vishalvvr/pbench/issues/new/choose) and click "Get Started", also feel free to file a bug and see how it files an issue :) 
- This is a feature by GitHub called "issue forms", if you want to explore more options refer [syntax](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) page.