### PR TITLE
Initial commit for merging sos and result data

### DIFF
--- a/contrib/analysis/README
+++ b/contrib/analysis/README
@@ -1,0 +1,18 @@
+To collect pbench-fio data, use script.sh. 
+
+The script requires four parameters.
+
+es_host: Elasticsearch hostname
+es_port: Elasticsearch port
+url_prefix: Pbench server URL
+sos_host: Server where the sosreports are stored
+
+The order is given below.
+
+./script.sh <es_host> <es_port> <url_prefix> <sos_host>
+
+Example
+
+./script.sh elasticsearch.example.com 8000 http://pbench.example.com sos.example.com
+
+Please see the contents of script.sh for a description of its behavior.

--- a/contrib/analysis/collect_config_data.py
+++ b/contrib/analysis/collect_config_data.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import json
+import time
+import requests
+import tarfile
+import pandas as pd
+import logging
+import multiprocessing
+
+
+def _strip(o):
+    return o.strip()
+
+
+def decode_bytes(inbytes):
+    try:
+        unibytes = inbytes.decode("utf-8")
+    except UnicodeDecodeError:
+        unibytes = inbytes.decode("iso8859-1")
+    return unibytes
+
+
+# collect data from the lscpu file
+def collect_lsblk(fobj):
+    data = dict()
+    lsblk_disks = []
+    for line in decode_bytes(fobj.read()).splitlines()[1:]:
+        parts = list(map(_strip, line.split(" ", 1)))
+        if parts[0] and parts[0][0].isalpha():
+           lsblk_disks.append(parts[0])
+    data['lsblk_disks'] = lsblk_disks
+    return data
+
+
+# collect data from the lsblk file
+def collect_lscpu(fobj):
+    data = dict()
+    physical = "True"
+    for line in decode_bytes(fobj.read()).splitlines():
+        parts = list(map(_strip, line.split(":", 1)))
+        featurename = parts[0].replace(" ", "_")
+        if featurename in ["Architecture", "Model_name"]:
+            data[featurename] = parts[1]
+        elif featurename in [
+            "CPU(s)",
+            "Core(s)_per_socket",
+            "Socket(s)",
+            "Thread(s)_per_core",
+            "NUMA_node(s)"   # recommended by Peter
+        ]:
+            data[featurename] = int(parts[1])
+        elif featurename in [
+            "L1d_cache",
+            "L1i_cache",
+            "L2_cache",
+            "L3_cache"
+        ]:
+            if "KiB" in parts[1]:
+                data[featurename] = int(parts[1][:-4])
+            elif "MiB" in parts[1]:
+                data[featurename] = int(parts[1][:-4])*1000
+            elif "M" in parts[1]:
+                data[featurename] = int(parts[1][:-1])*1000 # do not include M for megabytes
+            else:
+                data[featurename] = int(parts[1][:-1]) # do not include K for kilobytes
+        elif featurename == "Hypervisor_vendor":
+            physical = False
+    if physical:
+        data['Type'] = 'phy'
+    else:
+        data['Type'] = 'virt'
+    return data
+
+
+# collect data from the meminfo file
+def collect_meminfo(fobj):
+    data = dict()
+    for line in decode_bytes(fobj.read()).splitlines():
+        parts = list(map(_strip, line.split(":", 1)))
+        featurename = parts[0].replace(" ", "_")
+        if featurename == "MemTotal":
+            data[featurename] = int(parts[1][:-3])  # do not include kB
+    return data
+
+
+# collect system uuid from the dmidecode command output
+def collect_uuid(fobj):
+    data = dict()
+    blocks = decode_bytes(fobj.read()).split("\n\n")
+    for block in blocks[:-1]:
+        if block.splitlines()[1] == "System Information":
+            for line in block.splitlines()[2:]: # ignore first two lines
+                parts = list(map(_strip, line.split(':', 1)))
+                if parts[0] == 'UUID':
+                    data['UUID'] = parts[1]
+                    break
+    return data
+
+
+# collect kernel version from the uname_-a command output
+def collect_kernel_version(fobj):
+    data = dict()
+    line = decode_bytes(fobj.read())
+    parts = list(map(_strip, line.split()))
+    data["Static_hostname"] = parts[1]
+    data["Kernel"] = parts[0] + " " + parts[2]
+    return data
+
+
+# collect data from all the files with a single integer value
+def collect_single_value(fobj):
+    data = int(decode_bytes(fobj.read()))
+    return data
+
+
+# collect active tuned profile
+def collect_tuned_profile(fobj):
+    data = decode_bytes(fobj.read())
+    return data
+
+
+# collect scheduler type from the disk parameters
+def collect_scheduler(fobj):
+    data = dict()
+    scheduler = "Missing"
+    line = decode_bytes(fobj.read())
+    parts = list(map(_strip, line.split()))
+    for part in parts:
+        if part[0] == '[' and part[-1] == ']':
+            scheduler = part[1:-1]
+    data["scheduler"] = scheduler
+    return data
+
+
+# extract block parameters from block-params.log
+def extract_block_params(url, filenames):
+    data = dict()
+    # check if the page is accessible
+    r = requests.head(url, allow_redirects=True)
+    if r.status_code == 200: # successful
+        page = requests.get(url)
+        for line in page.iter_lines():
+            for name in filenames:
+                if name in line.decode():
+                    parts = list(map(_strip, (line.decode()).split()))
+                    head, tail = os.path.split(parts[0])
+                    if tail == 'scheduler':
+                        data[tail] = parts[1]
+                    else:
+                        data[tail] = int(parts[1])    
+    return data
+
+
+def collect_sosreport_data(rootdir, dirname, filenames, sos_with_runids, url_prefix):
+    record = dict()  # data from one sosreport
+    filesread = 0
+
+    # find the run id associated with the sosreport
+    for id in sos_with_runids:
+        if dirname in sos_with_runids[id]['sosreports'].keys():
+            run_id = id
+            time = sos_with_runids[id]['sosreports'][dirname]['time']
+            host = sos_with_runids[id]['sample.client_hostname']
+            shorthost = sos_with_runids[id]['sosreports'][dirname]['hostname-s']
+            disknames = sos_with_runids[id]['disknames']
+            controller_dir = sos_with_runids[id]['controller_dir']
+            runname = sos_with_runids[id]['run.name']
+
+    # check if run_id is set, otherwise no need to process the sosreport
+    if 'run_id' not in locals(): 
+        return dict()      
+
+    try:
+        with tarfile.open(os.path.join(rootdir, dirname)) as tar:
+
+            # store the run.id and sosreport name in the record
+            record['run_id'] = run_id
+            record['sosreport'] = dirname
+            record['time'] = time
+            record['host'] = host
+
+            for member in tar.getmembers():
+                parts = (member.name).split("/")
+                filename = "/".join(parts[1:])
+                if filename in filenames:
+		    
+                    f = tar.extractfile(member)
+
+                    # check if all the files needed exist and are not empty
+                    if f is None or member.size == 0:
+                        isvalid = False
+                        sys.stderr.write(
+                            "Error: Invalid sosreport:"
+                            f" {dirname}:{parts[-1]}"
+                            " file not found or is empty.\n")
+                        continue
+                    if parts[-1] == "meminfo":
+                        record.update(collect_meminfo(f))
+                    elif parts[-1] == "lscpu":
+                        record.update(collect_lscpu(f))
+                    elif parts[-1] == "lsblk":
+                        record.update(collect_lsblk(f))
+                        if len(record["lsblk_disks"]) == 1:
+                            record['disk'] = record["lsblk_disks"][0]
+                        elif len(list(set(disknames))) == 1 and \
+                            disknames[0] in record["lsblk_disks"]:
+                            record['disk'] = disknames[0]
+                        if 'disk' not in record.keys():
+                            record['disk'] = 'Missing'
+                        else:
+                            # replace sdX in filenames with the disk used
+                            for index, name in enumerate(filenames):
+                                filenames[index] = name.replace("sdX", record['disk'])
+                        record['lsblk_disks'] = ','.join(record['lsblk_disks'])
+                    elif parts[-1] == "uname_-a":
+                        record.update(collect_kernel_version(f))
+                    elif parts[-1] == "scheduler":
+                        record.update(collect_scheduler(f))
+                    elif parts[-1] == "active_profile":
+                        record["active_profile"] = collect_tuned_profile(f)
+                    else:
+                        record[parts[-1]] = collect_single_value(f)
+                    filesread += 1
+    except Exception:
+        logger.exception("Error working with sosreport %s", dirname)
+ 
+    # for cases where lsblk is empty or missing
+    if 'disk' not in record.keys():
+        return dict()
+
+    # Extract block parameters 
+    url = f"{url_prefix}/incoming/{controller_dir}/{runname}/sysinfo/end/{shorthost}/block-params.log" 
+    diskparams = extract_block_params(url, filenames)
+    record.update(diskparams)
+    filesread += len(diskparams)
+
+    return record
+
+
+def main(args, logger):
+    # Directory with sosreports
+    rootdir = args[1]  
+
+    # Mapping between runs and sosreports
+    with open(args[2]) as json_file: 
+        sos_with_runids = json.load(json_file)  
+ 
+    # URL prefix to fetch unpacked data
+    url_prefix = args[3]
+
+    filenames = [
+        "proc/meminfo",
+        "sos_commands/processor/lscpu",
+        "proc/sys/kernel/sched_rr_timeslice_ms",
+        "proc/sys/vm/nr_hugepages",
+        "proc/sys/vm/nr_overcommit_hugepages",
+        "proc/sys/vm/overcommit_memory",
+        "proc/sys/vm/dirty_ratio",
+        "proc/sys/vm/dirty_background_ratio",
+        "proc/sys/vm/overcommit_ratio",
+        "proc/sys/vm/max_map_count",
+        "proc/sys/vm/min_free_kbytes",
+        "proc/sys/vm/swappiness",
+        "proc/sys/fs/aio-max-nr",
+        "proc/sys/fs/file-max",
+        "proc/sys/kernel/msgmax",
+        "proc/sys/kernel/msgmnb",
+        "proc/sys/kernel/msgmni",
+        "proc/sys/kernel/shmall",
+        "proc/sys/kernel/shmmax",
+        "proc/sys/kernel/shmmni",
+        "proc/sys/kernel/threads-max",
+        "sos_commands/kernel/uname_-a",
+        "sos_commands/block/lsblk",
+        "sys/block/sdX/queue/add_random",
+        "sys/block/sdX/queue/iostats",
+        "sys/block/sdX/queue/max_sectors_kb",
+        "sys/block/sdX/queue/nomerges",
+        "sys/block/sdX/queue/nr_requests",
+        "sys/block/sdX/queue/optimal_io_size",
+        "sys/block/sdX/queue/read_ahead_kb",
+        "sys/block/sdX/queue/rotational",
+        "sys/block/sdX/queue/rq_affinity",
+        "sys/block/sdX/queue/scheduler",
+        "etc/tuned/active_profile" # recommended by Peter
+    ]
+
+    # stores output from all the sosreports 
+    result_list = []
+
+    scan_start = time.time()
+    pool = multiprocessing.Pool(multiprocessing.cpu_count()-1 or 1) # no. of processes to run in parellel
+
+    scan_count = 0
+    for direntry in os.scandir(rootdir):
+        if direntry.name.endswith(".md5"):
+            continue
+        #print(direntry.name)
+        scan_count += 1
+        result_list.append(pool.apply_async(collect_sosreport_data, 
+                                            args=(rootdir, direntry.name, filenames, sos_with_runids, url_prefix, )))
+
+    pool.close()  # no more parallel work to submit
+    pool.join()   # wait for the worker processes to terminate
+
+    database = dict()  # stores config data for all the pbench runs
+
+    for res in result_list: 
+        record = res.get()
+        if record:
+            run_id = record['run_id']
+            record.pop('run_id', None)
+
+            # Use config data only from sosreports collected at the 'end' of a run
+            if run_id not in database.keys() and \
+               record['time'] == 'end' and \
+               record['Static_hostname'] in record['host']: # since -1 might be appended at the end of record[host]
+                database[run_id] = record
+    
+    print ("Total records: " + str(len(database)))
+
+    # Find pbench runs for which we do not have sosreport information available
+    for id in sos_with_runids:
+        if id not in database.keys():
+            print (sos_with_runids[id])
+ 
+    scan_end = time.time()
+    duration = scan_end - scan_start
+    scan_rate = duration / scan_count if scan_count > 0 else 0
+    print(
+        f"--- sosreport scan took {duration:0.2f} seconds"
+        f" for {scan_count} sosreports ({scan_rate:0.2f} secs per rpt) ---"
+    )
+
+    # Exit if none of the sosreports is valid and the database is empty
+    if not database:
+        sys.stdout.write("None of the sosreports are valid.\nExiting now...\n")
+        return 0
+
+    # Form a dataframe using the data collected from all the files
+    df = pd.DataFrame(database.values(), index=database.keys())
+
+    # Print number of uniqe values for each feature
+    print(df.nunique())
+
+    # Covert dataframe to a csv file
+    df.to_csv(r"config.csv", sep=";", mode="a")
+
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    logger = logging.getLogger(os.path.basename(sys.argv[0]))
+    start_time = time.time()
+    status = main(sys.argv, logger)
+    duration = time.time() - start_time
+    print(f"--- {duration:0.2f} seconds ---")
+    sys.exit(status)

