### PR TITLE
Use debug-level environment variables

### DIFF
--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -299,7 +299,7 @@ def start_tms_via_ssh(
                 )
                 tms[host] = {"status": "failed"}
             else:
-                # Record the child pid to wait below.
+                # Record the the host command has spawned
                 tms[host] = {"status": "spawned"}
 
     for host, tm_proc in tms.items():

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -1062,7 +1062,7 @@ def main(_prog: str, cli_params: Namespace) -> int:
             try:
                 sysinfo_path.mkdir(parents=True)
             except Exception as e:
-                logger.debug("Unable to create sysinfo-dump directory {}: {}", sysinfo_path, e)
+                logger.debug("Unable to create sysinfo-dump directory %s: %s", sysinfo_path, e)
                 error_log(
                     f"Unable to create sysinfo-dump directory base path: {sysinfo_path}"
                 )

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -244,16 +244,15 @@ def start_tms_via_ssh(
     failures = 0
     successes = 0
     tool_meister_cmd = exec_dir / "tool-meister" / "pbench-tool-meister"
-    base_args = [ssh_cmd]
-    base_args.extend(shlex.split(ssh_opts))
-    args = [
-        "<host replace me>",
-        f"{tool_meister_cmd}-remote",
-        redis_server.host,
-        str(redis_server.port),
-        "<tm param key>",
-        "yes",  # Yes, request the tool meister daemonize itself
-    ]
+    debug_level = os.environ.get("_PBENCH_TOOL_MEISTER_LOG_LEVEL")
+    cmd = f"{tool_meister_cmd}-remote {redis_server.host} {redis_server.port} {{tm_param_key}} yes"
+    if debug_level:
+        cmd += f" {debug_level}"
+    template = TemplateSsh(
+        ssh_cmd,
+        shlex.split(ssh_opts),
+        cmd
+    )
     tms = dict()
     tm_count = 0
     for host in tool_group.hostnames.keys():
@@ -276,6 +275,7 @@ def start_tms_via_ssh(
                             str(redis_server.port),
                             tm_param_key,
                             "yes",  # Yes, daemonize yourself TM ...
+                            debug_level
                         ]
                     )
                     sys.exit(status)
