### PR TITLE
Rev-lock `pbench-trafficgen` to our fork of the trafficgen repo

### DIFF
--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -40,6 +40,8 @@ orig_cmd="${*}"
 
 benchmark_name="trafficgen"
 export benchmark=${benchmark_name}
+trafficgen_repo="https://github.com/distributed-system-analysis/trafficgen.git"
+trafficgen_tag="v0.71"
 
 # General pbench defaults
 export benchmark_run_dir=""
@@ -410,7 +412,8 @@ function usage {
 	printf -- "  running already)\n"
 	printf -- "\n"
 	printf -- "--skip-git-pull\n"
-	printf -- "  Do not call git pull on the trafficgen repo if it already exists\n"
+	printf -- "  By default, this script will maintain a compatible version of trafficgen\n"
+	printf -- "  in ${trafficgen_dir}; use this switch to disable updates.\n"
 	printf -- "\n\n"
 	printf -- "options common in most pbench benchmark scripts\n"
 	printf -- "-----------------------------------------------\n"
@@ -875,25 +878,31 @@ if [ "${postprocess_only}" == "n" ]; then
 
 	if [ -d $trafficgen_dir ]; then
 		if [ $skip_git_pull == "n" ]; then
-			if pushd $trafficgen_dir >/dev/null && git pull && git checkout master; then
-				echo "trafficgen is up to date"
-				trafficgen_version=$(git log --max-count=1 --pretty=%h)
-				popd >/dev/null
+			if ( cd $trafficgen_dir >/dev/null && \
+					git fetch --force --quiet --depth=1 origin ${trafficgen_tag} && \
+					git checkout --force ${trafficgen_tag} )
+			then
+				echo "Updated trafficgen ${trafficgen_tag} from ${trafficgen_repo}."
 			else
-				error_log "could not pull latest trafficgen"
+				error_log "Updating trafficgen ${trafficgen_tag} from ${trafficgen_repo} failed."
 				exit 1
 			fi
 		fi
 	else
-		if pushd /opt >/dev/null && git clone https://github.com/atheurer/trafficgen.git; then
-			trafficgen_version=$(git log --max-count=1 --pretty=%h)
-			echo "trafficgen cloned"
-			popd >/dev/null
+		if git clone \
+				--branch $trafficgen_tag \
+				--single-branch \
+				--depth 1 \
+				--no-tags \
+				$trafficgen_repo $trafficgen_dir
+		then
+			echo "Checked out trafficgen ${trafficgen_tag} from ${trafficgen_repo}."
 		else
-			error_log "could not clone latest trafficgen"
+			error_log "Cloning trafficgen ${trafficgen_tag} from ${trafficgen_repo} to \"${trafficgen_dir}\" failed."
 			exit 1
 		fi
 	fi
+	trafficgen_version=$(cd $trafficgen_dir >/dev/null && git log --max-count=1 --pretty=%h)
 
 	# Moongen is built under the trafficgen repo
 	if [ $traffic_generator == "moongen-txrx" ]; then

--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -791,7 +791,10 @@ if [ "${postprocess_only}" == "n" ]; then
 		warn_log "Warning:  could not find IOMMU option, intel_iommu=on, in /proc/cmdline"
 	fi
 	# - dpdk-tools package must be installed
-	check_install_rpm dpdk-tools
+
+	##### DEBUG (this should not be commented out....) #####
+	# check_install_rpm dpdk-tools
+
 	echo "found dpdk-tools, continuing"
 	# - PCI devices bound to vfio-pci
 	if [ -z "$devices" ]; then
@@ -903,6 +906,8 @@ if [ "${postprocess_only}" == "n" ]; then
 		fi
 	fi
 	trafficgen_version=$(cd $trafficgen_dir >/dev/null && git log --max-count=1 --pretty=%h)
+
+exit 0  #### DEBUG
 
 	# Moongen is built under the trafficgen repo
 	if [ $traffic_generator == "moongen-txrx" ]; then

--- a/agent/bench-scripts/pbench-trafficgen
+++ b/agent/bench-scripts/pbench-trafficgen
@@ -785,8 +785,7 @@ if [ "${postprocess_only}" == "n" ]; then
 	if cat /proc/cmdline | grep -q "intel_iommu=on"; then
 		echo "found IOMMU option, continuing"
 	else
-		error_log "could not find IOMMU option, intel_iommu=on, in /proc/cmdline, exiting"
-		exit 1
+		warn_log "Warning:  could not find IOMMU option, intel_iommu=on, in /proc/cmdline"
 	fi
 	# - dpdk-tools package must be installed
 	check_install_rpm dpdk-tools


### PR DESCRIPTION
Pbench has been having problems with version skew between `pbench-trafficgen` and trafficgen.  Until we can implement a permanent, go-forward solution for running benchmark workloads, we are going to fork trafficgen and freeze the version of it which `pbench-trafficgen` uses.

This change modifies `pbench-trafficgen` to pull trafficgen from the fork in the `distributed-system-analysis` organization and to pull a specific tag, rather than fetching the tip of the main branch.  This will establish a stable version of trafficgen which `pbench-trafficgen` can support.  (Fixes #2223.)

In addition to tweaking how we use Git, this change also changes the IOMMU check from a fatal error to a warning.  (Fixes #2676.)

Note that this PR is still a draft, pending better testing; once that's in place, the last commit from this branch, which contains debugging hacks, will be removed.
