### PR TITLE
re-try tar command if we encounter an error

### DIFF
--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1323,9 +1323,9 @@ class ToolMeister:
             )
             tar_args.insert(2, "--warning=none")
             cp = tar(tar_args)
+            if cp.returncode != 0:
+                self.logger.warning("Failed to create tarball, %s", cp.stdout)
 
-        if cp.returncode != 0:
-            self.logger.warning("Failed to create tarball, %s", cp.stdout)
         return cp
 
     def _send_directory(self, directory, uri, ctx):

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1322,7 +1322,7 @@ class ToolMeister:
                 cp.returncode,
             )
             if retry:
-                tar_args.insert(2, f"--warning=none")
+                tar_args.insert(2, "--warning=none")
                 self._create_tar(directory, tar_file, tar_args)
             else:
                 return cp

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1322,7 +1322,7 @@ class ToolMeister:
                 cp.stdout.decode("utf-8"),
                 cp.returncode,
                 directory,
-                "re-trying ignoring all warnings using --warning=none" if retry else "",
+                "re-trying with --warning=none" if retry else "",
             )
             if retry:
                 tar_args.insert(2, "--warning=none")

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1364,7 +1364,9 @@ class ToolMeister:
                 if self._create_tar(Path("/dev/null"), tar_file) != 0:
                     # Empty tarball creation failed, so we're going to skip the PUT
                     # operation.
-                    raise ToolMeisterError("Failed to create an empty tar %s", tar_file)
+                    raise ToolMeisterError(
+                        f"Failed to create an empty tar {str(tar_file)}"
+                    )
         except ToolMeisterError:
             raise
         except Exception:

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -149,13 +149,13 @@ class TestSendDirectory:
         responses.add(responses.PUT, uri, status=code, body=text)
 
     @staticmethod
-    def fake_tar(returncode: int, stdout: bytes):
+    def fake_create_tar(returncode: int, stdout: bytes):
         def f(directory: pathlib.Path, tar_file: pathlib.Path):
             return subprocess.CompletedProcess(
                 args=[], returncode=returncode, stdout=stdout, stderr=None
             )
 
-        TestSendDirectory.function_called.append("fake_tar")
+        TestSendDirectory.function_called.append("fake_create_tar")
         return f
 
     @staticmethod
@@ -199,7 +199,7 @@ class TestSendDirectory:
             logger=logging.getLogger(),
         )
 
