### PR TITLE
Stop using `selinux` virtualenv wrapper

### DIFF
--- a/lib/pbench/common/selinux.py
+++ b/lib/pbench/common/selinux.py
@@ -1,0 +1,34 @@
+"""SELinux wrapper module.
+
+There is no "pip" installable `selinux` python module, just a shim, of sorts [1],
+which provides a way to add the installed (via RPM) system's `selinux` module to
+a virtualenv.  But that does not work when the virtualenv uses a version of
+python different from the python version where the real `selinux` module is
+installed.
+
+This wrapper acts as a pass-through to the real `selinux` module for the methods
+we need, when that module is present.  When that module is not present, we
+provide module methods to mimic the behaviors we need.
+
+[1] https://github.com/pycontribs/selinux
+"""
+try:
+    import selinux
+except ImportError:
+    # The import failed; provide stub implementations.
+
+    def is_selinux_enabled():
+        """Always indicates "disabled"."""
+        return 0
+
+    def restorecon(path):
+        """Always raises an exception, to identify logic problems."""
+        raise NotImplementedError(
+            "Logic bomb!  selinux.restorecon() called when selinux is not enabled."
+        )
+
+
+else:
+    # The import succeeded; forward our functions to the real implementations.
+    is_selinux_enabled = selinux.is_selinux_enabled
+    restorecon = selinux.restorecon

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -6,9 +6,9 @@ import shutil
 from typing import Dict, List, Union
 
 from dateutil import parser as date_parser
-import selinux
 import tarfile
 
+from pbench.common import selinux
 from pbench.server import PbenchServerConfig, JSON
 from pbench.server.database.models.datasets import Dataset
 

--- a/lib/pbench/test/unit/server/test_file_tree.py
+++ b/lib/pbench/test/unit/server/test_file_tree.py
@@ -51,7 +51,7 @@ def selinux_disabled(monkeypatch):
     """
     Pretend that selinux is disabled so restorecon isn't called
     """
-    monkeypatch.setattr("selinux.is_selinux_enabled", lambda: 0)
+    monkeypatch.setattr("pbench.common.selinux.is_selinux_enabled", lambda: 0)
 
 
 @pytest.fixture()
@@ -59,8 +59,8 @@ def selinux_enabled(monkeypatch):
     """
     Pretend that selinux is enabled but make restorecon exit with no action
     """
-    monkeypatch.setattr("selinux.is_selinux_enabled", lambda: 1)
-    monkeypatch.setattr("selinux.restorecon", lambda a: None)
+    monkeypatch.setattr("pbench.common.selinux.is_selinux_enabled", lambda: 1)
+    monkeypatch.setattr("pbench.common.selinux.restorecon", lambda a: None)
 
 
 class TestFileTree:

--- a/server/bin/pbench-server-prep-shim-002.py
+++ b/server/bin/pbench-server-prep-shim-002.py
@@ -12,11 +12,11 @@ import os
 import sys
 import glob
 import shutil
-import selinux
 import tempfile
 
 from pathlib import Path
 
+from pbench.common import selinux
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,5 @@ pyesbulk>=2.0.1
 PyJwt
 psycopg2
 requests
-selinux
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6


### PR DESCRIPTION
Fixes #2645.

Basically, there is no real `selinux` python module provided via `pip` install. All that is out there is a "shim" [1], which is really broken.  On module load, it forks an invocation of the predominate `/usr/bin/python3` program [2] to get it's list of site packages, and replaces itself with a module load of the `selinux` module it finds among those site package locations.

The goal of that virtualenv wrapper is to allow a virtualenv using the same python version as the real installed `selinux` module to work "seamlessly."

But if your virtualenv is for a python version different from what is installed on the system, then the `selinux` import will fail with an error trying to load a module that doesn't work with the version of python in the virtualenv.

We no longer use the `selinux` pip installed module.  Instead we provide our own wrapper which provides pass-through methods for `is_selinux_enabled()` and `restorecon()` when a `selinux` module is found, and mocks for those same methods where the `is_selinux_enabled()` method returns `False`, and the `restorecon()` method raises an exception to help detect logic errors.

For our testing environments, we already provide proper mocks of the `selinux` module to get the desired behavior (now updated to work with the new wrapper).

This is foundational work for PR #2551.

[1] https://github.com/pycontribs/selinux
[2] https://github.com/pycontribs/selinux/blob/master/selinux/__init__.py#L76