### PR TITLE
Add the new `pbench-tools-kill` command

### DIFF
--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 import re
 import shutil
-from typing import Iterable
+from typing import Iterable, Optional
 
 
 class BadToolGroup(Exception):
@@ -20,7 +20,7 @@ class ToolGroup:
     TOOL_GROUP_PREFIX = "tools-v1"
 
     @staticmethod
-    def verify_tool_group(name: str, pbench_run: str = None) -> Path:
+    def verify_tool_group(name: str, pbench_run: Optional[str] = None) -> Path:
         """verify_tool_group - given a tool group name, verify it exists in the
         ${pbench_run} directory as a properly prefixed tool group directory
         name.
@@ -57,7 +57,7 @@ class ToolGroup:
             else:
                 return tg_dir
 
-    def __init__(self, name: str, pbench_run: str = None):
+    def __init__(self, name: str, pbench_run: Optional[str] = None):
         """Construct a ToolGroup object from the on-disk data of the given
         tool group.
 
@@ -182,6 +182,5 @@ def gen_tool_groups(pbench_run: str) -> Iterable[ToolGroup]:
     """
     for tg_dir in Path(pbench_run).glob(f"{ToolGroup.TOOL_GROUP_PREFIX}-*"):
         # All on-disk tool group directories will have names that look like
-        # above, where the prefix also contains a '-'.  To strip the prefix,
-        # we split the string and use the last component of the split.
-        yield ToolGroup(tg_dir.name.split("-", 2)[2], pbench_run)
+        # above.
+        yield ToolGroup(tg_dir.name[len(ToolGroup.TOOL_GROUP_PREFIX) + 1 :], pbench_run)

--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -76,7 +76,7 @@ class ToolGroup:
 
         Raises BadToolGroup via the verify_tool_group() method on error.
         """
-        self.tg_dir = ToolGroup.verify_tool_group(name, pbench_run)
+        self.tg_dir = self.verify_tool_group(name, pbench_run)
         self.name = name
 
         # __trigger__

--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -19,7 +19,7 @@ class ToolGroup:
     TOOL_GROUP_PREFIX = "tools-v1"
 
     @staticmethod
-    def verify_tool_group(name, pbench_run=None):
+    def verify_tool_group(name: str, pbench_run: str = None) -> Path:
         """verify_tool_group - given a tool group name, verify it exists in the
         ${pbench_run} directory as a properly prefixed tool group directory
         name.
@@ -56,7 +56,7 @@ class ToolGroup:
             else:
                 return tg_dir
 
-    def __init__(self, name):
+    def __init__(self, name: str, pbench_run: str = None):
         """Construct a ToolGroup object from the on-disk data of the given
         tool group.
 
@@ -75,7 +75,7 @@ class ToolGroup:
 
         Raises BadToolGroup via the verify_tool_group() method on error.
         """
-        self.tg_dir = self.verify_tool_group(name)
+        self.tg_dir = ToolGroup.verify_tool_group(name, pbench_run)
         self.name = name
 
         # __trigger__

--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+from typing import Iterable
 
 
 class BadToolGroup(Exception):
@@ -173,3 +174,14 @@ class ToolGroup:
             0
         """
         shutil.copytree(str(self.tg_dir), target_dir / self.tg_dir.name, symlinks=False)