-        monkeypatch.setattr(tm, "_create_tar", self.fake_tar(0, b""))
+        monkeypatch.setattr(tm, "_create_tar", self.fake_create_tar(0, b""))
 
         url = (
             f"http://{TestCreateTar.tm_params['tds_hostname']}:{TestCreateTar.tm_params['tds_port']}/uri"
@@ -209,7 +209,7 @@ class TestSendDirectory:
 
         failures = tm._send_directory(self.directory, "uri", "ctx")
         assert self.function_called == [
-            "fake_tar",
+            "fake_create_tar",
             "fake_md5",
             "fake_open",
             "fake_rmtree",
@@ -217,7 +217,7 @@ class TestSendDirectory:
         ]
         assert failures == 0
 
-    def test_tar_create_failure(self, mock_tar_failure, monkeypatch):
+    def test_tar_create_failure(self, monkeypatch):
         """Check if the tar creation error is properly captured in send_directory"""
         tm = ToolMeister(
             pbench_install_dir=None,
@@ -230,7 +230,7 @@ class TestSendDirectory:
         )
 
         monkeypatch.setattr(
-            tm, "_create_tar", self.fake_tar(1, b"Error in tarball creation")
+            tm, "_create_tar", self.fake_create_tar(1, b"Error in tarball creation")
         )
 
         with pytest.raises(ToolMeisterError) as exc:

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -13,12 +13,7 @@ logger = get_logger("__logger__")
 @pytest.fixture()
 def mock_tar(monkeypatch):
     def fake_run(*args, **kwargs):
-        def f():
-            return
-
-        f.returncode = 0
-        f.stdout = b""
-        return f
+        return subprocess.CompletedProcess(args, returncode=0, stdout=b"", stderr=None)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -26,16 +21,14 @@ def mock_tar(monkeypatch):
 @pytest.fixture()
 def mock_tar_no_warnings(monkeypatch):
     def fake_run(*args, **kwargs):
-        def f():
-            return
-
         if "--warning=none" in args[0]:
-            f.returncode = 0
-            f.stdout = b""
+            return subprocess.CompletedProcess(
+                args, returncode=0, stdout=b"", stderr=None
+            )
         else:
-            f.returncode = 1
-            f.stdout = b"Some error running tar"
-        return f
+            return subprocess.CompletedProcess(
+                args, returncode=1, stdout=b"Some error running tar", stderr=None
+            )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
@@ -43,12 +36,9 @@ def mock_tar_no_warnings(monkeypatch):
 @pytest.fixture()
 def mock_tar_failure(monkeypatch):
     def fake_run(*args, **kwargs):
-        def f():
-            return
-
-        f.returncode = 1
-        f.stdout = b"Some error running tar"
-        return f
+        return subprocess.CompletedProcess(
+            args, returncode=1, stdout=b"Some error running tar", stderr=None
+        )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -147,11 +147,11 @@ class TestSendDirectory:
         functions_called = []
 
         def mock_unlink(*args):
-            assert args[0] == Path(f"{TestSendDirectory.directory}.tar.xz")
+            assert args[0] == Path(f"{self.directory}.tar.xz")
             functions_called.append("mock_unlink")
 
         def mock_open(*args):
-            assert args[0] == Path(f"{TestSendDirectory.directory}.tar.xz")
+            assert args[0] == Path(f"{self.directory}.tar.xz")
             functions_called.append("mock_open")
             return io.StringIO()
 
@@ -196,7 +196,7 @@ class TestSendDirectory:
         functions_called = []
 
         def mock_unlink(*args):
-            assert args[0] == Path(f"{TestSendDirectory.directory}.tar.xz")
+            assert args[0] == Path(f"{self.directory}.tar.xz")
             functions_called.append("mock_unlink")
 
         monkeypatch.setattr(Path, "unlink", mock_unlink)

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -11,7 +11,7 @@ from http import HTTPStatus
 import pytest
 import responses
 
-from pbench.agent.tool_meister import ToolMeister, ToolMeisterError, get_logger
+from pbench.agent.tool_meister import ToolMeister, ToolMeisterError
 
 tar_file = "test.tar.xz"
 
@@ -41,7 +41,7 @@ def mock_tar(monkeypatch, agent_setup):
 
 @pytest.fixture(scope="function")
 def logger_fixture(request):
-    logger = get_logger("__logger__")
+    logger = logging.getLogger(f"__logger__{request.node.name}")
     try:
         logger.setLevel(level=request.param)
     except AttributeError:

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -1,0 +1,113 @@
+"""
+Tests for the Tool Data Meister modules.
+"""
+import pathlib
+import tarfile
+import pytest
+
+from pbench.agent.tool_meister import ToolMeister, get_logger
+
+
+@pytest.fixture()
+def get_params():
+    a = {
+        "benchmark_run_dir": "",
+        "channel_prefix": "",
+        "tds_hostname": "test.hostname.com",
+        "tds_port": 4242,
+        "controller": "test.hostname.com",
+        "group": "",
+        "hostname": "test.hostname.com",
+        "label": None,
+        "tool_metadata": {"persistent": {}, "transient": {}},
+        "tools": [],
+    }
+    return a
+
+
+def test_create_tar(agent_setup, get_params):
+    """Test create tar file"""
+    tm = ToolMeister(
+        pbench_install_dir=None,
+        tmp_dir=None,
+        tar_path="/usr/bin/tar",
+        sysinfo_dump=None,
+        params=get_params,
+        redis_server=None,
+        logger=None,
+    )
+    tmp_dir = agent_setup["tmp"]
+
+    # create a file in tmp directory
+    (tmp_dir / "file1").write_text("")
+
+    target_dir = tmp_dir.name
+    parent_dir = tmp_dir.parent
+    tar_file = parent_dir / f"{target_dir}.tar.xz"
+
+    cp = tm._create_tar(tmp_dir, tar_file)
+    assert cp.returncode == 0
+    assert cp.stdout == b""
+    tar_file.unlink()
+
+
+def test_create_tar_ignore_warnings(agent_setup, get_params):
+    """Test if we can suppress the errors raised during the tar creation"""
+    logger = get_logger("__logger__")
+    tm = ToolMeister(
+        pbench_install_dir=None,
+        tmp_dir=None,
+        tar_path="/usr/bin/tar",
+        sysinfo_dump=None,
+        params=get_params,
+        redis_server=None,
+        logger=logger,
+    )
+    tmp_dir = agent_setup["tmp"]
+
+    # create a file in tmp directory
+    (tmp_dir / "file1").write_text("")
+
+    target_dir = tmp_dir.name
+    tar_file = tmp_dir / f"{target_dir}.tar.xz"
+
+    cp = tm._create_tar(tmp_dir, tar_file)
+    assert cp.returncode == 1
+    assert b"file changed as we read it" in cp.stdout
+
+    cp = tm._create_tar(tmp_dir, tar_file, retry=True)
+    assert cp.returncode == 0
+    assert cp.stdout == b""
+    tar_file.unlink()
+
+
+def test_create_empty_tar(agent_setup, get_params):
+    """Test empty tar creation"""
+    logger = get_logger("__logger__")
+    tm = ToolMeister(
+        pbench_install_dir=None,
+        tmp_dir=None,
+        tar_path="/usr/bin/tar",
+        sysinfo_dump=None,
+        params=get_params,
+        redis_server=None,
+        logger=logger,
+    )
+    tmp_dir = agent_setup["tmp"]
+
+    # create a file in tmp directory
+    (tmp_dir / "file1").write_text("")
+
+    target_dir = tmp_dir.name
+    tar_file = tmp_dir / f"{target_dir}.tar.xz"
+
+    cp = tm._create_tar(pathlib.Path("/dev/null"), tar_file)
+    assert cp.returncode == 0
+    assert cp.stdout == b""
+
+    tar = tarfile.open(tar_file)
+    # There should be only one member inside this tar file i.e. null
+    for member in tar.getmembers():
+        assert member.name == "null"
+
+    tar_file.unlink()

--- a/lib/pbench/test/unit/agent/test_tool_meister.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister.py
@@ -15,34 +15,35 @@ from pbench.agent.tool_meister import ToolMeister, ToolMeisterError
 
 tar_file = "test.tar.xz"
 tmp_dir = pathlib.Path("nonexistent/tmp/dir")
+tm_params = {
+    "benchmark_run_dir": "",
+    "channel_prefix": "",
+    "tds_hostname": "test.hostname.com",
+    "tds_port": 4242,
+    "controller": "test.hostname.com",
+    "group": "",
+    "hostname": "test.hostname.com",
+    "label": None,
+    "tool_metadata": {"persistent": {}, "transient": {}},
+    "tools": [],
+}
+
+
+@pytest.fixture
+def tool_meister():
+    return ToolMeister(
+        pbench_install_dir=None,
+        tmp_dir=None,
+        tar_path="tar_path",
+        sysinfo_dump=None,
+        params=tm_params,
+        redis_server=None,
+        logger=logging.getLogger(),
+    )
 
 
 class TestCreateTar:
-    tm_params = {
-        "benchmark_run_dir": "",
-        "channel_prefix": "",
-        "tds_hostname": "test.hostname.com",
-        "tds_port": 4242,
-        "controller": "test.hostname.com",
-        "group": "",
-        "hostname": "test.hostname.com",
-        "label": None,
-        "tool_metadata": {"persistent": {}, "transient": {}},
-        "tools": [],
-    }
-
-    @staticmethod
-    @pytest.fixture
-    def tool_meister():
-        return ToolMeister(
-            pbench_install_dir=None,
-            tmp_dir=None,
-            tar_path="tar_path",
-            sysinfo_dump=None,
-            params=__class__.tm_params,
-            redis_server=None,
-            logger=logging.getLogger(),
-        )
+    """Test the ToolMeister._create_tar() method behaviors."""
 
     @staticmethod
     def test_create_tar(tool_meister, monkeypatch):
@@ -113,7 +114,8 @@ class TestCreateTar:
         assert cp.returncode == 1
         assert cp.stdout == b"Some error running tar command, empty tar creation failed"
         assert (
-            f"Tarball creation failed with 1 (stdout 'Some error running tar command, empty tar creation failed') on {tmp_dir}: Re-trying now"
+            "Tarball creation failed with 1 (stdout 'Some error running tar"
+            f" command, empty tar creation failed') on {tmp_dir}: Re-trying now"
             in caplog.text
         )
 
@@ -122,15 +124,9 @@ class TestSendDirectory:
     """Test ToolMeister._send_directory()'s use of ._create_tar()"""
 
     # Record all the mock functions called by a test
-    function_called = []
+    functions_called = []
 
-    directory = tmp_dir / f"{TestCreateTar.tm_params['hostname']}"
-
-    @staticmethod
-    def add_http_mock_response(
-        uri: str, code: HTTPStatus = HTTPStatus.OK, text: str = "succeeded"
-    ):
-        responses.add(responses.PUT, uri, status=code, body=text)
+    directory = tmp_dir / f"{tm_params['hostname']}"
 
     @staticmethod
     def fake_create_tar(returncode: int, stdout: bytes):
@@ -139,60 +135,47 @@ class TestSendDirectory:
                 args=[], returncode=returncode, stdout=stdout, stderr=None
             )
 
