### PR TITLE
Archive the input tool group data during start

### DIFF
--- a/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-53.txt
@@ -56,6 +56,10 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.out
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-default
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-default/prometheus_data.tar.xz
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-default
@@ -242,6 +246,13 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-default/prometheus/prometheus.yml file contents
++++ tools-v1-default/testhost.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-default/testhost.example.com/dcgm file contents
++++ tools-v1-default/testhost.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-default/testhost.example.com/mpstat file contents
 +++ mock-run/sysinfo/beg/testhost.example.com/contents.lis file contents
 sysinfo='block,security_mitigations,sos'
 sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'

--- a/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-56.txt
@@ -128,6 +128,20 @@ Collecting system information
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp_data.tar.xz
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus_data.tar.xz
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/remote
 /var/tmp/pbench-test-utils/pbench/remote/remote-a.example.com
@@ -592,6 +606,37 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-lite/prometheus/prometheus.yml file contents
++++ tools-v1-lite/remote-a.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-a.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/__label__ file contents
+blue
+--- tools-v1-lite/remote-b.example.com/__label__ file contents
++++ tools-v1-lite/remote-b.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-b.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/node-exporter file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-b.example.com/node-exporter file contents
++++ tools-v1-lite/remote-c.example.com/__label__ file contents
+red
+--- tools-v1-lite/remote-c.example.com/__label__ file contents
++++ tools-v1-lite/remote-c.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-c.example.com/dcgm file contents
++++ tools-v1-lite/remote-c.example.com/pcp file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-c.example.com/pcp file contents
++++ tools-v1-lite/testhost.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/testhost.example.com/dcgm file contents
++++ tools-v1-lite/testhost.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/testhost.example.com/mpstat file contents
 +++ mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
 sysinfo='block,security_mitigations,sos'
 sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'

--- a/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-57.txt
@@ -107,6 +107,20 @@ pbench-tool-meister-stop: system information not collected when --interrupt spec
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/pcp_data.tar.xz
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-lite/prometheus_data.tar.xz
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/remote
 /var/tmp/pbench-test-utils/pbench/remote/remote-a.example.com
@@ -552,6 +566,37 @@ scrape_configs:
     static_configs:
     - targets: ['testhost.example.com:9400']
 --- tools-lite/prometheus/prometheus.yml file contents
++++ tools-v1-lite/remote-a.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-a.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/__label__ file contents
+blue
+--- tools-v1-lite/remote-b.example.com/__label__ file contents
++++ tools-v1-lite/remote-b.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-b.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/node-exporter file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-b.example.com/node-exporter file contents
++++ tools-v1-lite/remote-c.example.com/__label__ file contents
+red
+--- tools-v1-lite/remote-c.example.com/__label__ file contents
++++ tools-v1-lite/remote-c.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-c.example.com/dcgm file contents
++++ tools-v1-lite/remote-c.example.com/pcp file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-c.example.com/pcp file contents
++++ tools-v1-lite/testhost.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/testhost.example.com/dcgm file contents
++++ tools-v1-lite/testhost.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/testhost.example.com/mpstat file contents
 +++ mock-run/sysinfo/beg/blue:remote-b.example.com/contents.lis file contents
 sysinfo='block,security_mitigations,sos'
 sysinfo_install_dir='/var/tmp/pbench-test-utils/opt/pbench-agent'

--- a/agent/util-scripts/gold/test-client-tool-meister/test-61.txt
+++ b/agent/util-scripts/gold/test-client-tool-meister/test-61.txt
@@ -28,6 +28,20 @@ ERROR - "pbench-tool-meister-start --sysinfo='block,security_mitigations,sos' 'l
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.err
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.logs
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.out
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-a.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-b.example.com/node-exporter
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/__label__
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/remote-c.example.com/pcp
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/dcgm
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-lite/testhost.example.com/mpstat
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/remote
 /var/tmp/pbench-test-utils/pbench/remote/remote-a.example.com
@@ -279,6 +293,37 @@ testhost.example.com INFO pbench-tool-meister __exit__ -- testhost.example.com: 
 --- mock-run/tm/tm.logs file contents
 +++ mock-run/tm/tm.out file contents
 --- mock-run/tm/tm.out file contents