+
+
+def gen_tool_groups(pbench_run: str) -> Iterable[ToolGroup]:
+    """Generate a series of ToolGroup objects for each on-disk tool group
+    found in the given pbench run directory.
+    """
+    for tg_dir in Path(pbench_run).glob(f"{ToolGroup.TOOL_GROUP_PREFIX}-*"):
+        # All on-disk tool group directories will have names that look like
+        # above, where the prefix also contains a '-'.  To strip the prefix,
+        # we split the string and use the last component of the split.
+        yield ToolGroup(tg_dir.name.split("-", 2)[2], pbench_run)

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -1,0 +1,249 @@
+# -*- mode: python -*-
+
+"""Tool Meister "Kill"
+
+Module responsible for hunting down and stopping all Tool Meisters, the Tool
+Data Sink, and the Redis server orchestrated by pbench-tool-meister-start.
+
+This is a "big hammer" approach that is offered to users when they find the
+distributed system state of the Pbench Agent not working correctly.
+
+The algorithm is fairly straight-forward:
+
+  For each pbench run directory in ${pbench_run}
+  1. If the run was NOT orchestrated by pbench-tool-meister-start, ignore
+  2. Find the recorded pids for the Redis Server, Tool Data Sink, and local
+     Tool Meister in their respective pid files, and stop those processes
+     from running
+  3. Determine all the remote hosts used for that run
+  4. For each remote host:
+     a. `ssh` to that remote host
+     b. Stop the Tool Meister running on that host
+
+The pbench-tool-meister-start uses a UUID in the command line of all the
+remote Tool Meister processes. Any Tool Meister process with that UUID in its
+command line string will be stopped via `kill -KILL`, along with all of its
+child processes.
+"""
+
+from collections import defaultdict
+import pathlib
+import shlex
+from typing import Callable, List, Tuple
+
+import click
+import psutil
+
+from pbench.agent.base import BaseCommand
+from pbench.agent.tool_group import ToolGroup
+from pbench.agent.utils import LocalRemoteHost, TemplateSsh
+from pbench.cli.agent import CliContext, pass_cli_context
+from pbench.cli.agent.options import common_options
+
+
+def kill_family(proc: psutil.Process):
+    """Kill a parent process and all its children."""
+    try:
+        # Get the list of children of the parent before killing it.
+        children = list(proc.children())
+    except psutil.NoSuchProcess:
+        return
+    try:
+        proc.kill()
+    except psutil.NoSuchProcess:
+        pass
+    for child in children:
+        try:
+            child.kill()
+        except psutil.NoSuchProcess:
+            pass
+
+
+class PidSource:
+    """For a given PID file name keep track of discovered PIDs and UUIDs as
+    Tool Meister directories are `load()`ed.  The `killem()` method is invoked
+    by the caller at their discretion.
+
+    The `killem()` method clears out all accumlated data.
+    """
+
+    def __init__(self, file_name: str, display_name: str):
+        self.file_name = file_name
+        self.display_name = display_name
+        self.pids_by_uuid = {}
+        self.uuid_to_tmdir = {}
+
+    def load(self, tm_dir: pathlib.Path, uuid: str) -> bool:
+        """Load a PID from the given directory associated with the given UUID.
+
+        Records the loaded PID if it has a live process associated with it and
+        returns True, otherwise returns False.
+        """
+        try:
+            pid = (tm_dir / self.file_name).read_text()
+        except FileNotFoundError:
+            return False
+        try:
+            self.pids_by_uuid[uuid] = psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            return False
+        self.uuid_to_tmdir[uuid] = tm_dir
+        return True
+
+    def killem(self, echo: Callable[[str], None]) -> None:
+        """Kill all PIDs found, and their children."""
+        if not self.pids_by_uuid:
+            return
+        echo(f"Killing {self.display_name} PIDs ...")
+        pids_by_uuid, self.pids_by_uuid = self.pids_by_uuid, {}
+        uuid_to_tmdir, self.uuid_to_tmdir = self.uuid_to_tmdir, {}
+        for uuid, proc in pids_by_uuid.items():
+            pid = proc.pid
+            echo(f"\tKilling {pid} (from {uuid_to_tmdir[uuid]})")
+            try:
+                kill_family(proc)
+            except Exception as exc:
+                echo(f"\t\terror killing {pid}: {exc}", err=True)
+
+
+def gen_run_directories(pbench_run: pathlib.Path) -> Tuple[pathlib.Path, str]:
+    """Generate the list of run directories available under ${pbench_run},
+    yielding a Path object for that directory, along with its recorded
+    UUID.
+
+    Yields a tuple of the run directory Path object and associated UUID.
+    """
+    for entry in pbench_run.iterdir():
+        if not entry.is_dir():
+            continue
+        tm_dir = entry / "tm"
+        try:
+            uuid = (tm_dir / ".uuid").read_text()
+        except FileNotFoundError:
+            # This is either not a pbench run directory, or the Tool Meister
+            # sub-system was not orchestrated by pbench-tool-meister-start
+            # for this run.
+            continue
+        yield tm_dir, uuid
+
+
+def gen_host_names(tm_dir: pathlib.Path) -> str:
+    """Read the registered tool data saved for this run and return the list
+    of remote hosts.
+    """
+    run_dir = tm_dir.parent
+    tool_group_dirs = list(run_dir.glob(f"{ToolGroup.TOOL_GROUP_PREFIX}-*"))
+    if not tool_group_dirs:
+        return
+
+    lrh = LocalRemoteHost()
+
+    for tool_group_dir in tool_group_dirs:
+        tg_name = tool_group_dir.name.split("-", 2)[2]
+        tg = ToolGroup(tg_name, run_dir)
+        for host_name_k in tg.hostnames.keys():
+            host_name = str(host_name_k)
+            if lrh.is_local(host_name):
+                continue
+            yield host_name
+
+
+class KillTools(BaseCommand):
+    """Find and stop all orchestrated Tool Meister instances."""
+
+    def execute(self, uuids: List[str]) -> int:
+        """Execute the tools kill operation.
+
+        If any UUIDs are passed as arguments, we only want to look for, and
+        locally kill, processes having those UUIDs.
+
+        Without command line arguemnts, kill all the local PIDs from all the
+        discovered run directories.
+
+        All the Redis server PIDs are killed first, then the Tool Data Sinks,
+        and finally the local Tool Meisters.
+
+        We then remotely kill (via `ssh`) all the Tool Meisters by invoking
+        this same command on a remote host with the list of UUIDs found across
+        all runs involving that host.
+        """
+        if uuids:
+            # We have a list of UUIDs to kill, implying that we search locally
+            # by UUID and only kill those PIDs found with the UUID in their
+            # registered command line.
+            for proc in psutil.process_iter():
+                # Consider each command line element.
+                for el in proc.cmdline():
+                    for uuid in uuids:
+                        if uuid in el:
+                            pid = proc.pid
+                            click.echo(f"\tKilling {pid} with UUID '{uuid}'")
+                            try:
+                                kill_family(proc)
+                            except Exception as exc:
+                                click.echo(f"\t\terror killing {pid}: {exc}", err=True)
+            return 0
+
+        # All three dictionaries for PID files that might be found, in the
+        # order in which we'll kill their PIDs.
+        all_pids = [
+            PidSource("redis.pid", "redis server"),
+            PidSource("pbench-tool-data-sink.pid", "tool data sink"),
+            PidSource("tm.pid", "local tool meister"),
+        ]
+        local_pids = False
+        remote_tms = defaultdict(list)
+        for tm_dir, uuid in gen_run_directories(self.pbench_run):
+            # If a run directory has any dangling components of the Tool
+            # Meister sub-system active, that is PID files for any local
+            # component, record those components.
+            for pidsrc in all_pids:
+                found = pidsrc.load(tm_dir, uuid)
+                if found:
+                    local_pids = True
+            # Find all the remotes for this run that need to be tracked down.
+            for host in gen_host_names(tm_dir.parent):
+                remote_tms[host].append(uuid)
+
+        if not local_pids and not remote_tms:
+            # No local or remote pids found, nothing to do.
+            return 0
+
+        # Kill all the local PIDs (and their children).
+
+        # We kill all the Redis Servers first in case killing them causes all
+        # the other processes to just exit on their own.  Then we kill all the
+        # Tool Data Sinks, and their children.  Then we kill all the (local)
+        # Tool Meisters, and their children.
+        for pidsrc in all_pids:
+            pidsrc.killem(click.echo)
+
+        # Kill all the remote Tool Meisters.
+
+        cmd = "pbench-tools-kill {{uuids}}"
+        template = TemplateSsh("ssh", shlex.split(self.ssh_opts), cmd)
+
+        # First fire off a number of background ssh processes, one per remote
+        # host.
+        remotes = []
+        for host, uuids in remote_tms.items():
+            click.echo(f"Killing all Tool Meister processes on remote host {host}...")
+            template.start(host, uuids=" ".join(uuids))
+            remotes.append(host)
+
+        # Wait for them all to complete, oldest to youngest.
+        for host in remotes:
+            template.wait(host)
+
+        return 0
+
+
+@click.command(
+    help="Ensure all instances of running tools are stopped locally or remotely"
+)
+@common_options
+@click.argument("uuids", nargs=-1)
+@pass_cli_context
+def main(ctxt: CliContext, uuids: List[str]):
+    status = KillTools(ctxt).execute(uuids)
+    click.get_current_context().exit(status)

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -29,7 +29,7 @@ will be stopped via `kill -KILL`, along with all of its child processes.
 from collections import defaultdict
 import pathlib
 import shlex
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, Iterable, List, Tuple
 
 import click
 import psutil