-        TestSendDirectory.function_called.append("fake_create_tar")
+        __class__.functions_called.append("fake_create_tar")
         return f
 
-    @staticmethod
-    def fake_unlink(*args):
-        assert args[0] == pathlib.Path(f"{TestSendDirectory.directory}.tar.xz")
-        TestSendDirectory.function_called.append("fake_unlink")
-        pass
-
-    @staticmethod
-    def fake_open(*args):
-        assert args[0] == pathlib.Path(f"{TestSendDirectory.directory}.tar.xz")
-        TestSendDirectory.function_called.append("fake_open")
-        return io.StringIO()
-
-    def fake_rmtree(self, directory: pathlib.Path):
-        assert directory == tmp_dir
-        self.function_called.append("fake_rmtree")
-        pass
-
-    def fake_md5(self, tar_file: pathlib.Path):
-        assert tar_file == pathlib.Path(f"{self.directory}.tar.xz")
-        self.function_called.append("fake_md5")
-        return 10, "random_md5"
-
     @responses.activate
-    def test_tar_create_success(self, monkeypatch):
+    def test_tar_create_success(self, tool_meister, monkeypatch):
         """This test should pass the tar creation in send directory"""
 
-        monkeypatch.setattr(shutil, "rmtree", self.fake_rmtree)
-        monkeypatch.setattr("pbench.agent.tool_meister.md5sum", self.fake_md5)
-        monkeypatch.setattr(pathlib.Path, "unlink", self.fake_unlink)
-        monkeypatch.setattr(pathlib.Path, "open", self.fake_open)
+        def fake_unlink(*args):
+            assert args[0] == pathlib.Path(f"{self.directory}.tar.xz")
+            self.functions_called.append("fake_unlink")
 