++++ tools-v1-lite/remote-a.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-a.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/__label__ file contents
+blue
+--- tools-v1-lite/remote-b.example.com/__label__ file contents
++++ tools-v1-lite/remote-b.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-b.example.com/mpstat file contents
++++ tools-v1-lite/remote-b.example.com/node-exporter file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-b.example.com/node-exporter file contents
++++ tools-v1-lite/remote-c.example.com/__label__ file contents
+red
+--- tools-v1-lite/remote-c.example.com/__label__ file contents
++++ tools-v1-lite/remote-c.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/remote-c.example.com/dcgm file contents
++++ tools-v1-lite/remote-c.example.com/pcp file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/remote-c.example.com/pcp file contents
++++ tools-v1-lite/testhost.example.com/dcgm file contents
+--inst=/var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts
+--- tools-v1-lite/testhost.example.com/dcgm file contents
++++ tools-v1-lite/testhost.example.com/mpstat file contents
+--interval=42
+--options=forty-two
+--- tools-v1-lite/testhost.example.com/mpstat file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/cp -rL /etc/ssh/ssh_config.d /var/tmp/pbench-test-utils/pbench/mock-run/
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -50,6 +50,10 @@ pbench-tool-meister-stop: waiting for tool-data-sink (#####) to exit
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.logs
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.out
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-default
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-default/testhost.example.com/perf
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-default
@@ -272,6 +276,12 @@ testhost.example.com 0027 DEBUG pbench-tool-meister _send_client_status -- publi
 --- mock-run/tm/tm.logs file contents
 +++ mock-run/tm/tm.out file contents
 --- mock-run/tm/tm.out file contents
++++ tools-v1-default/testhost.example.com/mpstat file contents
+--- tools-v1-default/testhost.example.com/mpstat file contents
++++ tools-v1-default/testhost.example.com/perf file contents
+--record-opts="-a -freq=100 -g --event=branch-misses --event=cache-misses --event=instructions"
+--report-opts="-I -g"
+--- tools-v1-default/testhost.example.com/perf file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n perf

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -50,6 +50,10 @@ pbench-tool-meister-stop: waiting for tool-data-sink (#####) to exit
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.logs
 /var/tmp/pbench-test-utils/pbench/mock-run/tm/tm.out
 /var/tmp/pbench-test-utils/pbench/mock-run/tools-mygroup
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-mygroup
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-mygroup/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-mygroup/testhost.example.com/mpstat
+/var/tmp/pbench-test-utils/pbench/mock-run/tools-v1-mygroup/testhost.example.com/perf
 /var/tmp/pbench-test-utils/pbench/pbench.log
 /var/tmp/pbench-test-utils/pbench/tmp
 /var/tmp/pbench-test-utils/pbench/tools-v1-mygroup
@@ -272,6 +276,12 @@ testhost.example.com 0027 DEBUG pbench-tool-meister _send_client_status -- publi
 --- mock-run/tm/tm.logs file contents
 +++ mock-run/tm/tm.out file contents
 --- mock-run/tm/tm.out file contents
++++ tools-v1-mygroup/testhost.example.com/mpstat file contents
+--- tools-v1-mygroup/testhost.example.com/mpstat file contents
++++ tools-v1-mygroup/testhost.example.com/perf file contents
+--record-opts="-a -freq=100 -g --event=branch-misses --event=cache-misses --event=instructions"
+--report-opts="-I -g"
+--- tools-v1-mygroup/testhost.example.com/perf file contents
 +++ test-execution.log file contents
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n pbench-sysstat
 /var/tmp/pbench-test-utils/opt/pbench-agent/unittest-scripts/rpm --query --queryformat=%{EVR}\n perf

--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 
 from pathlib import Path
 
@@ -154,3 +155,22 @@ class ToolGroup:
         that host.
         """
         return self.labels.get(host, "")
+
+    def archive(self, target_dir: Path):
+        """Copy the entire tool group on-disk state to the target directory.
+        No interpretation is applied.
+
+        This is intentionally a convenience layer around shutil.copytree.
+
+        For example:
+
+            obj.tg_dir = "/a/b/tools-v1-red"
+            target_dir = "/d/e/target_dir"
+
+            obj.archive(target_dir)
+
+            $ diff -r /a/b/tools-v1-red /d/e/target_dir/tools-v1-red
+            $ echo ${?}
+            0
+        """
+        shutil.copytree(str(self.tg_dir), target_dir / self.tg_dir.name, symlinks=False)

--- a/lib/pbench/agent/tool_meister_start.py
+++ b/lib/pbench/agent/tool_meister_start.py
@@ -1084,6 +1084,14 @@ def start(_prog: str, cli_params: Namespace) -> int:
         # -
 
         logger.debug("4. push tool group data and metadata")
+
+        # First we copy the entire directory hierarchy to the benchmark run
+        # directory. We do this as part of the start-up since we don't want to
+        # rely on the Tool Data Sink for recording the processed version of
+        # this data in the metadata.log file.  We need to have this on hand to
+        # determine what the inputs were to the start operation.
+        tool_group.archive(benchmark_run_dir)
+
         tool_group_data = dict()
         for host, params in tool_group.hostnames.items():
             tools = tool_group.get_tools(host)


### PR DESCRIPTION
We archive the valid tool group data when we start the Tool Meister sub-system so that we have a record of the inputs used during orchestration.  We don't want to rely on the Tool Data Sink to save that for us.