### PR TITLE
Steps to collect pbench-fio data

### DIFF
--- a/contrib/analysis/README
+++ b/contrib/analysis/README
@@ -1,0 +1,18 @@
+To collect pbench-fio data, use script.sh. 
+
+The script requires four parameters.
+
+es_host: Elasticsearch hostname
+es_port: Elasticsearch port
+url_prefix: Pbench server URL
+sos_host: Server where the sosreports are stored
+
+The order is given below.
+
+./script.sh <es_host> <es_port> <url_prefix> <sos_host>
+
+Example
+
+./script.sh elasticsearch.example.com 8000 http://pbench.example.com sos.example.com
+
+Please see the contents of script.sh for a description of its behavior.

--- a/contrib/analysis/collect_config_data.py
+++ b/contrib/analysis/collect_config_data.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+
+import os
+import re
+import sys
+import json
+import time
+import requests
+import tarfile
+import collections
+import pandas as pd
+import logging
+import multiprocessing
+
+
+def _strip(o):
+    return o.strip()
+
+
+def decode_bytes(inbytes):
+    try:
+        unibytes = inbytes.decode("utf-8")
+    except UnicodeDecodeError:
+        unibytes = inbytes.decode("iso8859-1")
+    return unibytes
+
+
+# collect data from the lscpu file
+def collect_lsblk(fobj):
+    data = dict()
+    lsblk_disks = []
+    for line in decode_bytes(fobj.read()).splitlines()[1:]:
+        parts = list(map(_strip, line.split(" ", 1)))
+        if parts[0] and parts[0][0].isalpha():
+           lsblk_disks.append(parts[0])
+    data['lsblk_disks'] = lsblk_disks
+    return data
+
+
+# collect data from the lsblk file
+def collect_lscpu(fobj):
+    data = dict()
+    physical = "True"
+    for line in decode_bytes(fobj.read()).splitlines():
+        parts = list(map(_strip, line.split(":", 1)))
+        featurename = parts[0].replace(" ", "_")
+        if featurename in ["Architecture", "Model_name"]:
+            data[featurename] = parts[1]
+        elif featurename in [
+            "CPU(s)",
+            "Core(s)_per_socket",
+            "Socket(s)",
+            "Thread(s)_per_core",
+            "NUMA_node(s)"   # recommended by Peter
+        ]:
+            data[featurename] = int(parts[1])
+        elif featurename in [
+            "L1d_cache",
+            "L1i_cache",
+            "L2_cache",
+            "L3_cache"
+        ]:
+            if "KiB" in parts[1]:
+                data[featurename] = int(parts[1][:-4])
+            elif "MiB" in parts[1]:
+                data[featurename] = int(parts[1][:-4])*1000
+            elif "M" in parts[1]:
+                data[featurename] = int(parts[1][:-1])*1000 # do not include M for megabytes
+            else:
+                data[featurename] = int(parts[1][:-1]) # do not include K for kilobytes
+        elif featurename == "Hypervisor_vendor":
+            physical = False
+    if physical:
+        data['Type'] = 'phy'
+    else:
+        data['Type'] = 'virt'
+    return data
+
+
+# collect data from the meminfo file
+def collect_meminfo(fobj):
+    data = dict()
+    for line in decode_bytes(fobj.read()).splitlines():
+        parts = list(map(_strip, line.split(":", 1)))
+        featurename = parts[0].replace(" ", "_")
+        if featurename == "MemTotal":
+            data[featurename] = int(parts[1][:-3])  # do not include kB
+    return data
+
+
+# collect system uuid from the dmidecode command output
+def collect_uuid(fobj):
+    data = dict()
+    blocks = decode_bytes(fobj.read()).split("\n\n")
+    for block in blocks[:-1]:
+        if block.splitlines()[1] == "System Information":
+            for line in block.splitlines()[2:]: # ignore first two lines
+                parts = list(map(_strip, line.split(':', 1)))
+                if parts[0] == 'UUID':
+                    data['UUID'] = parts[1]
+                    break
+    return data
+
+
+# collect kernel version from the uname_-a command output
+def collect_kernel_version(fobj):
+    data = dict()
+    line = decode_bytes(fobj.read())
+    parts = list(map(_strip, line.split()))
+    data["Static_hostname"] = parts[1]
+    data["Kernel"] = parts[0] + " " + parts[2]
+    return data
+
+
+# collect data from all the files with a single integer value
+def collect_single_value(fobj):
+    data = int(decode_bytes(fobj.read()))
+    return data
+
+
+# collect active tuned profile
+def collect_tuned_profile(fobj):
+    data = decode_bytes(fobj.read())
+    return data
+
+
+# collect scheduler type from the disk parameters
+def collect_scheduler(fobj):
+    data = dict()
+    scheduler = "Missing"
+    line = decode_bytes(fobj.read())
+    parts = list(map(_strip, line.split()))
+    for part in parts:
+        if part[0] == '[' and part[-1] == ']':
+            scheduler = part[1:-1]
+    data["scheduler"] = scheduler
+    return data
+
+
+# extract block parameters from block-params.log
+def extract_block_params(url, filenames):
+    data = dict()
+    # check if the page is accessible
+    r = requests.head(url, allow_redirects=True)
+    if r.status_code == 200: # successful
+        page = requests.get(url)
+        for line in page.iter_lines():
+            for name in filenames:
+                if name in line.decode():
+                    parts = list(map(_strip, (line.decode()).split()))
+                    head, tail = os.path.split(parts[0])
+                    if tail == 'scheduler':
+                        data[tail] = parts[1]
+                    else:
+                        data[tail] = int(parts[1])    
+    return data
+
+
+def collect_sosreport_data(rootdir, dirname, filenames, sos_with_runids, url_prefix):
+    record = dict()  # data from one sosreport
+    filesread = 0
+
+    # find the run id associated with the sosreport
+    for id in sos_with_runids:
+        if dirname in sos_with_runids[id]['sosreports'].keys():
+            run_id = id
+            time = sos_with_runids[id]['sosreports'][dirname]['time']
+            host = sos_with_runids[id]['sample.client_hostname']
+            shorthost = sos_with_runids[id]['sosreports'][dirname]['hostname-s']
+            disknames = sos_with_runids[id]['disknames']
+            controller_dir = sos_with_runids[id]['controller_dir']
+            runname = sos_with_runids[id]['run.name']
+
+    # check if run_id is set, otherwise no need to process the sosreport
+    if 'run_id' not in locals(): 
+        return dict()      
+
+    try:
+        with tarfile.open(os.path.join(rootdir, dirname)) as tar:
+
+            # store the run.id and sosreport name in the record
+            record['run_id'] = run_id
+            record['sosreport'] = dirname
+            record['time'] = time
+            record['host'] = host
+
+            for member in tar.getmembers():
+                parts = (member.name).split("/")
+                filename = "/".join(parts[1:])
+                if filename in filenames:
+		    
+                    f = tar.extractfile(member)
+
+                    # check if all the files needed exist and are not empty
+                    if f is None or member.size == 0:
+                        isvalid = False
+                        sys.stderr.write(
+                            "Error: Invalid sosreport:"
+                            f" {dirname}:{parts[-1]}"
+                            " file not found or is empty.\n")
+                        continue
+                    if parts[-1] == "meminfo":
+                        record.update(collect_meminfo(f))
+                    elif parts[-1] == "lscpu":
+                        record.update(collect_lscpu(f))
+                    elif parts[-1] == "lsblk":
+                        record.update(collect_lsblk(f))
+                        if len(record["lsblk_disks"]) == 1:
+                            record['disk'] = record["lsblk_disks"][0]
+                        elif len(list(set(disknames))) == 1 and \
+                            disknames[0] in record["lsblk_disks"]:
+                            record['disk'] = disknames[0]
+                        if 'disk' not in record.keys():
+                            record['disk'] = 'Missing'
+                        else:
+                            # replace sdX in filenames with the disk used
+                            for index, name in enumerate(filenames):
+                                filenames[index] = name.replace("sdX", record['disk'])
+                        record['lsblk_disks'] = ','.join(record['lsblk_disks'])
+                    elif parts[-1] == "uname_-a":
+                        record.update(collect_kernel_version(f))
+                    elif parts[-1] == "scheduler":
+                        record.update(collect_scheduler(f))
+                    elif parts[-1] == "active_profile":
+                        record["active_profile"] = collect_tuned_profile(f)
+                    else:
+                        record[parts[-1]] = collect_single_value(f)
+                    filesread += 1
+    except Exception:
+        logger.exception("Error working with sosreport %s", dirname)
+ 
+    # for cases where lsblk is empty or missing
+    if 'disk' not in record.keys():
+        return dict()
+
+    # Extract block parameters 
+    url = f"{url_prefix}/incoming/{controller_dir}/{runname}/sysinfo/end/{shorthost}/block-params.log" 
+    diskparams = extract_block_params(url, filenames)
+    record.update(diskparams)
+    filesread += len(diskparams)
+
+    return record
+
+
+def main(args, logger):
+    # Directory with sosreports
+    rootdir = args[1]  
+
+    # Mapping between runs and sosreports
+    with open(args[2]) as json_file: 
+        sos_with_runids = json.load(json_file)  
+ 
+    # URL prefix to fetch unpacked data
+    url_prefix = args[3]
+
+    filenames = [
+        "proc/meminfo",
+        "sos_commands/processor/lscpu",
+        "proc/sys/kernel/sched_rr_timeslice_ms",
+        "proc/sys/vm/nr_hugepages",
+        "proc/sys/vm/nr_overcommit_hugepages",
+        "proc/sys/vm/overcommit_memory",
+        "proc/sys/vm/dirty_ratio",
+        "proc/sys/vm/dirty_background_ratio",
+        "proc/sys/vm/overcommit_ratio",
+        "proc/sys/vm/max_map_count",
+        "proc/sys/vm/min_free_kbytes",
+        "proc/sys/vm/swappiness",
+        "proc/sys/fs/aio-max-nr",
+        "proc/sys/fs/file-max",
+        "proc/sys/kernel/msgmax",
+        "proc/sys/kernel/msgmnb",
+        "proc/sys/kernel/msgmni",
+        "proc/sys/kernel/shmall",
+        "proc/sys/kernel/shmmax",
+        "proc/sys/kernel/shmmni",
+        "proc/sys/kernel/threads-max",
+        "sos_commands/kernel/uname_-a",
+        "sos_commands/block/lsblk",
+        "sys/block/sdX/queue/add_random",
+        "sys/block/sdX/queue/iostats",
+        "sys/block/sdX/queue/max_sectors_kb",
+        "sys/block/sdX/queue/nomerges",
+        "sys/block/sdX/queue/nr_requests",
+        "sys/block/sdX/queue/optimal_io_size",
+        "sys/block/sdX/queue/read_ahead_kb",
+        "sys/block/sdX/queue/rotational",
+        "sys/block/sdX/queue/rq_affinity",
+        "sys/block/sdX/queue/scheduler",
+        "etc/tuned/active_profile" # recommended by Peter
+    ]
+
+    # stores output from all the sosreports 
+    result_list = []
+
+    scan_start = time.time()
+    pool = multiprocessing.Pool(multiprocessing.cpu_count()-1 or 1) # no. of processes to run in parellel
+
+    scan_count = 0
+    for direntry in os.scandir(rootdir):
+        if direntry.name.endswith(".md5"):
+            continue
+        #print(direntry.name)
+        scan_count += 1
+        result_list.append(pool.apply_async(collect_sosreport_data, 
+                                            args=(rootdir, direntry.name, filenames, sos_with_runids, url_prefix, )))
+
+    pool.close()  # no more parallel work to submit
+    pool.join()   # wait for the worker processes to terminate
+
+    database = dict()  # stores config data for all the pbench runs
+
+    for res in result_list: 
+        record = res.get()
+        if record:
+            run_id = record['run_id']
+            record.pop('run_id', None)
+
+            # Use config data only from sosreports collected at the 'end' of a run
+            if run_id not in database.keys() and \
+               record['time'] == 'end' and \
+               record['Static_hostname'] in record['host']: # since -1 might be appended at the end of record[host]
+                database[run_id] = record
+    
+    print ("Total records: " + str(len(database)))
+
+    # Find pbench runs for which we do not have sosreport information available
+    for id in sos_with_runids:
+        if id not in database.keys():
+            print (sos_with_runids[id])
+ 
+    scan_end = time.time()
+    duration = scan_end - scan_start
+    scan_rate = duration / scan_count if scan_count > 0 else 0
+    print(
+        f"--- sosreport scan took {duration:0.2f} seconds"
+        f" for {scan_count} sosreports ({scan_rate:0.2f} secs per rpt) ---"
+    )
+
+    # Exit if none of the sosreports is valid and the database is empty
+    if not database:
+        sys.stdout.write("None of the sosreports are valid.\nExiting now...\n")
+        return 0
+
+    # Form a dataframe using the data collected from all the files
+    df = pd.DataFrame(database.values(), index=database.keys())
+
+    # Print number of uniqe values for each feature
+    print(df.nunique())
+
+    # Covert dataframe to a csv file
+    df.to_csv(r"config.csv", sep=";", mode="a")
+
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    logger = logging.getLogger(os.path.basename(sys.argv[0]))
+    start_time = time.time()
+    status = main(sys.argv, logger)
+    duration = time.time() - start_time
+    print(f"--- {duration:0.2f} seconds ---")
+    sys.exit(status)

