### PR TITLE
Add linting support for agent ansible roles

### DIFF
--- a/agent/ansible/Makefile
+++ b/agent/ansible/Makefile
@@ -11,14 +11,16 @@ version = $(shell ./bin/yamlconf -C ./pbench/agent/galaxy.yml version)
 tb = ${namespace}-${collection}-${version}.tar.gz
 colldir = collections/ansible_collections/${namespace}/${collection}
 
-build:
+lint:
+	make -C pbench/agent
+
+build:	lint
 	ansible-galaxy collection build ${namespace}/${collection}
 
 test:   build
 	ansible-galaxy collection install ${tb} -p ./collections
 	git submodule update --init --recursive
 	cd ${colldir}; ansible-test sanity
-	# test for README.md in *every* role
 
 publish: clean build
 	ansible-galaxy collection publish -vvv -s "${apiserver}"  --api-key "${apikey}" ${tb}

--- a/agent/ansible/Makefile
+++ b/agent/ansible/Makefile
@@ -11,7 +11,7 @@ version = $(shell ./bin/yamlconf -C ./pbench/agent/galaxy.yml version)
 tb = ${namespace}-${collection}-${version}.tar.gz
 colldir = collections/ansible_collections/${namespace}/${collection}
 
-all:	test
+.DEFAULT_GOAL := test
 
 lint:
 	make -C pbench/agent

--- a/agent/ansible/Makefile
+++ b/agent/ansible/Makefile
@@ -11,6 +11,8 @@ version = $(shell ./bin/yamlconf -C ./pbench/agent/galaxy.yml version)
 tb = ${namespace}-${collection}-${version}.tar.gz
 colldir = collections/ansible_collections/${namespace}/${collection}
 
+all:	test
+
 lint:
 	make -C pbench/agent
 

--- a/agent/ansible/pbench/agent/Makefile
+++ b/agent/ansible/pbench/agent/Makefile
@@ -1,0 +1,21 @@
+ROLES = $(wildcard  roles/*)
+NROLES = $(shell echo ${ROLES} | wc -w)
+README = $(wildcard roles/*/README.md)
+NREADME= $(shell echo ${README} | wc -w)
+
+
+all:	lint check-readme
+
+lint:
+	ansible-lint -c ansible-lint.yml
+	yaml-lint $$(find . -type f -name '*.yml')
+
+check-readme:
+	@if [ ${NROLES} != ${NREADME} ] ;then\
+		echo "Mismatch between roles and README.md files";\
+		echo "roles: ${ROLES}";\
+	     	echo "role README files: ${README}";\
+		exit 1\
+	;fi
+	if [ ! -f ./README.md ] ;then exit 1 ;fi
+	if [ ! -f ./plugins/README.md ] ;then exit 1 ;fi

--- a/agent/ansible/pbench/agent/Makefile
+++ b/agent/ansible/pbench/agent/Makefile
@@ -1,9 +1,3 @@
-ROLES = $(wildcard  roles/*)
-NROLES = $(shell echo ${ROLES} | wc -w)
-README = $(wildcard roles/*/README.md)
-NREADME= $(shell echo ${README} | wc -w)
-
-
 all:	lint check-readme
 
 lint:

--- a/agent/ansible/pbench/agent/Makefile
+++ b/agent/ansible/pbench/agent/Makefile
@@ -11,11 +11,4 @@ lint:
 	yaml-lint $$(find . -type f -name '*.yml')
 
 check-readme:
-	@if [ ${NROLES} != ${NREADME} ] ;then\
-		echo "Mismatch between roles and README.md files";\
-		echo "roles: ${ROLES}";\
-	     	echo "role README files: ${README}";\
-		exit 1\
-	;fi
-	if [ ! -f ./README.md ] ;then exit 1 ;fi
-	if [ ! -f ./plugins/README.md ] ;then exit 1 ;fi
+	./check-readmes

--- a/agent/ansible/pbench/agent/ansible-lint.yml
+++ b/agent/ansible/pbench/agent/ansible-lint.yml
@@ -1,0 +1,4 @@
+---
+skip_list:
+  - experimental  # all rules tagged as experimental
+  - no-changed-when  # Commands should not change things if nothing needs doing.