--- a/contrib/analysis/create_sos_with_runids.py
+++ b/contrib/analysis/create_sos_with_runids.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import collections
+
+def main(args):
+    # File containing pbench results and run data
+    filename = args[1]
+
+    records = []
+    for line in open(filename, 'r'):
+        records.append(json.loads(line)) 
+
+    sos_and_runids = dict()
+
+    for result in records:
+        if result["run.id"] not in sos_and_runids.keys(): # and len(data[resid]["hostnames"]) == 1:
+            sos_and_runids[result["run.id"]] = {"sosreports" : result["sosreports"],
+                                                "sample.client_hostname" : result["sample.client_hostname"],
+                                                "disknames" : result["disknames"],
+                                                "controller_dir" : result["controller_dir"],
+                                                "run.name" : result["run.name"],
+                                               }
+
+    # count sosreports associated with each run
+    count = []
+    for id in sos_and_runids:
+        count.append(len(sos_and_runids[id]['sosreports'].keys()))
+
+    counter = collections.Counter(count)
+    print(counter)
+          
+    with open('sos_and_runids.json', 'w') as outfile:
+        json.dump(sos_and_runids, outfile) 
+
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    status = main(sys.argv)   

--- a/contrib/analysis/merge.py
+++ b/contrib/analysis/merge.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+import pandas as pd
+
+
+def main(args):
+    # File containing pbench results and run data
+    pbench_fio = args[1]
+
+    # File containing configuration data
+    config_data = args[2]
+
+    pbench_records = []
+    for line in open(pbench_fio, 'r'):
+        pbench_records.append(json.loads(line)) 
+
+    config_df = pd.read_csv(config_data, delimiter=';', index_col=0)
+    config_dict = config_df.to_dict('index')
+
+    pbench = dict()
+
+    index = 1
+    for result in pbench_records:
+        del result['sosreports']
+        for runid in config_dict:
+            # second condition elimintes runs/results with error in fio-result.txt
+            if result['run.id'] == runid and result['disknames']:
+                pbench[index] = result
+                pbench[index].update(config_dict[runid])
+                index = index + 1
+
+    # Form individual dataframes for different results using the dictionary
+    df = pd.DataFrame(pbench.values(), index=pbench.keys())
+    slat_df = df[df['sample.measurement_title'] == 'slat']
+    clat_df = df[df['sample.measurement_title'] == 'clat']
+    lat_df = df[df['sample.measurement_title'] == 'lat']
+    thr_df = df[df['sample.measurement_type'] == 'throughput']   
+
+    # Covert dataframes to csv files
+    slat_df.to_csv(r"latency_slat.csv", sep=";", mode="a")
+    clat_df.to_csv(r"latency_clat.csv", sep=";", mode="a")
+    lat_df.to_csv(r"latency_lat.csv", sep=";", mode="a")
+    thr_df.to_csv(r"throughput_iops_sec.csv", sep=";", mode="a")
+           
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    status = main(sys.argv)   

