### PR TITLE
New API to fetch date range of accessible datasets

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -15,7 +15,7 @@ from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.api.auth import Auth
-from pbench.server.api.resources.datasets_daterange import DatasetsDaterange
+from pbench.server.api.resources.datasets_daterange import DatasetsDateRange
 from pbench.server.api.resources.datasets_list import DatasetsList
 from pbench.server.api.resources.datasets_metadata import DatasetsMetadata
 from pbench.server.api.resources.endpoint_configure import EndpointConfig
@@ -60,7 +60,7 @@ def register_endpoints(api, app, config):
         resource_class_args=(config, logger),
     )
     api.add_resource(
-        DatasetsDaterange,
+        DatasetsDateRange,
         f"{base_uri}/datasets/daterange",
         resource_class_args=(config, logger),
     )

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -15,6 +15,7 @@ from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.api.auth import Auth
+from pbench.server.api.resources.datasets_daterange import DatasetsDaterange
 from pbench.server.api.resources.datasets_list import DatasetsList
 from pbench.server.api.resources.datasets_metadata import DatasetsMetadata
 from pbench.server.api.resources.endpoint_configure import EndpointConfig
@@ -56,6 +57,11 @@ def register_endpoints(api, app, config):
     api.add_resource(
         DatasetsContents,
         f"{base_uri}/datasets/contents",
+        resource_class_args=(config, logger),
+    )
+    api.add_resource(
+        DatasetsDaterange,
+        f"{base_uri}/datasets/daterange",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -722,7 +722,9 @@ class ApiBase(Resource):
         # Normalize and validate the keys we got via the HTTP query string.
         # These aren't automatically validated by the superclass, so we
         # have to do it here.
-        return schema.validate(json)
+        if json:
+            return schema.validate(json)
+        return {}
 
     def _check_authorization(self, user_id: Union[str, None], access: Union[str, None]):
         """

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -679,7 +679,7 @@ class ApiBase(Resource):
         self.schema = schema
         self.role = role
 
-    def _collect_query_params(self, request: Request, schema: Schema) -> JSONOBJECT:
+    def _validate_query_params(self, request: Request, schema: Schema) -> JSONOBJECT:
         """
         When an API accepts HTTP query parameters from the URL, these aren't
         automatically validated by the dispatcher. This method collects query
@@ -719,7 +719,10 @@ class ApiBase(Resource):
         if badkey:
             raise BadQueryParam(badkey)
 
-        return json
+        # Normalize and validate the keys we got via the HTTP query string.
+        # These aren't automatically validated by the superclass, so we
+        # have to do it here.
+        return schema.validate(json)
 
     def _check_authorization(self, user_id: Union[str, None], access: Union[str, None]):
         """

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -652,7 +652,7 @@ class ApiBase(Resource):
         self,
         config: PbenchServerConfig,
         logger: Logger,
-        schema: Schema,
+        schema: Union[Schema, None],
         *,  # following parameters are keyword-only
         role: API_OPERATION = API_OPERATION.READ,
     ):
@@ -679,12 +679,11 @@ class ApiBase(Resource):
         self.schema = schema
         self.role = role
 
-    def _validate_query_params(self, request: Request, schema: Schema) -> JSONOBJECT:
+    def _collect_query_params(self, request: Request, schema: Schema) -> JSONOBJECT:
         """
         When an API accepts HTTP query parameters from the URL, these aren't
         automatically validated by the dispatcher. This method collects query
-        parameters into a JSON object and validates them against a specified
-        schema.
+        parameters into a JSON object which can be validated against a Schema.
 
         Note that a multi-valued query parameter can be specified *either* by
         a comma-separated single string value *or* by a list of individual
@@ -720,10 +719,7 @@ class ApiBase(Resource):
         if badkey:
             raise BadQueryParam(badkey)
 
-        # Normalize and validate the keys we got via the HTTP query string.
-        # These aren't automatically validated by the superclass, so we
-        # have to do it here.
-        return schema.validate(json)
+        return json
 
     def _check_authorization(self, user_id: Union[str, None], access: Union[str, None]):
         """
@@ -904,7 +900,7 @@ class ApiBase(Resource):
 
         Args:
             JSON query parameters containing keys:
-                "owner": Pbench username to restrict search to datasets owned by
+                "owner": Pbench user ID to restrict search to datasets owned by
                     a specific user.
                 "access": Access category, "public" or "private" to restrict
                     search to datasets with a specific access category.

--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -1,0 +1,83 @@
+from logging import Logger
+import logging
+
+from flask.json import jsonify
+from flask.wrappers import Request, Response
+from sqlalchemy import func
+
+from pbench.server import PbenchServerConfig
+from pbench.server.api.resources import (
+    ApiBase,
+    API_OPERATION,
+    Parameter,
+    ParamType,
+    Schema,
+)
+from pbench.server.database.database import Database
+from pbench.server.database.models.datasets import Dataset
+
+
+class DatasetsDaterange(ApiBase):
+    """
+    API class to retrieve the available date range of accessible datasets.
+    """
+
+    GET_SCHEMA = Schema(
+        Parameter("owner", ParamType.USER, required=False),
+        Parameter("access", ParamType.ACCESS, required=False),
+    )
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            None,
+            role=API_OPERATION.READ,
+        )
+
+    def _get(self, _, request: Request) -> Response:
+        """
+        Get the date range for which datasets are available to the client based
+        on authentication plus optional dataset owner and access criteria.
+
+        Args:
+            json_data: For a GET, this contains only the Flask URI template
+                values, which aren't used here
+            request: The original Request object containing query parameters
+
+
+        GET /api/v1/datasets/daterange?owner=user&access=public
+        """
+
+        json = self._collect_query_params(request, self.GET_SCHEMA)
+        new_json = self.GET_SCHEMA.validate(json) if json else json
+
+        access = new_json.get("access")
+        owner = json.get("owner")
+        self.logger.info("Getting date range for user {!r}, access {!r}", owner, access)
+
+        # Validate the authenticated user's authorization for the combination
+        # of "owner" and "access".
+        self._check_authorization(owner, access)
+
+        # Build a SQLAlchemy Query object expressing all of our constraints
+        query = Database.db_session.query(
+            func.min(Dataset.created), func.max(Dataset.created)
+        )
+        query = self._build_sql_query(new_json, query)
+
+        # Useful for debugging, but verbose: this displays the fully expanded
+        # SQL `SELECT` statement.
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug(
+                "QUERY {}",
+                query.statement.compile(compile_kwargs={"literal_binds": True}),
+            )
+
+        # Execute the query, returning a tuple of the 'min' date and the
+        # 'max' date.
+        results = query.first()
+
+        self.logger.info("Results: {!r}", results)
+
+        return jsonify({"from": results[0].isoformat(), "to": results[1].isoformat()})

--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -3,7 +3,7 @@ from flask.wrappers import Request, Response
 from logging import Logger
 from sqlalchemy import func
 
-from pbench.server import PbenchServerConfig
+from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
     ApiBase,
     API_OPERATION,
@@ -33,12 +33,13 @@ class DatasetsDateRange(ApiBase):
             role=API_OPERATION.READ,
         )
 
-    def _get(self, _, request: Request) -> Response:
+    def _get(self, json_data: JSON, request: Request) -> Response:
         """
         Get the date range for which datasets are available to the client based
         on authentication plus optional dataset owner and access criteria.
 
         Args:
+            json_data: Ignored because GET has no JSON payload
             request: The original Request object containing query parameters
 
         GET /api/v1/datasets/daterange?owner=user&access=public

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -3,7 +3,7 @@ import logging
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import PbenchServerConfig
+from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
     API_OPERATION,
     ApiBase,
@@ -45,7 +45,7 @@ class DatasetsList(ApiBase):
             role=API_OPERATION.READ,
         )
 