@@ -107,7 +107,7 @@ class PidSource:
                 echo(f"\t\terror killing {pid}: {exc}", err=True)
 
 
-def gen_run_directories(pbench_run: pathlib.Path) -> Tuple[pathlib.Path, str]:
+def gen_run_directories(pbench_run: pathlib.Path) -> Iterable[Tuple[pathlib.Path, str]]:
     """Generate the list of run directories available under ${pbench_run},
     yielding a Path object for that directory, along with its recorded
     UUID.
@@ -128,7 +128,7 @@ def gen_run_directories(pbench_run: pathlib.Path) -> Tuple[pathlib.Path, str]:
         yield tm_dir, uuid
 
 
-def gen_host_names(tm_dir: pathlib.Path) -> str:
+def gen_host_names(tm_dir: pathlib.Path) -> Iterable[str]:
     """Read the registered tool data saved for this run and return the list
     of remote hosts.
     """

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -198,7 +198,9 @@ class KillTools(BaseCommand):
         for tm_dir, uuid in gen_run_directories(self.pbench_run):
             # If a run directory has any dangling components of the Tool
             # Meister sub-system active, that is PID files for any local
-            # component, record those components.
+            # component, record those components.  NOTE: we use a list
+            # comprehension here to ensure that the .load() method is invoked
+            # on each PidSource object.
             local_pids |= any([pidsrc.load(tm_dir, uuid) for pidsrc in all_pids])
             # Find all the remotes for this run that need to be tracked down.
             for host in gen_host_names(tm_dir.parent):

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -159,7 +159,11 @@ class KillTools(BaseCommand):
         discovered run directories.
 
         All the Redis server PIDs are killed first, then the Tool Data Sinks,
-        and finally the local Tool Meisters.
+        and finally the local Tool Meisters.  We kill all the Redis Servers
+        first in case killing them causes all the other processes to just exit
+        on their own.  Then we kill all the Tool Data Sinks, and their
+        children.  Then we kill all the (local) Tool Meisters, and their
+        children.
 
         We then remotely kill (via `ssh`) all the Tool Meisters by invoking
         this same command on a remote host with the list of UUIDs found across
@@ -206,10 +210,6 @@ class KillTools(BaseCommand):
 
         # Kill all the local PIDs (and their children).
 
-        # We kill all the Redis Servers first in case killing them causes all
-        # the other processes to just exit on their own.  Then we kill all the
-        # Tool Data Sinks, and their children.  Then we kill all the (local)
-        # Tool Meisters, and their children.
         for pidsrc in all_pids:
             pidsrc.killem(click.echo)
 

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -195,10 +195,7 @@ class KillTools(BaseCommand):
             # If a run directory has any dangling components of the Tool
             # Meister sub-system active, that is PID files for any local
             # component, record those components.
-            for pidsrc in all_pids:
-                found = pidsrc.load(tm_dir, uuid)
-                if found:
-                    local_pids = True
+            local_pids |= any([pidsrc.load(tm_dir, uuid) for pidsrc in all_pids])
             # Find all the remotes for this run that need to be tracked down.
             for host in gen_host_names(tm_dir.parent):
                 remote_tms[host].append(uuid)

--- a/lib/pbench/cli/agent/commands/tools/kill.py
+++ b/lib/pbench/cli/agent/commands/tools/kill.py
@@ -45,7 +45,7 @@ def kill_family(proc: psutil.Process):
     """Kill a parent process and all its children."""
     try:
         # Get the list of children of the parent before killing it.
-        children = list(proc.children())
+        children = list(proc.children(recursive=True))
     except psutil.NoSuchProcess:
         return
     try:

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -140,14 +140,13 @@ class TestPidSource:
         for uuid, vals in pid_data.items():
             ps.load(AnotherPath(vals["dirname"], vals["pid"]), uuid)
         ps.killem(ourecho)
-        assert len(mock_kf.mock_calls) == 3
-        idx = 0
-        for uuid in pid_data.keys():
-            assert mock_kf.mock_calls[idx][1][0].pid == int(pid_data[uuid]["pid"])
-            idx += 1
-        # Verify a second call to killem() is a no-op.
-        ps.killem(ourecho)
         assert len(mock_kf.mock_calls) == len(pid_data)
+        for idx, uuid in enumerate(pid_data.keys()):
+            assert mock_kf.mock_calls[idx][1][0].pid == int(pid_data[uuid]["pid"])
+        # Verify a second call to killem() is a no-op.
+        mock_kf.reset_mock()
+        ps.killem(ourecho)
+        mock_kf.assert_not_called()
         captured = capsys.readouterr()
         expected_output = "Killing display this PIDs ...\n"
         for uuid, vals in pid_data.items():
@@ -209,8 +208,7 @@ class TestKillTools:
         monkeypatch.setattr(
             "pbench.cli.agent.commands.tools.kill.gen_tool_groups", mock_gen_tool_groups
         )
-        hosts = list(kill.gen_host_names(pathlib.Path("no-tool-group-dirs")))
-        assert len(hosts) == 0
+        assert not any(kill.gen_host_names(pathlib.Path("no-tool-group-dirs")))
 
     @staticmethod
     def test_gen_host_names(monkeypatch):

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -20,7 +20,14 @@ class AnotherPath:
     """
 
     def __init__(self, name: str, val: Optional[str] = None):
-        self.name = name
+        """Approximate mocked behavior of a Path object where the"""
+        p = pathlib.Path(name)
+        self.parts = p.parts
+        self.name = p.name
+        if p.parent is p or name == ".":
+            self.parent = self
+        else:
+            self.parent = AnotherPath(str(p.parent))
         self.val = val
 
     def is_dir(self):