--- a/contrib/analysis/collect_config_data.py
+++ b/contrib/analysis/collect_config_data.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
 import os
-import re
 import sys
 import json
 import time
 import requests
 import tarfile
-import collections
 import pandas as pd
 import logging
 import multiprocessing

--- a/contrib/analysis/create_sos_with_runids.py
+++ b/contrib/analysis/create_sos_with_runids.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import collections
+
+def main(args):
+    # File containing pbench results and run data
+    filename = args[1]
+
+    records = []
+    for line in open(filename, 'r'):
+        records.append(json.loads(line)) 
+
+    sos_and_runids = dict()
+
+    for result in records:
+        if result["run.id"] not in sos_and_runids.keys(): # and len(data[resid]["hostnames"]) == 1:
+            sos_and_runids[result["run.id"]] = {"sosreports" : result["sosreports"],
+                                                "sample.client_hostname" : result["sample.client_hostname"],
+                                                "disknames" : result["disknames"],
+                                                "controller_dir" : result["controller_dir"],
+                                                "run.name" : result["run.name"],
+                                               }
+
+    # count sosreports associated with each run
+    count = []
+    for id in sos_and_runids:
+        count.append(len(sos_and_runids[id]['sosreports'].keys()))
+
+    counter = collections.Counter(count)
+    print(counter)
+          
+    with open('sos_and_runids.json', 'w') as outfile:
+        json.dump(sos_and_runids, outfile) 
+
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    status = main(sys.argv)   