-    def _get(self, _, request: Request) -> Response:
+    def _get(self, json_data: JSON, request: Request) -> Response:
         """
         Get a list of datasets matching a set of criteria.
 
@@ -53,6 +53,7 @@ class DatasetsList(ApiBase):
         desired metadata keys; instead we rely on URI query parameters.
 
         Args:
+            json_data: Ignored because GET has no JSON payload
             request: The original Request object containing query parameters
 
         GET /api/v1/datasets/list?start=1970-01-01&end=2040-12-31&owner=fred&metadata=dashboard.seen,server.deletion

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -71,9 +71,7 @@ class DatasetsList(ApiBase):
         query = Database.db_session.query(Dataset)
         if "start" in json and "end" in json:
             self.logger.info("Adding start / end query")
-            query = query.filter(
-                Dataset.created.between(json["start"], json["end"])
-            )
+            query = query.filter(Dataset.created.between(json["start"], json["end"]))
         elif "start" in json:
             self.logger.info("Adding start query")
             query = query.filter(Dataset.created >= json["start"])

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -4,7 +4,7 @@ from logging import Logger
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import JSONOBJECT, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
 from pbench.server.api.resources import (
     APIAbort,
     API_OPERATION,
@@ -54,7 +54,7 @@ class DatasetsMetadata(ApiBase):
             role=API_OPERATION.UPDATE,
         )
 
-    def _get(self, _, request: Request) -> Response:
+    def _get(self, json_data: JSON, request: Request) -> Response:
         """
         Get the values of client-accessible dataset metadata keys.
 
