### PR TITLE
Scrub the pytests

### DIFF
--- a/agent/test-requirements.txt
+++ b/agent/test-requirements.txt
@@ -1,5 +1,6 @@
 ansible
 coverage
+filelock
 gitpython
 mock>=3.0.5
 pytest>=4.6.3, < 5

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -148,7 +148,7 @@ def register_endpoints(api, app, config):
     )
 
 
-def get_server_config():
+def get_server_config() -> PbenchServerConfig:
     cfg_name = os.environ.get("_PBENCH_SERVER_CONFIG")
     if not cfg_name:
         raise ConfigFileNotSpecified(

--- a/lib/pbench/test/__init__.py
+++ b/lib/pbench/test/__init__.py
@@ -1,0 +1,40 @@
+"""Common test support functions."""
+import json
+
+from filelock import FileLock
+from pathlib import Path
+from typing import Callable
+
+
+def on_disk_config(
+    tmp_path_factory, prefix: str, setup_func: Callable[[Path], Path]
+) -> dict:
+    """Base on-disk configuration recorder.  It returns a dictionary with two
+    items, "tmp" and "cfg_dir", two Path objects for the temporary directory
+    in which the configuration directory is created.
+
+    The first argument is the temporary directory creator factory to be used.
+
+    The second argument is a prefix to use for the JSON marker file in which
+    will be store the dictionary containing the temporary directory and the
+    configuration directory created by the setup_func.
+
+    The third argument is the setup function itself.
+
+    The setup_func is expected to take one argument, a Path object
+    representing the created temporary directory, which this method invokes
+    before it is called.
+    """
+    root_tmp_dir = tmp_path_factory.getbasetemp()
+    marker = root_tmp_dir / f"{prefix}-marker.json"
+    with FileLock(f"{marker}.lock"):
+        if marker.is_file():
+            the_setup = json.loads(marker.read_text())
+            the_setup["tmp"] = Path(the_setup["tmp"])
+            the_setup["cfg_dir"] = Path(the_setup["cfg_dir"])
+        else:
+            tmp_d = tmp_path_factory.mktemp(f"{prefix}-tmp")
+            cfg_dir = setup_func(tmp_d)
+            marker.write_text(json.dumps(dict(tmp=str(tmp_d), cfg_dir=str(cfg_dir))))
+            the_setup = dict(tmp=tmp_d, cfg_dir=cfg_dir)
+    return the_setup

--- a/lib/pbench/test/__init__.py
+++ b/lib/pbench/test/__init__.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 def on_disk_config(
     tmp_path_factory, prefix: str, setup_func: Callable[[Path], Path]
-) -> dict[Path, Path]:
+) -> dict[str, Path]:
     """Base on-disk configuration recorder.
 
     Callers use this method to ensure an on-disk configuration is only created
@@ -16,18 +16,19 @@ def on_disk_config(
 
     Args:
         tmp_path_factory:  the temporary directory creator factory to be used
-        prefix:            a value to be prefixed to the name of the JSON marker
-                           file in which will be store the dictionary containing
-                           the temporary directory and the configuration
-                           directory created by the setup_func.
+        prefix:            a value to be prefixed to the name of the JSON
+                           marker file in which will be stored the dictionary
+                           containing the temporary directory and the
+                           configuration directory created by the setup_func
         setup_func:        the setup function provided by the caller, which
                            expects to be called with a Path argument for the
-                           temporary directory to use, and returns a Path object
-                           for the configuration directory created.
+                           temporary directory to use, and returns a Path
+                           object for the configuration directory created
 
     Returns:
         a dictionary with two items, "tmp" and "cfg_dir", two Path objects for
-        the temporary directory in which the configuration directory is created
+        the temporary directory in which the configuration directory is
+        created
     """
     root_tmp_dir = tmp_path_factory.getbasetemp()
     marker = root_tmp_dir / f"{prefix}-marker.json"

--- a/lib/pbench/test/functional/agent/cli/commands/test_config.py
+++ b/lib/pbench/test/functional/agent/cli/commands/test_config.py
@@ -2,7 +2,7 @@ import os
 import pytest
 
 
-def test_pbench_run(monkeypatch, tmpdir, agent_config, pbench_run):  # noqa F811
+def test_pbench_run(monkeypatch, agent_config, pbench_run):
     """Use pbench_run value from pbench-agent.cfg file"""
     assert os.environ.get("pbench_run") is None
     command = ["pbench-list-tools"]