@@ -102,9 +109,9 @@ class TestKillTools:
     def test_gen_run_directories():
         class FakePbenchRun:
             """A very specific mock for a pbench_run Path object where we
-            leverage the AnotherPath class to yield a series of YAP objects
-            which respond as directories, passing along the value to be read
-            from a file they contain.
+            leverage the AnotherPath class to yield a series of AnotherPath
+            objects which respond as directories, passing along the value to
+            be read from a file they contain.
             """
 
             def __init__(self, dir_pairs: List[Tuple[str, str]]):
@@ -123,8 +130,16 @@ class TestKillTools:
             ]
         )
         pairs = list(kill.gen_run_directories(pr))
-        assert pairs[0][0].name == "run1/tm" and pairs[0][1] == "abcdef"
-        assert pairs[1][0].name == "run2/tm" and pairs[1][1] == "ghijkl"
+        assert (
+            pairs[0][0].parent.name == "run1"
+            and pairs[0][0].name == "tm"
+            and pairs[0][1] == "abcdef"
+        )
+        assert (
+            pairs[1][0].parent.name == "run2"
+            and pairs[1][0].name == "tm"
+            and pairs[1][1] == "ghijkl"
+        )
 
     @staticmethod
     def test_gen_host_names(monkeypatch):

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -1,7 +1,7 @@
 import pathlib
 import sys
 from typing import Any, Callable, Iterable, List, Optional, Tuple
-from unittest import mock
+from unittest.mock import MagicMock
 
 from click.testing import CliRunner
 import psutil
@@ -72,19 +72,21 @@ class TestPidSource:
         assert ps.load(mydir, "uuid1") is True
 
     @staticmethod
-    @mock.patch("pbench.cli.agent.commands.tools.kill.kill_family")
-    def test_noop_killem(mock_kf):
+    def test_noop_killem(monkeypatch):
+        mock_kf = MagicMock()
+        monkeypatch.setattr(kill, "kill_family", mock_kf)
         ps = kill.PidSource("this.pid", "display this")
         ps.killem(ourecho)
         assert not mock_kf.called
 
     @staticmethod
-    @mock.patch("pbench.cli.agent.commands.tools.kill.kill_family")
-    def test_killem(mock_kf, monkeypatch):
-        ps = kill.PidSource("this.pid", "display this")
+    def test_killem(monkeypatch):
+        mock_kf = MagicMock()
+        monkeypatch.setattr(kill, "kill_family", mock_kf)
         monkeypatch.setattr(
             "pbench.cli.agent.commands.tools.kill.psutil.Process", MyProcess
         )
+        ps = kill.PidSource("this.pid", "display this")
         ps.load(AnotherPath("fake_dir1", "123"), "uuid1")
         ps.load(AnotherPath("fake_dir2", "456"), "uuid2")
         ps.load(AnotherPath("fake_dir3", "789"), "uuid3")

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -25,7 +25,7 @@ class AnotherPath:
 
     def __init__(self, name: str, val: Optional[str] = None):
         """Approximate mocked behavior of a Path object where an actual Path
-        object is used provide the `name` and `parts` fields.
+        object is used to provide the `name` and `parts` fields.
         """
         p = pathlib.Path(name)
         self._str = str(p)
@@ -42,8 +42,9 @@ class AnotherPath:
         return not self.name.endswith((".uuid", ".pid", ".file"))
 
     def read_text(self) -> str:
