### PR TITLE
Fix "index map" APIs to use dataset name

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -23,7 +23,7 @@ class MissingDatasetNameParameter(SchemaError):
 
     NOTE: This is a development error, not a client error, and will be raised
     when the API is initialized at server startup. Arguably, this could be an
-    `assert` since it prevents launching the server.
+    assert since it prevents launching the server.
     """
 
     def __init__(self, subclass_name: str):
@@ -31,7 +31,7 @@ class MissingDatasetNameParameter(SchemaError):
         self.subclass_name = subclass_name
 
     def __str__(self) -> str:
-        return f"API {self.subclass_name} is missing schema parameter `name`"
+        return f"API {self.subclass_name} is missing schema parameter, name"
 
 
 class IndexMapBase(ElasticBase):
@@ -40,12 +40,12 @@ class IndexMapBase(ElasticBase):
     indices.
 
     This class extends the ElasticBase class and implements a common
-    `preprocess` method based on client provided dataset name. The ElasticBase
+    'preprocess' method which finds a target dataset by name. The ElasticBase
     methods 'assemble' and 'postprocess' must be implemented by the respective
     subclasses.
 
-    Note that dataset `name` is a required schema parameter for all the classes
-    extending this class. The common "preprocess" provides json context with a
+    Note that dataset 'name' is a required schema parameter for all the classes
+    extending this class. The common 'preprocess' provides json context with a
     dataset that's passed to the assemble and postprocess methods.
     """
 
@@ -99,9 +99,7 @@ class IndexMapBase(ElasticBase):
         try:
             dataset = Dataset.query(name=dataset_name)
         except DatasetNotFound:
-            raise APIAbort(
-                HTTPStatus.NOT_FOUND, f"Dataset {dataset_name!r} not found."
-            )
+            raise APIAbort(HTTPStatus.NOT_FOUND, f"Dataset {dataset_name!r} not found.")
         owner = User.query(id=dataset.owner_id)
         if not owner:
             self.logger.error(
@@ -114,7 +112,7 @@ class IndexMapBase(ElasticBase):
         # will raise UnauthorizedAccess on failure.
         self._check_authorization(owner.username, dataset.access)
 
-        # The dataset exists, and authenticated user has access, so continue
+        # The dataset exists, and the authenticated user has access, so process
         # the operation with the appropriate CONTEXT.
         return {"dataset": dataset}
 

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -14,7 +14,7 @@ from pbench.server.api.resources import (
     SchemaError,
 )
 
-from pbench.server.api.resources.query_apis.datasets import RunIdBase
+from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 from pbench.server.database.models.template import Template, TemplateNotFound
 
 
@@ -74,7 +74,7 @@ class DatasetsMappings(ApiBase):
                     "dataset_view",
                     ParamType.KEYWORD,
                     required=True,
-                    keywords=list(RunIdBase.ES_INTERNAL_INDEX_NAMES.keys()),
+                    keywords=list(IndexMapBase.ES_INTERNAL_INDEX_NAMES.keys()),
                     uri_parameter=True,
                 )
             ),
@@ -101,7 +101,7 @@ class DatasetsMappings(ApiBase):
         except SchemaError as e:
             raise APIAbort(HTTPStatus.BAD_REQUEST, str(e))
 
-        index = RunIdBase.ES_INTERNAL_INDEX_NAMES[json_data["dataset_view"]]
+        index = IndexMapBase.ES_INTERNAL_INDEX_NAMES[json_data["dataset_view"]]
         try:
             index_name = index["index"]
             template = Template.find(index_name)

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -23,7 +23,7 @@ class TestDatasetsContents(Commons):
             cls_obj=DatasetsContents(client.config, client.logger),
             pbench_endpoint="/datasets/contents",
             elastic_endpoint="/_search",
-            payload={"run_id": "random_md5_string1", "parent": "/1-default"},
+            payload={"name": "drb", "parent": "/1-default"},
             index_from_metadata="run-toc",
         )
 
@@ -464,7 +464,7 @@ class TestDatasetsContents(Commons):
         if expected_status == HTTPStatus.NOT_FOUND:
             res_json = response.json
             expected_result = {
-                "message": "No directory '/1-default' in 'random_md5_string1' contents."
+                "message": "No directory '/1-default' in 'drb' contents."
             }
             assert expected_result == res_json
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -473,13 +473,13 @@ class TestDatasetsContents(Commons):
         indices = self.cls_obj.get_index(drb, self.index_from_metadata)
         assert indices == "unit-test.v6.run-toc.2020-05"
 
-    @pytest.mark.parametrize("run_id", ("wrong", "", None))
-    def test_missing_run_id(self, client, server_config, pbench_token, run_id):
-        if run_id is None:
-            del self.payload["run_id"]
+    @pytest.mark.parametrize("name", ("wrong", "", None))
+    def test_missing_name(self, client, server_config, pbench_token, name):
+        if name is None:
+            del self.payload["name"]
             expected_status = HTTPStatus.BAD_REQUEST
         else:
-            self.payload["run_id"] = run_id
+            self.payload["name"] = name
             expected_status = HTTPStatus.NOT_FOUND
         response = client.post(
             f"{server_config.rest_uri}{self.pbench_endpoint}",

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -25,7 +25,7 @@ class TestSamplesNamespace(Commons):
             cls_obj=SampleNamespace(client.config, client.logger),
             pbench_endpoint="/datasets/namespace/iterations",
             elastic_endpoint="/_search",
-            payload={"run_id": "random_md5_string1"},
+            payload={"name": "drb"},
             index_from_metadata="result-data-sample",
         )
 
@@ -404,7 +404,7 @@ class TestSampleValues(Commons):
             cls_obj=SampleValues(client.config, client.logger),
             pbench_endpoint="/datasets/values/iterations",
             elastic_endpoint="/_search",
-            payload={"run_id": "random_md5_string1"},
+            payload={"name": "drb"},
             index_from_metadata="result-data-sample",
         )
 


### PR DESCRIPTION
PBENCH-644

To align with the service layer of the old dashboard, the search, mappings, and contents APIs were designed to identify datasets using the Elasticsearch run document MD5 (run_id or run.id) rather than the more straightforward model of relying on the dataset name.

As we approach the verge of using TOC data in the new dashboard, fixing this seems timely.