### PR TITLE
Move abort() call to top-level API handling

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -5,10 +5,10 @@ from flask.wrappers import Request, Response
 
 from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
-    ApiBase,
     API_OPERATION,
-    Parameter,
+    ApiBase,
     ParamType,
+    Parameter,
     Schema,
 )
 from pbench.server.database.database import Database

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -1,8 +1,6 @@
 from http import HTTPStatus
 from logging import Logger
 
-from flask_restful import abort
-
 from pbench.server import PbenchServerConfig
 from pbench.server.api.resources import (
     JSON,
@@ -65,14 +63,7 @@ class DatasetsContents(RunIdBase):
 
         # Retrieve the ES indices that belong to this run_id from the metadata
         # table
-
         indices = self.get_index(dataset, "run-toc")
-        if not indices:
-            self.logger.debug(
-                f"Found no indices matching the prefix run-toc"
-                f" for a dataset {dataset!r}"
-            )
-            abort(HTTPStatus.NOT_FOUND, message="Found no matching indices")
 
         return {
             "path": f"/{indices}/_search",

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -3,14 +3,14 @@ from logging import Logger
 
 from flask import jsonify
 from flask.wrappers import Request, Response
-from flask_restful import abort
 
 from pbench.server import PbenchServerConfig, JSON
 from pbench.server.api.resources import (
+    APIAbort,
     ApiBase,
-    Schema,
-    Parameter,
     ParamType,
+    Parameter,
+    Schema,
     SchemaError,
 )
 
@@ -99,7 +99,7 @@ class DatasetsMappings(ApiBase):
         try:
             self.schema.validate(json_data)
         except SchemaError as e:
-            abort(HTTPStatus.BAD_REQUEST, message=str(e))
+            raise APIAbort(HTTPStatus.BAD_REQUEST, str(e))
 
         index = RunIdBase.ES_INTERNAL_INDEX_NAMES[json_data["dataset_view"]]
         try:
@@ -120,4 +120,4 @@ class DatasetsMappings(ApiBase):
             self.logger.exception(
                 "Document template {} not found in the database.", index_name
             )
-            abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")
+            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/lib/pbench/server/api/resources/query_apis/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_detail.py
@@ -1,10 +1,9 @@
 from http import HTTPStatus
 from flask import jsonify
-from flask_restful import abort
 from logging import Logger
 
 from pbench.server import PbenchServerConfig, JSON
-from pbench.server.api.resources import Schema, Parameter, ParamType
+from pbench.server.api.resources import APIAbort, ParamType, Parameter, Schema
 from pbench.server.api.resources.query_apis import (
     CONTEXT,
     ElasticBase,
@@ -158,12 +157,11 @@ class DatasetsDetail(ElasticBase):
         try:
             m = self._get_metadata(src["run"]["name"], context["metadata"])
         except DatasetNotFound:
-            abort(
-                HTTPStatus.BAD_REQUEST,
-                message=f"Dataset {src['run']['name']} not found",
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST, f"Dataset {src['run']['name']} not found"
             )
         except MetadataError as e:
-            abort(HTTPStatus.BAD_REQUEST, message=str(e))
+            raise APIAbort(HTTPStatus.BAD_REQUEST, str(e))
 
         if m:
             result["serverMetadata"] = m

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -472,3 +472,18 @@ class TestDatasetsContents(Commons):
         drb = Dataset.query(name="drb")
         indices = self.cls_obj.get_index(drb, self.index_from_metadata)
         assert indices == "unit-test.v6.run-toc.2020-05"
+
+    @pytest.mark.parametrize("run_id", ("wrong", "", None))
+    def test_missing_run_id(self, client, server_config, pbench_token, run_id):
+        if run_id is None:
+            del self.payload["run_id"]
+            expected_status = HTTPStatus.BAD_REQUEST
+        else:
+            self.payload["run_id"] = run_id
+            expected_status = HTTPStatus.NOT_FOUND
+        response = client.post(
+            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            headers={"Authorization": "Bearer " + pbench_token},
+            json=self.payload,
+        )
+        assert response.status_code == expected_status

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -178,7 +178,7 @@ class TestDatasetsDelete:
 
         # Verify the report and status
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert response.json["data"] == {"ok": 28, "failure": 3}
+        assert response.json["message"] == {"ok": 28, "failure": 3}
         assert (
             "pbench.server.api",
             ERROR,
@@ -235,4 +235,4 @@ class TestDatasetsDelete:
 
         # Verify the failure
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert response.json["message"] == "INTERNAL ERROR"
+        assert response.json["message"] == HTTPStatus.INTERNAL_SERVER_ERROR.phrase

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
@@ -127,4 +127,4 @@ class TestDatasetsMappings:
         with client:
             response = client.get(f"{server_config.rest_uri}/datasets/mappings/summary")
             assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-            assert response.json["message"] == "Internal Server Error"
+            assert response.json["message"] == HTTPStatus.INTERNAL_SERVER_ERROR.phrase

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -159,7 +159,7 @@ class TestDatasetsPublish:
 
         # Verify the report and status
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert response.json["data"] == {"ok": 28, "failure": 3}
+        assert response.json["message"] == {"ok": 28, "failure": 3}
         assert (
             "pbench.server.api",
             ERROR,
@@ -217,4 +217,4 @@ class TestDatasetsPublish:
 
         # Verify the failure
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert response.json["message"] == "INTERNAL ERROR"
+        assert response.json["message"] == HTTPStatus.INTERNAL_SERVER_ERROR.phrase

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -1,7 +1,7 @@
 from http import HTTPStatus
 
 import pytest
-from werkzeug.exceptions import InternalServerError
+from pbench.server.api.resources import APIAbort
 
 from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleNamespace,
@@ -764,9 +764,9 @@ class TestSampleValues(Commons):
         test = Dataset.query(name="test")
 
         # When server index_map is None we expect 500
-        with pytest.raises(InternalServerError) as exc:
+        with pytest.raises(APIAbort) as exc:
             self.cls_obj.get_index(test, self.index_from_metadata)
-        assert exc.value.code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert exc.value.http_status == HTTPStatus.INTERNAL_SERVER_ERROR
 
         Metadata.setvalue(
             dataset=test,


### PR DESCRIPTION
As mentioned in [#2529](https://github.com/distributed-system-analysis/pbench/issues/2529) comments,
Implemented fix  for this `/datasets/contents` API request :

- Moved `abort()` to the top-level API handling function
- Implemented an `InvalidAPIRequest` Exception.
- Created multiple unit tests for this API based on various edge cases with run_id

Resolves #2529