### PR TITLE
PBENCH-199 access server endpoints API, with local dev mode nodeJS mirror

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,6 +9,7 @@
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.26.1",
+    "nvm": "0.0.4",
     "patternfly": "^3.59.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -21,9 +22,12 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "server": "node server",
+    "dev": "npm run server & npm run start",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
+  "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": [
       "react-app",
@@ -41,5 +45,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "express": "^4.17.3"
   }
 }

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -30,6 +30,16 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!-- runtime endpoints config -->
+    <script type="text/javascript">
+      fetch("/api/v1/endpoints").then((response) => {
+        if (response.ok) {
+          response.text().then((data) => {
+            window.endpoints = JSON.parse(data);
+          });
+        }
+      });
+    </script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const axios = require('axios');
+require('dotenv').config()
+
+
+const app = express()
+app.get('/api/v1/endpoints', (req, res) => {
+    console.log('Mirror engaged: ', process.env.PBENCH_SERVER)
+    axios.get(
+            `${process.env.PBENCH_SERVER}/api/v1/endpoints`,
+            { headers: { 'Accept': 'application/json' } })
+        .then(endpoints => {
+            res.setHeader('Content-Type', 'application/json');
+            res.send(endpoints.data);
+        })
+        .catch(err => {
+            console.log('Error: ', err.message);
+        })
+})
+
+app.listen(3001, () => console.log('Mirror server running on localhost:3001'));

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -15,7 +15,7 @@ function App() {
  
   return (
     <div className="App">
-      Pbench Dashboard
+      <b>Pbench Dashboard for {window.endpoints.identification}</b>
       <MainLayout />
     </div> 
   );


### PR DESCRIPTION
This includes two pieces:

1. We introduce an early call to the server's /api/v1/endpoints API to identify the full URL for each functional API endpoint;
2. We introduce a nodeJS "mirror" that will run under local npm development mode to gather the endpoint configuration of a remote Pbench server.

For now, we demonstrate that we successfully fetched the endpoint definitions by adding the server's identification string to the "Pbench Dashboard" text. Essentially, to call `datasets/list` you'd now reference the API map as `window.endpoints.api.datasets_list`.

The idea here is that `.env` defines a `PBENCH_SERVER` environment variable to point to the actual Pbench server when running the dashboard in local dev mode. The `index.html` was "hacked" to read the server endpoints definition from `/api/v1/endpoints`. In a production mode, where the dashboard `index.html` and Javascript are loaded from the server, this will resolve directly to the server endpoints definitions. In dev mode (`npm run dev`) we'll start up a small nodeJS express "mirror" that simply listens on `localhost:3001/api/v1/endpoints`, makes the call to the endpoints API on the configured Pbench server, and returns the results. The `index.html` stores this data on the Javascript window object as `window.endpoints` for use anywhere in the Pbench dashboard application. (This was just the way it worked out in the old dashboard, from which I lifted the `index.html` code; if you have a better idea, let's do it.)

This adds a `"proxy"` definition to the `package.json`, which tells npm to proxy access to port 3001 (the express app) through the primary dashboard port (usually 3000) so the app will respond to the request on `window.origin`. This also adds `nvm` as a dependency, which (in the process of floundering to run this with apparently a very old npm) I found to ensure I was getting the right npm code.