-        """The read text value is return that was provided when the mock'd
-        object was created, otherwise a FileNotFoundError is raised.
+        """The read text value is returned using the value that was provided
+        when the mock'd object was created, otherwise a FileNotFoundError is
+        raised.
         """
         if self.val is None:
             raise FileNotFoundError(self.name)
@@ -202,8 +203,8 @@ class TestKillTools:
             """Override kill.gen_tool_groups definition to yield no ToolGroup
             objects.
             """
-            for hosts in []:
-                yield ToolGroup(hosts)
+            for group in []:
+                yield ToolGroup(group)
 
         monkeypatch.setattr(
             "pbench.cli.agent.commands.tools.kill.gen_tool_groups", mock_gen_tool_groups

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -280,7 +280,8 @@ class TestKillTools:
 
         def mock_gen_run_directories(
             run_dir: pathlib.Path,
-        ) -> List[Tuple[pathlib.Path, str]]:
+        ) -> Iterable[Tuple[pathlib.Path, str]]:
+            """Intentional generator which does not yield anything."""
             for run_dir in []:
                 yield run_dir, "uuid"
 
@@ -330,7 +331,7 @@ class TestKillTools:
 
         def mock_gen_run_directories(
             pbench_run_dir: pathlib.Path,
-        ) -> Tuple[pathlib.Path, str]:
+        ) -> Iterable[Tuple[pathlib.Path, str]]:
             for run_dir in [
                 (pathlib.Path("run0/tm"), "uuid1abc"),
                 (pathlib.Path("run1/tm"), "uuid2def"),

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -221,7 +221,8 @@ class TestKillTools:
                 self._children = children
                 self._do = do
 
-            def children(self):
+            def children(self, recursive: Optional[bool] = False):
+                assert recursive
                 if not self._children:
                     return
                 for child in self._children:

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -1,0 +1,440 @@
+import pathlib
+import sys
+from typing import Any, Callable, List, Optional, Tuple
+from unittest import mock
+
+from click.testing import CliRunner
+import psutil
+
+from pbench.cli.agent.commands.tools import kill
+
+
+def ourecho(msg: str, err: bool = False):
+    """Simplistic mock of click.echo."""
+    print(msg, file=(sys.stderr if err else sys.stdout))
+
+
+class AnotherPath:
+    """Another "Path" implementation to help unit tests mock the behavior of
+    Path based on the contents of the name argument given in the constructor.
+    """
+
+    def __init__(self, name: str, val: Optional[str] = None):
+        self.name = name
+        self.val = val
+
+    def is_dir(self):
+        return not self.name.endswith((".uuid", ".pid", ".file"))
+
+    def read_text(self):
+        if self.val is None:
+            raise FileNotFoundError(self.name)
+        return self.val
+
+    def __truediv__(self, arg: str):
+        return AnotherPath(f"{self.name}/{arg}", val=self.val)
+
+
+class MyProcess:
+    """Very simple psutil.Process object mock which only has a `pid` attribute."""
+
+    def __init__(self, pid: str):
+        self.pid = int(pid)
+
+
+class TestPidSource:
+    @staticmethod
+    def test_load_fnf():
+        mydir = AnotherPath("fake_dir")
+        ps = kill.PidSource("that.pid", "display that")
+        assert ps.load(mydir, "uuid1") is False
+
+    @staticmethod
+    def test_load_nsp():
+        class MyNoSuchProcess:
+            def __init__(self, pid: int):
+                raise psutil.NoSuchProcess(pid)
+
+        mydir = AnotherPath("fake_dir", "12345")
+        ps = kill.PidSource("that.pid", "display that")
+        with mock.patch(
+            "pbench.cli.agent.commands.tools.kill.psutil.Process", MyNoSuchProcess
+        ):
+            assert ps.load(mydir, "uuid1") is False
+
+    @staticmethod
+    def test_load_found():
+        mydir = AnotherPath("fake_dir", "67890")
+        ps = kill.PidSource("that.pid", "display that")
+        with mock.patch(
+            "pbench.cli.agent.commands.tools.kill.psutil.Process", MyProcess
+        ):
+            assert ps.load(mydir, "uuid1") is True
+
+    @staticmethod
+    @mock.patch("pbench.cli.agent.commands.tools.kill.kill_family")
+    def test_noop_killem(mock_kf):
+        ps = kill.PidSource("this.pid", "display this")
+        ps.killem(ourecho)
+        assert not mock_kf.called
+
+    @staticmethod
+    @mock.patch("pbench.cli.agent.commands.tools.kill.kill_family")
+    def test_killem(mock_kf):
+        ps = kill.PidSource("this.pid", "display this")
+        with mock.patch(
+            "pbench.cli.agent.commands.tools.kill.psutil.Process", MyProcess
+        ):
+            ps.load(AnotherPath("fake_dir1", "123"), "uuid1")
+            ps.load(AnotherPath("fake_dir2", "456"), "uuid2")
+            ps.load(AnotherPath("fake_dir3", "789"), "uuid3")
+            ps.killem(ourecho)
+        assert len(mock_kf.mock_calls) == 3
+        assert mock_kf.mock_calls[0][1][0].pid == 123
+        assert mock_kf.mock_calls[1][1][0].pid == 456
+        assert mock_kf.mock_calls[2][1][0].pid == 789
+
+
+class TestKillTools:
+    @staticmethod
+    def test_gen_run_directories():
+        class FakePbenchRun:
+            """A very specific mock for a pbench_run Path object where we
+            leverage the AnotherPath class to yield a series of YAP objects
+            which respond as directories, passing along the value to be read
+            from a file they contain.
+            """
+
+            def __init__(self, dir_pairs: List[Tuple[str, str]]):
+                self.dir_names = dir_pairs
+
+            def iterdir(self):
+                for name, val in self.dir_names:
+                    yield AnotherPath(name, val)
+
+        pr = FakePbenchRun(
+            [
+                ("abc.file", None),  # top level file
+                ("filenotf", None),  # directory with no .uuid file
+                ("run1", "abcdef"),  # directory with a file
+                ("run2", "ghijkl"),  # directory with a file
+            ]
+        )
+        pairs = list(kill.gen_run_directories(pr))
+        assert pairs[0][0].name == "run1/tm" and pairs[0][1] == "abcdef"
+        assert pairs[1][0].name == "run2/tm" and pairs[1][1] == "ghijkl"
+
+    @staticmethod
+    def test_gen_host_names():
+        class MockToolGroup:
+            """A simple ToolGroup mock to generate host names from different
+            tool group directories.
+            """
+
+            TOOL_GROUP_PREFIX = "tests-v9"
+
+            _named_sets = {
+                "light": {
+                    "remote1.example.com": None,
+                    "localhost.example.com": None,
+                },
+                "medium": {
+                    "remote2.example.com": None,
+                    "remote3.example.com": None,
+                },
+                "heavy": {"localhost.example.com": None},
+            }
+
+            _expected_hosts = set(
+                ("remote1.example.com", "remote2.example.com", "remote3.example.com")
+            )
+
+            def __init__(self, name: str, run_dir: Any):
+                self.hostnames = self._named_sets[name]
+
+        class MockPathGlob:
+            """Mock of a Path object to direct the `.glob()` method's behavior."""
+
+            def __init__(self, name: str):
+                self.name = name
+
+            def glob(self, prefix: str):
+                if self.name == "no-tool-group-dirs":
+                    # The special name which for a directory which "does not
+                    # have tool groups".
+                    return
+                for n in MockToolGroup._named_sets.keys():
+                    # Return the 3 tools groups that are found with the prefix
+                    # attached.
+                    yield AnotherPath(f"{prefix[:-2]}-{n}")
+
+        class MockPathForGlob:
+            """Mock of a Path object just to generate a parent object which
+            uses the MockPathGlob class.  We don't need a name for the object
+            itself, just need to hand out the parent when referenced.
+            """
+
+            def __init__(self, parent: str):
+                self.parent = MockPathGlob(parent)
+
+        class MockLocalRemoteHost:
+            """A simple mock for the LocalRemoteHost behaviors."""
+
+            def is_local(self, host_name: str):
+                return host_name.startswith("localhost")
+
+        # To verify the case where there are no tool groups created, we make a
+        # special Path object which will behavior like it has no tool groups.
+        hosts = list(kill.gen_host_names(MockPathForGlob("no-tool-group-dirs")))
+        assert len(hosts) == 0
+
+        with mock.patch(
+            "pbench.cli.agent.commands.tools.kill.ToolGroup", MockToolGroup
+        ), mock.patch(
+            "pbench.cli.agent.commands.tools.kill.LocalRemoteHost", MockLocalRemoteHost
+        ):
+            # Using the special Path object which does have tool groups, we
+            # verify that the expected generated list of remote hosts are all
+            # the expected hosts listed in the MockToolGroup class above.
+            hosts = set(kill.gen_host_names(MockPathForGlob("have-tool-group-dirs")))
+            assert hosts == MockToolGroup._expected_hosts
+
+    @staticmethod
+    def test_with_uuids():
+        """Verify UUID arguments work correctly.
+
+        The scenario we construct artificially starts with an invocation using
+        3 UUIDs, one won't be found.  The mocked-out `psutil.process_iter()`
+        will generate 3 PIDs, one of which will have child processes, which
+        will all operate normally with no expections.  Of the other two, one
+        will raise an expected exception, and the other will not be found.
+        """
+        action_list = []
+        uuid_list = ["uuid1abc", "uuid2def", "uuid3ghi"]
+
+        class MockProcess:
+            """Behavior mock for the `psutil.Process` class."""
+
+            def __init__(
+                self,
+                pid: int,
+                uuid: Optional[str] = None,
+                children: Optional[List[Any]] = None,
+                do: Optional[str] = None,
+            ):
+                self.pid = pid
+                self._uuid = uuid
+                self._children = children
+                self._do = do
+
+            def children(self):
+                if not self._children:
+                    return
+                for child in self._children:
+                    yield child
+
+            def cmdline(self):
+                return [
+                    "arg0",
+                    "arg1",
+                    "arg2" if not self._uuid else self._uuid,
+                    "arg3",
+                ]
+
+            def kill(self):
+                if self._do == "nosuch":
+                    action_list.append(("kill-nosuch", self.pid, self._uuid))
+                    raise psutil.NoSuchProcess(self.pid)
+                if self._do == "exc":
+                    action_list.append(("kill-except", self.pid, self._uuid))
+                    raise Exception("generic exception")
+                action_list.append(("kill", self.pid, self._uuid))
+
+        class mock_psutil:
+            """Even though the target `psutil` is a module, we just use a
+            class with a static method to duck-type it.
+            """
+
+            @staticmethod
+            def process_iter():
+                # First pid has 3 children
+                yield MockProcess(
+                    12345,
+                    uuid=uuid_list[0],
+                    children=[
+                        MockProcess(12346),
+                        MockProcess(12347),
+                        MockProcess(12348, do="nosuch"),
+                    ],
+                )
+                yield MockProcess(23456)
+                yield MockProcess(34567, uuid=uuid_list[1], do="exc")
+                yield MockProcess(45678, uuid=uuid_list[2], do="nosuch")
+
+        runner = CliRunner(mix_stderr=False)
+        with mock.patch("pbench.cli.agent.commands.tools.kill.psutil", mock_psutil):
+            result = runner.invoke(kill.main, uuid_list)
+        assert result.exit_code == 0
+        expected_action_list = [
+            ("kill", 12345, "uuid1abc"),
+            ("kill", 12346, None),
+            ("kill", 12347, None),
+            ("kill-nosuch", 12348, None),
+            ("kill-except", 34567, "uuid2def"),
+            ("kill-nosuch", 45678, "uuid3ghi"),
+        ]
+        assert action_list == expected_action_list, (
+            f"action_list={action_list!r},"
+            f" expected_action_list={expected_action_list!r},"
+            f" stdout={result.stdout!r},"
+            f" stderr={result.stdout!r}"
+        )
+
+    @staticmethod
+    def test_without_uuids_no_action():
+        """Exercise the code path where no run directories are found, so there
+        is nothing to kill.
+        """
+
+        class MockPidSource:
+            """No-op mock for PidSource."""
+
+            def __init__(self, file_name: str, display_name: str):
+                self.file_name = file_name
+                self.display_name = display_name
+
+        def mock_gen_run_directories(
+            run_dir: pathlib.Path,
+        ) -> List[Tuple[pathlib.Path, str]]:
+            return []
+
+        runner = CliRunner(mix_stderr=False)
+        with (
+            mock.patch("pbench.cli.agent.commands.tools.kill.PidSource", MockPidSource),
+            mock.patch(
+                "pbench.cli.agent.commands.tools.kill.gen_run_directories",
+                mock_gen_run_directories,
+            ),
+        ):
+            result = runner.invoke(kill.main)
+        assert (
+            result.exit_code == 0
+        ), f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+        assert (
+            result.stdout == ""
+        ), f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+
+    @staticmethod
+    def test_without_uuids_wi_action():
+        """Exercise the code paths for both local and remote PIDs to kill.
+
+        Since the PidSource object is mocked out, we just care that the
+        .load() and .killem() methods are invoked for all three PID sources.
+
+        For the remotes we just need to have a few remote hosts generated, one
+        with a single UUID, and another with multiple UUIDs.  We just care
+        that expected TemplateSsh object's .start() and .wait() methods are
+        called for the given hosts.
+        """
+        action_list = []
+
+        class MockPidSource:
+            """No-op mock for PidSource."""
+
+            def __init__(self, file_name: str, display_name: str):
+                self.file_name = file_name
+                self.display_name = display_name
+
+            def load(self, tm_dir: pathlib.Path, uuid: str) -> bool:
+                action_list.append(("load", self.file_name, str(tm_dir), uuid))
+                return True
+
+            def killem(self, echo: Callable[[str], None]) -> None:
+                action_list.append(("killem", self.display_name))
+
+        def mock_gen_run_directories(
+            pbench_run_dir: pathlib.Path,
+        ) -> Tuple[pathlib.Path, str]:
+            return [
+                (pathlib.Path("run0/tm"), "uuid1abc"),
+                (pathlib.Path("run1/tm"), "uuid2def"),
+                (pathlib.Path("run2/tm"), "uuid3ghi"),
+            ]
+
+        def mock_gen_host_names(run_dir: pathlib.Path) -> str:
+            hosts = {"run0": ["hostA", "hostB"], "run2": ["host3"]}
+            return hosts.get(run_dir.name, [])
+
+        class MockTemplateSsh:
+            def __init__(self, name: str, ssh_opts: List[str], cmd: str):
+                self.name = name
+                self.ssh_opts = ssh_opts
+                self.cmd = cmd
+
+            def start(self, host: str, **kwargs):
+                action_list.append(("start", host, repr(kwargs)))
+
+            def wait(self, host: str):
+                action_list.append(("wait", host))
+
+        runner = CliRunner(mix_stderr=False)
+        with (
+            mock.patch("pbench.cli.agent.commands.tools.kill.PidSource", MockPidSource),
+            mock.patch(
+                "pbench.cli.agent.commands.tools.kill.gen_run_directories",
+                mock_gen_run_directories,
+            ),
+            mock.patch(
+                "pbench.cli.agent.commands.tools.kill.gen_host_names",
+                mock_gen_host_names,
+            ),
+            mock.patch(
+                "pbench.cli.agent.commands.tools.kill.TemplateSsh", MockTemplateSsh
+            ),
+        ):
+            result = runner.invoke(kill.main, catch_exceptions=False)
+        assert (
+            result.exit_code == 0
+        ), f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+        expected_action_list = [
+            ("load", "redis.pid", "run0/tm", "uuid1abc"),
+            ("load", "pbench-tool-data-sink.pid", "run0/tm", "uuid1abc"),
+            ("load", "tm.pid", "run0/tm", "uuid1abc"),
+            ("load", "redis.pid", "run1/tm", "uuid2def"),
+            ("load", "pbench-tool-data-sink.pid", "run1/tm", "uuid2def"),
+            ("load", "tm.pid", "run1/tm", "uuid2def"),
+            ("load", "redis.pid", "run2/tm", "uuid3ghi"),
+            ("load", "pbench-tool-data-sink.pid", "run2/tm", "uuid3ghi"),
+            ("load", "tm.pid", "run2/tm", "uuid3ghi"),
+            ("killem", "redis server"),
+            ("killem", "tool data sink"),
+            ("killem", "local tool meister"),
+            ("start", "hostA", "{'uuids': 'uuid1abc'}"),
+            ("start", "hostB", "{'uuids': 'uuid1abc'}"),
+            ("start", "host3", "{'uuids': 'uuid3ghi'}"),
+            ("wait", "hostA"),
+            ("wait", "hostB"),
+            ("wait", "host3"),
+        ]
+        assert action_list == expected_action_list, (
+            f"action_list={action_list!r},"
+            f" stdout={result.stdout!r},"
+            f" stderr={result.stderr!r}"
+        )
+        expected_stdout = """Killing all Tool Meister processes on remote host hostA...
+Killing all Tool Meister processes on remote host hostB...
+Killing all Tool Meister processes on remote host host3...
+"""
+        assert result.stdout == expected_stdout, (
+            f"action_list={action_list!r},"
+            f" stdout={result.stdout!r},"
+            f" stderr={result.stderr!r}"
+        )
+
+    @staticmethod
+    def test_help():
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(kill.main, ["--help"])
+        assert result.exit_code == 0
+        assert str(result.stdout).startswith("Usage:")
+        assert not result.stderr_bytes

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -43,7 +43,7 @@ class AnotherPath:
 
     def read_text(self) -> str:
         """The read text value is returned using the value that was provided
-        when the mock'd object was created, otherwise a FileNotFoundError is
+        when the mocked object was created, otherwise a FileNotFoundError is
         raised.
         """
         if self.val is None:

