### PR TITLE
Fix `oc-datalog` to properly reap subprocesses

### DIFF
--- a/agent/tool-scripts/datalog/mock-bin/oc
+++ b/agent/tool-scripts/datalog/mock-bin/oc
@@ -16,11 +16,10 @@ if [[ "${1}" == "get" ]]; then
             ;;
         *)
             if [[ -x /bin/sleep ]]; then
-                /bin/sleep 120
+                exec /bin/sleep 120
             else
-                /usr/bin/sleep 120
+                exec /usr/bin/sleep 120
             fi
-            echo "${2} slept a long time!"
             ;;
     esac
     exit 0

--- a/agent/tool-scripts/datalog/oc-datalog
+++ b/agent/tool-scripts/datalog/oc-datalog
@@ -116,7 +116,7 @@ else:
 # Gather "nodes" and "events" before we start other watchers.
 gather_nodes_ev("start")
 
-cmd_fmt = "oc get {all_ns_opt} {component} -o wide -w"
+cmd_fmt = "oc get {all_ns_opt}{component} -o wide -w"
 opts = {}
 pids = {}
 
@@ -129,7 +129,7 @@ try:
         # Wait 5 seconds between starting watchers.
         time.sleep(_OC_DELAY)
 
-        opts['all_ns_opt'] = "" if component in ('cs', 'pv') else "--all-namespaces"
+        opts['all_ns_opt'] = "" if component in ('cs', 'pv') else "--all-namespaces "
         opts['component'] = component
         cmd = cmd_fmt.format(**opts)
         cfp = open(os.path.join(tool_output_dir, f"{component}.txt"), "w")
@@ -146,7 +146,7 @@ try:
             stdout=cfp,
             stderr=subprocess.STDOUT,
             shell=True)
-        pids['component'] = (oc_cmd, log_ts, cfp)
+        pids[component] = (oc_cmd, log_ts, cfp)
 
     # Wait for all sub-processes to complete
     while not terminate:


### PR DESCRIPTION
The `oc-datalog` was not properly reaping its sub-processes, which left lingering processes after `tox -e datalog` test runs.  Since they would eventually timeout, it wasn't really noticeable.

 We also fix the `mock-bin/oc` command to exec the `sleep 120` process so that it is properly reaped (the real `oc` handles its own sub-process clean up).