-        tm = ToolMeister(
-            pbench_install_dir=None,
-            tmp_dir=None,
-            tar_path="tar_path",
-            sysinfo_dump=None,
-            params=TestCreateTar.tm_params,
-            redis_server=None,
-            logger=logging.getLogger(),
-        )
+        def fake_open(*args):
+            assert args[0] == pathlib.Path(f"{self.directory}.tar.xz")
+            self.functions_called.append("fake_open")
+            return io.StringIO()
 
-        monkeypatch.setattr(tm, "_create_tar", self.fake_create_tar(0, b""))
+        def fake_rmtree(directory: pathlib.Path):
+            assert directory == tmp_dir
+            self.functions_called.append("fake_rmtree")
+
+        def fake_md5(tar_file: pathlib.Path):
+            assert tar_file == pathlib.Path(f"{self.directory}.tar.xz")
+            self.functions_called.append("fake_md5")
+            return 10, "random_md5"
+
+        monkeypatch.setattr(shutil, "rmtree", fake_rmtree)
+        monkeypatch.setattr("pbench.agent.tool_meister.md5sum", fake_md5)
+        monkeypatch.setattr(pathlib.Path, "unlink", fake_unlink)
+        monkeypatch.setattr(pathlib.Path, "open", fake_open)
+
+        monkeypatch.setattr(tool_meister, "_create_tar", self.fake_create_tar(0, b""))
 
         url = (
-            f"http://{TestCreateTar.tm_params['tds_hostname']}:{TestCreateTar.tm_params['tds_port']}/uri"
-            f"/ctx/{TestCreateTar.tm_params['hostname']}"
+            f"http://{tm_params['tds_hostname']}:{tm_params['tds_port']}/uri"
+            f"/ctx/{tm_params['hostname']}"
         )
