### PR TITLE
Add environment variable to ignore check_install_rpm

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -145,6 +145,18 @@ if [[ -z "${scp_opts}" ]]; then
     export scp_opts
 fi
 
+if [[ -z "${PBENCH_RPM_REQUIREMENT_MODE}" ]]; then
+    PBENCH_RPM_REQUIREMENT_MODE=$(pbench-config rpm_requirement_mode pbench-agent)
+fi
+if [[ "${PBENCH_RPM_REQUIREMENT_MODE}" != "strict" && "${PBENCH_RPM_REQUIREMENT_MODE}" != "relaxed" ]]; then
+    error_log "[${script_name}] Invalid PBENCH_RPM_REQUIREMENT_MODE, '${PBENCH_RPM_REQUIREMENT_MODE}', expected 'strict' or 'relaxed'"
+    exit 1
+fi
+
+#+
+# Helper functions
+#-
+
 function is_redhat() {
     grep -q 'Red Hat' /etc/redhat-release
     return $?
@@ -170,10 +182,16 @@ function check_install_rpm {
     _rpm=$(require-rpm "${_n}" "${_v}" "${_m}")
     local rc=${?}
     if [[ ${rc} -ne 0 ]]; then
-        error_log "[${script_name}] required ${_rpm} is not installed"
-        exit ${rc}
+        if [[ "${PBENCH_RPM_REQUIREMENT_MODE}" == "strict" ]]; then
+            error_log "[${script_name}] required ${_rpm} is not installed"
+            exit ${rc}
+        else
+            warn_log "[${script_name}] required ${_rpm} is not installed"
+            log "[${script_name}] please do not report any issues until the required RPM (${_rpm}) is installed"
+        fi
+    else
+        debug_log "[${script_name}] required ${_rpm} is installed"
     fi
-    debug_log "[${script_name}] required ${_rpm} is installed"
 }
 
 # Constants

--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -12,6 +12,8 @@ heavy-tool-set = %(medium-tool-set)s, mpstat, perf, pidstat, proc-interrupts, pr
 install-dir = %(pbench_install_dir)s
 pbench_run = /var/lib/pbench-agent
 pbench_log = %(pbench_run)s/pbench.log
+# RPM requirement mode: strict vs relaxed
+rpm_requirement_mode = strict
 
 [logging]
 logger_type = file


### PR DESCRIPTION
sometimes people might need to disable the "check_install_rpm" check to
use non-rpm tools or tool of a different version. Let's add an
environment variable "PBENCH_IGNORE_CHECK_INSTALL_RPM" to ignore
check_install_rpm failures while adding a note to the log about
not-running-the-expected-tool-version so people need to reproduce with
the expected tool version to file issues.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>