### PR TITLE
Quick v0.71 fixes

### DIFF
--- a/lib/pbench/agent/tool_meister.py
+++ b/lib/pbench/agent/tool_meister.py
@@ -663,9 +663,9 @@ class PcpTool(PersistentTool):
         if executable is None:
             return InstallationResult(returncode=1, output="pcp tool (pmcd) not found")
         # FIXME - The Tool Data Sink and Tool Meister have to agree on the
-        # exact port number to use.  We can't use the default `pmcd` port
-        # number because it might conflict with an existing `pmcd`
-        # deployment out of our control.
+        #     exact port number to use.  We can't use the default `pmcd` port
+        #     number because it might conflict with an existing `pmcd`
+        #     deployment out of our control.
         self.args = [
             executable,
             "--foreground",
@@ -1798,7 +1798,7 @@ class ToolMeister:
 def get_logger(
     logger_name: str, is_daemon: bool = False, level: str = "info"
 ) -> logging.Logger:
-    """Contruct a logger for a Tool Meister instance.
+    """Construct a logger for a Tool Meister instance.
 
     If in the Unit Test environment, just log to console.
     If in non-unit test environment:

--- a/lib/pbench/agent/tool_meister_start.py
+++ b/lib/pbench/agent/tool_meister_start.py
@@ -304,7 +304,7 @@ def start_tms_via_ssh(
     cmd = f"{tool_meister_cmd} {redis_server.host} {redis_server.port} {{tm_param_key}} yes"
     if debug_level:
         cmd += f" {debug_level}"
-    template = TemplateSsh(Path(ssh_cmd), shlex.split(ssh_opts), cmd)
+    template = TemplateSsh(ssh_cmd, shlex.split(ssh_opts), cmd)
     tms: Dict[str, Union[str, int, Dict[str, str]]] = {}
     tm_count = 0
     for host in tool_group.hostnames.keys():
@@ -909,9 +909,8 @@ def start(_prog: str, cli_params: Namespace) -> int:
 
     try:
         if orchestrate:
-            ssh_cmd = "ssh"
-            ssh_path = shutil.which(ssh_cmd)
-            if ssh_path is None:
+            ssh_cmd = shutil.which("ssh")
+            if ssh_cmd is None:
                 raise CleanupTime(
                     ReturnCode.MISSINGSSHCMD, "required ssh command not in our PATH"
                 )
@@ -926,7 +925,7 @@ def start(_prog: str, cli_params: Namespace) -> int:
             origin_ip = set()
             any_remote = False
             template = TemplateSsh(
-                Path(ssh_path), shlex.split(ssh_opts), "echo ${SSH_CONNECTION}"
+                ssh_cmd, shlex.split(ssh_opts), "echo ${SSH_CONNECTION}"
             )
             recovery.add(template.abort, "stop TM clients")
 
@@ -995,7 +994,7 @@ def start(_prog: str, cli_params: Namespace) -> int:
                 if not redis_server_spec:
                     redis_server_spec = origin
 
-        # NOTE: These two assigments create server objects, but neither
+        # NOTE: These two assignments create server objects, but neither
         # constructor starts a server, so no cleanup action is needed at this
         # time.
         try:
@@ -1169,7 +1168,6 @@ def start(_prog: str, cli_params: Namespace) -> int:
 
         if orchestrate:
             try:
-                # FIXME:  Should we use ssh_path instead of ssh_cmd?
                 start_tms_via_ssh(
                     prog.parent, ssh_cmd, tool_group, ssh_opts, redis_server, logger
                 )

--- a/lib/pbench/agent/tool_meister_start.py
+++ b/lib/pbench/agent/tool_meister_start.py
@@ -255,10 +255,19 @@ def _waitpid(pid: int) -> int:
     Raises an exception if the final exit PID is different from the given PID.
     """
     exit_pid, _exit_status = os.waitpid(pid, 0)
-    if pid != exit_pid:
-        raise Exception(f"Logic bomb!  exit pid, {exit_pid}, does not match pid, {pid}")
-    exit_status = os.WEXITSTATUS(_exit_status)
-    return exit_status
+    assert pid == exit_pid, f"os.waitpid() returned pid {exit_pid}; expected {pid}"
+    if os.WIFEXITED(_exit_status):
+        return os.WEXITSTATUS(_exit_status)
+    elif os.WIFSIGNALED(_exit_status):
+        raise StartTmsErr(
+            f"child process killed by signal {os.WTERMSIG(_exit_status)}",
+            ReturnCode.TDSWAITFAILURE,
+        )
+    else:
+        raise StartTmsErr(
+            f"wait for child process returned unexpectedly, status = {_exit_status}",
+            ReturnCode.TDSWAITFAILURE,
+        )
 
 
 class StartTmsErr(ReturnCode.Err):
@@ -446,9 +455,9 @@ class ToolDataSink(BaseServer):
                 # Wait for the child to finish daemonizing itself.
                 retcode = _waitpid(pid)
                 if retcode != 0:
-                    logger.error(
-                        "failed to create pbench data sink, daemonized; return code: %d",
-                        retcode,
+                    raise self.Err(
+                        f"failed to create pbench data sink, daemonized; return code: {retcode}",
+                        ReturnCode.TDSWAITFAILURE,
                     )
 
         except Exception:
@@ -487,7 +496,9 @@ class ToolDataSink(BaseServer):
         if pid_file.exists():
             self.pid_file = pid_file
         else:
-            logger.error("TDS daemonization didn't create %s", pid_file)
+            raise self.Err(
+                f"TDS daemonization didn't create {pid_file}", ReturnCode.TDSWAITFAILURE
+            )
 
     @staticmethod
     def wait(chan: RedisChannelSubscriber, logger: logging.Logger) -> int:

--- a/lib/pbench/agent/utils.py
+++ b/lib/pbench/agent/utils.py
@@ -1,7 +1,6 @@
 import ipaddress
 import logging
 import os
-from pathlib import Path
 import signal
 import socket
 import subprocess
@@ -221,16 +220,16 @@ def setup_logging(debug, logfile):
     level = logging.DEBUG if debug else logging.INFO
     fmt = "%(message)s"
 
-    rootLogger = logging.getLogger()
+    root_logger = logging.getLogger()
     # cause all messages to be processed when the logger is the root logger
     # or delegation to the parent when the logger is a non-root logger
     # see https://docs.python.org/3/library/logging.html
-    rootLogger.setLevel(logging.NOTSET)
+    root_logger.setLevel(logging.NOTSET)
 
     streamhandler = logging.StreamHandler()
     streamhandler.setLevel(level)
     streamhandler.setFormatter(logging.Formatter(fmt))
-    rootLogger.addHandler(streamhandler)
+    root_logger.addHandler(streamhandler)
 
     if logfile:
         if not os.environ.get("_PBENCH_UNIT_TESTS"):
@@ -240,13 +239,13 @@ def setup_logging(debug, logfile):
         filehandler = logging.FileHandler(logfile)
         filehandler.setLevel(logging.NOTSET)
         filehandler.setFormatter(logging.Formatter(fmt))
-        rootLogger.addHandler(filehandler)
+        root_logger.addHandler(filehandler)
 
-    return rootLogger
+    return root_logger
 
 
 def _log_date():
-    """_log_data - helper function to mimick previous bash code behaviors
+    """helper function to mimic previous bash code behaviors
 
     Returns an ISO format date string of the current time.  If running in
     a unit test environment, returns a fixed date string.
@@ -259,13 +258,13 @@ def _log_date():
 
 
 def _pbench_log(message):
-    """_pbench_log - helper function for logging to the ${pbench_log} file."""
+    """helper function for logging to the ${pbench_log} file."""
     with open(os.environ["pbench_log"], "a+") as fp:
         print(message, file=fp)
 
 
 def warn_log(msg):
-    """warn_log - mimick previous bash behavior of writing warning logs to
+    """mimic previous bash behavior of writing warning logs to
     both stderr and the ${pbench_log} file.
     """
     message = f"[warn][{_log_date()}] {msg}"
@@ -274,7 +273,7 @@ def warn_log(msg):
 
 
 def error_log(msg):
-    """error_log - mimick previous bash behavior of writing error logs to
+    """mimic previous bash behavior of writing error logs to
     both stderr and the ${pbench_log} file.
     """
     message = f"[error][{_log_date()}] {msg}"
@@ -283,7 +282,7 @@ def error_log(msg):
 
 
 def info_log(msg):
-    """info_log - mimick previous bash behavior of writing info logs to
+    """mimic previous bash behavior of writing info logs to
     the ${pbench_log} file.
     """
     message = f"[info][{_log_date()}] {msg}"
@@ -383,7 +382,7 @@ def collect_local_info(pbench_bin):
         )
         hostdata[arg] = cp.stdout.strip() if cp.stdout is not None else ""
 
-    return (version, seqno, sha1, hostdata)
+    return version, seqno, sha1, hostdata
 
 
 class TemplateSsh:
@@ -397,12 +396,12 @@ class TemplateSsh:
         stdout: str
         stderr: str
 
-    def __init__(self, ssh_cmd: Path, ssh_args: List[str], cmd: str):
+    def __init__(self, ssh_cmd: str, ssh_args: List[str], cmd: str):
         """
         Create an SSH template object
 
         Args:
-            ssh_cmd: Path to the ssh command
+            ssh_cmd: file path of the ssh command
             ssh_args: A partial argv representing ssh command options
             cmd: A templated string representing a remote command to be executed
         """


### PR DESCRIPTION
This PR consists of two commits:  the first is a bunch of lint-pickings; the second is some quick fixes for problems identified during the v0.71 Test Day (and subsequent code review):
- a mis-handling of the return status in the `_wait_pid()` function in `tool_meister_start.py`;
- a change to raise an exception if the TDS daemon-child process fails before detaching itself; and,
- a change to raise an exception if the TDS PID file is missing after start up.

I recommend reviewing the commits individually.  The second (and only the second) commit should be backported to v0.71.

(Several of the changes originally in this PR landed in #2797.)