--- a/agent/ansible/pbench/agent/check-readmes
+++ b/agent/ansible/pbench/agent/check-readmes
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+status=0
+if [[ ! -f ./README.md ]] ;then
+    echo "${PWD}/README.md is missing or not a regular file"
+    status=1
+fi
+
+if [[ ! -f ./plugins/README.md ]] ;then
+    echo "{PWD}/plugins/README.md is missing or not a regular file"
+    status=1
+fi
+
+for role in roles/* ;do
+    if [[ ! -f ${role}/README.md ]] ;then
+        echo "${PWD}/${role}/README.md is missing or not a regular file"
+        status=1
+    fi
+done
+
+exit ${status}

--- a/agent/ansible/pbench/agent/galaxy.yml
+++ b/agent/ansible/pbench/agent/galaxy.yml
@@ -1,3 +1,4 @@
+---
 ### REQUIRED
 
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all
@@ -17,7 +18,7 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-- The Pbench team
+  - The Pbench team
 
 
 ### OPTIONAL but strongly recommended
@@ -28,7 +29,7 @@ description: Roles that help install pbench-agent
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
 license:
-- GPL-3.0-or-later
+  - GPL-3.0-or-later
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'

--- a/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/epel_repo_install/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: install the EPEL repo
-  package:
+  ansible.builtin.package:
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm
-    state: latest
   when: ansible_distribution == "RedHat" or ansible_distribution == "CentOS"

--- a/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_config/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # pbench agent configuration
 - name: "pbench agent configuration - install config file(s)"
-  include_role:
+  ansible.builtin.include_role:
     name: pbench_agent_files_install
   vars:
     source: "{{ pbench_config_url }}"
@@ -10,7 +10,7 @@
     files: "{{ pbench_config_files }}"
 
 - name: "pbench agent configuration - install ssh key"
-  include_role:
+  ansible.builtin.include_role:
     name: pbench_agent_files_install
   vars:
     source: "{{ pbench_key_url }}"

--- a/agent/ansible/pbench/agent/roles/pbench_agent_files_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_files_install/tasks/main.yml
@@ -2,37 +2,37 @@
 # Install file(s) for pbench agent.
 - name: create temp dir to store the file(s) locally
   delegate_to: localhost
-  become: no
-  tempfile:
+  become: false
+  ansible.builtin.tempfile:
     state: directory
     prefix: "{{ inventory_hostname }}-"
   register: tempdir_1
 
 - name: relax perms
   delegate_to: localhost
-  become: no
-  file:
+  become: false
+  ansible.builtin.file:
     path: "{{ tempdir_1.path }}"
     mode: 0755
 
 - name: install the file(s) locally
   delegate_to: localhost
-  become: no
-  get_url:
+  become: false
+  ansible.builtin.get_url:
     url: "{{ source }}/{{ item }}"
     dest: "{{ tempdir_1.path }}/{{ item }}"
   with_items: "{{ files }}"
 
 - name: copy the file(s) to the remote
-  copy:
-    src:  "{{ tempdir_1.path }}/{{ item }}"
+  ansible.builtin.copy:
+    src: "{{ tempdir_1.path }}/{{ item }}"
     dest: "{{ dest }}"
     mode: "{{ mode }}"
   with_items: "{{ files }}"
 
 - name: delete local temp dir
   delegate_to: localhost
-  become: no
-  file:
+  become: false
+  ansible.builtin.file:
     state: absent
     path: "{{ tempdir_1.path }}"

--- a/agent/ansible/pbench/agent/roles/pbench_agent_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_agent_install/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- import_role:
+- name: Run the role that expunges the yum cache completely
+  ansible.builtin.import_role:
     name: pbench_clean_yum_cache
 
-- name: "Install RPMs"
-  package:
+- name: Install RPMs
+  ansible.builtin.package:
     name: "{{ item }}"
-    state: latest
   with_items:
     - pbench-agent
     - pbench-sysstat

--- a/agent/ansible/pbench/agent/roles/pbench_clean_yum_cache/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_clean_yum_cache/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Clean yum cache
-  command: yum clean all
+  ansible.builtin.command: yum clean all
   args:
-    warn: False
+    warn: false
 
 - name: Delete /var/cache/yum directory
-  file:
+  ansible.builtin.file:
     path: /var/cache/yum
     state: absent

--- a/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_firewall_open_ports/tasks/main.yml
@@ -3,8 +3,8 @@
 - name: "pbench agent configuration - open firewall ports for tool meister"
   ansible.posix.firewalld:
     port: "{{ item }}/tcp"
-    permanent: yes
-    offline: yes
+    permanent: true
+    offline: true
     state: enabled
   with_items:
     - "{{ pbench_redis_port }}"

--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/tasks/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # Install pbench.repo
 - name: ensure we have the pbench.repo file properly in place
-  template:
+  ansible.builtin.template:
     src: etc/yum.repos.d/pbench.repo.j2
     dest: /etc/yum.repos.d/pbench.repo
     owner: root


### PR DESCRIPTION
- Modify the roles to pacify ansible-lint and yaml-lint.
- Add a skip list for ansible-lint: a couple of its tests cannot be
  satisfied with the current roles.
- Add a Makefile to run these two, and also to check that there is a
  README.md file for every role (as well as a top level README.md and
  one in the plugins subdir).
- Invoke the above Makefile's default target from the main Makefile in
  agent/ansible when testing the collection before it is sent to
  Ansible Galaxy. Galaxy is very picky in what it accepts, so it
  behooves us to find as many problems as possible *before* sending.