### PR TITLE
PBENCH-164 experiment with Jira linkage

### DIFF
--- a/lib/pbench/cli/agent/commands/cleanup.py
+++ b/lib/pbench/cli/agent/commands/cleanup.py
@@ -19,7 +19,7 @@ class Cleanup(BaseCommand):
             "%s deprecated, will be removed in future release in favor of pbench-clear-results",
             self.name,
         )
-        run_command("pbench-clear-results")
+        run_command("pbench-clear-results", self.logger)
 
 
 @click.command()


### PR DESCRIPTION
This is just an experiment to debug the Jira linkage to GitHub PRs,
although it happens to appear to relate to resolving an issue found
during a recent refactoring exercise. (Note that the `run_command`
function seems to be called in only one place, which provides only
a string for "args"; I was tempted to remove `env` and `name`
entirely and make `logger` required. That's probably not worth the
effort for 0.71, but when I thought of some minor change just to
test Jira integration, my mind wandered here.)