--- a/lib/pbench/test/functional/agent/conftest.py
+++ b/lib/pbench/test/functional/agent/conftest.py
@@ -2,13 +2,14 @@ import os
 import pytest
 import subprocess
 
-from pbench.test.unit.agent.conftest import on_disk_agent_config
+from pbench.test import on_disk_config
+from pbench.test.unit.agent.conftest import do_setup
 
 
 @pytest.fixture(scope="session", autouse=True)
 def func_setup(tmp_path_factory):
     """Test package setup for functional tests"""
-    return on_disk_agent_config(tmp_path_factory)
+    return on_disk_config(tmp_path_factory, "agent", do_setup)
 
 
 @pytest.helpers.register
@@ -19,7 +20,7 @@ def capture(command):
 
 
 @pytest.fixture
-def pbench_run(monkeypatch, tmp_path):
+def pbench_run(tmp_path):
     assert "pbench_run" not in os.environ
     pbench_agent_d = tmp_path / "var" / "lib" / "pbench-agent"
     pbench_agent_d.mkdir(parents=True, exist_ok=True)

--- a/lib/pbench/test/functional/agent/conftest.py
+++ b/lib/pbench/test/functional/agent/conftest.py
@@ -2,12 +2,13 @@ import os
 import pytest
 import subprocess
 
-from pbench.test.unit.agent.conftest import base_setup
+from pbench.test.unit.agent.conftest import on_disk_agent_config
 
 
 @pytest.fixture(scope="session", autouse=True)
-def setup(request, pytestconfig):
-    return base_setup(request, pytestconfig)
+def func_setup(tmp_path_factory):
+    """Test package setup for functional tests"""
+    return on_disk_agent_config(tmp_path_factory)
 
 
 @pytest.helpers.register

--- a/lib/pbench/test/functional/agent/conftest.py
+++ b/lib/pbench/test/functional/agent/conftest.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import pytest
 import subprocess
 
@@ -7,7 +8,7 @@ from pbench.test.unit.agent.conftest import do_setup
 
 
 @pytest.fixture(scope="session", autouse=True)
-def func_setup(tmp_path_factory):
+def func_setup(tmp_path_factory) -> dict[str, Path]:
     """Test package setup for functional tests"""
     return on_disk_config(tmp_path_factory, "agent", do_setup)
 

--- a/lib/pbench/test/functional/agent/test_pbench_config.py
+++ b/lib/pbench/test/functional/agent/test_pbench_config.py
@@ -1,7 +1,5 @@
 import pytest
 
-from pbench.test.unit.agent.conftest import setup  # noqa F401
-
 
 def test_pbench_config():
     command = ["pbench-config"]
@@ -16,8 +14,11 @@ def test_pbench_config_help():
     assert exitcode == 0
 
 
