### PR TITLE
Move metadata creation to linpack.sh

### DIFF
--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -228,9 +228,10 @@ for thread in ${threads//,/ }; do
 
 		for client in ${clients//,/ }; do
 			if pbench-is-local "${client}"; then
+				\rm -f "${iteration_dir}/linpack.finished"
 				( cd "${iteration_dir}" && screen -dmS pbench-linpack ./linpack.sh )
 			else
-				ssh ${ssh_opts} ${client} "cd '${iteration_dir}' && screen -dmS pbench-linpack './linpack.sh'"
+				ssh ${ssh_opts} ${client} "cd '${iteration_dir}' && \rm -f linpack.finished && screen -dmS pbench-linpack './linpack.sh'"
 			fi
 		done
 

--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -254,7 +254,7 @@ for thread in ${threads//,/ }; do
 			client_result_dir="${sample_dir}/clients/${client}"
 			mkdir -p "${client_result_dir}"
 			if pbench-is-local "${client}"; then
-				cp "${iteration_dir}/"linpack.{out,meta} "${client_result_dir}"
+				mv "${iteration_dir}/"linpack.{out,meta} "${client_result_dir}"
 			else
 				scp ${scp_opts} "${client}:${iteration_dir}"/linpack.{out,meta} "${client_result_dir}"
 			fi

--- a/agent/bench-scripts/postprocess/linpack-prepare-input-file
+++ b/agent/bench-scripts/postprocess/linpack-prepare-input-file
@@ -151,14 +151,19 @@ cp -v ${linpack_binary} "${output_dir}${linpack_binary_file}"
 echo
 file "${output_dir}${linpack_binary_file}"
 echo
-echo "binary=${linpack_binary}" > "${output_dir}${linpack_metadata_file}"
+
+echo "Creating linpack script file"
+echo
+echo "#!/bin/bash" > "${output_dir}${linpack_script_file}"
+
+echo "echo binary='${linpack_binary}' > '${linpack_metadata_file}'" > "${output_dir}${linpack_script_file}"
 
 
 if [ "${use_omp}" != "y" -a "${use_omp}" != "n" ]; then
 	echo "ERROR: --use-omp must either by 'y' or 'n'!"
 	exit 5
 fi
-echo "use_omp=${use_omp}" >> "${output_dir}${linpack_metadata_file}"
+echo "echo use_omp='${use_omp}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 
 num_problem_sizes=$(echo "${problem_sizes}" | wc -w)
 num_leading_dimensions=$(echo "${leading_dimensions}" | wc -w)
@@ -171,19 +176,19 @@ if [ "${num_problem_sizes}" != "${num_leading_dimensions}" -o "${num_leading_dim
 else
 	number_of_tests=${num_problem_sizes}
 fi
-echo "problem_sizes=${problem_sizes}" >> "${output_dir}${linpack_metadata_file}"
-echo "leading_dimensions=${leading_dimensions}" >> "${output_dir}${linpack_metadata_file}"
-echo "run_samples=${run_samples}" >> "${output_dir}${linpack_metadata_file}"
-echo "alignment_values=${alignment_values}" >> "${output_dir}${linpack_metadata_file}"
+echo "echo problem_sizes='${problem_sizes}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
+echo "echo leading_dimensions='${leading_dimensions}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
+echo "echo run_samples='${run_samples}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
+echo "echo alignment_values='${alignment_values}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 
 numactl_cmd=""
 if [ -n "${numactl_args}" ]; then
 	numactl_cmd="numactl ${numactl_args}"
 fi
-echo "numactl_cmd=${numactl_cmd}" >> "${output_dir}${linpack_metadata_file}"
+echo "echo numactl_cmd='${numactl_cmd}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 
-echo "lininput_header=${lininput_header}" >> "${output_dir}${linpack_metadata_file}"
-echo "lininput_subheader=${lininput_subheader}" >> "${output_dir}${linpack_metadata_file}"
+echo "echo lininput_header='${lininput_header}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
+echo "echo lininput_subheader='${lininput_subheader}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 
 echo "${lininput_header}" > "${output_dir}${linpack_input_file}"
 echo "${lininput_subheader}" >> "${output_dir}${linpack_input_file}"
@@ -196,10 +201,6 @@ echo "${alignment_values} # alingment values (in KBytes)" >> "${output_dir}${lin
 echo "Linpack input file:"
 cat "${output_dir}${linpack_input_file}"
 echo
-
-echo "Creating linpack script file"
-echo
-echo "#!/bin/bash" > "${output_dir}${linpack_script_file}"
 
 if [ "${use_omp}" == "y" ]; then
 	echo "Enabling OMP..."
@@ -215,10 +216,10 @@ if [ "${use_omp}" == "y" ]; then
 	echo "export KMP_AFFINITY=${kmp_affinity}" >> "${output_dir}${linpack_script_file}"
 	echo
 
-	echo "kmp_affinity=${kmp_affinity}" >> "${output_dir}${linpack_metadata_file}"
+	echo "echo kmp_affinity='${kmp_affinity}' >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 else
-	echo "kmp_affinity=" >> "${output_dir}${linpack_metadata_file}"
-	echo "threads=" >> "${output_dir}${linpack_metadata_file}"
+	echo "echo kmp_affinity= >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
+	echo "echo threads= >> '${linpack_metadata_file}'" >> "${output_dir}${linpack_script_file}"
 fi
 
 cmd="${numactl_cmd} ./${linpack_binary_file} ${linpack_input_file}"

--- a/agent/bench-scripts/tests/pbench-linpack/test-65.pre
+++ b/agent/bench-scripts/tests/pbench-linpack/test-65.pre
@@ -3,6 +3,6 @@
 # Setup a fake install of linpack but with a stub for the expected executable.
 _linpack_dir=${_testtmp}/linpack
 mkdir ${_linpack_dir} || exit 1
-printf -- "#!/bin/bash\nexit 0\n" > ${_linpack_dir}/xlinpack_xeon64 || exit 1
+printf -- "#!/bin/bash\nfor ext in out meta finished; do touch '${_linpack_dir}/linpack'.$ext; done\nexit 0\n" > ${_linpack_dir}/xlinpack_xeon64 || exit 1
 chmod 775 ${_linpack_dir}/xlinpack_xeon64 || exit 1
 exit 0


### PR DESCRIPTION
to ensure we are not using outdated files let's move the linpack
metadata creation to the linpack.sh (part of it was already there)
and move the files instead of copying them. The main benefit here
should be not relying on files from previous iteration which might not
have been updated.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>

Add working unit tests for `--clients`