--- a/contrib/analysis/merge.py
+++ b/contrib/analysis/merge.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import sys
+import csv
+import json
+import pandas as pd
+
+
+def main(args):
+    # File containing pbench results and run data
+    pbench_fio = args[1]
+
+    # File containing configuration data
+    config_data = args[2]
+
+    pbench_records = []
+    for line in open(pbench_fio, 'r'):
+        pbench_records.append(json.loads(line)) 
+
+    config_df = pd.read_csv(config_data, delimiter=';', index_col=0)
+    config_dict = config_df.to_dict('index')
+
+    pbench = dict()
+
+    index = 1
+    for result in pbench_records:
+        del result['sosreports']
+        for runid in config_dict:
+            # second condition elimintes runs/results with error in fio-result.txt
+            if result['run.id'] == runid and result['disknames']:
+                pbench[index] = result
+                pbench[index].update(config_dict[runid])
+                index = index + 1
+
+    # Form individual dataframes for different results using the dictionary
+    df = pd.DataFrame(pbench.values(), index=pbench.keys())
+    slat_df = df[df['sample.measurement_title'] == 'slat']
+    clat_df = df[df['sample.measurement_title'] == 'clat']
+    lat_df = df[df['sample.measurement_title'] == 'lat']
+    thr_df = df[df['sample.measurement_type'] == 'throughput']   
+
+    # Covert dataframes to csv files
+    slat_df.to_csv(r"latency_slat.csv", sep=";", mode="a")
+    clat_df.to_csv(r"latency_clat.csv", sep=";", mode="a")
+    lat_df.to_csv(r"latency_lat.csv", sep=";", mode="a")
+    thr_df.to_csv(r"throughput_iops_sec.csv", sep=";", mode="a")
+           
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    status = main(sys.argv)   

