### PR TITLE
Enable CodeQL only for `main` branch

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main, b0.69, b0.70 ]
+    branches: [ main ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ main ]


### PR DESCRIPTION
This is not ideal, but it looks like we have to add the names of branches to this file *in* the branches where this file lives.  Ick.