### PR TITLE
Get rid of the `pbench-perl-JSON-XS` dependency

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -23,16 +23,8 @@ Requires:  scl-utils, rh-python36
 Requires:  python3-pip
 %endif
 
-%if 0%{?fedora} == 0
-# NOT fedora
-%define perljsonxs pbench-perl-JSON-XS
-%else
-%define perljsonxs perl-JSON-XS
-%endif
-
-
 Requires:  bzip2, tar, xz, screen
-Requires:  perl, perl-JSON, %{perljsonxs}, perl-Time-HiRes, perl-Data-UUID
+Requires:  perl, perl-JSON, perl-JSON-XS, perl-Time-HiRes, perl-Data-UUID
 Requires:  net-tools, numactl, perf, psmisc, bc, sos, %{turbostatpkg}
 # The following are needed by UBI containers which are bare bones - most other
 # systems will probably already have them installed.

--- a/agent/rpm/rpm.mk
+++ b/agent/rpm/rpm.mk
@@ -36,11 +36,7 @@ _copr_user = ${USER}
 endif
 
 copr\
-copr-test \
-copr-interim \
-copr-index \
-copr-inotify \
-copr-dashboard:	$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
+copr-test:	$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
 	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 veryclean:: clean rpm-clean


### PR DESCRIPTION
All distros of interest now make perl-JSON-XS available either in
EPEL (for RHEL7) or in the CRB repo (for RHEL8 and above). The Fedoras
always had it available.

Delete obsolete targets in rpm.mk.