--- a/contrib/analysis/merge.py
+++ b/contrib/analysis/merge.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import sys
-import csv
 import json
 import pandas as pd
 

--- a/contrib/analysis/merge_sos_and_perf_parallel.py
+++ b/contrib/analysis/merge_sos_and_perf_parallel.py
@@ -466,7 +466,7 @@ def main(args):
     stats = dict()
 
     with open("sosreport_fio.txt", "w") as log, open(
-        "output_latest_fio.json", "w"
+        "pbench_fio.json", "w"
     ) as outfile:
         generator = process_results(
             es, now, session, incoming_url, pool, pbench_runs, stats

--- a/contrib/analysis/script.sh
+++ b/contrib/analysis/script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Steps to collect Pbench fio data.
+
+es_host=$1
+es_port=$2
+url_prefix=$3
+sos_host=$4
+
+# 1) The following code collects Pbench runs data and Pbench results data from Elasticsearch for the past one year. Pbench runs data gives us the mapping between runs and configuration data. Pbench results data gives us the performance results and workload metadata. The code generates two output files: "pbench_fio.json" and "sosreport_fio.txt". The first file contains complete information about a pbench run with sosreport names but missing configuration data. The second file contains the sosreport names to be copied from the production server. The code also extracts the disk name from fio-result.txt located in each individual sample (can only be accessed using a URL).
+
+./merge_sos_and_perf_parallel.py 1 $es_host $es_port $url_prefix;
+
+# 2) "sosreport_fio.txt" contains a list of all the sosreports from the past one year with pbench-fio results. Use the following command to figure out the unique set of sosreports that we should copy from the production server.
+
+sort sosreport_fio.txt | uniq > sos_fio.lis;
+
+# 3) Use the following command to copy all the sosreports listed in "sos_fio.lis" to your system.
+
+mkdir -p ./sosreports;
+while read sos; do scp vos@$sos_host:~/VoS/archive/${sos} ./sosreports/; done < sos_fio.lis;
+
+# 4) Use "pbench_fio.json" to generate "sos_and_runids.json" using <create_sos_with_runids.py>. You could modify the code to filter out certain runs. For example, runs with multiple clients.  
+
+./create_sos_with_runids.py pbench_fio.json;
+
+# 5) Run <collect_config_data.py> that takes in the directory "sosreports", "sos_and_runids.json" and the hostname to collect block parameters. It generates "config.csv" that contains configuration data.
+
+./collect_config_data.py sosreports/ sos_and_runids.json $url_prefix;
+
+# 6) To merge the information from sosreports, workload metadata and performance results, use <merge.py>. It takes in "config.csv" and "pbench_fio.json" and generates four files: "latency_slat.csv", "latency_clat.csv", "latency_lat.csv" and "throughput_iops_sec.csv".
+
+./merge.py pbench_fio.json config.csv;


### PR DESCRIPTION
This contains all the steps needed to combine the indexed Pbench data and on-disk configuration data. The output is a set of `.csv` files for each different `fio` result type.  Each `.csv` file contains workload metadata, configuration data and performance results. For example, you may see the following files generated as a result of running `script.sh`:

 * `latency_clat.csv`
 * `latency_lat.csv`
 * `latency_slat.csv`
 * `throughput_iops_sec.csv`