### PR TITLE
Remove `pbench-sysinfo-dump` reliance on `base`

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -241,6 +241,16 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-default/prometheus/prometheus.yml file contents
++++ mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='testhost.example.com'
+--- mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
++++ mock-run/sysinfo/end/testhost.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='testhost.example.com'
+--- mock-run/sysinfo/end/testhost.example.com/contents.lis file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/cp -rL /etc/ssh/ssh_config.d /var/tmp/pbench-test-utils/pbench/mock-run/
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -584,6 +584,46 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-lite/prometheus/prometheus.yml file contents
++++ mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-b.example.com'
+--- mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-c.example.com'
+--- mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/remote-a.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-a.example.com'
+--- mock-run/sysinfo/beg/remote-a.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='testhost.example.com'
+--- mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
++++ mock-run/sysinfo/end/blue:remote-b.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-b.example.com'
+--- mock-run/sysinfo/end/blue:remote-b.example.com/contents.lis file contents
++++ mock-run/sysinfo/end/red:remote-c.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-c.example.com'
+--- mock-run/sysinfo/end/red:remote-c.example.com/contents.lis file contents
++++ mock-run/sysinfo/end/remote-a.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-a.example.com'
+--- mock-run/sysinfo/end/remote-a.example.com/contents.lis file contents
++++ mock-run/sysinfo/end/testhost.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='testhost.example.com'
+--- mock-run/sysinfo/end/testhost.example.com/contents.lis file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/cp -rL /etc/ssh/ssh_config.d /var/tmp/pbench-test-utils/pbench/mock-run/
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -544,6 +544,26 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-lite/prometheus/prometheus.yml file contents
++++ mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-b.example.com'
+--- mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-c.example.com'
+--- mock-run/sysinfo/beg/red:remote-c.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/remote-a.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='remote-a.example.com'
+--- mock-run/sysinfo/beg/remote-a.example.com/contents.lis file contents
++++ mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
+sysinfo='block,security_mitigations,sos'
+sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'
+sysinfo_full_hostname='testhost.example.com'
+--- mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/cp -rL /etc/ssh/ssh_config.d /var/tmp/pbench-test-utils/pbench/mock-run/
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/dcgm-exporter

--- a/agent/util-scripts/test-bin/mock-cmd
+++ b/agent/util-scripts/test-bin/mock-cmd
@@ -23,7 +23,12 @@ _sleep = 0
 if _prog == "pbench-sysinfo-dump":
     tgtdir = Path(sys.argv[1])
     sysinfo = sys.argv[2]
-    (tgtdir / "contents.lis").write_text(sysinfo)
+    sysinfo_install_dir = os.environ.get("sysinfo_install_dir", "")
+    sysinfo_full_hostname = os.environ.get("sysinfo_full_hostname", "")
+    (tgtdir / "contents.lis").write_text(
+        f"sysinfo={sysinfo!r}\nsysinfo_install_dir={sysinfo_install_dir!r}\n"
+        f"sysinfo_full_hostname={sysinfo_full_hostname!r}\n"
+    )
 elif _prog in _sleepers or (_prog == "prometheus" and sys.argv[1] == "run"):
     _sleep = 9999
 

--- a/agent/util-scripts/tool-meister/pbench-sysinfo-dump
+++ b/agent/util-scripts/tool-meister/pbench-sysinfo-dump
@@ -1,6 +1,24 @@
 #!/bin/bash
 # -*- mode: shell-script; indent-tabs-mode: t; sh-basic-offset: 8; sh-indentation: 8; tab-width: 8 -*-
 
+# Installation directory.
+install_dir="$(realpath -e ${sysinfo_install_dir} 2> /dev/null)"
+if [[ ${?} -ne 0 ]]; then
+	printf -- "You must provide an installation directory that exists, \"%s\" is not a real path\n" "${sysinfo_install_dir}" >&2
+	exit 1
+fi
+if [[ ! -d "${install_dir}" ]]; then
+	printf -- "You must provide an installation directory that exists, \"%s\" does not\n" "${install_dir}" >&2
+	exit 1
+fi
+
+# Ensure we have a host name to use.
+if [[ -z "${sysinfo_full_hostname}" ]]; then
+	printf -- "You must provide a FQDN host name via 'sysinfo_full_hostname'\n" >&2
+	exit 1
+fi
+
+# Target directory where data should be written.
 dir="$(realpath -e ${1} 2> /dev/null)"
 if [[ ${?} -ne 0 ]]; then
 	printf -- "You must provide a directory that exists, \"%s\" is not a real path\n" "${1}" >&2
