### PR TITLE
Convert authorization to use ID rather than string

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -62,7 +62,7 @@ class DatasetsList(ApiBase):
 
         # Validate the authenticated user's authorization for the combination
         # of "owner" and "access".
-        self._check_authorization(json_data.get("owner"), new_json.get("access"))
+        self._check_authorization(new_json.get("owner"), new_json.get("access"))
 
         # Build a SQLAlchemy Query object expressing all of our constraints
         query = Database.db_session.query(Dataset)

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -623,13 +623,6 @@ class ElasticBulkBase(ApiBase):
         except DatasetNotFound as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
 
-        owner = User.query(id=dataset.owner_id)
-        if not owner:
-            self.logger.error(
-                "Dataset owner ID {} cannot be found in Users", dataset.owner_id
-            )
-            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
-
         # For bulk Elasticsearch operations, we check authorization against the
         # ownership of a designated dataset rather than having an explicit
         # "user" JSON parameter. If the subclass schema includes an "access"
@@ -638,7 +631,7 @@ class ElasticBulkBase(ApiBase):
         #
         # This will raise UnauthorizedAccess on failure.
         try:
-            self._check_authorization(owner.username, dataset.access)
+            self._check_authorization(str(dataset.owner_id), dataset.access)
         except UnauthorizedAccess as e:
             raise APIAbort(e.http_status, str(e))
 

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -13,7 +13,6 @@ from pbench.server.database.models.datasets import (
     MetadataError,
 )
 from pbench.server.database.models.template import Template
-from pbench.server.database.models.users import User
 
 
 class MissingDatasetNameParameter(SchemaError):
@@ -100,17 +99,11 @@ class IndexMapBase(ElasticBase):
             dataset = Dataset.query(name=dataset_name)
         except DatasetNotFound:
             raise APIAbort(HTTPStatus.NOT_FOUND, f"Dataset {dataset_name!r} not found.")
-        owner = User.query(id=dataset.owner_id)
-        if not owner:
-            self.logger.error(
-                "Dataset owner ID {!r} cannot be found in Users", dataset.owner_id
-            )
-            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
 
         # We check authorization against the ownership of the dataset that was
         # selected rather than having an explicit "user" JSON parameter. This
         # will raise UnauthorizedAccess on failure.
-        self._check_authorization(owner.username, dataset.access)
+        self._check_authorization(str(dataset.owner_id), dataset.access)
 
         # The dataset exists, and the authenticated user has access, so process
         # the operation with the appropriate CONTEXT.

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -634,16 +634,16 @@ def pbench_admin_token(client, server_config, create_admin_user):
 @pytest.fixture()
 def create_drb_user(client, server_config, fake_email_validator):
     # Create a user
-    response = register_user(
-        client,
-        server_config,
-        username="drb",
-        firstname="firstname",
-        lastname="lastName",
-        email="user@domain.com",
+    drb = User(
+        email="drb@example.com",
+        id=3,
         password=generic_password,
+        username="drb",
+        first_name="Authorized",
+        last_name="User",
     )
-    assert response.status_code == HTTPStatus.CREATED
+    drb.add()
+    return drb
 
 
 @pytest.fixture()
@@ -682,22 +682,14 @@ def build_auth_header(request, server_config, pbench_token, pbench_admin_token, 
 
 
 @pytest.fixture()
-def current_user_drb(monkeypatch, fake_email_validator):
-    drb = User(
-        email="drb@example.com",
-        id=3,
-        username="drb",
-        first_name="Authorized",
-        last_name="User",
-    )
-
+def current_user_drb(monkeypatch, create_drb_user, fake_email_validator):
     class FakeHTTPTokenAuth:
         def current_user(self) -> User:
-            return drb
+            return create_drb_user
 
     with monkeypatch.context() as m:
         m.setattr(Auth, "token_auth", FakeHTTPTokenAuth())
-        yield drb
+        yield create_drb_user
 
 
 @pytest.fixture()

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -182,7 +182,7 @@ class TestDatasetsDelete:
         assert (
             "pbench.server.api",
             ERROR,
-            'DatasetsDelete:dataset drb(1)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+            'DatasetsDelete:dataset drb(3)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
         ) in caplog.record_tuples
 
         # Verify that the Dataset still exists

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -163,7 +163,7 @@ class TestDatasetsPublish:
         assert (
             "pbench.server.api",
             ERROR,
-            'DatasetsPublish:dataset drb(1)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+            'DatasetsPublish:dataset drb(3)|node|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
         ) in caplog.record_tuples
 
         # Verify that the Dataset access didn't change


### PR DESCRIPTION
PBENCH-646

User authorization via ApiBase._check_authorization has always used the "raw" specified username string from the client. It makes more sense to use the validated internal form (the stringified DB row ID), and this in particular will simplify handling of a username that appears in a URL query parameter.

Resolves #2824 