### PR TITLE
Use an explicit cache directory for pip installs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist = py
 
 [testenv]
 description = Lints code and runs all agent and server unit/functional tests
-install_command = pip install --no-cache-dir --progress-bar off --prefix={envdir} {opts} {packages}
+install_command = pip install --cache-dir={toxworkdir}/cache --progress-bar off --prefix={envdir} {opts} {packages}
 passenv =
     PY_COLORS
     NO_COLORS


### PR DESCRIPTION
This does not help the Jenkins CI job much, since we are using an ephermal mount for the virtualenvs.  It does help a little bit for local development environments.