@@ -67,6 +67,7 @@ class DatasetsMetadata(ApiBase):
         query parameters.
 
         Args:
+            json_data: Ignored because GET has no JSON payload
             request: The original Request object containing query parameters
 
         GET /api/v1/datasets/metadata?name=dname&metadata=dashboard.seen,server.deletion

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -66,10 +66,16 @@ class DatasetsMetadata(ApiBase):
         GET. In this case, we're going to experiment with an alternative, using
         query parameters.
 
+        Args:
+            json_data: For a GET, this contains only the Flask URI template
+                values, which aren't used here
+            request: The original Request object containing query parameters
+
         GET /api/v1/datasets/metadata?name=dname&metadata=dashboard.seen,server.deletion
         """
 
-        new_json = self._validate_query_params(request, self.GET_SCHEMA)
+        json = self._collect_query_params(request, self.GET_SCHEMA)
+        new_json = self.GET_SCHEMA.validate(json) if json else json
         name = new_json.get("name")
         keys = new_json.get("metadata")
 

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -67,17 +67,14 @@ class DatasetsMetadata(ApiBase):
         query parameters.
 
         Args:
-            json_data: For a GET, this contains only the Flask URI template
-                values, which aren't used here
             request: The original Request object containing query parameters
 
         GET /api/v1/datasets/metadata?name=dname&metadata=dashboard.seen,server.deletion
         """
 
-        json = self._collect_query_params(request, self.GET_SCHEMA)
-        new_json = self.GET_SCHEMA.validate(json) if json else json
-        name = new_json.get("name")
-        keys = new_json.get("metadata")
+        json = self._validate_query_params(request, self.GET_SCHEMA)
+        name = json.get("name")
+        keys = json.get("metadata")
 
         self.logger.info("GET metadata {} for {}", keys, name)
         try:

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -294,6 +294,13 @@ def attach_dataset(create_drb_user, create_user):
     Create test Datasets for the authorized user ("drb") and for another user
     ("test")
 
+    The resulting datasets are:
+
+        Owner   Access  Date        Name
+        ------- ------- ----------- ---------
+        drb     private 2020-02-15  drb
+        test    private 2002-05-16  test
+
     Args:
         create_drb_user: create a "drb" user
         create_user: create a "test" user

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -324,6 +324,49 @@ def attach_dataset(create_drb_user, create_user):
 
 
 @pytest.fixture()
