### PR TITLE
Correct `check_required_rpm` behavior

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -580,10 +580,10 @@ install)
 		local _tpn="${1}"
 		local _tpv="${2}"
 		local _installed_rpm
-		local rc
-    _installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
-    rc=${?} 
-		if [[ ${rc} != 0 ]]; then
+		local _rc
+		_installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
+		_rc=${?} 
+		if [[ ${_rc} != 0 ]]; then
 			if [[ ! -z "${_tpv}" ]]; then
 				_tpv="-${_tpv}"
 			fi
@@ -591,7 +591,7 @@ install)
 		else
 			printf -- "%s: %s is installed\n" "${tool}" "${_installed_rpm}"
 		fi
-		return ${rc}
+		return ${_rc}
 	}
 	if [[ ! -z "${tool_package_name}" ]]; then
 		check_required_rpm ${tool_package_name} ${tool_package_ver}

--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -584,10 +584,7 @@ install)
 		_installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
 		_rc=${?} 
 		if [[ ${_rc} != 0 ]]; then
-			if [[ ! -z "${_tpv}" ]]; then
-				_tpv="-${_tpv}"
-			fi
-			printf -- "%s: %s is not installed\n" "${tool}" "${_tpn}${_tpv}" >&2
+			printf -- "%s: %s is not installed\n" "${tool}" "${_tpn}${_tpv:+-${_tpv}}" >&2
 		else
 			printf -- "%s: %s is installed\n" "${tool}" "${_installed_rpm}"
 		fi

--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -579,8 +579,10 @@ install)
 	function check_required_rpm {
 		local _tpn="${1}"
 		local _tpv="${2}"
-		local _installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
-		local rc=${?}
+		local _installed_rpm
+		local rc
+    _installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
+    rc=${?} 
 		if [[ ${rc} != 0 ]]; then
 			if [[ ! -z "${_tpv}" ]]; then
 				_tpv="-${_tpv}"


### PR DESCRIPTION
Pulled out as a separate commit from PR #2659.  If you have a `local` statement for a variable where that variable is assigned the result of executing a command, `${?}` will always have a `0` (success) since the `local` statement records its success after the command execution.