### PR TITLE
Improve Jenkins container run mechanism

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -2,7 +2,6 @@ pipeline {
     agent { label 'pbench' }
     environment {
         COV_REPORT_LOC="cov.${BUILD_NUMBER}.xml"
-        EXTRA_PODMAN_SWITCHES='--user=root'
         NO_COLORS=0
         PY_COLORS=0
         TERM='dumb'

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -17,6 +17,12 @@
 # chosen over any installed ones, and it adds `/usr/sbin` to the end of the
 # path for the `ip` command, used by pbench-register-tool.
 
+# Override the inherited HOME (which is a path generally not mapped inside the
+# container) so that pip and setup.py will install to a directory that exists
+# and doesn't require root access (e.g., to create /home/jenkins/.local/)
+export HOME=/tmp/jenkins
+mkdir -p ${HOME}
+
 PATH=$(python3 -m site --user-base)/bin:${PATH}:/usr/sbin
 unset PYTHONPATH
 pip3 install --user -r lint-requirements.txt -r docs/requirements.txt -r agent/requirements.txt -r server/requirements.txt -r agent/test-requirements.txt -r server/test-requirements.txt

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -17,12 +17,6 @@
 # chosen over any installed ones, and it adds `/usr/sbin` to the end of the
 # path for the `ip` command, used by pbench-register-tool.
 
-# Override the inherited HOME (which is a path generally not mapped inside the
-# container) so that pip and setup.py will install to a directory that exists
-# and doesn't require root access (e.g., to create /home/jenkins/.local/)
-export HOME=/tmp/jenkins
-mkdir -p ${HOME}
-
 PATH=$(python3 -m site --user-base)/bin:${PATH}:/usr/sbin
 unset PYTHONPATH
 pip3 install --user -r lint-requirements.txt -r docs/requirements.txt -r agent/requirements.txt -r server/requirements.txt -r agent/test-requirements.txt -r server/test-requirements.txt

--- a/jenkins/run
+++ b/jenkins/run
@@ -33,6 +33,7 @@ podman run \
     ${GIT_BASE_VOLUME} \
     -w /src/pbench \
     --env-host \
+    --env HOME=/tmp/jenkins \
     --ulimit nofile=65536:65536 \
     --rm \
     ${EXTRA_PODMAN_SWITCHES} \

--- a/jenkins/run
+++ b/jenkins/run
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+# Run commands within the pbench-devel container image.
+#
+# Generally you want to run a shell, and `source jenkins/python-setup.py` to
+# initialize a Pbench testing environment.
+#
+# Several customizing inputs can be given via environment variables:
+#
+# CONTAINER_HOME []
+# CONTAINER_HOME_OPTION [z] (used only if CONTAINER_HOME is given)
+# EXTRA_PODMAN_SWITCHES []
+# IMAGE_REPO [quay.io/pbench]
+#
+# For example, run with HOME mapped to /tmp/jenkins in the host system, and run
+# an interactive bash shell:
+#
+#     EXTRA_PODMAN_SWITCHES=-it CONTAINER_HOME=/tmp/jenkins jenkins/run bash
+#
 if [[ "$(realpath -e $(pwd)/jenkins)" != "$(realpath -e $(dirname ${0}))" ]]; then
     printf -- "ERROR - Jenkins running from an unexpected directory, %s\n" "$(pwd)" >&2
     exit 1
@@ -16,6 +33,14 @@ if [[ -z "${IMAGE_REPO}" ]]; then
     IMAGE_REPO="quay.io/pbench"
 fi
 
+IHOME=/container/home
+
+if [[ -z "${CONTAINER_HOME}" ]]; then
+    HOME_VOLUME=${IHOME}
+else
+    HOME_VOLUME="${CONTAINER_HOME}:${IHOME}:${CONTAINER_HOME_OPTION:="z"}"
+fi
+
 # The PBR in our setup.py Pbench installer relies on `git` knowledge and can't
 # handle a git worktree. This handy sequence solves the problem by importing
 # the base git tree into the container along with the worktree.
@@ -30,10 +55,11 @@ podman run \
     --pull=always \
     --userns=keep-id \
     --volume $(pwd):/src/pbench:z \
+    --volume ${HOME_VOLUME} \
     ${GIT_BASE_VOLUME} \
     -w /src/pbench \
     --env-host \
-    --env HOME=/tmp/jenkins \
+    --env HOME=${IHOME} \
     --ulimit nofile=65536:65536 \
     --rm \
     ${EXTRA_PODMAN_SWITCHES} \

--- a/jenkins/run
+++ b/jenkins/run
@@ -16,10 +16,21 @@ if [[ -z "${IMAGE_REPO}" ]]; then
     IMAGE_REPO="quay.io/pbench"
 fi
 
+# The PBR in our setup.py Pbench installer relies on `git` knowledge and can't
+# handle a git worktree. This handy sequence solves the problem by importing
+# the base git tree into the container along with the worktree.
+GIT_BASE_VOLUME=""
+git_dir="$(git rev-parse --absolute-git-dir)"
+if [ "${git_dir}" != "$(pwd)/.git" ]; then
+    git_common_dir="$(git rev-parse --git-common-dir)"
+    GIT_BASE_VOLUME="--volume ${git_common_dir}:${git_common_dir}:z"
+fi
+
 podman run \
     --pull=always \
     --userns=keep-id \
     --volume $(pwd):/src/pbench:z \
+    ${GIT_BASE_VOLUME} \
     -w /src/pbench \
     --env-host \
     --ulimit nofile=65536:65536 \


### PR DESCRIPTION
There are several small related issues here; one is that we currently require `--user=root` to run reliably, but we really don't actually "need" to be running our tests as root. This turns out to be mostly required because of the second issue, and with this change is no longer  required.

The main issue is that the container inherits the `HOME` environment variable; for example, in Jenkins, typically `/home/jenkins`. This value is used for `pip install --user` and to install our package with PBR for testing. Because `/home/jenkins` doesn't exist in the container, we require `root` to create the path. Instead, we'll now override the definition of `HOME` in order to redirect the `--user` to `/tmp/jenkins` which we can create without privilege.

In conjunction, this removes the default definition of `EXTRA_PODMAN_SWITCHES` from Pipeline.gy.

There's another "convenience" feature in here useful for local manual testing using the container from git worktrees; because a worktree is a mapping of a root branch, we need to map both the worktree directory and the referenced branch directory inside the container. This uses the `git rev-parse` command to figure out the environment and add a second
podman `--volume` option if necessary.