### PR TITLE
Update the Jenkins development container

### DIFF
--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -43,7 +43,6 @@
 FROM quay.io/fedora/fedora:33
 
 RUN \
-    mkdir /tmp/jenkins && \
     dnf install -y \
         `#` \
         `# Install Agent dependencies` \

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -40,9 +40,10 @@
 #
 # [1] See https://www.redhat.com/sysadmin/user-flag-rootless-containers
 
-FROM docker.io/library/fedora:33
+FROM quay.io/fedora/fedora:33
 
 RUN \
+    mkdir /tmp/jenkins && \
     dnf install -y \
         `#` \
         `# Install Agent dependencies` \
@@ -174,6 +175,7 @@ RUN \
         `# Install utilities for building RPMs, evaluating test results, etc.` \
         copr-cli \
         diffutils \
+        copr-cli \
         git \
         less \
         python3-jinja2-cli \
@@ -181,6 +183,6 @@ RUN \
         rpmlint \
         rpm-build \
         sqlite && \
-        `#` \
-        `# Save space in the container image.` \
-        dnf -y clean all && rm -rf /var/cache/dnf
+    `#` \
+    `# Save space in the container image.` \
+    dnf -y clean all && rm -rf /var/cache/dnf


### PR DESCRIPTION
Two quick updates for the Jenkins container (plus a cosmetic fix):
- Switch container registry for the base container from `docker.io` to `quay.io`
- Add `copr-cli` for building RPMs