### PR TITLE
Ensure `args` parameter is sent on terminate

### DIFF
--- a/agent/util-scripts/pbench-tool-meister-start
+++ b/agent/util-scripts/pbench-tool-meister-start
@@ -708,7 +708,12 @@ def terminate_no_wait(
         redis_client: Redis client
         key: TDS Redis pubsub key
     """
-    terminate_msg = {"action": "terminate", "group": group, "directory": None}
+    terminate_msg = {
+        "action": "terminate",
+        "group": group,
+        "directory": None,
+        "args": {"interrupt": False},
+    }
     try:
         ret = redis_client.publish(
             key,


### PR DESCRIPTION
Currently the `args` parameter is required, though this code is not tested in our unit tests.