### PR TITLE
Convert server APIs to ISO 8601 UTC dates

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -21,7 +21,7 @@ from pbench.server.database.models.datasets import (
     MetadataNotFound,
 )
 from pbench.server.database.models.users import User
-from pbench.server.utils import IsoTimeHelper
+from pbench.server.utils import UtcTimeHelper
 
 
 class UnauthorizedAccess(Exception):
@@ -990,11 +990,11 @@ class ApiBase(Resource):
             if i == Dataset.ACCESS:
                 metadata[i] = dataset.access
             elif i == Dataset.CREATED:
-                metadata[i] = IsoTimeHelper(dataset.created).iso()
+                metadata[i] = UtcTimeHelper(dataset.created).to_iso_string()
             elif i == Dataset.OWNER:
                 metadata[i] = dataset.owner.username
             elif i == Dataset.UPLOADED:
-                metadata[i] = IsoTimeHelper(dataset.uploaded).iso()
+                metadata[i] = UtcTimeHelper(dataset.uploaded).to_iso_string()
             elif Metadata.is_key_path(i, Metadata.USER_METADATA):
                 try:
                     metadata[i] = Metadata.getvalue(dataset=dataset, key=i)

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -21,6 +21,7 @@ from pbench.server.database.models.datasets import (
     MetadataNotFound,
 )
 from pbench.server.database.models.users import User
+from pbench.server.utils import IsoTimeHelper
 
 
 class UnauthorizedAccess(Exception):
@@ -989,11 +990,11 @@ class ApiBase(Resource):
             if i == Dataset.ACCESS:
                 metadata[i] = dataset.access
             elif i == Dataset.CREATED:
-                metadata[i] = f"{dataset.created:%Y-%m-%d:%H:%M}"
+                metadata[i] = IsoTimeHelper(dataset.created).iso()
             elif i == Dataset.OWNER:
                 metadata[i] = dataset.owner.username
             elif i == Dataset.UPLOADED:
-                metadata[i] = f"{dataset.uploaded:%Y-%m-%d:%H:%M}"
+                metadata[i] = IsoTimeHelper(dataset.uploaded).iso()
             elif Metadata.is_key_path(i, Metadata.USER_METADATA):
                 try:
                     metadata[i] = Metadata.getvalue(dataset=dataset, key=i)

--- a/lib/pbench/server/api/resources/query_apis/datasets_search.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_search.py
@@ -3,7 +3,7 @@ from logging import Logger
 
 from flask import jsonify
 
-from pbench.server import PbenchServerConfig, JSON
+from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
     Parameter,
     ParamType,
@@ -14,6 +14,7 @@ from pbench.server.api.resources.query_apis import (
     ElasticBase,
     PostprocessError,
 )
+from pbench.server.utils import IsoTimeHelper
 
 
 class DatasetsSearch(ElasticBase):
@@ -81,11 +82,8 @@ class DatasetsSearch(ElasticBase):
         # If no fields are specified, the query will return all the fields from Elasticsearch hits
         selected_fields = json_data.get("fields", [])
 