-def test_pbench_agent_config(setup):  # noqa F811
-    TMP = setup["tmp"]
+def test_pbench_agent_config(func_setup, monkeypatch):
+    TMP = func_setup["tmp"]
+    monkeypatch.setenv(
+        "_PBENCH_AGENT_CONFIG", str(func_setup["cfg_dir"] / "pbench-agent.cfg")
+    )
     command = ["pbench-config", "pbench_run", "pbench-agent"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert f"{TMP}/var/lib/pbench-agent".encode("UTF-8") in out

--- a/lib/pbench/test/functional/agent/test_pbench_config.py
+++ b/lib/pbench/test/functional/agent/test_pbench_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pbench.test.unit.agent.conftest import valid_config, agent_config_env  # noqa F401
+from pbench.test.unit.agent.conftest import setup  # noqa F401
 
 
 def test_pbench_config():
@@ -16,8 +16,8 @@ def test_pbench_config_help():
     assert exitcode == 0
 
 
-def test_pbench_agent_config(valid_config, agent_config_env, pytestconfig):  # noqa F811
-    TMP = pytestconfig.cache.get("TMP", None)
+def test_pbench_agent_config(setup):  # noqa F811
+    TMP = setup["tmp"]
     command = ["pbench-config", "pbench_run", "pbench-agent"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert f"{TMP}/var/lib/pbench-agent".encode("UTF-8") in out

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -53,11 +53,11 @@ def setup(tmp_path_factory, agent_setup, monkeypatch):
     """Test package setup for pbench-agent"""
     var = agent_setup["tmp"] / "var" / "lib" / "pbench-agent"
     try:
-        if var.exists():
-            assert var.is_dir()
-            shutil.rmtree(str(var))
-    except Exception as exc:
-        print(exc)
+        shutil.rmtree(str(var))
+    except FileNotFoundError:
+        pass
+    except NotADirectoryError:
+        var.unlink()
     var.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv(
         "_PBENCH_AGENT_CONFIG", str(agent_setup["cfg_dir"] / "pbench-agent.cfg")

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import pytest
 import shutil
 
@@ -18,7 +19,7 @@ files = pbench-agent-default.cfg
 """
 
 
-def do_setup(tmp_d):
+def do_setup(tmp_d: Path) -> Path:
     """Perform on disk agent config setup.
 
     Accept a single temporary directory created by its caller, creating a
@@ -42,14 +43,14 @@ def do_setup(tmp_d):
     return pbench_cfg
 
 
-@pytest.fixture(scope="session", autouse=True)
-def agent_setup(tmp_path_factory):
+@pytest.fixture(scope="session")
+def agent_setup(tmp_path_factory) -> dict[Path, Path]:
     """Test package setup for agent unit tests"""
     return on_disk_config(tmp_path_factory, "agent", do_setup)
 
 
 @pytest.fixture(autouse=True)
-def setup(tmp_path_factory, agent_setup, monkeypatch):
+def setup(tmp_path_factory, agent_setup, monkeypatch) -> dict[Path, Path]:
     """Test package setup for pbench-agent"""
     var = agent_setup["tmp"] / "var" / "lib" / "pbench-agent"
     try:

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -37,8 +37,7 @@ def do_setup(tmp_d):
     )
 
     cfg_file = pbench_cfg / "pbench-agent.cfg"
-    with open(cfg_file, "w") as fp:
-        fp.write(agent_cfg_tmpl.format(TMP=tmp_d))
+    cfg_file.write_text(agent_cfg_tmpl.format(TMP=tmp_d))
 
     return pbench_cfg
 

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -44,13 +44,13 @@ def do_setup(tmp_d: Path) -> Path:
 
 
 @pytest.fixture(scope="session")
-def agent_setup(tmp_path_factory) -> dict[Path, Path]:
+def agent_setup(tmp_path_factory) -> dict[str, Path]:
     """Test package setup for agent unit tests"""
     return on_disk_config(tmp_path_factory, "agent", do_setup)
 
 
 @pytest.fixture(autouse=True)
-def setup(tmp_path_factory, agent_setup, monkeypatch) -> dict[Path, Path]:
+def setup(tmp_path_factory, agent_setup, monkeypatch) -> dict[str, Path]:
     """Test package setup for pbench-agent"""
     var = agent_setup["tmp"] / "var" / "lib" / "pbench-agent"
     try:

--- a/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
+++ b/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
@@ -1,14 +1,12 @@
 import configparser
-from pathlib import Path
 
 from pbench.cli.agent.commands.log import add_metalog_option
 
 
 class TestAddMetalogOption:
     @staticmethod
-    def test_add_metalog_option(pytestconfig):
-        TMP = pytestconfig.cache.get("TMP", None)
-        mdlog = Path(TMP) / "metadata.log"
+    def test_add_metalog_option(tmp_path):
+        mdlog = tmp_path / "metadata.log"
         mdlog.write_text(
             """[existing]
             existing_option = 41

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -15,7 +15,7 @@ from pbench.test.unit.agent.task.common import tarball, bad_tarball
 
 class TestCopyResults:
     @pytest.fixture(autouse=True)
-    def config_and_logger(self, valid_config):
+    def config_and_logger(self):
         # Setup the configuration and logger
         self.config = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
         self.logger = get_pbench_logger("pbench", self.config)
@@ -24,7 +24,7 @@ class TestCopyResults:
         self.config, self.logger = None, None
 
     @responses.activate
-    def test_copy_tar(self, valid_config):
+    def test_copy_tar(self):
         tbname = Path(tarball)
         responses.add(
             responses.PUT,
@@ -42,7 +42,7 @@ class TestCopyResults:
         crt.copy_result_tb("token")
 
     @responses.activate
-    def test_bad_tar(self, caplog, valid_config):
+    def test_bad_tar(self, caplog):
         responses.add(
             responses.PUT,
             f"http://pbench.example.com/api/v1/upload/{bad_tarball}",

--- a/lib/pbench/test/unit/agent/task/test_generate_token.py
+++ b/lib/pbench/test/unit/agent/task/test_generate_token.py
@@ -50,7 +50,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_help(pytestconfig):
+    def test_help():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(generate_token.main, ["--help"])
         assert result.exit_code == 0
@@ -59,7 +59,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_args_both(valid_config, pytestconfig):
+    def test_args_both():
         TestGenerateToken.add_success_mock_response()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -77,7 +77,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_args_username(valid_config, pytestconfig):
+    def test_args_username():
         TestGenerateToken.add_success_mock_response()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -95,7 +95,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_args_password(valid_config, pytestconfig):
+    def test_args_password():
         TestGenerateToken.add_success_mock_response()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -113,7 +113,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_args_none(valid_config, pytestconfig):
+    def test_args_none():
         TestGenerateToken.add_success_mock_response()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -132,7 +132,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_bad_login(valid_config, pytestconfig):
+    def test_bad_login():
         TestGenerateToken.add_badlogin_mock_response()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -150,7 +150,7 @@ class TestGenerateToken:
 
     @staticmethod
     @responses.activate
-    def test_connection_failed(valid_config, pytestconfig):
+    def test_connection_failed():
 
         TestGenerateToken.add_connectionerr_mock_response()
         runner = CliRunner(mix_stderr=False)

--- a/lib/pbench/test/unit/agent/task/test_make_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_make_result_tb.py
@@ -17,7 +17,7 @@ from pbench.test.unit.agent.task.common import MockDatetime
 
 class TestMakeResultTb:
     @pytest.fixture(autouse=True)
-    def config_and_logger(self, valid_config):
+    def config_and_logger(self):
         with tempfile.TemporaryDirectory() as target_dir, tempfile.TemporaryDirectory() as run_dir:
             # Setup the configuration and logger
             self.controller = "controller-42.example.com"

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -1,7 +1,5 @@
 import datetime
 import logging
-import os
-from pathlib import Path
 
 import responses
 from click.testing import CliRunner
@@ -54,7 +52,7 @@ class TestMoveResults:
 
     @staticmethod
     @responses.activate
-    def test_help(pytestconfig):
+    def test_help():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0
@@ -65,7 +63,7 @@ class TestMoveResults:
 
     @staticmethod
     @responses.activate
-    def test_args(valid_config, pytestconfig):
+    def test_args():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -92,18 +90,15 @@ class TestMoveResults:
 
     @staticmethod
     @responses.activate
-    def test_results_move(monkeypatch, caplog, pytestconfig):
+    def test_results_move(monkeypatch, caplog, setup):
         monkeypatch.setenv("_pbench_full_hostname", "localhost")
         monkeypatch.setattr(datetime, "datetime", MockDatetime)
-
-        ctx = {"args": {"config": os.environ["_PBENCH_AGENT_CONFIG"]}}
 
         # In order for a pbench tar ball to be moved/copied to a pbench-server
         # the run directory has to have one file in it, a "metadata.log" file.
         # We make a run directory and populate it with our test specific
         # information.
-        TMP = pytestconfig.cache.get("TMP", None)
-        pbrun = Path(TMP) / "var" / "lib" / "pbench-agent"
+        pbrun = setup["tmp"] / "var" / "lib" / "pbench-agent"
         script = "pbench-user-benchmark"
         config = "test-results-move"
         date = "YYYY.MM.DDTHH.MM.SS"

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -40,7 +40,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_help(pytestconfig):
+    def test_help():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, ["--help"])
         assert result.exit_code == 0, result.stderr
@@ -49,7 +49,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_missing_arg(valid_config, pytestconfig):
+    def test_missing_arg():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -64,7 +64,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_bad_arg(valid_config, pytestconfig):
+    def test_bad_arg():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -86,7 +86,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_extra_arg(valid_config, pytestconfig):
+    def test_extra_arg():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -103,7 +103,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_args(valid_config, pytestconfig):
+    def test_args():
         """Test normal operation when all arguments and options are specified"""
 
         TestResultsPush.add_http_mock_response()
@@ -122,7 +122,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_token_prompt(valid_config, pytestconfig):
+    def test_token_prompt():
         """Test normal operation when the token option is omitted"""
 
         TestResultsPush.add_http_mock_response()
@@ -137,7 +137,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_token_envar(monkeypatch, caplog, valid_config, pytestconfig):
+    def test_token_envar(monkeypatch, caplog):
         """Test normal operation with the token in an environment variable"""
 
         monkeypatch.setenv("PBENCH_ACCESS_TOKEN", TestResultsPush.TOKN_TEXT)
@@ -150,7 +150,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_connection_error(monkeypatch, caplog, valid_config, pytestconfig):
+    def test_connection_error(monkeypatch, caplog):
         """Test handling of connection errors"""
 
         monkeypatch.setenv("PBENCH_ACCESS_TOKEN", TestResultsPush.TOKN_TEXT)
@@ -163,7 +163,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_http_error(monkeypatch, caplog, valid_config, pytestconfig):
+    def test_http_error(monkeypatch, caplog):
         """Test handling of 404 errors"""
 
         monkeypatch.setenv("PBENCH_ACCESS_TOKEN", TestResultsPush.TOKN_TEXT)

--- a/lib/pbench/test/unit/agent/test_config.py
+++ b/lib/pbench/test/unit/agent/test_config.py
@@ -1,30 +1,38 @@
 import os
 import pytest
+import shutil
 
 from pbench.agent import PbenchAgentConfig
 from pbench.common.exceptions import BadConfig
 
 
-def test_invalid_config(invalid_config):
+def test_invalid_config(setup, monkeypatch):
+    shutil.copyfile(
+        "./lib/pbench/test/unit/agent/config/pbench-agent.invalid.cfg",
+        str(setup["cfg_dir"] / "pbench-agent.invalid.cfg"),
+    )
+    monkeypatch.setenv(
+        "_PBENCH_AGENT_CONFIG", str(setup["cfg_dir"] / "pbench-agent.invalid.cfg")
+    )
     with pytest.raises(BadConfig):
         PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
 
 
-def test_valid_config(valid_config):
+def test_valid_config():
     config = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
     assert "pbench-agent" in config.conf
     assert "results" in config.conf
 
 
-def test_agent_attr(valid_config, pytestconfig):
-    TMP = pytestconfig.cache.get("TMP", None)
+def test_agent_attr(setup):
+    TMP = setup["tmp"]
     assert (
         f"{TMP}/var/lib/pbench-agent"
         == PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"]).agent["pbench_run"]
     )
 
 
-def test_results_attr(valid_config):
+def test_results_attr():
     assert (
         "pbench"
         in PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"]).results["user"]

--- a/lib/pbench/test/unit/agent/test_config.py
+++ b/lib/pbench/test/unit/agent/test_config.py
@@ -11,11 +11,8 @@ def test_invalid_config(setup, monkeypatch):
         "./lib/pbench/test/unit/agent/config/pbench-agent.invalid.cfg",
         str(setup["cfg_dir"] / "pbench-agent.invalid.cfg"),
     )
-    monkeypatch.setenv(
-        "_PBENCH_AGENT_CONFIG", str(setup["cfg_dir"] / "pbench-agent.invalid.cfg")
-    )
     with pytest.raises(BadConfig):
-        PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
+        PbenchAgentConfig(setup["cfg_dir"] / "pbench-agent.invalid.cfg")
 
 
 def test_valid_config():

--- a/lib/pbench/test/unit/agent/test_tool_data_sink.py
+++ b/lib/pbench/test/unit/agent/test_tool_data_sink.py
@@ -31,12 +31,16 @@ class TestBenchmarkRunDir:
         yield
         try:
             shutil.rmtree(self.int_pb_run)
-        except Exception as exc:
-            print(exc)
+        except FileNotFoundError:
+            pass
+        except NotADirectoryError:
+            self.int_pb_run.unlink()
         try:
             shutil.rmtree(self.ext_pb_run)
-        except Exception as exc:
-            print(exc)
+        except FileNotFoundError:
+            pass
+        except NotADirectoryError:
+            self.ext_pb_run.unlink()
 
     def test_validate(self, cleanup_tmp):
         """test_validate - verify the behavior of the validate() using both an

--- a/lib/pbench/test/unit/agent/test_tool_data_sink.py
+++ b/lib/pbench/test/unit/agent/test_tool_data_sink.py
@@ -8,7 +8,6 @@ import time
 
 from http import HTTPStatus
 from io import BytesIO
-from pathlib import Path
 from threading import Condition, Lock, Thread
 from unittest.mock import patch
 from wsgiref.simple_server import WSGIRequestHandler
@@ -26,10 +25,9 @@ class TestBenchmarkRunDir:
     """
 
     @pytest.fixture
-    def cleanup_tmp(self, pytestconfig):
-        TMP = Path(pytestconfig.cache.get("TMP", None))
-        self.int_pb_run = TMP / "pbench-run-int"
-        self.ext_pb_run = TMP / "pbench-run-ext"
+    def cleanup_tmp(self, tmp_path):
+        self.int_pb_run = tmp_path / "pbench-run-int"
+        self.ext_pb_run = tmp_path / "pbench-run-ext"
         yield
         try:
             shutil.rmtree(self.int_pb_run)

--- a/lib/pbench/test/unit/agent/test_utils.py
+++ b/lib/pbench/test/unit/agent/test_utils.py
@@ -1,7 +1,6 @@
 """Tests for the utils module.
 """
 import os
-import pathlib
 import signal
 import socket
 import time
@@ -94,14 +93,13 @@ class TestBaseServer:
         assert bs.bind_port == 2345
         assert repr(bs) == "forty-two - bind.example.com:2345 / host.example.com:6789"
 
-    def test_kill(self, pytestconfig, monkeypatch):
+    def test_kill(self, tmp_path, monkeypatch):
         bs = OurServer("localhost", "localhost")
         with pytest.raises(AssertionError):
             bs.kill(1)
 
         bs = OurServer("localhost", "localhost")
-        TMP = pathlib.Path(pytestconfig.cache.get("TMP", None))
-        pidfile = TMP / "test.pid"
+        pidfile = tmp_path / "test.pid"
         pidfile.write_text("12345")
         bs.pid_file = pidfile
         ret = bs.kill(42)
@@ -111,7 +109,7 @@ class TestBaseServer:
         ret = bs.kill(42)
         assert ret == (BaseReturnCode.KILL_BADPID * 100) + 42
 
-        bs.pid_file = TMP / "enoent.pid"
+        bs.pid_file = tmp_path / "enoent.pid"
         ret = bs.kill(42)
         assert ret == 42
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -90,8 +90,7 @@ def do_setup(tmp_d: Path) -> dict:
     )
 
     cfg_file = pbench_cfg / "pbench-server.cfg"
-    with cfg_file.open(mode="w") as fp:
-        fp.write(server_cfg_tmpl.format(TMP=str(tmp_d)))
+    cfg_file.write_text(server_cfg_tmpl.format(TMP=str(tmp_d)))
 
     return pbench_cfg
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -63,7 +63,7 @@ admin_email = "test_admin@example.com"
 generic_password = "12345"
 
 
-def do_setup(tmp_d: Path) -> dict:
+def do_setup(tmp_d: Path) -> Path:
     """Perform on disk server config setup."""
     # Create a single temporary directory for the "/srv/pbench" and
     # "/opt/pbench-server" directories.
@@ -96,7 +96,7 @@ def do_setup(tmp_d: Path) -> dict:
 
 
 @pytest.fixture(scope="session")
-def on_disk_server_config(tmp_path_factory) -> dict:
+def on_disk_server_config(tmp_path_factory) -> dict[Path, Path]:
     """Test package setup for pbench-server
     """
     return on_disk_config(tmp_path_factory, "server", do_setup)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -14,6 +14,7 @@ import shutil
 from stat import ST_MTIME
 import tarfile
 
+from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
 from pbench.server.api.auth import Auth
 from pbench.server.database.database import Database
@@ -63,7 +64,7 @@ admin_email = "test_admin@example.com"
 generic_password = "12345"
 
 
-def do_setup(tmp_path_factory):
+def do_setup(tmp_path_factory) -> dict:
     """Perform on disk server config setup."""
     # Create a single temporary directory for the "/srv/pbench" and
     # "/opt/pbench-server" directories.
@@ -99,7 +100,7 @@ def do_setup(tmp_path_factory):
 
 
 @pytest.fixture(scope="session")
-def on_disk_server_config(tmp_path_factory):
+def on_disk_server_config(tmp_path_factory) -> dict:
     """Test package setup for pbench-server
 
     See https://github.com/pytest-dev/pytest-xdist.
@@ -118,7 +119,7 @@ def on_disk_server_config(tmp_path_factory):
 
 
 @pytest.fixture
-def server_config(on_disk_server_config, monkeypatch):
+def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
     """
     Mock a pbench-server.cfg configuration as defined above.
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -96,7 +96,7 @@ def do_setup(tmp_d: Path) -> Path:
 
 
 @pytest.fixture(scope="session")
-def on_disk_server_config(tmp_path_factory) -> dict[Path, Path]:
+def on_disk_server_config(tmp_path_factory) -> dict[str, Path]:
     """Test package setup for pbench-server
     """
     return on_disk_config(tmp_path_factory, "server", do_setup)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -98,7 +98,7 @@ def do_setup(tmp_path_factory):
     return dict(tmp=tmp_d, cfg_file=str(cfg_file))
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def on_disk_server_config(tmp_path_factory):
     """Test package setup for pbench-server
 

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -281,14 +281,13 @@ class TestUpload:
         self,
         client,
         bad_extension,
-        pytestconfig,
+        tmp_path,
         caplog,
         server_config,
         setup_ctrl,
         pbench_token,
     ):
-        tmp_d = pytestconfig.cache.get("TMP", None)
-        datafile = Path(tmp_d, bad_extension)
+        datafile = tmp_path / bad_extension
         datafile.write_text("compressed tar ball")
         with datafile.open("rb") as data_fp:
             response = client.put(
@@ -325,11 +324,10 @@ class TestUpload:
         assert not self.filetree_created
 
     def test_empty_upload(
-        self, client, pytestconfig, caplog, server_config, setup_ctrl, pbench_token
+        self, client, tmp_path, caplog, server_config, setup_ctrl, pbench_token
     ):
         filename = "tmp.tar.xz"
-        tmp_d = pytestconfig.cache.get("TMP", None)
-        datafile = Path(tmp_d, filename)
+        datafile = tmp_path / filename
         datafile.touch()
         with datafile.open("rb") as data_fp:
             response = client.put(
@@ -349,14 +347,7 @@ class TestUpload:
         assert not self.filetree_created
 
     def test_upload_filetree_error(
-        self,
-        client,
-        pytestconfig,
-        caplog,
-        server_config,
-        setup_ctrl,
-        pbench_token,
-        tarball,
+        self, client, caplog, server_config, setup_ctrl, pbench_token, tarball,
     ):
         """
         Cause the FileTree.create() to fail; this should trigger the cleanup
@@ -383,14 +374,7 @@ class TestUpload:
         assert not Path(str(self.filetree_create_path) + ".md5").exists()
 
     def test_upload(
-        self,
-        client,
-        pytestconfig,
-        caplog,
-        server_config,
-        setup_ctrl,
-        pbench_token,
-        tarball,
+        self, client, caplog, server_config, setup_ctrl, pbench_token, tarball,
     ):
         datafile, _, md5 = tarball
         with datafile.open("rb") as data_fp, freeze_time("1970-01-01"):
@@ -419,14 +403,7 @@ class TestUpload:
             assert record.levelname in ["DEBUG", "INFO"]
 
     def test_upload_duplicate(
-        self,
-        client,
-        pytestconfig,
-        caplog,
-        server_config,
-        setup_ctrl,
-        pbench_token,
-        tarball,
+        self, client, caplog, server_config, setup_ctrl, pbench_token, tarball,
     ):
         datafile, _, md5 = tarball
         with datafile.open("rb") as data_fp, freeze_time("1970-01-01"):
@@ -458,14 +435,7 @@ class TestUpload:
         assert TestUpload.filetree_created is None
 
     def test_upload_duplicate_diff_md5(
-        self,
-        client,
-        pytestconfig,
-        caplog,
-        server_config,
-        setup_ctrl,
-        pbench_token,
-        tarball,
+        self, client, caplog, server_config, setup_ctrl, pbench_token, tarball,
     ):
         datafile, _, md5 = tarball
         with datafile.open("rb") as data_fp, freeze_time("1970-01-01"):
@@ -507,7 +477,6 @@ class TestUpload:
     def test_upload_metadata_error(
         self,
         client,
-        pytestconfig,
         caplog,
         monkeypatch,
         server_config,

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -11,8 +11,8 @@ from pbench.test.unit.server.conftest import register_user, login_user, admin_us
 
 class TestUserAuthentication:
     @staticmethod
-    def test_registration(client, server_config, pytestconfig):
-        client.config["SESSION_FILE_DIR"] = pytestconfig.cache.get("TMP", None)
+    def test_registration(client, server_config, tmp_path):
+        client.config["SESSION_FILE_DIR"] = tmp_path
         """ Test for user registration """
         with client:
             response = register_user(

--- a/lib/pbench/test/unit/server/test_user_management_cli.py
+++ b/lib/pbench/test/unit/server/test_user_management_cli.py
@@ -48,14 +48,14 @@ class TestUserManagement:
     USER_CREATE_TIMESTAMP = datetime.datetime.now()
 
     @staticmethod
-    def test_help(pytestconfig):
+    def test_help():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(cli.user_create, ["--help"])
         assert result.exit_code == 0, result.stderr
         assert str(result.stdout).startswith("Usage:")
 
     @staticmethod
-    def test_valid_user_registration_with_password_input(server_config, pytestconfig):
+    def test_valid_user_registration_with_password_input(server_config):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -78,7 +78,7 @@ class TestUserManagement:
         )
 
     @staticmethod
-    def test_admin_user_creation(server_config, pytestconfig):
+    def test_admin_user_creation(server_config):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -101,7 +101,7 @@ class TestUserManagement:
         assert result.stdout == "Admin user test_user registered\n"
 
     @staticmethod
-    def test_user_creation_with_invalid_role(server_config, pytestconfig):
+    def test_user_creation_with_invalid_role(server_config):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -124,7 +124,7 @@ class TestUserManagement:
         assert result.stderr.find("Invalid value for '--role'") > -1
 
     @staticmethod
-    def test_valid_user_delete(monkeypatch, server_config, pytestconfig):
+    def test_valid_user_delete(monkeypatch, server_config):
         monkeypatch.setattr(User, "delete", mock_valid_delete)
         runner = CliRunner(mix_stderr=False)
 
@@ -132,7 +132,7 @@ class TestUserManagement:
         assert result.exit_code == 0, result.stderr
 
     @staticmethod
-    def test_invalid_user_delete(pytestconfig, server_config):
+    def test_invalid_user_delete(server_config):
         runner = CliRunner(mix_stderr=False)
         # Give username that doesn't exists to delete
         result = runner.invoke(cli.user_delete, args=["wrong_username"])
@@ -140,7 +140,7 @@ class TestUserManagement:
         assert result.stderr == "User wrong_username does not exist\n"
 
     @staticmethod
-    def test_valid_user_list(monkeypatch, server_config, pytestconfig):
+    def test_valid_user_list(monkeypatch, server_config):
         monkeypatch.setattr(User, "query_all", mock_valid_list)
         runner = CliRunner(mix_stderr=False)
 
@@ -172,7 +172,7 @@ class TestUserManagement:
             (LAST_NAME_SWITCH, "newuser"),
         ],
     )
-    def test_valid_user_update(monkeypatch, server_config, pytestconfig, switch, value):
+    def test_valid_user_update(monkeypatch, server_config, switch, value):
         user = create_user()
 
         def mock_valid_update(**kwargs):
@@ -191,7 +191,7 @@ class TestUserManagement:
         assert result.stdout == "User test_user updated\n"
 
     @staticmethod
-    def test_invalid_role_update(server_config, pytestconfig):
+    def test_invalid_role_update(server_config):
         runner = CliRunner(mix_stderr=False)
 
         # Update with invalid role for the user
@@ -202,7 +202,7 @@ class TestUserManagement:
         assert result.stderr.find("Invalid value for '--role'") > -1
 
     @staticmethod
-    def test_invalid_user_update(server_config, pytestconfig):
+    def test_invalid_user_update(server_config):
         runner = CliRunner(mix_stderr=False)
 
         # Update with non-existent username

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+filelock
 gitpython
 mock>=3.0.5
 pytest>=4.6.3, < 5


### PR DESCRIPTION
Lots of little changes towards a test suite which can be parallelized.

The first change is to remove the use of the session scoped `pytestconfig`.  Session scoped fixtures make it difficult to share them across test sub-systems (one has to be aware of how different sub-systems will interact, which is prone to error).

As a result of dropping `pytestconfig`, `tmp_path` is used instead to give us a proper temporary directory using a fixture that can handle the coming parallelism.

In order to share fixtures between the agent unit and functional tests, a separate on-disk config method allows both fixtures to leverage the disk setup which is fixed and common.  The environment variable monkey-patching is moved to non-session scoped fixtures.

A similar discipline is applied to the server-side on-disk configuration as well.

The `invalid_config` fixture is removed in favor of having the one test the used to handling the monkeypatching, and then make its sister fixture, `valid_config`, be marked `autouse`.

We also take the opportunity to remove any unnecessary fixtures.

This PR is a base enabler for PR #2551.