### PR TITLE
Support non-DNS controller hosts

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -88,24 +88,8 @@ cp -a agent/* %{?buildroot}/%{installdir}/
 # configtools installed: zap it.
 if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
 
-%post
-%if 0%{?rhel} == 7
-# This is a very ugly work-around for RHEL 7 / CentOS 7 environments. The
-# version of `pip3` that is available in those environments no longer works
-# to install the latest Python3 modules, which we need. So we have to fetch
-# our own copy of `pip3`, as described at:
-#   https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py 
-# We then install it separately from the existing version and set `PATH` and
-# `PYTHONPATH` so that we use this updated version when we install our module
-# dependencies below.
-curl -X GET -o /%{installdir}/get-pip.py https://bootstrap.pypa.io/get-pip.py > /%{installdir}/pip3-update.log 2>&1
-python3 /%{installdir}/get-pip.py --prefix=/%{installdir} >> /%{installdir}/pip3-update.log 2>&1
-export PYTHONPATH=/%{installdir}/lib/python3.6/site-packages:${PYTHONPATH}
-export PATH=/%{installdir}/bin:${PATH}
-%endif
-
-# Install python dependencies
-pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
+python3 -m pip install --upgrade pip 2>&1 > /%{installdir}/pip3-upgrade.log
+python3 -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
 
 # link the pbench profile, so it'll automatically be sourced on login
 ln -sf /%{installdir}/profile /etc/profile.d/pbench-agent.sh

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -88,6 +88,9 @@ cp -a agent/* %{?buildroot}/%{installdir}/
 # configtools installed: zap it.
 if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
 
+%post
+
+# Install python dependencies
 python3 -m pip install --upgrade pip 2>&1 > /%{installdir}/pip3-upgrade.log
 python3 -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
 

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -89,10 +89,23 @@ cp -a agent/* %{?buildroot}/%{installdir}/
 if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;fi
 
 %post
+%if 0%{?rhel} == 7
+# This is a very ugly work-around for RHEL 7 / CentOS 7 environments. The
+# version of `pip3` that is available in those environments no longer works
+# to install the latest Python3 modules, which we need. So we have to fetch
+# our own copy of `pip3`, as described at:
+#   https://pip.pypa.io/en/latest/installing/#installing-with-get-pip-py 
+# We then install it separately from the existing version and set `PATH` and
+# `PYTHONPATH` so that we use this updated version when we install our module
+# dependencies below.
+curl -X GET -o /%{installdir}/get-pip.py https://bootstrap.pypa.io/get-pip.py > /%{installdir}/pip3-update.log 2>&1
+python3 /%{installdir}/get-pip.py --prefix=/%{installdir} >> /%{installdir}/pip3-update.log 2>&1
+export PYTHONPATH=/%{installdir}/lib/python3.6/site-packages:${PYTHONPATH}
+export PATH=/%{installdir}/bin:${PATH}
+%endif
 
 # Install python dependencies
-python3 -m pip install --upgrade pip 2>&1 > /%{installdir}/pip3-upgrade.log
-python3 -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
+pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
 
 # link the pbench profile, so it'll automatically be sourced on login
 ln -sf /%{installdir}/profile /etc/profile.d/pbench-agent.sh

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -640,6 +640,9 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-a.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-a.example.com echo ${SSH_CONNECTION}
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-b.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-b.example.com echo ${SSH_CONNECTION}
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-c.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-c.example.com echo ${SSH_CONNECTION}
 --- test-execution.log file contents

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -596,6 +596,9 @@ scrape_configs:
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-a.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-a.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-a.example.com echo ${SSH_CONNECTION}
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-b.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-b.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-b.example.com echo ${SSH_CONNECTION}
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-c.example.com /var/tmp/pbench-test-utils/opt/pbench-agent/util-scripts/tool-meister/pbench-tool-meister-remote localhost 17001 tm-lite-remote-c.example.com yes
+/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/ssh -o BatchMode=yes -o StrictHostKeyChecking=no remote-c.example.com echo ${SSH_CONNECTION}
 --- test-execution.log file contents

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -753,7 +753,7 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # us connecting, and we'll use that (by default) as the server address.
         localhost = LocalRemoteHost()
         origin_ip = set()
-        template = TemplateSsh(ssh_cmd, shlex.split(ssh_opts), ['echo', '${SSH_CONNECTION}'])
+        template = TemplateSsh(ssh_cmd, shlex.split(ssh_opts), "echo ${SSH_CONNECTION}")
         for host in tool_group.hostnames.keys():
             if not localhost.is_local(host):
                 template.start(host)
@@ -762,14 +762,14 @@ def main(_prog: str, cli_params: Namespace) -> int:
             if not localhost.is_local(host):
                 connection = template.wait(host)
                 logger.debug("Host %s reports connection `%s`", host, connection)
-                if connection[0] == 0 and connection[1]:
+                if connection.status == 0 and connection.stdout:
                     # The SSH_CONNECTION value is the full `stdout` and we
                     # don't expect a stderr on success; the format is
                     #   "origin_node origin_port local_node local_port"
                     # we only need the origin node because we know that's an
                     # IP for our local TDS and Redis host that the remote can
-                    # understand.
-                    origin = connection[1].split()[0]
+                    # reach.
+                    origin = connection.stdout.split()[0]
                     origin_ip.add(origin)
 
                     # Store the origin reported by this remote in its parameter
@@ -777,12 +777,13 @@ def main(_prog: str, cli_params: Namespace) -> int:
                     # we send the init handshake to that remote later.
                     params["origin_host"] = origin
                 else:
-                    # If `ssh` fails, there's no point in continuing!
+                    # If `ssh` fails, we can't orchestrate anything on this
+                    # remote, so terminate with an error.
                     logger.error("Host %s reports %s", host, connection)
                     return ReturnCode.REMOTENOTREACHABLE
 
-        # Convert the de-duplicating set into an indexable list. Ideally there
-        # will be only a single entry here, since the current BaseServer init
+        # Process the collected origin addresses from our remotes. Ideally we
+        # have only a single entry here, since the current BaseServer init
         # (and the Bottle WSGI server) doesn't support listening on multiple
         # addresses; however we're going to just take the first returned origin
         # address and hope they can all connect.
@@ -791,21 +792,15 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # connection spec) to always listen on '0.0.0.0', but this eliminates
         # IPv6, and we currently lack the mechanism to listen on both '0.0.0.0'
         # and '::' (the IPv6 equivalent, aka '0:0:0:0:0:0:0:0').
-        origin_list = list(origin_ip)
-
+        #
         # NOTE: If the caller/human supplied explicit PBENCH_REDIS_SERVER or
         # PBENCH_TOOL_DATA_SINK (--redis-server or --tool-data-sink), we'll use
         # those, but by default we'll use the ssh connection origin instead of
         # the local `hostname` which may not be reachable by the remotes (or
         # necessarily routable at all).
-        #
-        # If we aren't able to contact any remotes, or if there were no remotes
-        # in the first place, then the origin_list will be empty, and we'll
-        # proceed with the default local hostname. If we have SSH origin IPs,
-        # however, we'll use the first of them.
-        if len(origin_list) > 0:
-            logger.debug("Our connection hosts are %s", origin_list)
-            ip = ipaddress.ip_address(origin_list[0])
+        if len(origin_ip) > 0:
+            logger.debug("Our connection hosts are %s", origin_ip)
+            ip = ipaddress.ip_address(iter(origin_ip).next())
             if isinstance(ip, ipaddress.IPv6Address):
                 origin = f"[{str(ip)}]"
             else:

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -802,12 +802,12 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # necessarily routable at all).
         if len(origin_ip) != 1 and any_remote:
             logger.warning(
-                "Remote hosts don't report a single controller "
-                "origin IP: this may be a problem: origins are %s",
-                origin_ip
+                "Remote hosts don't agree on a single controller "
+                "origin IP, which may indicate a problem: origin(s) %s",
+                ",".join(origin_ip) if origin_ip else "<none>"
             )
         if len(origin_ip) > 0:
-            logger.debug("Our connection hosts are %s", origin_ip)
+            logger.debug("Our connection host(s): %s", ",".join(origin_ip))
             ip = ipaddress.ip_address(next(iter(origin_ip)))
             if isinstance(ip, ipaddress.IPv6Address):
                 origin = f"[{str(ip)}]"

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -97,6 +97,7 @@ the benchmark execution environment:
   - ssh-opts
 """
 
+import ipaddress
 import json
 import logging
 import os
@@ -108,7 +109,6 @@ import time
 from argparse import ArgumentParser, Namespace
 from distutils.spawn import find_executable
 from pathlib import Path
-
 import redis
 
 from pbench.agent.constants import (
@@ -133,6 +133,7 @@ from pbench.agent.utils import (
     info_log,
     LocalRemoteHost,
     RedisServerCommon,
+    TemplateSsh
 )
 from pbench.common.utils import validate_hostname
 
@@ -194,6 +195,7 @@ class ReturnCode(BaseReturnCode):
     BADFULLHOSTNAME = 37
     BADHOSTNAME = 38
     INVALIDORCHESTRATE = 39
+    REMOTENOTREACHABLE = 40
 
 
 def _waitpid(pid: int) -> int:
@@ -732,6 +734,9 @@ def main(_prog: str, cli_params: Namespace) -> int:
         ssh_opts=ssh_opts,
     )
 
+    redis_server_spec = cli_params.redis_server
+    tds_server_spec = cli_params.tool_data_sink
+
     if cli_params.orchestrate == "create":
         orchestrate = True
         ssh_cmd = "ssh"
@@ -739,6 +744,76 @@ def main(_prog: str, cli_params: Namespace) -> int:
         if ssh_path is None:
             logger.error("required ssh command not in our PATH")
             return ReturnCode.MISSINGSSHCMD
+
+        # Connect with each of the tool hosts: if we can't connect via ssh,
+        # this isn't going to work, so if any of them fails we'll terminate
+        # with an error code.
+        #
+        # If we can connect, they'll tell us the IP address from which they see
+        # us connecting, and we'll use that (by default) as the server address.
+        localhost = LocalRemoteHost()
+        origin_ip = set()
+        template = TemplateSsh(ssh_cmd, shlex.split(ssh_opts), ['echo', '${SSH_CONNECTION}'])
+        for host in tool_group.hostnames.keys():
+            if not localhost.is_local(host):
+                template.start(host)
+
+        for host, params in tool_group.hostnames.items():
+            if not localhost.is_local(host):
+                connection = template.wait(host)
+                logger.debug("Host %s reports connection `%s`", host, connection)
+                if connection[0] == 0 and connection[1]:
+                    # The SSH_CONNECTION value is the full `stdout` and we
+                    # don't expect a stderr on success; the format is
+                    #   "origin_node origin_port local_node local_port"
+                    # we only need the origin node because we know that's an
+                    # IP for our local TDS and Redis host that the remote can
+                    # understand.
+                    origin = connection[1].split()[0]
+                    origin_ip.add(origin)
+
+                    # Store the origin reported by this remote in its parameter
+                    # block: we'll program this as the connection address when
+                    # we send the init handshake to that remote later.
+                    params["origin_host"] = origin
+                else:
+                    # If `ssh` fails, there's no point in continuing!
+                    logger.error("Host %s reports %s", host, connection)
+                    return ReturnCode.REMOTENOTREACHABLE
+
+        # Convert the de-duplicating set into an indexable list. Ideally there
+        # will be only a single entry here, since the current BaseServer init
+        # (and the Bottle WSGI server) doesn't support listening on multiple
+        # addresses; however we're going to just take the first returned origin
+        # address and hope they can all connect.
+        #
+        # NOTE: an alternative would be (in the absence of an explicit
+        # connection spec) to always listen on '0.0.0.0', but this eliminates
+        # IPv6, and we currently lack the mechanism to listen on both '0.0.0.0'
+        # and '::' (the IPv6 equivalent, aka '0:0:0:0:0:0:0:0').
+        origin_list = list(origin_ip)
+
+        # NOTE: If the caller/human supplied explicit PBENCH_REDIS_SERVER or
+        # PBENCH_TOOL_DATA_SINK (--redis-server or --tool-data-sink), we'll use
+        # those, but by default we'll use the ssh connection origin instead of
+        # the local `hostname` which may not be reachable by the remotes (or
+        # necessarily routable at all).
+        #
+        # If we aren't able to contact any remotes, or if there were no remotes
+        # in the first place, then the origin_list will be empty, and we'll
+        # proceed with the default local hostname. If we have SSH origin IPs,
+        # however, we'll use the first of them.
+        if len(origin_list) > 0:
+            logger.debug("Our connection hosts are %s", origin_list)
+            ip = ipaddress.ip_address(origin_list[0])
+            if isinstance(ip, ipaddress.IPv6Address):
+                origin = f"[{str(ip)}]"
+            else:
+                origin = str(ip)
+            if not tds_server_spec:
+                tds_server_spec = origin
+            if not redis_server_spec:
+                redis_server_spec = origin
     else:
         assert (
             cli_params.orchestrate == "existing"
@@ -753,13 +828,13 @@ def main(_prog: str, cli_params: Namespace) -> int:
         orchestrate = False
 
     try:
-        redis_server = RedisServer(cli_params.redis_server, full_hostname)
+        redis_server = RedisServer(redis_server_spec, full_hostname)
     except RedisServer.Err as exc:
         logger.error(str(exc))
         return exc.return_code
 
     try:
-        tool_data_sink = ToolDataSink(cli_params.tool_data_sink, full_hostname)
+        tool_data_sink = ToolDataSink(tds_server_spec, full_hostname)
     except ToolDataSink.Err as exc:
         logger.error(str(exc))
         return exc.return_code
@@ -835,12 +910,12 @@ def main(_prog: str, cli_params: Namespace) -> int:
 
     logger.debug("4. push tool group data and metadata")
     tool_group_data = dict()
-    for host in tool_group.hostnames.keys():
+    for host, params in tool_group.hostnames.items():
         tools = tool_group.get_tools(host)
         tm = dict(
             benchmark_run_dir=str(benchmark_run_dir),
             channel_prefix=cli_tm_channel_prefix,
-            tds_hostname=tool_data_sink.host,
+            tds_hostname=params["origin_host"] if "origin_host" in params else tool_data_sink.host,
             tds_port=tool_data_sink.port,
             controller=full_hostname,
             group=group,

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -798,6 +798,12 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # those, but by default we'll use the ssh connection origin instead of
         # the local `hostname` which may not be reachable by the remotes (or
         # necessarily routable at all).
+        if len(origin_ip) != 1:
+            logger.warning(
+                "Remote hosts don't report a single controller "
+                "origin IP: this may be a problem: origins are %s",
+                origin_ip
+            )
         if len(origin_ip) > 0:
             logger.debug("Our connection hosts are %s", origin_ip)
             ip = ipaddress.ip_address(iter(origin_ip).next())

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -753,9 +753,11 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # us connecting, and we'll use that (by default) as the server address.
         localhost = LocalRemoteHost()
         origin_ip = set()
+        any_remote = False
         template = TemplateSsh(ssh_cmd, shlex.split(ssh_opts), "echo ${SSH_CONNECTION}")
         for host in tool_group.hostnames.keys():
             if not localhost.is_local(host):
+                any_remote = True
                 template.start(host)
 
         for host, params in tool_group.hostnames.items():
@@ -798,7 +800,7 @@ def main(_prog: str, cli_params: Namespace) -> int:
         # those, but by default we'll use the ssh connection origin instead of
         # the local `hostname` which may not be reachable by the remotes (or
         # necessarily routable at all).
-        if len(origin_ip) != 1:
+        if len(origin_ip) != 1 and any_remote:
             logger.warning(
                 "Remote hosts don't report a single controller "
                 "origin IP: this may be a problem: origins are %s",
@@ -806,7 +808,7 @@ def main(_prog: str, cli_params: Namespace) -> int:
             )
         if len(origin_ip) > 0:
             logger.debug("Our connection hosts are %s", origin_ip)
-            ip = ipaddress.ip_address(iter(origin_ip).next())
+            ip = ipaddress.ip_address(next(iter(origin_ip)))
             if isinstance(ip, ipaddress.IPv6Address):
                 origin = f"[{str(ip)}]"
             else:

--- a/agent/util-scripts/test-bin/ssh
+++ b/agent/util-scripts/test-bin/ssh
@@ -24,7 +24,7 @@ shift
 if [[ "${1}" == "hostname" && "${2}" == "-s" ]]; then
     echo "${remote}"
     exit_code=0
-elif [[ "${1}" == "echo" ]]; then
+elif [[ "${1}" == "echo"* ]]; then
     echo "127.0.0.1 54038 ${remote} 22"
     exit_code=0
 elif [[ "$(basename -- "${1}")" == "pbench-tool-meister-remote" ]]; then

--- a/agent/util-scripts/test-bin/ssh
+++ b/agent/util-scripts/test-bin/ssh
@@ -24,6 +24,9 @@ shift
 if [[ "${1}" == "hostname" && "${2}" == "-s" ]]; then
     echo "${remote}"
     exit_code=0
+elif [[ "${1}" == "echo" ]]; then
+    echo "127.0.0.1 54038 ${remote} 22"
+    exit_code=0
 elif [[ "$(basename -- "${1}")" == "pbench-tool-meister-remote" ]]; then
     _dir=$(dirname ${0})
     _pbench_full_hostname="${remote}" _pbench_hostname="${remote}" _tool_bin=${_dir}/mpstat ${1} localhost "${3}" "${4}" "${5}"

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -1,14 +1,16 @@
-import ifaddr
 import ipaddress
 import logging
 import os
+from pathlib import Path
 import signal
 import socket
 import subprocess
 import sys
 import time
+from typing import Dict, List, Tuple
 
 from datetime import datetime
+import ifaddr
 
 from pbench.agent.constants import (
     def_redis_port,
@@ -394,6 +396,58 @@ def collect_local_info(pbench_bin):
         hostdata[arg] = cp.stdout.strip() if cp.stdout is not None else ""
 
     return (version, seqno, sha1, hostdata)
+
+
+class TemplateSsh:
+    """
+    Set up to easily launch repeated asynchronous ssh commands from a template
+    and acquire the stdout and stderr streams along with the completion status.
+    """
+
+    def __init__(self, ssh_cmd: Path, ssh_args: List[str], cmd: List[str]):
+        """
+        Create an SSH template object
+
+        Args:
+            ssh_cmd: Path to the ssh command
+            ssh_args: A partial argv representing ssh command options
+            cmd: A partial argv representing a remote command to be executed
+        """
+        self.command = cmd
+        self.procs: Dict[str, subprocess.Popen] = {}
+        self.base_args = [ssh_cmd] + ssh_args
+
+    def start(self, host: str):
+        """
+        Begin an asynchronous ssh command on the specified remote host
+
+        Args:
+            host: hostname or IP
+        """
+        args = self.base_args + [host] + self.command
+        popen = subprocess.Popen(args, stdout=subprocess.PIPE, universal_newlines=True)
+        self.procs[host] = popen
+
+    def wait(self, host: str) -> Tuple[int, str, str]:
+        """
+        Wait for an asynchronous ssh command to complete, returning the
+        completion status, stdout and stderr streams as strings.
+
+        Args:
+            host: Remote host
+
+        Returns:
+            Tuple of completion status, stdout, stderr
+        """
+        popen: subprocess.Popen = self.procs[host]
+        try:
+            out, err = popen.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            popen.kill()
+            out, err = popen.communicate()
+        status = popen.returncode
+        del self.procs[host]
+        return (status, out, err)
 
 
 class LocalRemoteHost:

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -454,7 +454,7 @@ class TemplateSsh:
             out, err = popen.communicate()
         status = popen.returncode
         del self.procs[host]
-        return self.Return(status, out, err)
+        return self.Return(status=status, stdout=out, stderr=err)
 
 
 class LocalRemoteHost:


### PR DESCRIPTION
By default, TDS and Redis are started listening on (and remote hosts are set to connect to) the controller node's `hostname`. If this is not a routable DNS name, Tool Meister start hangs.

Instead, identify a routable IP address for the host by determining the origin of ssh connections to the remote hosts. We need to establish that the remotes are reachable anyway; this allows us to do so early in startup before creating the local TDS and Redis instances.

If "orchestration=create" mode isn't selected, or if `PBENCH_REDIS_SERVER` (`--redis-server`) or `PBENCH_TOOL_DATA_SINK` (`--too-data-sink`) configuration options are specified, these values are used regardless, trusting the external input.

Resolves #2610 