### PR TITLE
Record the Tool Meister data in Redis

### DIFF
--- a/lib/pbench/agent/constants.py
+++ b/lib/pbench/agent/constants.py
@@ -21,6 +21,8 @@ tm_channel_suffix_to_tms = "to-tms"
 tm_channel_suffix_from_tms = "from-tms"
 # Channel suffix for the Tool Meister logging channel
 tm_channel_suffix_to_logging = "to-logging"
+# Tool-Meisters info key
+tm_data_key = "tool-meister-data-key"
 
 # List of allowed actions from the Pbench Agent CLI commands.
 cli_tm_allowed_actions = frozenset(("start", "stop", "send"))

--- a/lib/pbench/agent/tool_data_sink.py
+++ b/lib/pbench/agent/tool_data_sink.py
@@ -39,6 +39,7 @@ from pbench.agent.constants import (
     tm_channel_suffix_to_client,
     tm_channel_suffix_to_logging,
     tm_channel_suffix_to_tms,
+    tm_data_key,
 )
 from pbench.agent.redis_utils import RedisChannelSubscriber, wait_for_conn_and_key
 from pbench.agent.toolmetadata import ToolMetadata
@@ -1252,6 +1253,9 @@ class ToolDataSink(Bottle):
             # Record the collected information about the Tool Meisters in the
             # run directory.
             self._tm_tracking = self.record_tms(tms)
+            self.redis_server.set(
+                tm_data_key, json.dumps(self._tm_tracking, sort_keys=True)
+            )
             self._num_tms = len(self._tm_tracking.keys())
 
             # Tell the entity that started us who we are, indicating we're


### PR DESCRIPTION
In order to enable other work that relies on the Tool Meister data collected by the Tool Data Sink, we set the "tool-meister-data" key in Redis without any other changes.

This pulls out a very small portion of work from PR #2659.