@@ -290,16 +290,9 @@ def start_tms_via_ssh(
                 # Record the child pid to wait below.
                 tms[host] = {"pid": pid, "status": "forked"}
         else:
-            args[0] = host
-            args[4] = tm_param_key
-            ssh_args = base_args + args
-            logger.debug(
-                "6b. starting remote tool meister, ssh_path=%r ssh_args=%r",
-                ssh_path,
-                ssh_args,
-            )
+            logger.debug("6b. starting remote tool meister on %s", host)
             try:
-                pid = os.spawnv(os.P_NOWAIT, ssh_path, ssh_args)
+                template.start(host, tm_param_key=tm_param_key)
             except Exception:
                 logger.exception(
                     "failed to create a tool meister instance for host %s", host
@@ -307,28 +300,40 @@ def start_tms_via_ssh(
                 tms[host] = {"status": "failed"}
             else:
                 # Record the child pid to wait below.
-                tms[host] = {"pid": pid, "status": "spawned"}
+                tms[host] = {"status": "spawned"}
 
     for host, tm_proc in tms.items():
         if tm_proc["status"] == "failed":
             failures += 1
             continue
-        pid = tm_proc["pid"]
-        try:
-            exit_status = _waitpid(pid)
-        except Exception:
-            failures += 1
-            logger.exception(
-                "failed to create a tool meister instance for host %s", host
-            )
-        else:
-            if exit_status != 0:
+        elif tm_proc["status"] == "forked":
+            pid = tm_proc["pid"]
+            try:
+                exit_status = _waitpid(pid)
+            except Exception:
+                failures += 1
+                logger.exception(
+                    "failed to create a tool meister instance for host %s", host
+                )
+            else:
+                if exit_status != 0:
+                    failures += 1
+                    logger.error(
+                        "failed to start tool meister on remote host '%s'"
+                        " (pid %d), exit status: %d",
+                        host,
+                        pid,
+                        exit_status,
+                    )
+                else:
+                    successes += 1
+        elif tm_proc["status"] == "spawned":
+            status = template.wait(host)
+            if status.status != 0:
                 failures += 1
                 logger.error(
-                    "failed to start tool meister on remote host '%s'"
-                    " (pid %d), exit status: %d",
+                    "failed to start tool meister on remote host '%s', exit status: %d",
                     host,
-                    pid,
                     exit_status,
                 )
             else:
@@ -390,6 +395,7 @@ class ToolDataSink(BaseServer):
                         str(redis_server.port),
                         tds_param_key,
                         "yes",  # Request tool-data-sink daemonize itself
+                        os.environ.get("_PBENCH_TOOL_DATA_SINK_LOG_LEVEL", "info")
                     ]
                 )
                 sys.exit(status)
@@ -1055,7 +1061,8 @@ def main(_prog: str, cli_params: Namespace) -> int:
             sysinfo_path = benchmark_run_dir / "sysinfo" / "beg"
             try:
                 sysinfo_path.mkdir(parents=True)
-            except Exception:
+            except Exception as e:
+                logger.debug("Unable to create sysinfo-dump directory {}: {}", sysinfo_path, e)
                 error_log(
                     f"Unable to create sysinfo-dump directory base path: {sysinfo_path}"
                 )

--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -299,7 +299,7 @@ def start_tms_via_ssh(
                 )
                 tms[host] = {"status": "failed"}
             else:
-                # Record the the host command has spawned
+                # Record that the host command has spawned
                 tms[host] = {"status": "spawned"}
 
     for host, tm_proc in tms.items():

--- a/agent/util-scripts/test-bin/ssh
+++ b/agent/util-scripts/test-bin/ssh
@@ -27,7 +27,7 @@ if [[ "${1}" == "hostname" && "${2}" == "-s" ]]; then
 elif [[ "${1}" == "echo"* ]]; then
     echo "127.0.0.1 54038 ${remote} 22"
     exit_code=0
-elif [[ "$(basename -- "${1}")" == "pbench-tool-meister-remote" ]]; then
+elif [[ "$(basename -- "${1%% *}")" == "pbench-tool-meister-remote" ]]; then
     _dir=$(dirname ${0})
     _pbench_full_hostname="${remote}" _pbench_hostname="${remote}" _tool_bin=${_dir}/mpstat ${1} localhost "${3}" "${4}" "${5}"
     exit_code=$?

--- a/agent/util-scripts/test-bin/test-client-tool-meister
+++ b/agent/util-scripts/test-bin/test-client-tool-meister
@@ -71,7 +71,7 @@ if [[ ${status} -ne 0 ]]; then
 fi
 
 function _timeout {
-    timeout --kill-after=10 --signal TERM 20 $*
+    timeout --verbose --kill-after=10 --signal TERM 20 $*
 }
 
 source ${_script_path}/common-tm-cleanup

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 from threading import Thread, Lock, Condition
-from typing import Any, Dict, NamedTuple, Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple
 
 from bottle import Bottle, ServerAdapter, request, abort
 from configparser import DuplicateSectionError
@@ -1831,7 +1831,7 @@ class ToolDataSink(Bottle):
             abort(500, "INTERNAL ERROR")
 
 
-def get_logger(PROG: str, daemon: bool = False, level: bool = "info") -> logging.Logger:
+def get_logger(PROG: str, daemon: bool = False, level: str = "info") -> logging.Logger:
     """construct a logger for a Tool Meister Data Sync instance.
 
     If in the Unit Test environment, just log to console.
@@ -1880,6 +1880,7 @@ def driver(
     optional_md: Dict[str, Any],
     logger: logging.Logger = None,
 ):
+    """Create and drive a Tool Data Sink instance"""
     if logger is None:
         logger = get_logger(PROG, level=parsed.level)
 
@@ -1931,6 +1932,7 @@ def daemon(
     params: Dict[str, Any],
     optional_md: Dict[str, Any],
 ):
+    """Daemonize a Tool Data Sink instance"""
     # Disconnect any existing connections to the Redis server.
     redis_server.connection_pool.disconnect()
     del redis_server
@@ -1983,11 +1985,22 @@ def daemon(
 
 
 def start(prog: Path, parsed: Arguments):
+    """
+    Start a tool data sink instance.
+
+    Args:
+        prog    The Path to the program binary
+        parsed  The Namespace resulting from parse_args
+
+    Returns:
+        integer status code (0 success, > 0 coded failure)
+    """
+
     PROG = prog.name
     # The Tool Data Sink executable is in:
     #   ${pbench_bin}/util-scripts/tool-meister/pbench-tool-data-sink
     # So .parent at each level is:
-    #   _prog       ${pbench_bin}/util-scripts/tool-meister/pbench-tool-data-sink
+    #   prog       ${pbench_bin}/util-scripts/tool-meister/pbench-tool-data-sink
     #     .parent   ${pbench_bin}/util-scripts/tool-meister
     #     .parent   ${pbench_bin}/util-scripts
     #     .parent   ${pbench_bin}
@@ -2068,7 +2081,7 @@ def start(prog: Path, parsed: Arguments):
     return ret_val
 
 
-def main(argv):
+def main(argv: List[str]):
     """Main program for the Tool Meister.
 
     Arguments:  argv - a list of parameters

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -45,12 +45,11 @@ from pbench.agent.redis import RedisChannelSubscriber, wait_for_conn_and_key
 from pbench.agent.toolmetadata import ToolMetadata
 from pbench.agent.utils import collect_local_info
 from pbench.common import MetadataLog
-from pbench.common.logger import HostnameFilter
 
 
 # Logging format string for unit tests
 fmtstr_ut = "%(levelname)s %(name)s %(funcName)s -- %(message)s"
-fmtstr = "%(asctime)s %(levelname)s %(hostname)s %(process)s %(thread)s %(name)s %(funcName)s %(lineno)d -- %(message)s"
+fmtstr = "%(asctime)s %(levelname)s %(process)s %(thread)s %(name)s %(funcName)s %(lineno)d -- %(message)s"
 
 
 # Read in 64 KB chunks off the wire for HTTP PUT requests.
@@ -1856,7 +1855,6 @@ def get_logger(PROG: str, daemon: bool = False, level: bool = "info") -> logging
     shf = logging.Formatter(fmtstr_ut if unit_tests else fmtstr)
     sh.setFormatter(shf)
     logger.addHandler(sh)
-    logger.addFilter(HostnameFilter())
 
     return logger
 

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1987,7 +1987,7 @@ def start(prog: Path, parsed: Arguments) -> int:
         tmp_dir,
         parsed,
         params,
-        redis_server
+        redis_server,
     )
 
 

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -71,13 +71,12 @@ from pbench.agent.redis import (
 )
 from pbench.agent.toolmetadata import ToolMetadata
 from pbench.agent.utils import collect_local_info