--- a/lib/pbench/test/unit/agent/task/test_tools_kill.py
+++ b/lib/pbench/test/unit/agent/task/test_tools_kill.py
@@ -181,16 +181,17 @@ class TestKillTools:
             ]
         )
         pairs = list(kill.gen_result_tm_directories(pr))
+        assert len(pairs) == 2, f"Expected 2 TM directories, got: {pairs!r}"
         assert (
             pairs[0][0].parent.name == "res1"
             and pairs[0][0].name == "tm"
             and pairs[0][1] == "abcdef"
-        )
+        ), f"Unexpected TM directories: {pairs!r}"
         assert (
             pairs[1][0].parent.name == "res2"
             and pairs[1][0].name == "tm"
             and pairs[1][1] == "ghijkl"
-        )
+        ), f"Unexpected TM directories: {pairs!r}"
 
     @staticmethod
     def test_gen_host_names_no_tool_groups(monkeypatch):

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -125,7 +125,9 @@ class Test_ToolGroup:
             """Mocked directory check"""
             raise FileNotFoundError("Mock Path.resolve()")
 
-        monkeypatch.setattr(ToolGroup, "verify_tool_group", self.mock_verify_tool_group)
+        monkeypatch.setattr(
+            ToolGroup, "verify_tool_group", staticmethod(self.mock_verify_tool_group)
+        )
         monkeypatch.setattr(os, "listdir", lambda path: [])
         monkeypatch.setattr(Path, "is_dir", self.mock_is_dir)
         monkeypatch.setattr(Path, "read_text", mock_read_text)
