### PR TITLE
Add `pbench-run-benchmark.pl` to the Agent's installed files list

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -82,6 +82,7 @@ bench-scripts = \
 	pbench-migrate \
 	pbench-netperf \
 	pbench-run-benchmark \
+	pbench-run-benchmark.pl \
 	pbench-run-benchmark-sample \
 	pbench-specjbb2005 \
 	pbench-trafficgen \


### PR DESCRIPTION
`pbench-run-benchmark` is a trampline bash script which sets up the environment and then transfers control to a Perl script, `pbench-run-benchmark.pl`.  (This seems to be a unique case in Pbench at the moment....)  Unfortunately, the target of the transfer was never added to the list of files to be installed.  This PR remedies that omission.