-from pbench.common.logger import HostnameFilter
 from pbench.common.utils import md5sum
 
 
 # Logging format string for unit tests
 fmtstr_ut = "%(levelname)s %(name)s %(funcName)s -- %(message)s"
-fmtstr = "%(asctime)s %(levelname)s %(hostname)s %(process)s %(thread)s %(name)s %(funcName)s %(lineno)d -- %(message)s"
+fmtstr = "%(asctime)s %(levelname)s %(process)s %(thread)s %(name)s %(funcName)s %(lineno)d -- %(message)s"
 
 
 def log_subprocess_output(pipe: subprocess.PIPE, logger: logging.Logger):
@@ -1721,7 +1720,6 @@ def get_logger(PROG, daemon: bool = False, level: str = "info") -> logging.Logge
     shf = logging.Formatter(fmtstr_ut if unit_tests else fmtstr)
     sh.setFormatter(shf)
     logger.addHandler(sh)
-    logger.addFilter(HostnameFilter())
 
     return logger
 

--- a/lib/pbench/common/logger.py
+++ b/lib/pbench/common/logger.py
@@ -15,20 +15,22 @@ class HostnameFilter(logging.Filter):
     strings, in the form `%(hostname)s`
     """
 
-    def __init__(self, hostname: str = None):  # lgtm[py/missing-call-to-init]
+    def __init__(self, hostname: str = None):
         """
         Initialize the filter. By default, `%(hostname)s` will be expanded to
         the platform hostname. This can be overridden by specifying an explicit
         hostname value.
 
         NOTE: the `Filter` class is an "example" filter that filters for a