@@ -11,13 +29,15 @@ if [[ ! -d "${dir}" ]]; then
 	exit 1
 fi
 
+# Which pieces of system information should be collected. The options
+# available are the suffixes to all the collect_* functions.
 sysinfo="${2}"
 
-if [[ -z "${_PBENCH_UNIT_TESTS}" ]]; then
-	mode="${3}"
-else
-	# Force sequential mode for unit tests.
-	mode=""
+# Collection mode, serial or parallel.
+mode="${3}"
+if [[ "${mode}" != "serial" && "${mode}" != "parallel" ]]; then
+	printf -- "Invalid collection mode, \"%s\"\n" "${mode}" >&2
+	exit 1
 fi
 
 function collect_kernel_config {
@@ -115,7 +135,7 @@ function collect_sos {
 		_cksum_suffix="sha256"
 	fi
 
-	_name="pbench-${_pbench_full_hostname}"
+	_name="pbench-${sysinfo_full_hostname}"
 	_cmd="${dir}/sosreport-${_name}.cmd"
 	printf -- "%s" "${_sos_report_cmd}" > ${_cmd}
 	for mod in ${_modules}; do
@@ -146,8 +166,8 @@ function collect_sos {
 function collect_ara {
 	# collect data only when ara is installed
 	if python -c "import ara" &> /dev/null; then
-		ara_pb="${pbench_install_dir}/ansible/ara/ara.yml"
-		if [[ ! -d "${pbench_install_dir}" || ! -f ${ara_pb} ]]; then
+		ara_pb="${install_dir}/ansible/ara/ara.yml"
+		if [[ ! -d "${install_dir}" || ! -f ${ara_pb} ]]; then
 			printf -- "ERROR: ara playbook not found, '%s'\n" "${ara_pb}" >&2
 			return 1
 		fi
@@ -166,8 +186,8 @@ function collect_ara {
 }
 
 function collect_stockpile {
-	stockpile_playbook="${pbench_install_dir}/stockpile/stockpile.yml"
-	if [[ ! -d "${pbench_install_dir}" || ! -f ${stockpile_playbook} ]]; then
+	stockpile_playbook="${install_dir}/stockpile/stockpile.yml"
+	if [[ ! -d "${install_dir}" || ! -f ${stockpile_playbook} ]]; then
 		printf -- "ERROR: stockpile playbook not found, '%s'\n" "${stockpile_playbook}" >&2
 		return 1
 	fi
@@ -182,7 +202,7 @@ function collect_stockpile {
 	generate_inventory stockpile > ${INVENTORY}
 
 	stockpile_opts="stockpile_user=${USER} local_remote_user=${USER} host_remote_user=${USER} stockpile_output_path=${stockpile_output_path}"
-	stockpile_playbook="${pbench_install_dir}/stockpile/stockpile.yml"
+	stockpile_playbook="${install_dir}/stockpile/stockpile.yml"
 	echo "ansible-playbook -vv --extra-vars '"${stockpile_opts}"' -i ${INVENTORY} ${stockpile_playbook}" > ${dir}/stockpile/command
 	chmod +x ${dir}/stockpile/command
 
@@ -222,9 +242,9 @@ for item in ${sysinfo//,/ }; do
 	elif [[ "${item}" == "stockpile" ]]; then
 		:
 	elif [[ "${item}" == "insights" ]]; then
-                :
+		:
 	else
-		printf -- "bad sysinfo value, \"%s\"\n" "${item}" >&2
+		printf -- "WARNING: bad sysinfo value, \"%s\"; ignoring\n" "${item}" >&2
 		continue
 	fi
 	printf -- "collecting %s\n" "${item}"
@@ -235,6 +255,4 @@ for item in ${sysinfo//,/ }; do
 	fi
 done
 wait
-
-# FIXME - what?
-chmod -R 775 ${dir}
+exit 0

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -226,6 +226,11 @@ function _dump_logs {
             echo "--- ${pdir}/${file_dir}/${file_name} file contents" >> ${_testout}
         done
     done
+    for contents_lis in $(cd ${_testdir}; find */sysinfo -name contents.lis 2> /dev/null | sort); do
+        echo "+++ ${contents_lis} file contents" >> ${_testout}
+        cat ${_testdir}/${contents_lis} >> ${_testout} 2>&1
+        echo "--- ${contents_lis} file contents" >> ${_testout}
+    done
     if [[ -f ${_testlog} ]]; then
         echo "+++ test-execution.log file contents" >> ${_testout}
         cat ${_testlog} >> ${_testout} 2>&1

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -182,7 +182,7 @@ function _dump_logs {
         fi
     done
     local bm_run_dir="$(basename "${benchmark_run_dir}")"
-    for actionlog in $(cd ${_testdir}; find "${bm_run_dir}" \( -name 'stop.log' -o -name 'postprocess.log' \) 2> /dev/null | sort); do
+    for actionlog in $(cd ${_testdir} && find "${bm_run_dir}" \( -name 'stop.log' -o -name 'postprocess.log' \) 2> /dev/null | sort); do
         echo "+++ ${actionlog} file contents" >> ${_testout}
         cat ${_testdir}/${actionlog} >> ${_testout} 2>&1
         echo "--- ${actionlog} file contents" >> ${_testout}
@@ -218,7 +218,7 @@ function _dump_logs {
             continue
         fi
         pdir=$(basename "${persist_dir}")
-        for file in $(cd ${persist_dir}; find * ! -name '*.tar.xz' \( -type f -o -type l \) 2> /dev/null | sort); do
+        for file in $(cd ${persist_dir} && find * ! -name '*.tar.xz' \( -type f -o -type l \) 2> /dev/null | sort); do
             file_dir=$(dirname "${file}")
             file_name=$(basename "${file}")
             echo "+++ ${pdir}/${file_dir}/${file_name} file contents" >> ${_testout}
@@ -226,7 +226,7 @@ function _dump_logs {
             echo "--- ${pdir}/${file_dir}/${file_name} file contents" >> ${_testout}
         done
     done
-    for contents_lis in $(cd ${_testdir}; find */sysinfo -name contents.lis 2> /dev/null | sort); do
+    for contents_lis in $(cd ${_testdir} && find */sysinfo -name contents.lis 2> /dev/null | sort); do
         echo "+++ ${contents_lis} file contents" >> ${_testout}
         cat ${_testdir}/${contents_lis} >> ${_testout} 2>&1
         echo "--- ${contents_lis} file contents" >> ${_testout}

--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -1725,7 +1725,8 @@ class ToolMeister:
         try:
             with o_file.open("w") as ofp, e_file.open("w") as efp:
                 my_env = os.environ.copy()
-                my_env["pbench_install_dir"] = self.pbench_install_dir
+                my_env["sysinfo_install_dir"] = self.pbench_install_dir
+                my_env["sysinfo_full_hostname"] = self._params.hostname
                 cp = subprocess.run(
                     command,
                     cwd=instance_dir,


### PR DESCRIPTION
There are two environment variables provided by the `agent/base` script which `pbench-sysinfo-dump` was relying on to have in place.  One was explicitly set by the Tool Meister in the environment used to run the script, `pbench_install_dir`, the other was inherited, `_pbench_full_hostname`.

We change `pbench-sysinfo-dump` to use `sysinfo_install_dir` and `sysinfo_full_hostname` instead, with the Tool Meister setting those environment variables explicitly.

We also take the opportunity to remove a useless `_PBENCH_UNIT_TESTS` reference which is not used due to the existence of the mock, `agent/util-scripts/test-bin/pbench-sysinfo-dump`.