### PR TITLE
Fix unit testing for email_validator

### DIFF
--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -192,6 +192,7 @@ def fake_email_validator(monkeypatch):
     """
     Set up a mock for the email validator so we control failure modes.
     """
+
     def fake_email(value: str, **kwargs) -> ValidatedEmail:
 
         # The email validation failure case needs to see an error

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -1,17 +1,19 @@
 from configparser import ConfigParser
-import datetime
 import hashlib
-from freezegun import freeze_time
 from http import HTTPStatus
 import os
 import uuid
 from pathlib import Path
 from posix import stat_result
-import pytest
 import shutil
 from stat import ST_MTIME
 import tarfile
 from typing import Dict
+
+import datetime
+from email_validator import EmailNotValidError, ValidatedEmail
+from freezegun import freeze_time
+import pytest
 
 from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
@@ -102,7 +104,7 @@ def on_disk_server_config(tmp_path_factory) -> Dict[str, Path]:
     return on_disk_config(tmp_path_factory, "server", do_setup)
 
 
-@pytest.fixture
+@pytest.fixture()
 def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
     """
     Mock a pbench-server.cfg configuration as defined above.
@@ -121,8 +123,8 @@ def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
     return server_config
 
 
-@pytest.fixture
-def client(server_config):
+@pytest.fixture()
+def client(server_config, fake_email_validator):
     """A test client for the app.
 
     NOTE: the db_session fixture does something similar, but with implicit
@@ -139,7 +141,7 @@ def client(server_config):
     return app_client
 
 
-@pytest.fixture
+@pytest.fixture()
 def db_session(server_config):
     """
     Construct a temporary DB session for the test case that will reset on
@@ -186,7 +188,28 @@ def login_user(client, server_config, username, password):
 
 
 @pytest.fixture()
-def create_user(client) -> User:
+def fake_email_validator(monkeypatch):
+    """
+    Set up a mock for the email validator so we control failure modes.
+    """
+    def fake_email(value: str, **kwargs) -> ValidatedEmail:
+
+        # The email validation failure case needs to see an error
+        if "," in value:
+            raise EmailNotValidError("testing")
+
+        # Return just the part of ValidatedEmail we use
+        return ValidatedEmail(email=value)
+
+    # The SQLAlchemy model decorator binds the function oddly, so we have to
+    # reach into the module's namespace.
+    monkeypatch.setattr(
+        "pbench.server.database.models.users.validate_email", fake_email
+    )
+
+
+@pytest.fixture()
+def create_user(client, fake_email_validator) -> User:
     """
     Construct a test user and add it to the database.
 
@@ -204,8 +227,8 @@ def create_user(client) -> User:
     return user
 
 
-@pytest.fixture
-def create_admin_user(client) -> User:
+@pytest.fixture()
+def create_admin_user(client, fake_email_validator) -> User:
     """
     Construct an admin user and add it to the database.
 
@@ -590,8 +613,8 @@ def find_template(monkeypatch, fake_mtime):
         yield
 
 
-@pytest.fixture
-def pbench_admin_token(client, server_config, create_admin_user):
+@pytest.fixture()
+def pbench_admin_token(client, server_config, create_admin_user, fake_email_validator):
     # Login admin user to get valid pbench token
     response = login_user(client, server_config, admin_username, generic_password)
     assert response.status_code == HTTPStatus.OK
@@ -600,8 +623,8 @@ def pbench_admin_token(client, server_config, create_admin_user):
     return data["auth_token"]
 
 
-@pytest.fixture
-def create_drb_user(client, server_config):
+@pytest.fixture()
+def create_drb_user(client, server_config, fake_email_validator):
     # Create a user
     response = register_user(
         client,
@@ -615,7 +638,7 @@ def create_drb_user(client, server_config):
     assert response.status_code == HTTPStatus.CREATED
 
 
-@pytest.fixture
+@pytest.fixture()
 def pbench_token(client, server_config, create_drb_user):
     # Login user to get valid pbench token
     response = login_user(client, server_config, "drb", generic_password)
@@ -651,7 +674,7 @@ def build_auth_header(request, server_config, pbench_token, pbench_admin_token, 
 
 
 @pytest.fixture()
-def current_user_drb(monkeypatch):
+def current_user_drb(monkeypatch, fake_email_validator):
     drb = User(
         email="drb@example.com",
         id=3,
@@ -680,7 +703,7 @@ def current_user_none(monkeypatch):
         yield None
 
 
-@pytest.fixture
+@pytest.fixture()
 def tarball(tmp_path):
     """
     Create a test tarball and MD5 file; the tarball is empty, but has a real

--- a/server/bin/utils/run-unittest
+++ b/server/bin/utils/run-unittest
@@ -233,7 +233,7 @@ function _create_user {
     # of 2, which means bad configuration. This is because some unittests
     # deliberately run with a bad configuration file, and we don't want user
     # creation to obscure "real" problems.
-    pbench-user-create --username=${name} --email=${name}@example.com \
+    pbench-user-create --username=${name} --email=${name}.fake.user@redhat.com \
         --first-name=${name^} --last-name=User --password=password >/dev/null
     if [[ ${?} -eq 1 ]]; then
         exit 101


### PR DESCRIPTION
The `email_validator` package just upgraded to 1.2, which implements stricter validation and in particular now rejects the "@example.com" addresses used in our unit tests.

This adds a mock to replace use of the real `email_validator` package in unit testing so that we're in control (as we should be for all external dependencies). The legacy test fake users are created as `${user}.fake.user@redhat.com` to get by the domain validation and minimize the chances of accidentally using a real alias.