### PR TITLE
Replace `find_executable` with `shutil.which`

### DIFF
--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -133,7 +133,6 @@ import sys
 import time
 
 from argparse import ArgumentParser, Namespace
-from distutils.spawn import find_executable
 from pathlib import Path
 import redis
 
@@ -639,7 +638,7 @@ port {redis_port:d}
 
         # Start the Redis Server itself
         redis_srvr = "redis-server"
-        redis_srvr_path = find_executable(redis_srvr)
+        redis_srvr_path = shutil.which(redis_srvr)
         try:
             retcode = os.spawnl(os.P_WAIT, redis_srvr_path, redis_srvr, redis_conf)
         except Exception as exc:
@@ -828,7 +827,7 @@ def main(_prog: str, cli_params: Namespace) -> int:
         if cli_params.orchestrate == "create":
             orchestrate = True
             ssh_cmd = "ssh"
-            ssh_path = find_executable(ssh_cmd)
+            ssh_path = shutil.which(ssh_cmd)
             if ssh_path is None:
                 raise CleanupTime(
                     ReturnCode.MISSINGSSHCMD, "required ssh command not in our PATH"

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -1,9 +1,9 @@
 import collections
 import datetime
 import os
+import shutil
 import subprocess
 import urllib.parse
-from distutils.spawn import find_executable
 from logging import Logger
 from pathlib import Path
 
@@ -73,10 +73,10 @@ class MakeResultTb:
         assert (
             config and logger
         ), f"config, '{config!r}', and/or logger, '{logger!r}', not provided"
-        self.tar_path = find_executable("tar")
+        self.tar_path = shutil.which("tar")
         if self.tar_path is None:
             raise RuntimeError("External 'tar' executable not found")
-        self.xz_path = find_executable("xz")
+        self.xz_path = shutil.which("xz")
         if self.xz_path is None:
             raise RuntimeError("External 'xz' executable not found")
         self.result_dir = self._check_result_target_dir(result_dir, "Result")

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, NamedTuple, Tuple
 from bottle import Bottle, ServerAdapter, request, abort
 from configparser import DuplicateSectionError
 from daemon import DaemonContext
-from distutils.spawn import find_executable
 from jinja2 import Environment, FileSystemLoader
 import pidfile
 import redis
@@ -323,7 +322,7 @@ class PromCollector(BaseCollector):
         Prometheus collector, including how to instruct prometheus to gather
         tool data.
         """
-        self.prometheus_path = find_executable("prometheus")
+        self.prometheus_path = shutil.which("prometheus")
         if self.prometheus_path is None:
             raise ToolDataSinkError("External 'prometheus' executable not found")
 
@@ -418,15 +417,15 @@ class PcpCollector(BaseCollector):
         super().__init__(*args, **kwargs)
         self.redis_host = redis_host
         self.redis_port = redis_port
-        pmcd_wait_path = find_executable("pmcd_wait")
+        pmcd_wait_path = shutil.which("pmcd_wait")
         if pmcd_wait_path is None:
             pmcd_wait_path = self._pmcd_wait_path_def
         self.pmcd_wait_path = pmcd_wait_path
-        pmlogger_path = find_executable("pmlogger")
+        pmlogger_path = shutil.which("pmlogger")
         if pmlogger_path is None:
             pmlogger_path = self._pmlogger_path_def
         self.pmlogger_path = pmlogger_path
-        pmproxy_path = find_executable("pmproxy")
+        pmproxy_path = shutil.which("pmproxy")
         if pmproxy_path is None:
             pmproxy_path = self._pmproxy_path_def
         self.pmproxy_path = pmproxy_path
@@ -2006,12 +2005,12 @@ def start(prog: Path, parsed: Arguments):
     #     .parent   ${pbench_bin}
     pbench_bin = prog.parent.parent.parent
 
-    tar_path = find_executable("tar")
+    tar_path = shutil.which("tar")
     if tar_path is None:
         print("External 'tar' executable not found", file=sys.stderr)
         return 2
 
-    cp_path = find_executable("cp")
+    cp_path = shutil.which("cp")
     if cp_path is None:
         print("External 'cp' executable not found", file=sys.stderr)
         return 2

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -52,7 +52,6 @@ import time
 from typing import Any, Dict, List, NamedTuple
 
 from daemon import DaemonContext
-from distutils.spawn import find_executable
 from pathlib import Path
 import pidfile
 import redis
@@ -381,8 +380,8 @@ class PcpTransientTool(Tool):
         if "/usr/libexec/pcp/bin" not in os.environ["PATH"]:
             # FIXME - Shouldn't this be provided by the environment?
             os.environ["PATH"] += f"{os.pathsep}/usr/libexec/pcp/bin"
-        self.pmcd_path = find_executable("pmcd")
-        self.pmlogger_path = find_executable("pmlogger")
+        self.pmcd_path = shutil.which("pmcd")
+        self.pmlogger_path = shutil.which("pmlogger")
 
     def install(self):
         if not self.pmcd_path:
@@ -563,7 +562,7 @@ class DcgmTool(PersistentTool):
 
     def __init__(self, name, tool_opts, **kwargs):
         super().__init__(name, tool_opts, **kwargs)
-        executable = find_executable("dcgm-exporter")
+        executable = shutil.which("dcgm-exporter")
         self.args = None if executable is None else [executable]
 
     def install(self):
@@ -582,7 +581,7 @@ class NodeExporterTool(PersistentTool):
 
     def __init__(self, name, tool_opts, **kwargs):
         super().__init__(name, tool_opts, **kwargs)
-        executable = find_executable("node_exporter")
+        executable = shutil.which("node_exporter")
         self.args = None if executable is None else [executable]
 
     def install(self):
@@ -599,7 +598,7 @@ class PcpTool(PersistentTool):
 
     def __init__(self, name, tool_opts, **kwargs):
         super().__init__(name, tool_opts, **kwargs)
-        pmcd_path = find_executable("pmcd")
+        pmcd_path = shutil.which("pmcd")
         if pmcd_path is None:
             pmcd_path = self._pmcd_path_def
         executable = os.access(pmcd_path, os.X_OK)
@@ -1891,7 +1890,7 @@ def start(prog: Path, parsed: Arguments) -> int:
     """
     PROG = prog.name
 
-    tar_path = find_executable("tar")
+    tar_path = shutil.which("tar")
     if tar_path is None:
         print(f"{PROG}: External 'tar' executable not found.", file=sys.stderr)
         return 2
@@ -1917,7 +1916,7 @@ def start(prog: Path, parsed: Arguments) -> int:
         _path_list.append(str(prog.parent))
         os.environ["PATH"] = os.pathsep.join(_path_list)
 
-    sysinfo_dump = find_executable("pbench-sysinfo-dump")
+    sysinfo_dump = shutil.which("pbench-sysinfo-dump")
     if sysinfo_dump is None:
         print(
             f"{PROG}: External 'pbench-sysinfo-dump' executable not found.",


### PR DESCRIPTION
Fixes issue #2724 (deprecation of `find_executable` in Python 3.11).