+def more_datasets(
+    client, server_config, create_drb_user, create_admin_user, attach_dataset
+):
+    """
+    Supplement the conftest.py "attach_dataset" fixture with a few more
+    datasets so we can practice various queries. In combination with
+    attach_dataset, the resulting datasets are:
+
+        Owner   Access  Date        Name
+        ------- ------- ----------- ---------
+        drb     private 2020-02-15  drb
+        test    private 2002-05-16  test
+        drb     public  2020-02-15  fio_1
+        test    public  2002-05-16  fio_2
+
+    Args:
+        client: Provide a Flask API client
+        server_config: Provide a Pbench server configuration
+        create_drb_user: Create the "drb" user
+        create_admin_user: Create the "test_admin" user
+        attach_dataset: Provide some datasets
+    """
+    with freeze_time("1978-06-26 08:00:00"):
+        Dataset(
+            owner="drb",
+            created=datetime.datetime(2020, 2, 15),
+            uploaded=datetime.datetime(2022, 1, 1),
+            controller="node1",
+            name="fio_1",
+            access="public",
+            md5="random_md5_string3",
+        ).add()
+        Dataset(
+            owner="test",
+            created=datetime.datetime(2002, 5, 16),
+            controller="node2",
+            name="fio_2",
+            access="public",
+            md5="random_md5_string4",
+        ).add()
+
+
+@pytest.fixture()
 def provide_metadata(attach_dataset):
     """
     Create "real" metadata in the backing database, which will be accessible

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -5,11 +5,11 @@ from typing import Dict, List
 
 import pytest
 
-from pbench.server import PbenchServerConfig, JSON
+from pbench.server import JSON, PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset
 
 
-class TestDatasetsDaterange:
+class TestDatasetsDateRange:
     """
     Test the `datasets/daterange` API. We perform a variety of queries using a
     set of datasets provided by the `attach_dataset` fixture and the
@@ -64,8 +64,10 @@ class TestDatasetsDaterange:
         Returns:
             {"from": first_date, "to": last_date}
         """
-        from_time = datetime.datetime.now()
-        to_time = datetime.datetime(year=1970, month=1, day=1)
+        from_time = datetime.datetime.now(datetime.timezone.utc)
+        to_time = datetime.datetime(
+            year=1970, month=1, day=1, tzinfo=datetime.timezone.utc
+        )
         for name in sorted(name_list):
             dataset = Dataset.query(name=name)
             to_time = max(dataset.created, to_time)
@@ -83,9 +85,9 @@ class TestDatasetsDaterange:
             ("test_admin", {}, ["drb", "test", "fio_1", "fio_2"]),
         ],
     )
-    def test_dataset_list(self, query_as, login, query, results):
+    def test_dataset_daterange(self, query_as, login, query, results):
         """
-        Test the operation of `datasets/list` against our set of test
+        Test the operation of `datasets/daterange` against our set of test
         datasets.
 
         Args:
@@ -114,7 +116,7 @@ class TestDatasetsDaterange:
 
     def test_get_repeat_keys(self, query_as):
         """
-        Test case requesting repeated single-value metadata keys.
+        Test case requesting repeated single-value query param keys.
 
         NOTE that the request package processes a list of values for a query
         parameter by repeating the key name with each value since the HTTP

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -1,3 +1,4 @@
+import datetime
 from http import HTTPStatus
 import requests
 from typing import List

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -46,6 +46,7 @@ class TestEndpointConfig:
                 # corresponds to /datasets/mappings/<string:dataset_view>";
                 # see endpoint_configure.py for more detail.
                 "datasets_contents": f"{uri}/datasets/contents",
+                "datasets_daterange": f"{uri}/datasets/daterange",
                 "datasets_delete": f"{uri}/datasets/delete",
                 "datasets_detail": f"{uri}/datasets/detail",
                 "datasets_list": f"{uri}/datasets/list",


### PR DESCRIPTION
PBENCH-643

Add a new `datasets/daterange` API to return the earliest and latest creation date of datasets readable by the authenticated user and with specified owner and access filters.