### PR TITLE
Add gunicorn logging

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -77,6 +77,10 @@ def main():
             "/run/pbench-server/gunicorn.pid",
             "--bind",
             f"{host}:{port}",
+            "--access-logfile",
+            "/var/log/pbench-server/access_log",
+            "--error-logfile",
+            "/var/log/pbench-server/error_log",
             "pbench.cli.server.shell:app()",
         ]
     )

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -94,6 +94,9 @@ cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 # for the npm install below
 mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
+# The %dir directive creates this directory on install, but needs a source
+mkdir -p %{buildroot}/var/log/pbench-server/
+
 %post
 # Install python dependencies as pbench user into user's site-packages
 
@@ -179,6 +182,8 @@ fi
 %files
 
 %defattr(644, pbench, pbench, 755)
+%dir /var/log/pbench-server
+
 /%{installdir}
 %attr(755, pbench, pbench) /%{installdir}/bin
 %attr(644, pbench, pbench) /%{installdir}/bin/pbench-base.sh


### PR DESCRIPTION
PBENCH-504

This is a small change to permanently add error and access logging to our gunicorn server infrastructure: something I've done ad-hoc many times to triage problems and just did yesterday twice during a long session helping Siddardh get his development VM set up (both on his VM and on mine, trying to figure out how I broke a Postman query).

I think we want to aim for something more "elegant", perhaps integrating gunicorn logging into our pbench-server syslog stream; but until someone gets motivated to work that out, this is simple and effective. (And better than nothing... or rather, better than repeatedly undoing "nothing" manually.)

(Note, it's also an experiment in trying to link to Jira from a ticket reference that's not in the header line of a git commit.)