### PR TITLE
Remove references to logger method of base class

### DIFF
--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -54,7 +54,7 @@ class TestDatasets:
         ds1 = Dataset.query(name="fio")
         assert ds1 == ds
 
-    def test_construct_bad_owner(self):
+    def test_construct_bad_owner(self, db_session):
         """Test with a non-existent username
         """
         with pytest.raises(DatasetBadParameterType):


### PR DESCRIPTION
When the server unit tests run in parallel, there is something about how the Database.base class is modified to have a "logger" that is not working.

It seems a bad idea in general to do this kind of logging in a database class, and we should have the logging at the consumers of the database object.  Given the unit tests are not affected by this change, seems like it is a good opportunity to make this kind of a change.

We also fix a wayward server test.