### PR TITLE
PBENCH-158 Wait for TDS to terminate gracefully

### DIFF
--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -172,8 +172,9 @@ assert _def_orchestrate_choice in _orchestrate_choices, (
 )
 
 # Wait at most 60 seconds for the Tool Data Sink to start listening on its
-# logging sink channel.
+# logging sink channel and then to exit after terminate message is sent.
 _TDS_STARTUP_TIMEOUT = 60
+_TDS_TERMINATE_TIMEOUT = 60
 
 
 class ReturnCode(BaseReturnCode):
@@ -513,6 +514,40 @@ class ToolDataSink(BaseServer):
                     continue
                 break
         return 0 if status == "success" else 1
+
+    @staticmethod
+    def is_running(pid: int) -> bool:
+        """Is the given PID running?
+
+        See https://stackoverflow.com/questions/7653178/wait-until-a-certain-process-knowing-the-pid-end
+
+        Return True if a PID is running, else False if not.
+        """
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        return True
+
+    @staticmethod
+    def wait_for_pid(pid: int) -> bool:
+        """wait for a process to actually stop running, but eventually give up
+        to avoid a hang."""
+        running = True
+        timeout = time.time() + _TDS_STARTUP_TIMEOUT
+        while running:
+            running = __class__.is_running(pid)
+            if running:
+                if time.time() >= timeout:
+                    break
+                time.sleep(0.1)
+        return running
+
+    def shutdown_tds(self, status: int) -> None:
+        """Make sure TDS is shut down; wait for it to stop running on its own
+        and kill it if the wait times out."""
+        if self.wait_for_pid(self.get_pid()):
+            self.kill(status)
 
 
 class RedisServer(RedisServerCommon):
@@ -1095,7 +1130,8 @@ def main(_prog: str, cli_params: Namespace) -> int:
                 )
 
             recovery.add(
-                lambda: tool_data_sink.kill(ReturnCode.KEYBOARDINTERRUPT), "stop TDS"
+                lambda: tool_data_sink.shutdown_tds(ReturnCode.KEYBOARDINTERRUPT),
+                "stop TDS",
             )
 
         # We haven't yet started any remote clients; however, if we

--- a/lib/pbench/test/unit/agent/test_utils.py
+++ b/lib/pbench/test/unit/agent/test_utils.py
@@ -97,17 +97,21 @@ class TestBaseServer:
         with pytest.raises(AssertionError):
             bs.kill(1)
 
-        bs = OurServer("localhost", "localhost")
         pidfile = tmp_path / "test.pid"
+
+        bs = OurServer("localhost", "localhost")
         pidfile.write_text("12345")
         bs.pid_file = pidfile
         ret = bs.kill(42)
         assert ret == 42
 
+        bs = OurServer("localhost", "localhost")
+        bs.pid_file = pidfile
         pidfile.write_text("badpid")
         ret = bs.kill(42)
         assert ret == (BaseReturnCode.KILL_BADPID * 100) + 42
 
+        bs = OurServer("localhost", "localhost")
         bs.pid_file = tmp_path / "enoent.pid"
         ret = bs.kill(42)
         assert ret == 42
@@ -119,10 +123,12 @@ class TestBaseServer:
             def read_text(self):
                 raise self._exc
 
+        bs = OurServer("localhost", "localhost")
         bs.pid_file = MockPath(OSError(13, "fake oserror"))
         ret = bs.kill(42)
         assert ret == 342
 
+        bs = OurServer("localhost", "localhost")
         bs.pid_file = MockPath(Exception("fake exception"))
         ret = bs.kill(42)
         assert ret == 142
@@ -179,8 +185,6 @@ class TestBaseServer:
                     else:
                         raise ProcessLookupError(pid)
 
-        bs.pid_file = pidfile
-
         test_cases = [
             ("1001", 42, "Kill a pid that is found, successfully"),
             ("1002", 42, "Kill a pid that is not found, successfully"),
@@ -200,6 +204,8 @@ class TestBaseServer:
             ("1006", 542, "Exception raised killing a pid w KILL"),
         ]
         for pid_text, ret_code, desc in test_cases:
+            bs = OurServer("localhost", "localhost")
+            bs.pid_file = pidfile
             pidfile.write_text(pid_text)
             mock_time = MockTime()
             mock_kill = MockKill(pid_text)


### PR DESCRIPTION
Instead of lobbing a "terminate" message and then almost immediately killing the TDS and Redis, wait (for up to 60 seconds) for the TDS to terminate on its own, giving it time to contact the remote clients and shut down gracefully.

PBENCH-158 #in-progress #time 3h