@@ -134,7 +136,9 @@ class Test_ToolGroup:
 
     def test_target_trigger_empty_file(self, monkeypatch):
         """verify if the trigger file is empty"""
-        monkeypatch.setattr(ToolGroup, "verify_tool_group", self.mock_verify_tool_group)
+        monkeypatch.setattr(
+            ToolGroup, "verify_tool_group", staticmethod(self.mock_verify_tool_group)
+        )
         monkeypatch.setattr(os, "listdir", lambda path: [])
         monkeypatch.setattr(Path, "is_dir", self.mock_is_dir)
         monkeypatch.setattr(Path, "read_text", lambda path: "")
@@ -149,7 +153,9 @@ class Test_ToolGroup:
             """Mocked read file check"""
             return trigger_file_content
 
-        monkeypatch.setattr(ToolGroup, "verify_tool_group", self.mock_verify_tool_group)
+        monkeypatch.setattr(
+            ToolGroup, "verify_tool_group", staticmethod(self.mock_verify_tool_group)
+        )
         monkeypatch.setattr(os, "listdir", lambda path: [])
         monkeypatch.setattr(Path, "is_dir", self.mock_is_dir)
         monkeypatch.setattr(Path, "read_text", mock_read_text)
@@ -166,7 +172,9 @@ class Test_ToolGroup:
             """Mocked directory check"""
             raise FileNotFoundError("Mock Path.resolve()")
 
-        monkeypatch.setattr(ToolGroup, "verify_tool_group", self.mock_verify_tool_group)
+        monkeypatch.setattr(
+            ToolGroup, "verify_tool_group", staticmethod(self.mock_verify_tool_group)
+        )
         monkeypatch.setattr(os, "listdir", lambda path: [])
         monkeypatch.setattr(Path, "is_dir", mock_is_dir)
         monkeypatch.setattr(Path, "read_text", mock_read_text)
@@ -244,7 +252,9 @@ class Test_ToolGroup:
                 return opt_template.format(path.parent.name, path.name)
             raise AssertionError(f"Unexpected file in read_text() mock: {str(path)!r}")
 
-        monkeypatch.setattr(ToolGroup, "verify_tool_group", self.mock_verify_tool_group)
+        monkeypatch.setattr(
+            ToolGroup, "verify_tool_group", staticmethod(self.mock_verify_tool_group)
+        )
         monkeypatch.setattr(os, "listdir", mock_listdir)
         monkeypatch.setattr(Path, "is_dir", mock_is_dir)
         monkeypatch.setattr(Path, "read_text", mock_read_text)

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
@@ -269,7 +268,7 @@ class Test_ToolGroup:
         assert tg.get_label("bad-host") == ""
 
 