-        # We need to pass string dates as part of the Elasticsearch query; we
-        # use the unconverted strings passed by the caller rather than the
-        # adjusted and normalized datetime objects for this.
-        start_arg = f"{start:%Y-%m-%d}"
-        end_arg = f"{end:%Y-%m-%d}"
+        start_arg = IsoTimeHelper(start).iso()
+        end_arg = IsoTimeHelper(end).iso()
 
         self.logger.info(
             "Search query for user {}, prefix {}: ({} - {}) on query: {}",

--- a/lib/pbench/server/api/resources/query_apis/datasets_search.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_search.py
@@ -14,7 +14,7 @@ from pbench.server.api.resources.query_apis import (
     ElasticBase,
     PostprocessError,
 )
-from pbench.server.utils import IsoTimeHelper
+from pbench.server.utils import UtcTimeHelper
 
 
 class DatasetsSearch(ElasticBase):
@@ -82,8 +82,8 @@ class DatasetsSearch(ElasticBase):
         # If no fields are specified, the query will return all the fields from Elasticsearch hits
         selected_fields = json_data.get("fields", [])
 
-        start_arg = IsoTimeHelper(start).iso()
-        end_arg = IsoTimeHelper(end).iso()
+        start_arg = UtcTimeHelper(start).to_iso_string()
+        end_arg = UtcTimeHelper(end).to_iso_string()
 
         self.logger.info(
             "Search query for user {}, prefix {}: ({} - {}) on query: {}",

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -17,7 +17,7 @@ from pbench.server.database.models.datasets import (
     States,
 )
 from pbench.server.filetree import DatasetNotFound, FileTree, Tarball
-from pbench.server.utils import IsoTimeHelper, filesize_bytes
+from pbench.server.utils import UtcTimeHelper, filesize_bytes
 
 
 class CleanupTime(Exception):
@@ -333,7 +333,7 @@ class Upload(Resource):
                 Metadata.setvalue(
                     dataset=dataset,
                     key=Metadata.DELETION,
-                    value=IsoTimeHelper(deletion).iso(),
+                    value=UtcTimeHelper(deletion).to_iso_string(),
                 )
             except Exception as e:
                 raise CleanupTime(

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -1,16 +1,14 @@
 from http import HTTPStatus
-from typing import NamedTuple
-
-from email_validator import EmailNotValidError
-from flask import jsonify, make_response, request
-from flask_restful import abort, Resource
-from flask_bcrypt import check_password_hash
 import jwt
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
-
-from pbench.server.api.auth import Auth
-from pbench.server.database.models.active_tokens import ActiveTokens
+from flask import request, jsonify, make_response
+from flask_restful import Resource, abort
+from flask_bcrypt import check_password_hash
+from email_validator import EmailNotValidError
+from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from typing import NamedTuple
 from pbench.server.database.models.users import User
+from pbench.server.database.models.active_tokens import ActiveTokens
+from pbench.server.api.auth import Auth
 
 
 class RegisterUser(Resource):

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -1,14 +1,16 @@
 from http import HTTPStatus
-import jwt
-from flask import request, jsonify, make_response
-from flask_restful import Resource, abort
-from flask_bcrypt import check_password_hash
-from email_validator import EmailNotValidError
-from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from typing import NamedTuple
-from pbench.server.database.models.users import User
-from pbench.server.database.models.active_tokens import ActiveTokens
+
+from email_validator import EmailNotValidError
+from flask import jsonify, make_response, request
+from flask_restful import abort, Resource
+from flask_bcrypt import check_password_hash
+import jwt
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+
 from pbench.server.api.auth import Auth
+from pbench.server.database.models.active_tokens import ActiveTokens
+from pbench.server.database.models.users import User
 
 
 class RegisterUser(Resource):

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -314,6 +314,10 @@ def current_time() -> datetime.datetime:
     """
     Return the current time in UTC.
 
+    This provides a Callable that can be specified in the SQLAlchemy Column
+    to generate an appropriate (aware UTC) datetime object when a Dataset
+    object is created.
+
     Returns:
         Current UTC timestamp
     """
@@ -337,7 +341,7 @@ class TZDateTime(TypeDecorator):
         objects are converted to UTC and made "naive" by replacing the TZ
         for SQL storage.
         """
-        if value is not None and not value.tzinfo:
+        if value is not None and value.utcoffset() is not None:
             value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
         return value
 

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -2,13 +2,14 @@ import copy
 import datetime
 import enum
 import os
-import re
 from pathlib import Path
+import re
 from typing import Any, List, Tuple, Union
 
-from sqlalchemy import event, Column, DateTime, Enum, ForeignKey, Integer, JSON, String
+from sqlalchemy import Column, DateTime, Enum, event, ForeignKey, Integer, JSON, String
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import relationship, validates
-from sqlalchemy.exc import SQLAlchemyError, IntegrityError
+from sqlalchemy.types import TypeDecorator
 
 from pbench.server.database.database import Database
 from pbench.server.database.models.users import User
@@ -311,17 +312,44 @@ class States(enum.Enum):
 
 def current_time() -> datetime.datetime:
     """
-    Return the current time.
-
-    NOTE: we use this intermediary rather than binding the Column default
-    directly to datetime.datetime.now because that load-time binding defeats
-    unit test mocking. Binding it instead to this method allows a mock to
-    take effect.
+    Return the current time in UTC.
 
     Returns:
-        datetime.datetime.now()
+        Current UTC timestamp
     """
-    return datetime.datetime.now()
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+class TZDateTime(TypeDecorator):
+    """
+    SQLAlchemy protocol is that stored timestamps are naive UTC; so we use a
+    custom type decorator to ensure that our incoming and outgoing timestamps
+    are consistent by adjusting TZ before storage and enhancing with UTC TZ
+    on retrieval so that we're always working with "aware" UTC.
+    """
+
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        """
+        "Naive" datetime objects are treated as UTC, and "aware" datetime
+        objects are converted to UTC and made "naive" by replacing the TZ
+        for SQL storage.
+        """
+        if value is not None and not value.tzinfo:
+            value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(self, value, dialect):
+        """
+        Retrieved datetime objects are naive, and are assumed to be UTC, so set
+        the TZ to UTC to make them "aware". This ensures that we communicate
+        the "+00:00" ISO 8601 suffix to API clients.
+        """
+        if value is not None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return value
 
 
 class Dataset(Database.Base):
@@ -397,18 +425,18 @@ class Dataset(Database.Base):
     md5 = Column(String(255), unique=False, nullable=True)
 
     # Time of Dataset record creation
-    uploaded = Column(DateTime, nullable=False, default=current_time)
+    uploaded = Column(TZDateTime, nullable=False, default=current_time)
 
     # Time of the data collection run (from metadata.log `date`). This is the
     # time the data was generated as opposed to the date it was imported into
     # the server ("uploaded").
-    created = Column(DateTime, nullable=True, unique=False)
+    created = Column(TZDateTime, nullable=True, unique=False)
 
     # Current state of the Dataset
     state = Column(Enum(States), unique=False, nullable=False, default=States.UPLOADING)
 
     # Timestamp when Dataset state was last changed
-    transition = Column(DateTime, nullable=False, default=current_time)
+    transition = Column(TZDateTime, nullable=False, default=current_time)
 
     # NOTE: this relationship defines a `dataset` property in `Metadata`
     # that refers to the parent `Dataset` object.
@@ -683,7 +711,7 @@ class Dataset(Database.Base):
         # TODO: this would be a good place to generate an audit log
 
         self.state = new_state
-        self.transition = datetime.datetime.now()
+        self.transition = datetime.datetime.utcnow()
         self.update()
 
     def add(self):

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -10,7 +10,7 @@ import tarfile
 from pbench.common import selinux
 from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset
-from pbench.server.utils import IsoTimeHelper
+from pbench.server.utils import UtcTimeHelper
 
 
 class FiletreeError(Exception):
@@ -274,7 +274,7 @@ class Tarball:
         metadata = ConfigParser()
         metadata.read_string(data)
 
-        created = IsoTimeHelper.from_string(metadata.get("pbench", "date"))
+        created = UtcTimeHelper.from_string(metadata.get("pbench", "date"))
 
         return {
             "controller": {"hostname": metadata.get("controller", "hostname")},

--- a/lib/pbench/server/utils.py
+++ b/lib/pbench/server/utils.py
@@ -101,16 +101,16 @@ class UtcTimeHelper:
 
     def __init__(self, time: datetime.datetime):
         """
-        Capture a datetime object and; if it's "naive", set it to be UTC; if
+        Capture a datetime object: if it's "naive", set it to be UTC; if
         it's already "aware", adjust it to UTC.
 
         Args:
             time:   An aware or naive datetime object
         """
         self.utc_time = time
-        if self.utc_time.utcoffset() is None:
+        if self.utc_time.utcoffset() is None:  # naive
             self.utc_time = self.utc_time.replace(tzinfo=datetime.timezone.utc)
-        else:
+        elif self.utc_time.utcoffset():  # Not UTC
             self.utc_time = self.utc_time.astimezone(datetime.timezone.utc)
 
     @classmethod

--- a/lib/pbench/server/utils.py
+++ b/lib/pbench/server/utils.py
@@ -1,6 +1,9 @@
+import datetime
 import os
-import sys
 import shutil
+import sys
+
+from dateutil import parser as date_parser
 
 from pbench.server.database.models.datasets import Dataset, States, DatasetNotFound
 
@@ -88,3 +91,23 @@ def quarantine(dest, logger, *files):
                 'quarantine {} {!r}: "mv {} {}/" failed', dest, files, afile, dest
             )
             sys.exit(102)
+
+
+class IsoTimeHelper:
+    def __init__(self, time: datetime.datetime):
+        self.utc_time = time
+        if (
+            self.utc_time.tzinfo is None
+            or self.utc_time.tzinfo.utcoffset(self.utc_time) is None
+        ):
+            self.utc_time = self.utc_time.replace(tzinfo=datetime.timezone.utc)
+
+    @classmethod
+    def from_string(cls, time: str) -> "IsoTimeHelper":
+        return cls(date_parser.parse(time))
+
+    def iso(self) -> str:
+        return self.utc_time.isoformat()
+
+    def __str__(self) -> str:
+        return self.iso()

--- a/lib/pbench/server/utils.py
+++ b/lib/pbench/server/utils.py
@@ -93,21 +93,47 @@ def quarantine(dest, logger, *files):
             sys.exit(102)
 
 
-class IsoTimeHelper:
+class UtcTimeHelper:
+    """
+    A helper class to work with UTC "aware" datetime objects. A "naive" object
+    (without timezone offset) will be set to UTC timezone.
+    """
+
     def __init__(self, time: datetime.datetime):
+        """
+        Capture a datetime object and; if it's "naive", set it to be UTC; if
+        it's already "aware", adjust it to UTC.
+
+        Args:
+            time:   An aware or naive datetime object
+        """
         self.utc_time = time
-        if (
-            self.utc_time.tzinfo is None
-            or self.utc_time.tzinfo.utcoffset(self.utc_time) is None
-        ):
+        if self.utc_time.utcoffset() is None:
             self.utc_time = self.utc_time.replace(tzinfo=datetime.timezone.utc)
+        else:
+            self.utc_time = self.utc_time.astimezone(datetime.timezone.utc)
 
     @classmethod
-    def from_string(cls, time: str) -> "IsoTimeHelper":
+    def from_string(cls, time: str) -> "UtcTimeHelper":
+        """
+        Alternate constructor to build an object by parsing a date-time string.
+
+        Args:
+            time:   Standard parseable date-time string
+
+        Returns:
+            UtcTimeHelper object
+        """
         return cls(date_parser.parse(time))
 
-    def iso(self) -> str:
+    def to_iso_string(self) -> str:
+        """
+        Return an ISO 8601 standard date/time string.
+        """
         return self.utc_time.isoformat()
 
     def __str__(self) -> str:
-        return self.iso()
+        """
+        Define str() to return the standard ISO time string
+        """
+        return self.to_iso_string()

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -6,7 +6,7 @@ from typing import List
 from freezegun.api import freeze_time
 import pytest
 
-from pbench.server import PbenchServerConfig, JSON
+from pbench.server import JSON, PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset
 
 
@@ -118,7 +118,7 @@ class TestDatasetsList:
                     "controller": dataset.controller,
                     "run_id": dataset.md5,
                     "metadata": {
-                        "dataset.created": f"{dataset.created:%Y-%m-%d:%H:%M}"
+                        "dataset.created": datetime.datetime.isoformat(dataset.created)
                     },
                 }
             )

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import socket
 from typing import Any
 
-from dateutil import parser as date_parser
 from freezegun.api import freeze_time
 import pytest
 
@@ -17,7 +16,7 @@ from pbench.server.database.models.datasets import (
     States,
 )
 from pbench.server.filetree import FileTree, Tarball
-from pbench.server.utils import IsoTimeHelper
+from pbench.server.utils import UtcTimeHelper
 from pbench.test.unit.server.test_user_auth import login_user, register_user
 
 
@@ -132,7 +131,7 @@ class TestUpload:
 
             def get_metadata(self):
                 return {
-                    "pbench": {"date": IsoTimeHelper.from_string("2002-05-16").utc_time}
+                    "pbench": {"date": UtcTimeHelper.from_string("2002-05-16").utc_time}
                 }
 
         class FakeFileTree(FileTree):
@@ -409,8 +408,8 @@ class TestUpload:
         assert dataset.controller == self.controller
         assert dataset.name == datafile.name[:-7]
         assert dataset.state == States.UPLOADED
-        assert dataset.created == date_parser.parse("2002-05-16T00:00:00+00:00")
-        assert dataset.uploaded == date_parser.parse("1970-01-01T00:00:00+00:00")
+        assert dataset.created.isoformat() == "2002-05-16T00:00:00+00:00"
+        assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
         assert Metadata.getvalue(dataset, "dashboard") is None
         assert (
             Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-01T00:00:00+00:00"

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -1,10 +1,10 @@
-import dateutil
 from http import HTTPStatus
 from logging import Logger
 from pathlib import Path
 import socket
 from typing import Any
 
+from dateutil import parser as date_parser
 from freezegun.api import freeze_time
 import pytest
 
@@ -12,11 +12,12 @@ from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
+    Metadata,
     MetadataKeyError,
     States,
-    Metadata,
 )
 from pbench.server.filetree import FileTree, Tarball
+from pbench.server.utils import IsoTimeHelper
 from pbench.test.unit.server.test_user_auth import login_user, register_user
 
 
@@ -130,7 +131,9 @@ class TestUpload:
                 TestUpload.tarball_deleted = self.name
 
             def get_metadata(self):
-                return {"pbench": {"date": dateutil.parser.parse("2002-05-16")}}
+                return {
+                    "pbench": {"date": IsoTimeHelper.from_string("2002-05-16").utc_time}
+                }
 
         class FakeFileTree(FileTree):
             def __init__(self, options: PbenchServerConfig, logger: Logger):
@@ -406,10 +409,12 @@ class TestUpload:
         assert dataset.controller == self.controller
         assert dataset.name == datafile.name[:-7]
         assert dataset.state == States.UPLOADED
-        assert dataset.created == dateutil.parser.parse("2002-05-16")
-        assert dataset.uploaded == dateutil.parser.parse("1970-01-01")
+        assert dataset.created == date_parser.parse("2002-05-16T00:00:00+00:00")
+        assert dataset.uploaded == date_parser.parse("1970-01-01T00:00:00+00:00")
         assert Metadata.getvalue(dataset, "dashboard") is None
-        assert Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-01"
+        assert (
+            Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-01T00:00:00+00:00"
+        )
         assert self.filetree_created
         assert dataset.name in self.filetree_created
 

--- a/lib/pbench/test/unit/server/test_utils.py
+++ b/lib/pbench/test/unit/server/test_utils.py
@@ -1,6 +1,9 @@
+import datetime
+
+from freezegun.api import freeze_time
 import pytest
 
-from pbench.server.utils import filesize_bytes
+from pbench.server.utils import UtcTimeHelper, filesize_bytes
 
 
 _sizes = [("  10  ", 10)]
@@ -35,3 +38,23 @@ class TestFilesizeBytes:
             ), f"string '{size}', improperly converted to {res}, expected {exp_val}"
         with pytest.raises(Exception):
             res = filesize_bytes("bad")
+
+
+class TestUtcTimeHelper:
+    @freeze_time("1970-01-01")
+    def test_naive(self):
+        d = UtcTimeHelper(datetime.datetime.now())
+        assert d.to_iso_string() == "1970-01-01T00:00:00+00:00"
+        assert d.utc_time.isoformat() == d.to_iso_string()
+
+    @freeze_time("2002-05-16T10:23+00:00")
+    def test_aware_utc(self):
+        d = UtcTimeHelper(datetime.datetime.now(datetime.timezone.utc))
+        assert d.to_iso_string() == "2002-05-16T10:23:00+00:00"
+
+    @freeze_time("2002-05-16T10:23-04:00")
+    def test_aware_local(self):
+        d = UtcTimeHelper(
+            datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-4)))
+        )
+        assert d.to_iso_string() == "2002-05-16T14:23:00+00:00"


### PR DESCRIPTION
PBENCH-638

SQLAlchemy stores SQL dates in "naive UTC" by default; add logic to make this explicit and to add adjustment of aware dates on input and creation of aware UTC dates on retrieval.

Adopt ISO 8601 formatting for dates reported through the API. (This does not include a rigorous analysis of Elasticsearch data, although at least some already appear in ISO 8601 UTC.)