--- a/contrib/analysis/merge_sos_and_perf_parallel.py
+++ b/contrib/analysis/merge_sos_and_perf_parallel.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+
+import json
+import multiprocessing
+import os
+import requests
+import sys
+import time
+
+from collections import OrderedDict
+from datetime import datetime
+from dateutil import rrule
+from dateutil.relativedelta import relativedelta
+
+from elasticsearch1 import Elasticsearch
+from elasticsearch1.helpers import scan
+
+
+def _month_gen(now: datetime):
+    """Generate YYYY-MM stings from all the months, inclusively, between the
+    given start and end dates.
+    """
+    start = now - relativedelta(years=1)
+    first_month = start.replace(day=1)
+    last_month = now + relativedelta(day=31)
+    for m in rrule.rrule(rrule.MONTHLY, dtstart=first_month, until=last_month):
+        yield f"{m.year:04}-{m.month:02}"
+
+
+def result_index_gen(month_gen):
+    """Yield all the result index patterns for each month yielded from the given
+    generator.
+    """
+    for month in month_gen:
+        yield f"dsa-pbench.v4.result-data.{month}-*"
+
+
+def run_index_gen(month_gen):
+    """Yield all the run data index patterns for each month yielded from the given
+    generator.
+    """
+    for month in month_gen:
+        yield f"dsa-pbench.v4.run.{month}"
+
+
+def es_data_gen(es, index, doc_type):
+    """Yield documents where the `run.script` field is "fio" for the given index
+    and document type.
+    """
+    query = {"query": {"query_string": {"query": "run.script:fio"}}}
+
+    for doc in scan(es, query=query, index=index, doc_type=doc_type, scroll="1d",):
+        yield doc
+
+
+def pbench_runs_gen(es, month_gen):
+    """Yield all the pbench run documents using the given month generator.
+    """
+    for run_index in run_index_gen(month_gen):
+        for doc in es_data_gen(es, run_index, "pbench-run"):
+            yield doc
+
+
+def pbench_result_data_samples_gen(es, month_gen):
+    """Yield all the pbench result data sample documents using the given month
+    generator.
+    """
+    for result_index in result_index_gen(month_gen):
+        for doc in es_data_gen(es, result_index, "pbench-result-data-sample"):
+            yield doc
+
+
+def load_pbench_runs(es, now: datetime):
+    """Load all the pbench run data, sub-setting to contain only the fields we
+    require.
+
+    We also ignore any pbench run without a `controller_dir` field or without
+    a `sosreports` field.
+
+    A few statistics about the processing is printed to stdout.
+
+    Returns a dictionary containing the processed pbench run documents
+    """
+    pbench_runs = dict()
+
+    recs = 0
+    missing_ctrl_dir = 0
+    missing_sos = 0
+    sos_not_two = 0
+    accepted = 0
+
+    for _source in pbench_runs_gen(es, _month_gen(now)):
+        recs += 1
+
+        run = _source["_source"]
+        run_id = run["@metadata"]["md5"]
+        if "controller_dir" not in run["@metadata"]:
+            missing_ctrl_dir += 1
+            print(f"pbench run with no controller_dir: {run_id}")
+            continue
+
+        if "sosreports" not in run:
+            missing_sos += 1
+            continue
+
+        if len(run["sosreports"]) != 2:
+            sos_not_two += 1
+            continue
+
+        first = run["sosreports"][0]
+        second = run["sosreports"][1]
+        if first["hostname-f"] != second["hostname-f"]:
+            print(f"pbench run with sosreports from different hosts: {run_id}")
+            continue 
+
+        accepted += 1
+
+        run_index = _source["_index"]
+
+        sosreports = dict()
+        # FIXME: Should I remove the forloop here after the above change? 
+        for sosreport in run["sosreports"]:
+            sosreports[os.path.split(sosreport["name"])[1]] = {
+                "hostname-s": sosreport["hostname-s"],
+                "hostname-f": sosreport["hostname-f"],
+                "time": sosreport["name"].split("/")[2],
+                "inet": [nic["ipaddr"] for nic in sosreport["inet"]],
+                # FIXME: Key Error on inet6
+                #"inet6": [nic["ipaddr"] for nic in sosreport["inet6"]],
+            }
+
+        pbench_runs[run_id] = dict(
+            run_id=run_id,
+            run_index=run_index,
+            controller_dir=run["@metadata"]["controller_dir"],
+            sosreports=sosreports,
+        )
+
+    print(
+        f"Stats for pbench runs: accepted {accepted:n} records of"
+        f" {recs:n}, missing 'controller_dir' field {missing_ctrl_dir:n},"
+        f" missing 'sosreports' field {missing_sos:n}",
+        f" 'sosreports' not equal to two for single clients {sos_not_two:n}",
+        flush=True,
+    )
+
+    return pbench_runs
+
+
+# extract list of clients from the URL
+def extract_clients(results_meta, es):
+    run_index = results_meta["run_index"]
+    parent_id = results_meta["run.id"]
+    iter_name = results_meta["iteration.name"]
+    sample_name = results_meta["sample.name"]
+    parent_dir_name = f"/{iter_name}/{sample_name}/clients"
+    query = {
+        "query": {
+            "query_string": {
+                "query": f'_parent:"{parent_id}"'
+                f' AND ancestor_path_elements:"{iter_name}"'
+                f' AND ancestor_path_elements:"{sample_name}"'
+                f" AND ancestor_path_elements:clients"
+            }
+        }
+    }
+
+    client_names_raw = []
+    for doc in scan(
+        es, query=query, index=run_index, doc_type="pbench-run-toc-entry", scroll="1m",
+    ):
+        src = doc["_source"]
+        if src["parent"] == parent_dir_name:
+            client_names_raw.append(src["name"])
+    # FIXME: if we have an empty list, do we still want to use those results?
+    return list(set(client_names_raw))
+
+
+# extract host and disk names from fio-result.txt
+def extract_fio_result(results_meta, incoming_url, session):
+    url = (
+        incoming_url
+        + results_meta["controller_dir"]
+        + "/"
+        + results_meta["run.name"]
+        + "/"
+        + results_meta["iteration.name"]
+        + "/"
+        + results_meta["sample.name"]
+        + "/"
+        + "fio-result.txt"
+    )
+
+    # check if the page is accessible
+    response = session.get(url, allow_redirects=True)
+    if response.status_code != 200:  # successful
+        # FIXME: are these results we still want?
+        return ([], [])
+
+    try:
+        document = response.json()
+    except ValueError:
+        # print("Response content is not valid JSON")
+        # print(url)
+        # print(response.content)
+        # FIXME: are these results we still want?
+        return ([], [])
+
+    try:
+        disk_util = document["disk_util"]
+    except KeyError:
+        disknames = []
+    else:
+        disknames = [disk["name"] for disk in disk_util if "name" in disk]
+
+    try:
+        client_stats = document["client_stats"]
+    except KeyError:
+        hostnames = []
+    else:
+        hostnames = list(
+            set([host["hostname"] for host in client_stats if "hostname" in host])
+        )
+
+    return (disknames, hostnames)
+
+
+def transform_result(source, pbench_runs, results_seen, stats):
+    """Transform the raw result data sample document to a stripped down version,
+    augmented with pbench run data.
+    """
+    result_id = source["_id"]
+    assert result_id not in results_seen, f"Result ID {result_id} repeated"
+    results_seen[result_id] = True
+
+    try:
+        index = source["_source"]
+        run = index["run"]
+        run_id = run["id"]
+        run_name = run["name"]
+        iter_name = index["iteration"]["name"]
+        sample = index["sample"]
+        sample_name = sample["name"]
+        sample_m_type = sample["measurement_type"]
+        sample_m_title = sample["measurement_title"]
+        sample_m_idx = sample["measurement_idx"]
+    except KeyError as exc:
+        print(
+            # f"ERROR - {filename}, {exc}, {json.dumps(index)}", file=sys.stderr,
+            f"ERROR - {exc}, {json.dumps(index)}",
+            file=sys.stderr,
+        )
+        stats["errors"] += 1
+        return None
+
+    try:
+        pbench_run = pbench_runs[run_id]
+    except KeyError:
+        # print(
+        #    f"*** Result without a run: {run_id}/{run_name}/{iter_name}"
+        #    f"/{sample_name}/{sample_m_type}/{sample_m_title}"
+        #    f"/{sample_m_idx}",
+        #    flush=True,
+        # )
+        stats["missing_runs"] += 1
+        return None
+
+    if "mean" not in sample:
+        # run_ctrl = pbench_run["controller_dir"]
+        # print(
+        #    f"No 'mean' in {run_ctrl}/{run_name}/{iter_name}"
+        #    f"/{sample_name}/{sample_m_type}/{sample_m_title}"
+        #    f"/{sample_m_idx}",
+        #    flush=True,
+        # )
+        stats["missing_mean"] += 1
+        return None
+
+    if sample["client_hostname"] == 'all':
+        stats["aggregate_result"] += 1
+        return None
+
+    # The following field names are required
+    try:
+        benchmark = index["benchmark"]
+        result = OrderedDict()
+        result.update(
+            [
+                ("run.id", run_id),
+                ("iteration.name", iter_name),
+                ("sample.name", sample_name),
+                ("run.name", run_name),
+                ("benchmark.bs", benchmark["bs"]),
+                ("benchmark.direct", benchmark["direct"]),
+                ("benchmark.ioengine", benchmark["ioengine"]),
+                ("benchmark.max_stddevpct", benchmark["max_stddevpct"]),
+                ("benchmark.primary_metric", benchmark["primary_metric"]),
+                ("benchmark.rw", ", ".join(set((benchmark["rw"].split(","))))),
+                ("sample.client_hostname", sample["client_hostname"]),
+                ("sample.measurement_type", sample_m_type),
+                ("sample.measurement_title", sample_m_title),
+                ("sample.measurement_idx", sample_m_idx),
+                ("sample.mean", sample["mean"]),
+                ("sample.stddev", sample["stddev"]),
+                ("sample.stddevpct", sample["stddevpct"]),
+            ]
+        )
+    except KeyError as exc:
+        print(
+            # f"ERROR - {filename}, {exc}, {json.dumps(index)}", file=sys.stderr,
+            f"ERROR - {exc}, {json.dumps(index)}",
+            file=sys.stderr,
+        )
+        stats["errors"] += 1
+        return None
+
+    stats["mean"] += 1
+
+    result["run_index"] = pbench_run["run_index"]
+    result["controller_dir"] = pbench_run["controller_dir"]
+    result["sosreports"] = pbench_run["sosreports"]
+
+    # optional workload parameters
+    try:
+        result["benchmark.filename"] = ", ".join(
+            set((benchmark["filename"].split(",")))
+        )
+    except KeyError:
+        result["benchmark.filename"] = "/tmp/fio"
+    try:
+        result["benchmark.iodepth"] = benchmark["iodepth"]
+    except KeyError:
+        result["benchmark.iodepth"] = "32"
+    try:
+        result["benchmark.size"] = ", ".join(set((benchmark["size"].split(","))))
+    except KeyError:
+        result["benchmark.size"] = "4096M"
+    try:
+        result["benchmark.numjobs"] = ", ".join(set((benchmark["numjobs"].split(","))))
+    except KeyError:
+        result["benchmark.numjobs"] = "1"
+    try:
+        result["benchmark.ramp_time"] = benchmark["ramp_time"]
+    except KeyError:
+        result["benchmark.ramp_time"] = "none"
+    try:
+        result["benchmark.runtime"] = benchmark["runtime"]
+    except KeyError:
+        result["benchmark.runtime"] = "none"
+    try:
+        result["benchmark.sync"] = benchmark["sync"]
+    except KeyError:
+        result["benchmark.sync"] = "none"
+    try:
+        result["benchmark.time_based"] = benchmark["time_based"]
+    except KeyError:
+        result["benchmark.time_based"] = "none"
+
+    return result
+
+
+def process_results(es, now, session, incoming_url, pool, pbench_runs, stats):
+    """Intermediate generator for handling the fetching of the client names, disk
+    names, and host names.
+
+    """
+    stats["total_recs"] = 0
+    stats["missing_mean"] = 0
+    stats["missing_runs"] = 0
+    stats["aggregate_result"] = 0
+    stats["multiple_clients"] = 0
+    stats["no_clients"] = 0
+    stats["errors"] = 0
+    stats["mean"] = 0
+
+    results_seen = dict()
+    clientnames_map = dict()
+    diskhost_map = dict()
+
+    for _source in pbench_result_data_samples_gen(es, _month_gen(now)):
+        stats["total_recs"] += 1
+        result = transform_result(_source, pbench_runs, results_seen, stats)
+        if result is None:
+            continue
+
+        # Add host and disk names in the data here
+        key = f'{result["run.id"]}/{result["iteration.name"]}'
+        try:
+            disknames, hostnames = diskhost_map[key]
+        except KeyError:
+            print(f"{key} / fio-result.txt", flush=True)
+            disknames, hostnames = extract_fio_result(result, incoming_url, session)
+            diskhost_map[key] = (disknames, hostnames)
+        result["disknames"] = disknames
+        result["hostnames"] = hostnames
+
+        # Add client names here
+        key = result["run.id"]
+        try:
+            clientnames = clientnames_map[key]
+        except KeyError:
+            print(f"{key} / client names", flush=True)
+            clientnames = extract_clients(result, es)
+            clientnames_map[key] = clientnames
+
+        # Ignore result if 0 or more than 1 client names
+        if not clientnames: 
+            stats["no_clients"] += 1
+            continue 
+
+        if len(clientnames) > 1:
+            stats["multiple_clients"] += 1
+            continue 
+
+        result["clientnames"] = clientnames
+
+        yield result
+
+
+def main(args):
+    # Number of CPUs to use (where 0 = n CPUs)
+    concurrency = int(args[1])
+
+    es_host = args[2]
+    es_port = args[3]
+
+    # URL prefix to fetch unpacked data
+    url_prefix = args[4]
+    incoming_url = f"{url_prefix}/incoming/"
+
+    # If requested, profile memory usage
+    try:
+        profile_arg = int(args[5])
+    except (IndexError, ValueError):
+        profile = False
+    else:
+        profile = profile_arg != 0
+
+    if profile:
+        from guppy import hpy
+
+        memprof = hpy()
+    else:
+        memprof = None
+
+    if memprof:
+        print(f"Initial memory profile ... {memprof.heap()}", flush=True)
+
+    # We create the multiprocessing pool first to avoid forking a sub-process
+    # with lots of memory allocated.
+    ncpus = multiprocessing.cpu_count() - 1 if concurrency == 0 else concurrency
+    pool = multiprocessing.Pool(ncpus) if ncpus != 1 else None
+
+    es = Elasticsearch([f"{es_host}:{es_port}"])
+
+    session = requests.Session()
+    ua = session.headers["User-Agent"]
+    session.headers.update({"User-Agent": f"{ua} -- merge_sos_and_perf_parallel"})
+
+    scan_start = time.time()
+    now = datetime.utcfromtimestamp(scan_start)
+
+    pbench_runs = load_pbench_runs(es, now)
+
+    result_cnt = 0
+    stats = dict()
+
+    with open("sosreport_fio.txt", "w") as log, open(
+        "pbench_fio.json", "w"
+    ) as outfile:
+        generator = process_results(
+            es, now, session, incoming_url, pool, pbench_runs, stats
+        )
+        for result in generator:
+            result_cnt += 1
+            for sos in result["sosreports"].keys():
+                log.write("{}\n".format(sos))
+            log.flush()
+            outfile.write(json.dumps(result))
+            outfile.write("\n")
+            outfile.flush()
+
+    scan_end = time.time()
+    duration = scan_end - scan_start
+
+    print(f"final number of records: {result_cnt:n}", flush=True)
+    print(json.dumps(stats, indent=4), flush=True)
+    print(f"--- merging run and result data took {duration:0.2f} seconds", flush=True)
+
+    if memprof:
+        print(
+            f"Final memory profile ... {memprof.heap()}", flush=True,
+        )
+
+    return 0
+
+
+# point of entry
+if __name__ == "__main__":
+    status = main(sys.argv)