-def test_gen_tool_groups():
+def test_gen_tool_groups(monkeypatch):
     """Verify the tool group directory generator."""
 
     class MockPath:
@@ -307,15 +306,16 @@ def test_gen_tool_groups():
             self.name = name
             self.pbench_run = pbench_run
 
-    with mock.patch("pbench.agent.tool_group.Path", MockPath):
-        with mock.patch("pbench.agent.tool_group.ToolGroup", MockToolGroup):
-            # To verify the case where there are no tool groups created, we make
-            # a special Path object which will expose no tool groups.
-            tgs = list(gen_tool_groups(MockPath.NO_TOOL_GROUP_DIRS))
-            assert len(tgs) == 0
+    monkeypatch.setattr("pbench.agent.tool_group.Path", MockPath)
+    monkeypatch.setattr("pbench.agent.tool_group.ToolGroup", MockToolGroup)
 
-            # Using a Path object which does have tool groups, we verify that
-            # the expected generated list of Tool Group objects matches the list
-            # of names we expect.
-            names = {tg.name for tg in gen_tool_groups("some-pbench-run-dir")}
-            assert names == MockPath._names
+    # To verify the case where there are no tool groups created, we make
+    # a special Path object which will expose no tool groups.
+    tgs = list(gen_tool_groups(MockPath.NO_TOOL_GROUP_DIRS))
+    assert len(tgs) == 0
+
+    # Using a Path object which does have tool groups, we verify that
+    # the expected generated list of Tool Group objects matches the list
+    # of names we expect.
+    names = {tg.name for tg in gen_tool_groups("some-pbench-run-dir")}
+    assert names == MockPath._names

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -109,10 +109,11 @@ class Test_VerifyToolGroup:
 class Test_ToolGroup:
     """Verify ToolGroup class"""
 
-    def mock_verify_tool_group(name: str, pbench_run: Path):
+    @staticmethod
+    def mock_verify_tool_group(name: str, pbench_run: str) -> Path:
         return Path("/mock/pbench-agent")
 
-    def mock_is_dir(self: Path):
+    def mock_is_dir(self: Path) -> bool:
         """Mocked directory check"""
         return True
 

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -280,7 +280,7 @@ def test_gen_tool_groups():
         # The path name determines the behavior.
         NO_TOOL_GROUP_DIRS = "ntgd"
         # Tool group names that will be found by the `.glob()` method.
-        _names = set(("heavy", "light", "medium"))
+        _names = {"heavy", "light", "medium"}
 
         def __init__(self, name: str):
             self._name = name
@@ -317,5 +317,5 @@ def test_gen_tool_groups():
             # Using a Path object which does have tool groups, we verify that
             # the expected generated list of Tool Group objects matches the list
             # of names we expect.
-            names = set([tg.name for tg in gen_tool_groups("some-pbench-run-dir")])
+            names = {tg.name for tg in gen_tool_groups("some-pbench-run-dir")}
             assert names == MockPath._names

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from typing import Optional
 
 import pytest
 
@@ -110,7 +111,7 @@ class Test_ToolGroup:
     """Verify ToolGroup class"""
 
     @staticmethod
-    def mock_verify_tool_group(name: str, pbench_run: str) -> Path:
+    def mock_verify_tool_group(name: str, pbench_run: Optional[str] = None) -> Path:
         return Path("/mock/pbench-agent")
 
     def mock_is_dir(self: Path) -> bool:

--- a/lib/pbench/test/unit/agent/test_tool_group.py
+++ b/lib/pbench/test/unit/agent/test_tool_group.py
@@ -297,17 +297,15 @@ def test_gen_tool_groups():
             self.name = name
             self.pbench_run = pbench_run
 
-    with (
-        mock.patch("pbench.agent.tool_group.Path", MockPath),
-        mock.patch("pbench.agent.tool_group.ToolGroup", MockToolGroup),
-    ):
-        # To verify the case where there are no tool groups created, we make a
-        # special Path object which will expose no tool groups.
-        tgs = list(gen_tool_groups(MockPath.NO_TOOL_GROUP_DIRS))
-        assert len(tgs) == 0
+    with mock.patch("pbench.agent.tool_group.Path", MockPath):
+        with mock.patch("pbench.agent.tool_group.ToolGroup", MockToolGroup):
+            # To verify the case where there are no tool groups created, we make
+            # a special Path object which will expose no tool groups.
+            tgs = list(gen_tool_groups(MockPath.NO_TOOL_GROUP_DIRS))
+            assert len(tgs) == 0
 
-        # Using a Path object which does have tool groups, we verify that the
-        # expected generated list of Tool Group objects matches the list of
-        # names we expect.
-        names = set([tg.name for tg in gen_tool_groups("some-pbench-run-dir")])
-        assert names == MockPath._names
+            # Using a Path object which does have tool groups, we verify that
+            # the expected generated list of Tool Group objects matches the list
+            # of names we expect.
+            names = set([tg.name for tg in gen_tool_groups("some-pbench-run-dir")])
+            assert names == MockPath._names

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ console_scripts =
    pbench-results-move = pbench.cli.agent.commands.results.move:main
    pbench-results-push = pbench.cli.agent.commands.results.push:main
    pbench-server = pbench.cli.server.shell:main
+   pbench-tools-kill = pbench.cli.agent.commands.tools.kill:main
    pbench-user-create = pbench.cli.server.user_management:user_create
    pbench-user-delete = pbench.cli.server.user_management:user_delete
    pbench-user-list = pbench.cli.server.user_management:user_list


### PR DESCRIPTION
PBENCH-702

A new comprehensive command to hunt down and kill any and all Tool Meister sub-system components running locally or remotely, based on the recorded pbench "result" data directories found in the configured `${pbench_run}` directory hierarchy.

For example, if there are 5 pbench result directories found in `${pbench_run}`, and two of those results have left-over processes still running locally or remotely, this command will find and kill them all without prejudice.

The new `pbench.agent.tool_group.gen_tool_groups` helper module method is added to encapsulate searching for tool group data in result directories.