### PR TITLE
Create pbench_run directory on remote if it doesn't exists

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -16,10 +16,11 @@ if [[ -z "$pbench_run" ]]; then
         pbench_run=/var/lib/pbench-agent
     fi
     export pbench_run
-fi
-
-if [[ ! -d $pbench_run ]]; then
-    echo "[Warning] pbench run directory, ${pbench_run}, does not exist and will be created" >&2
+else
+    if [[ ! -d $pbench_run ]]; then
+        echo "[ERROR] the provided pbench run directory, ${pbench_run}, does not exist" >&2
+        exit 1
+    fi
 fi
 
 # the pbench temporary directory is always relative to the $pbench_run

--- a/agent/base
+++ b/agent/base
@@ -19,8 +19,7 @@ if [[ -z "$pbench_run" ]]; then
 fi
 
 if [[ ! -d $pbench_run ]]; then
-    echo "[ERROR] pbench run directory, ${pbench_run}, does not exist" >&2
-    exit 1
+    echo "[Warning] pbench run directory, ${pbench_run}, does not exist and will be created" >&2
 fi
 
 # the pbench temporary directory is always relative to the $pbench_run

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -26,7 +26,7 @@ class BaseCommand(metaclass=abc.ABCMeta):
             self.pbench_run = pathlib.Path(env_pbench_run)
             if not self.pbench_run.exists():
                 click.echo(
-                    f"[ERROR] pbench run directory does not exist, {env_pbench_run}",
+                    f"[ERROR] the provided pbench run directory, {env_pbench_run}, does not exist",
                     err=True,
                 )
                 click.get_current_context().exit(1)

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -23,13 +23,14 @@ class BaseCommand(metaclass=abc.ABCMeta):
 
         env_pbench_run = os.environ.get("pbench_run")
         if env_pbench_run:
-            self.pbench_run = pathlib.Path(env_pbench_run)
-            if not self.pbench_run.exists():
+            pbench_run = pathlib.Path(env_pbench_run)
+            if not pbench_run.is_dir():
                 click.echo(
                     f"[ERROR] the provided pbench run directory, {env_pbench_run}, does not exist",
                     err=True,
                 )
                 click.get_current_context().exit(1)
+            self.pbench_run = pbench_run
         else:
             self.pbench_run = pathlib.Path(self.config.pbench_run)
             if not self.pbench_run:

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -22,16 +22,18 @@ class BaseCommand(metaclass=abc.ABCMeta):
         self.name = os.path.basename(sys.argv[0])
 
         env_pbench_run = os.environ.get("pbench_run")
-        self.pbench_run = pathlib.Path(
-            env_pbench_run if env_pbench_run else self.config.pbench_run
-        )
-
-        if not self.pbench_run.exists():
-            click.echo(
-                f"[ERROR] pbench run directory does not exist, {self.pbench_run}",
-                err=True,
-            )
-            click.get_current_context().exit(1)
+        if env_pbench_run:
+            self.pbench_run = pathlib.Path(env_pbench_run)
+            if not self.pbench_run.exists():
+                click.echo(
+                    f"[ERROR] pbench run directory does not exist, {env_pbench_run}",
+                    err=True,
+                )
+                click.get_current_context().exit(1)
+        else:
+            self.pbench_run = pathlib.Path(self.config.pbench_run)
+            if not self.pbench_run:
+                self.pbench_run = pathlib.Path("/var/lib/pbench-agent")
 
         # the pbench temporary directory is always relative to the $pbench_run
         # directory

--- a/lib/pbench/test/functional/agent/cli/commands/test_config.py
+++ b/lib/pbench/test/functional/agent/cli/commands/test_config.py
@@ -13,13 +13,14 @@ def test_pbench_run(monkeypatch, agent_config, pbench_run):
 def test_pbench_run_dir_existence(monkeypatch, agent_config, pbench_run):
     """Verify that pbench_list_tools fail when pbench_run is defined
     to a directory that doesn't exist"""
-    monkeypatch.setenv("pbench_run", f"{pbench_run}/test")
+    my_pbench_run = f"{pbench_run}/test"
+    monkeypatch.setenv("pbench_run", my_pbench_run)
     command = ["pbench-list-tools"]
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 1
     assert b"" == out
     assert (
-        f"[ERROR] the provided pbench run directory, {os.getenv('pbench_run')}, does not exist\n".encode()
+        f"[ERROR] the provided pbench run directory, {my_pbench_run}, does not exist\n".encode()
         == err
     )
 

--- a/lib/pbench/test/functional/agent/cli/commands/test_config.py
+++ b/lib/pbench/test/functional/agent/cli/commands/test_config.py
@@ -18,7 +18,10 @@ def test_pbench_run_dir_existence(monkeypatch, agent_config, pbench_run):
     out, err, exitcode = pytest.helpers.capture(command)
     assert exitcode == 1
     assert b"" == out
-    assert b"[ERROR] pbench run directory does not exist," in err
+    assert (
+        f"[ERROR] the provided pbench run directory, {os.getenv('pbench_run')}, does not exist\n".encode()
+        == err
+    )
 
 
 def test_pbench_dir_existence(monkeypatch, pbench_run, agent_config):


### PR DESCRIPTION
Issue #2665 
If the `pbench_run` directory specified in pbench_agent config on remote host does not exist, we need to create it. 

We create it in our `lib/pbench/agent/base.BaseCommand` class if the directory does not exists already, however, if the same happens when running `agent/base` file we exit. I think we need to be consistent with our `pbench_run` directory creation.

If any script that runs `agent/base` file and need `pbench_run` directory, the base file will create it (if it does not exists already) when it creates the `tmp` directory (`"$pbench_run/tmp"`)