--- a/contrib/analysis/script.sh
+++ b/contrib/analysis/script.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Steps to collect Pbench fio data.
+
+es_host=$1
+es_port=$2
+url_prefix=$3
+sos_host=$4
+
+# 1) The following code collects Pbench runs data and Pbench results data from Elasticsearch for the past one year. Pbench runs data gives us the mapping between runs and configuration data. Pbench results data gives us the performance results and workload metadata. The code generates two output files: "pbench_fio.json" and "sosreport_fio.txt". The first file contains complete information about a pbench run with sosreport names but missing configuration data. The second file contains the sosreport names to be copied from the production server. The code also extracts the disk name from fio-result.txt located in each individual sample (can only be accessed using a URL).
+
+./merge_sos_and_perf_parallel.py 1 $es_host $es_port $url_prefix;
+
+# 2) "sosreport_fio.txt" contains a list of all the sosreports from the past one year with pbench-fio results. Use the following command to figure out the unique set of sosreports that we should copy from the production server.
+
+sort sosreport_fio.txt | uniq > sos_fio.lis;
+
+# 3) Use the following command to copy all the sosreports listed in "sos_fio.lis" to your system.
+
+mkdir -p ./sosreports;
+while read sos; do scp vos@$sos_host:~/VoS/archive/${sos} ./sosreports/; done < sos_fio.lis;
+
+# 4) Use "pbench_fio.json" to generate "sos_and_runids.json" using <create_sos_with_runids.py>. You could modify the code to filter out certain runs. For example, runs with multiple clients.  
+
+./create_sos_with_runids.py pbench_fio.json;
+
+# 5) Run <collect_config_data.py> that takes in the directory "sosreports", "sos_and_runids.json" and the hostname to collect block parameters. It generates "config.csv" that contains configuration data.
+
+./collect_config_data.py sosreports/ sos_and_runids.json $url_prefix;
+
+# 6) To merge the information from sosreports, workload metadata and performance results, use <merge.py>. It takes in "config.csv" and "pbench_fio.json" and generates four files: "latency_slat.csv", "latency_clat.csv", "latency_lat.csv" and "throughput_iops_sec.csv".
+
+./merge.py pbench_fio.json config.csv;


