### PR TITLE
Add support for --clients to pbench-linpack

### DIFF
--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -35,10 +35,12 @@ orig_cmd="${*}"
 tool_group="default"
 export config=""
 sysinfo="default"
+clients="localhost"
 
 function usage {
 	printf "\tThe following options are available:\n\n"
 	printf -- "\t-C str --config=str         name of the test config\n"
+	printf -- "\t-c str[,str...] --clients=str[,str...]      a list of one or more host names (hosta,hostb,hostc) where you want ${script_name} to run\n"
 	printf -- "\t       --samples=<int>      number of samples to use per test iteration (default is ${def_nr_samples})\n"
 	printf -- "\t       --threads=int[,int]  number of threads to use (default is # local CPUs)\n"
 	printf -- "\t       --tool-group=str\n"
@@ -47,7 +49,7 @@ function usage {
 }
 
 # Process options and arguments
-opts=$(getopt -q -o C:h --longoptions "config:,samples:,threads:,tool-group:,sysinfo:,help" -n "getopt.sh" -- "${@}")
+opts=$(getopt -q -o C:c:h --longoptions "config:,clients:,samples:,threads:,tool-group:,sysinfo:,help" -n "getopt.sh" -- "${@}")
 if [[ ${?} -ne 0 ]]; then
 	printf -- "${script_name} ${*}\n"
 	printf -- "\n"
@@ -63,6 +65,12 @@ while true; do
 	-c|--config)
 		if [[ -n "${1}" ]]; then
 			config="${1}"
+			shift;
+		fi
+		;;
+	-c|--clients)
+		if [[ -n "${1}" ]]; then
+			clients="${1}"
 			shift;
 		fi
 		;;
@@ -201,25 +209,56 @@ for thread in ${threads//,/ }; do
 	mkdir -p "${iteration_dir}"
 	record_iteration ${count} ${thread} ${iteration}
 	echo "Starting iteration ${iteration}"
-
-	# Pre-processing: generate the linpack.input dirs (in /var/lib/pbench-agent/tmp)
+	# Pre-processing: generate the linpack.input files
 	preprocess-iteration "${iteration_dir}" "${thread}"
+	# Distribute the linpack.input files to remote clients if necessary
+	for client in ${clients//,/ }; do
+		if ! pbench-is-local "${client}"; then
+			ssh ${ssh_opts} "${client}" "mkdir -p '${iteration_dir}'"
+			scp ${scp_opts} "${iteration_dir}/"linpack* "${client}:${iteration_dir}"
+		fi
+	done
 
 	for sample in $(seq 1 ${nr_samples}); do
 		echo "test sample ${sample} of ${nr_samples}"
 		sample_dir="${iteration_dir}/sample${sample}"
-		# Create the output directory expected by the postprocess script
-		mkdir -p "${sample_dir}/clients/localhost/"
 
 		# Run the benchmark and start/stop perf analysis tools
 		pbench-start-tools --group=${tool_group} --dir="${sample_dir}"
 
-		( cd "${iteration_dir}" && ./linpack.sh )
+		for client in ${clients//,/ }; do
+			if pbench-is-local "${client}"; then
+				( cd "${iteration_dir}" && screen -dmS pbench-linpack ./linpack.sh )
+			else
+				ssh ${ssh_opts} ${client} "cd '${iteration_dir}' && screen -dmS pbench-linpack './linpack.sh'"
+			fi
+		done
+
+		# Wait for all of them to finish
+		echo "Waiting for all clients to finish pbench-linpack jobs"
+		for client in ${clients//,/ }; do
+			if pbench-is-local "${client}"; then
+				while ! [ -e "${iteration_dir}/linpack.finished" ]; do
+					sleep 1
+				done
+			else
+				ssh ${ssh_opts} ${client} "while ! [ -e '${iteration_dir}/linpack.finished' ]; do sleep 1; done"
+			fi
+			echo "Iteration finished on ${client}"
+		done
 
 		pbench-stop-tools --group=${tool_group} --dir="${sample_dir}"
 
 		# Move the results to the output directory expected by the postprocess script
-		mv "${iteration_dir}/"linpack.{out,meta} "${sample_dir}/clients/localhost"
+		for client in ${clients//,/ }; do
+			client_result_dir="${sample_dir}/clients/${client}"
+			mkdir -p "${client_result_dir}"
+			if pbench-is-local "${client}"; then
+				mv "${iteration_dir}/"linpack.{out,meta} "${client_result_dir}"
+			else
+				scp ${scp_opts} "${client}:${iteration_dir}"/linpack.{out,meta} "${client_result_dir}"
+			fi
+		done
 
 		# Have the Tool Meisters send the tool data back and post-process it
 		pbench-send-tools --group=${tool_group} --dir="${sample_dir}"

--- a/agent/bench-scripts/postprocess/linpack-prepare-input-file
+++ b/agent/bench-scripts/postprocess/linpack-prepare-input-file
@@ -226,6 +226,7 @@ echo "linpack cmd: ${cmd}"
 echo
 
 echo "exec ${cmd} | stdbuf --input=0 tee -i ${linpack_output_file}" >> "${output_dir}${linpack_script_file}"
+echo "touch linpack.finished" >> "${output_dir}${linpack_script_file}"
 chmod +x "${output_dir}${linpack_script_file}"
 
 exit 0

--- a/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
+++ b/agent/bench-scripts/tests/test-benchmark-clis/test-CL.txt
@@ -508,6 +508,7 @@ Bench Script: pbench-linpack --help
 	The following options are available:
 
 	-C str --config=str         name of the test config
+	-c str[,str...] --clients=str[,str...]      a list of one or more host names (hosta,hostb,hostc) where you want pbench-linpack to run
 	       --samples=<int>      number of samples to use per test iteration (default is 2)
 	       --threads=int[,int]  number of threads to use (default is # local CPUs)
 	       --tool-group=str
@@ -523,6 +524,7 @@ Bench Script: pbench-linpack --tool-group=bad --sysinfo=bad
 	The following options are available:
 
 	-C str --config=str         name of the test config
+	-c str[,str...] --clients=str[,str...]      a list of one or more host names (hosta,hostb,hostc) where you want pbench-linpack to run
 	       --samples=<int>      number of samples to use per test iteration (default is 2)
 	       --threads=int[,int]  number of threads to use (default is # local CPUs)
 	       --tool-group=str
@@ -538,6 +540,7 @@ pbench-linpack --bad-to-the-bone
 	The following options are available:
 
 	-C str --config=str         name of the test config
+	-c str[,str...] --clients=str[,str...]      a list of one or more host names (hosta,hostb,hostc) where you want pbench-linpack to run
 	       --samples=<int>      number of samples to use per test iteration (default is 2)
 	       --threads=int[,int]  number of threads to use (default is # local CPUs)
 	       --tool-group=str


### PR DESCRIPTION
This PR builds on top of: https://github.com/distributed-system-analysis/pbench/pull/2710 and adds the last remaining piece I need to transition from `pbench-run-benchmark` to `pbench-linpack`. Note `pbench-run-benchmark` still allows greater flexibility in linpack configuration, but at this time I don't require that, but it can be added similarly to the threads support.

Note commits 95a5c62..ce0054a are already reviewed and part of the other PR, please focus only on the commit https://github.com/distributed-system-analysis/pbench/pull/2729/commits/d0c6ddbcfa8e4dcf2eb56586f2ce2d3176f7cd1e