-        self.add_http_mock_response(url)
+        responses.add(responses.PUT, url, status=HTTPStatus.OK, body="succeeded")
 
-        failures = tm._send_directory(self.directory, "uri", "ctx")
-        assert self.function_called == [
+        failures = tool_meister._send_directory(self.directory, "uri", "ctx")
+        functions_called, self.functions_called = self.functions_called, []
+        assert functions_called == [
             "fake_create_tar",
             "fake_md5",
             "fake_open",
@@ -201,25 +184,19 @@ class TestSendDirectory:
         ]
         assert failures == 0
 
-    def test_tar_create_failure(self, monkeypatch):
+    def test_tar_create_failure(self, tool_meister, monkeypatch):
         """Check if the tar creation error is properly captured in send_directory"""
-        tm = ToolMeister(
-            pbench_install_dir=None,
-            tmp_dir=None,
-            tar_path="tar_path",
-            sysinfo_dump=None,
-            params=TestCreateTar.tm_params,
-            redis_server=None,
-            logger=logging.getLogger(),
-        )
-
         monkeypatch.setattr(
-            tm, "_create_tar", self.fake_create_tar(1, b"Error in tarball creation")
+            tool_meister,
+            "_create_tar",
+            self.fake_create_tar(1, b"Error in tarball creation"),
         )
 
         with pytest.raises(ToolMeisterError) as exc:
-            failures = tm._send_directory(self.directory, "uri", "ctx")
+            failures = tool_meister._send_directory(self.directory, "uri", "ctx")
             assert failures == 1
+        functions_called, self.functions_called = self.functions_called, []
+        assert functions_called == ["fake_create_tar"]
         assert f"Failed to create an empty tar {self.directory}.tar.xz" in str(
             exc.value
         )


### PR DESCRIPTION
Part of an issue https://github.com/distributed-system-analysis/pbench/issues/2692 
Addresses Peter's comment about retrying the tar command if we encounter an error for the first time
> Let's ignore all warnings on the re-try only. Something like `tar --warning=none`, so that we capture the errors when we try the first time, but the tar up whatever we can on the re-try. And we should do something to remark in the data collection that we encountered warnings on the initial `tar` command.