### PR DESCRIPTION
----
`contrib/analysis/script.sh`: Steps to collect pbench-fio data.

Contains all the steps needed to combine the indexed Pbench data and
on-disk configuration data. The output is a set of `.csv` files for each
different fio result type. Each `.csv` file contains workload metadata,
configuration data and performance results. For example, you may see the
following files generated as a result of running `script.sh`.

 * `latency_clat.csv`
 * `latency_lat.csv`
 * `latency_slat.csv`
 * `throughput_iops_sec.csv`

The steps taken are listed in `script.sh`.

----
`contrib/analysis/merge_sos_and_perf_parallel.py`: Step 1 of `script.sh`

Responsible for generating a set of JSON documents for the "fio" runs
to consider, the sosreports related to those runs, and the disk used by
those runs.

----
`contrib/analysis/create_sos_with_runids.py`: Step 4 of `script.sh`

Prepares for sosreport data collection.

----
`contrib/analysis/collect_config_data.py`: Step 5 of `script.sh`

Performs sosreport data collection.

----
`contrib/analysis/merge.py`: Step 6 of `script.sh`

Merges collected sosreport data with the pbench run/result data.

----
Notes

 * Add an explicit value for the `User-Agent` header so that we can tell
   in the Nginx/Apache logs which client was being used.

 * Create `load_pbench_runs()` method

   The pbench run data is much smaller than the result data, so we
   create a very simple routine to load all the run data, apply the
   proper filters, massage it a bit, and store only the fields we
   need when processing the result data.  This provides a much smaller
   memory footprint.

 * Use a generator pattern for processing results

   We use a generator to load one record at a time from the JSON
   docs loaded from a file, process it, adorn it with pbench run
   data and then write it out without storing it.  This avoids an
   using memory to store all the data while processing.

   This does not implement the client names and/or disk/host names
   fetching required to complete the data adornment.