### PR TITLE
Ensure agent legacy unit tests pass

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -224,7 +224,7 @@ INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/pcp/pmcd.file,red:remote-c.example.com/dcgm/dcgm-exporter.file
+WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/dcgm/dcgm-exporter.file,red:remote-c.example.com/pcp/pmcd.file
 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
 INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
@@ -505,7 +505,7 @@ remote-c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for 
 remote-c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 remote-c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 remote-c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-remote-c.example.com 0008 WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/pcp/pmcd.file,red:remote-c.example.com/dcgm/dcgm-exporter.file
+remote-c.example.com 0008 WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/dcgm/dcgm-exporter.file,red:remote-c.example.com/pcp/pmcd.file
 remote-c.example.com 0009 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com block,security_mitigations,sos parallel
 remote-c.example.com 0010 INFO pbench-tool-meister _send_directory -- remote-c.example.com: PUT sysinfo-data completed lite /var/tmp/pbench-test-utils/pbench/tmp/tm.lite.NNNNN.nnnnnnnn/red:remote-c.example.com
 remote-c.example.com 0011 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -199,7 +199,7 @@ INFO pbench-tool-meister stop -- Terminate issued for persistent tool dcgm
 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/pcp/pmcd.file,red:remote-c.example.com/dcgm/dcgm-exporter.file
+WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/dcgm/dcgm-exporter.file,red:remote-c.example.com/pcp/pmcd.file
 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
 === /var/tmp/pbench-test-utils/pbench/tmp/tm-lite-remote-c.example.com.out:
 === /var/tmp/pbench-test-utils/pbench/tools-v1-lite/remote-a.example.com/mpstat:
@@ -469,7 +469,7 @@ remote-c.example.com 0004 INFO pbench-tool-meister stop -- Terminate issued for 
 remote-c.example.com 0005 INFO pbench-tool-meister stop -- Terminate issued for persistent tool pcp
 remote-c.example.com 0006 INFO pbench-tool-meister wait -- Stopped persistent tool dcgm
 remote-c.example.com 0007 INFO pbench-tool-meister wait -- Stopped persistent tool pcp
-remote-c.example.com 0008 WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/pcp/pmcd.file,red:remote-c.example.com/dcgm/dcgm-exporter.file
+remote-c.example.com 0008 WARNING pbench-tool-meister end_tools -- remote-c.example.com: unexpected temp files red:remote-c.example.com/dcgm/dcgm-exporter.file,red:remote-c.example.com/pcp/pmcd.file
 remote-c.example.com 0009 INFO pbench-tool-meister __exit__ -- remote-c.example.com: terminating
 testhost.example.com 0000 INFO pbench-tool-meister sysinfo -- pbench-sysinfo-dump -- /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/pbench-sysinfo-dump /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com block,security_mitigations,sos parallel
 testhost.example.com 0001 INFO pbench-tool-meister sysinfo -- testhost.example.com: sysinfo send (no-op) lite /var/tmp/pbench-test-utils/pbench/mock-run/sysinfo/beg/testhost.example.com

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1560,7 +1560,7 @@ class ToolMeister:
             self.logger.warning(
                 "%s: unexpected temp files %s",
                 self._hostname,
-                ",".join(unexpected_files),
+                ",".join(sorted(unexpected_files)),
             )
         try:
             shutil.rmtree(tool_dir)


### PR DESCRIPTION
The recent PR #2661 (commit 487f4ba) added reporting of left-over files in the Tool Meister's temporary directory.  But if the file-system discovery operation happens to return them in a different order than the unit tests are expecting test 56 and 57 of the agent 'util-scripts' tests will fail.