### PR TITLE
Ensure `${pbench_run}` directory exists

### DIFF
--- a/agent/base
+++ b/agent/base
@@ -15,6 +15,13 @@ if [[ -z "${pbench_run}" ]]; then
     if [[ -z "${pbench_run}" ]]; then
         pbench_run=/var/lib/pbench-agent
     fi
+    if [[ ! -d ${pbench_run} ]]; then
+        mkdir ${pbench_run}
+        if [[ ${?} -ne 0 ]]; then
+            echo "[ERROR] unable to create pbench_run directory, ${pbench_run}" >&2
+            exit 1
+        fi
+    fi
     export pbench_run
 else
     if [[ ! -d ${pbench_run} ]]; then
@@ -26,10 +33,12 @@ fi
 # the pbench temporary directory is always relative to the $pbench_run
 # directory
 pbench_tmp="${pbench_run}/tmp"
-mkdir -p ${pbench_tmp}
-if [[ ${?} -ne 0 ]]; then
-    echo "[ERROR] unable to create TMP directory, ${pbench_tmp}" >&2
-    exit 1
+if [[ ! -d ${pbench_tmp} ]]; then
+    mkdir ${pbench_tmp}
+    if [[ ${?} -ne 0 ]]; then
+        echo "[ERROR] unable to create TMP directory, ${pbench_tmp}" >&2
+        exit 1
+    fi
 fi
 export pbench_tmp
 

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -35,15 +35,22 @@ class BaseCommand(metaclass=abc.ABCMeta):
             self.pbench_run = pathlib.Path(self.config.pbench_run)
             if not self.pbench_run:
                 self.pbench_run = pathlib.Path("/var/lib/pbench-agent")
+            try:
+                self.pbench_run.mkdir(exist_ok=True)
+            except Exception as exc:
+                click.secho(
+                    f"[ERROR] unable to create pbench_run directory, '{self.pbench_run}': '{exc}'"
+                )
+                sys.exit(1)
 
         # the pbench temporary directory is always relative to the $pbench_run
         # directory
         self.pbench_tmp = self.pbench_run / "tmp"
         try:
-            self.pbench_tmp.mkdir(parents=True, exist_ok=True)
+            self.pbench_tmp.mkdir(exist_ok=True)
         except Exception as exc:
             click.secho(
-                f"[ERROR] unable to create TMP dir, '{self.pbench_tmp}': '{exc}'"
+                f"[ERROR] unable to create TMP directory, '{self.pbench_tmp}': '{exc}'"
             )
             sys.exit(1)
 


### PR DESCRIPTION
Fixes issue #2665.

We have to unconditionally create the `${pbench_run}` directory in `agent/base` (and `lib/pbench/agent/base.py` to maintain parallel behavior) because too many scripts depend on its existence for their correct function.

In particular, there are bench-scripts which try to report errors but if the `${pbench_run}` directory does not exist already, the `${pbench_log}` file location won't exist and the actual error is lost.

Rather than trying to fix the myriad number of places with this assumption, it is best to just create the directory to meet the assumed state.