### PR TITLE
Delete the spurious pbench3-devel RPM dependency

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -16,9 +16,6 @@ Requires:  ansible-core
 
 %if 0%{?rhel} == 7
 Requires:  python3, python3-pip
-# For RHEL boxen we need the python development environment in order for the
-# pip3 installs for some modules to be successful.
-Requires:  gcc python3-devel
 %endif
 
 %if 0%{?rhel} == 8


### PR DESCRIPTION
Fixes #2798

AFAICT, the python3-devel dependency (which only exists for RHEL7) is
spurious and in fact harmful: there seems to be no python3-devel
package for RHEL7.9, so installation fails with an unsatisfied
dependency, whereas an RPM built without it installs without
problems.