### PR TITLE
Remove references to the `pbench_results_redirector` configuration setting

### DIFF
--- a/agent/bench-scripts/tests/Defaults/pbench-agent.cfg
+++ b/agent/bench-scripts/tests/Defaults/pbench-agent.cfg
@@ -1,6 +1,5 @@
 # The "DEFAULT" section header and pbench_install_dir is provided by
 # the unit tests infrastructure.
-pbench_results_redirector = pbench.results.example.com
 pbench_web_server = pbench.example.com
 
 [packages]

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -21,10 +21,8 @@ logger_type = file
 
 [results]
 user = pbench
-host_path = http://%(pbench_result_redirector)s/pbench-archive-host
-webserver = %(pbench_web_server)s
 host_info_uri = pbench-results-host-info.versioned/pbench-results-host-info.URL002
-host_info_url = http://%(webserver)s/%(host_info_uri)s
+host_info_url = http://%(pbench_web_server)s/%(host_info_uri)s
 dir = /srv/pbench/public_html/incoming
 scp_opts = -o BatchMode=yes -o StrictHostKeyChecking=no
 ssh_opts = -o BatchMode=yes -o StrictHostKeyChecking=no
@@ -32,7 +30,7 @@ ssh_opts = -o BatchMode=yes -o StrictHostKeyChecking=no
 # REST API entrypoint
 api_version = 1
 rest_endpoint = api/v%(api_version)s
-server_rest_url = http://%(webserver)s/%(rest_endpoint)s
+server_rest_url = http://%(pbench_web_server)s/%(rest_endpoint)s
 
 [pbench/tools]
 default-tool-set = %(medium-tool-set)s

--- a/agent/config/pbench-agent.cfg
+++ b/agent/config/pbench-agent.cfg
@@ -1,8 +1,6 @@
 [DEFAULT]
 pbench_install_dir = /opt/pbench-agent
 # CHANGE ME!
-pbench_results_redirector = pbench.results.example.com
-# CHANGE ME!
 pbench_web_server = pbench.example.com
 
 [config]

--- a/agent/util-scripts/pbench-copy-result-tb
+++ b/agent/util-scripts/pbench-copy-result-tb
@@ -19,7 +19,7 @@ function usage() {
     printf -- "\nhost:\n"
     printf -- " The Pbench 0.69 server hostname to which the tarball will be copied; it should\n"
     printf -- " be the FQDN for the server host configured in the Pbench agent config file, as\n"
-    printf -- " reported by 'pbench-config webserver results'\n"
+    printf -- " reported by 'pbench-config pbench-web-server results'\n"
     printf -- "\nprefix:\n"
     printf -- " The Pbench server path where incoming tarballs are stored, as reported by\n"
     printf -- " 'pbench-config host_info_url results'\n"

--- a/agent/util-scripts/pbench-move-results
+++ b/agent/util-scripts/pbench-move-results
@@ -145,10 +145,10 @@ if [[ ! -f "${pbench_bin}/id_rsa" ]]; then
 fi
 
 # ask the server where to send the tarballs
-results_webserver=$(pbench-config webserver results)
+results_webserver=$(pbench-config pbench_web_server results)
 if [[ -z "${results_webserver}" ]]; then
     error_log "ERROR: No web server host configured from which we can fetch the FQDN of the host to which we ${_op} results"
-    debug_log "\"webserver\" variable in \"results\" section not set"
+    debug_log "\"pbench_web_server\" variable \"results\" section not set"
     exit 1
 fi
 

--- a/contrib/containerized-pbench/dockerfiles/controller/run.sh
+++ b/contrib/containerized-pbench/dockerfiles/controller/run.sh
@@ -5,7 +5,6 @@ mkdir -p /var/lib/pbench-agent/tools-default
 cp /root/.ssh/id_rsa /opt/pbench-agent/id_rsa
 
 # Set pbench-server in the config
-sed -i "/^pbench_results_redirector/c pbench_results_redirector = ${pbench_server}" /opt/pbench-agent/config/pbench-agent.cfg
 sed -i "/^pbench_web_server/c pbench_web_server = ${pbench_server}"  /opt/pbench-agent/config/pbench-agent.cfg
 
 # Clear tools

--- a/lib/pbench/test/unit/agent/config/pbench-agent.invalid.cfg
+++ b/lib/pbench/test/unit/agent/config/pbench-agent.invalid.cfg
@@ -1,4 +1,3 @@
 [DEFAULT]
 pbench_install_dir = ./opt/pbench-agent
-pbench_results_redirector = pbench.results.example.com
 pbench_web_server = pbench.example.com

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -7,7 +7,7 @@ from pbench.test import on_disk_config
 
 agent_cfg_tmpl = """[DEFAULT]
 pbench_install_dir = {TMP}/opt/pbench-agent
-pbench_results_redirector = pbench.results.example.com
+pbench_web_server = pbench.example.com
 
 [pbench-agent]
 debug_unittest = 1

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -166,9 +166,8 @@ dir = /path/to/sosreport/dir
 
 # This *has* to agree with the setting in the pbench-agent config file.
 [results]
-webserver = %(default-host)s
 host-info-path-prefix = pbench-results-host-info.versioned/pbench-results-host-info.URL
-host_info_url = http://%(webserver)s/%(host-info-path-prefix)s
+host_info_url = http://%(default-host)s/%(host-info-path-prefix)s
 
 # [pbench-backup-tarballs]
 # logging_level = DEBUG


### PR DESCRIPTION
Remove references to the `pbench_results_redirector` configuration setting.

The configuration setting was not used, and it was incorrectly spelled in the default agent config file.  As a result of removing that, we also remove unnecessary `webserver` and `host_path` variables.

Found while reviewing PR #2663.