-        "name" parameter. Calling the superclass constructor would add two
-        instance properties our `filter` will ignore. We suppress the warning
-        in LGTM.com.
+        logger "name". Calling the superclass constructor adds two instance
+        properties our `filter` will ignore, but LGTM.com complains if it's
+        omitted. In theory we can suppress the warning with
+        `# lgtm[py/missing-call-to-init]` but that doesn't seem to work.
 
         Args:
             hostname: Hostname to report. Defaults to platform.node().
         """
+        super().__init__()
         self.hostname = hostname if hostname else platform.node()
 
     def filter(self, record: logging.LogRecord) -> bool:

--- a/lib/pbench/common/logger.py
+++ b/lib/pbench/common/logger.py
@@ -1,11 +1,39 @@
 import logging
 import logging.handlers
+import platform
 
 from configparser import NoOptionError, NoSectionError
 from datetime import datetime
 from pathlib import Path
 
 from pbench.common.exceptions import BadConfig
+
+
+class HostnameFilter(logging.Filter):
+    """
+    This logging filter allows adding hostname to standard Python log format
+    strings, in the form `%(hostname)s`
+    """
+
+    def __init__(self, hostname: str = None):  # lgtm[py/missing-call-to-init]
+        """
+        Initialize the filter. By default, `%(hostname)s` will be expanded to
+        the platform hostname. This can be overridden by specifying an explicit
+        hostname value.
+
+        NOTE: the `Filter` class is an "example" filter that filters for a
+        "name" parameter. Calling the superclass constructor would add two
+        instance properties our `filter` will ignore. We suppress the warning
+        in LGTM.com.
+
+        Args:
+            hostname: Hostname to report. Defaults to platform.node().
+        """
+        self.hostname = hostname if hostname else platform.node()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.hostname = self.hostname
+        return True
 
 
 class _Message:

--- a/lib/pbench/common/logger.py
+++ b/lib/pbench/common/logger.py
@@ -1,41 +1,11 @@
 import logging
 import logging.handlers
-import platform
 
 from configparser import NoOptionError, NoSectionError
 from datetime import datetime
 from pathlib import Path
 
 from pbench.common.exceptions import BadConfig
-
-
-class HostnameFilter(logging.Filter):
-    """
-    This logging filter allows adding hostname to standard Python log format
-    strings, in the form `%(hostname)s`
-    """
-
-    def __init__(self, hostname: str = None):
-        """
-        Initialize the filter. By default, `%(hostname)s` will be expanded to
-        the platform hostname. This can be overridden by specifying an explicit
-        hostname value.
-
-        NOTE: the `Filter` class is an "example" filter that filters for a
-        logger "name". Calling the superclass constructor adds two instance
-        properties our `filter` will ignore, but LGTM.com complains if it's
-        omitted. In theory we can suppress the warning with
-        `# lgtm[py/missing-call-to-init]` but that doesn't seem to work.
-
-        Args:
-            hostname: Hostname to report. Defaults to platform.node().
-        """
-        super().__init__()
-        self.hostname = hostname if hostname else platform.node()
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        record.hostname = self.hostname
-        return True
 
 
 class _Message:


### PR DESCRIPTION
The remote Tool Meister has a defined environment variable to override the default "INFO" debug level; however it was not propagated to the remote over ssh. This adds a command line parameter to directly pass the value to the remote.

The same logic was replicated in the Tool Data Sink; although "create" orchestration always forks this on the same host, this allows a simple and consistent command line hook to enable debug log messages when a client launches either command directly via "existing" orchestration.

This code isn't as elegant as I'd like, but in the name of minimizing the size and mess, I'm going to stop here. I'm hoping to refactor a class out of the `start` methods in both `tool_meister.py` and `tool_data_sink.py`, probably with a common base class to encapsulate some commonality. I considered doing that here in a second commit, but so much is flying around in these files doing it piecemeal should help to minimize the merge conflicts.

This refactoring would also make it easier to write unit tests.