### PR TITLE
Clarify that md5sum() takes a Path not a string

### DIFF
--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import click
 
 from pbench.agent.base import BaseCommand
@@ -37,7 +39,14 @@ class ResultsPush(BaseCommand):
 @click.argument("controller")
 @click.argument(
     "result_tb_name",
-    type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True),
+    type=click.Path(
+        path_type=Path,
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+    ),
 )
 @pass_cli_context
 def main(

--- a/lib/pbench/common/utils.py
+++ b/lib/pbench/common/utils.py
@@ -5,6 +5,7 @@ from collections import deque
 import hashlib
 import ipaddress
 from logging import Logger
+from pathlib import Path
 import re
 from typing import Callable, Deque, NamedTuple
 
@@ -16,7 +17,7 @@ class Md5Result(NamedTuple):
     md5_hash: str
 
 
-def md5sum(filename: str) -> Md5Result:
+def md5sum(filename: Path) -> Md5Result:
     """
     Return the MD5 check-sum of a given file without reading the entire file
     into memory.

--- a/lib/pbench/test/unit/agent/task/test_make_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_make_result_tb.py
@@ -119,7 +119,7 @@ class TestMakeResultTb:
         assert tarball.samefile(expected_tb), f"{tarball} {expected_tb}"
         assert tarball.exists()
         assert tarball.stat().st_size == tarball_len and tarball_len > 0
-        calc_len, calc_md5 = md5sum(str(tarball))
+        calc_len, calc_md5 = md5sum(tarball)
         assert tarball_len == calc_len
         assert calc_md5 == tarball_md5
         with tarfile.open(str(tarball), "r:xz") as tf:


### PR DESCRIPTION
It turns out that _almost_ all callers of `md5sum()` pass in a `Path`, despite the fact that we declare it to accept a `str`.  Python's "duck typing" allows this to work, because what we actually require is a "path-like", and both `str`'s and `Path`'s qualify...but it's unsatisfying.  This PR makes it clear that `md5sum()` accepts a `Path` (and fixes the two inconsistent usages).