### PR TITLE
New user metadata namespace for Overview page

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1022,10 +1022,9 @@ class ApiBase(Resource):
                 metadata[i] = UtcTimeHelper(dataset.uploaded).to_iso_string()
             elif Metadata.is_key_path(i, Metadata.USER_METADATA):
                 native_key = Metadata.get_native_key(i)
-                user = None
+                user: Optional[User] = None
                 if native_key == Metadata.USER_NATIVE_KEY:
-                    authorized_user: Optional[User] = Auth.token_auth.current_user()
-                    user = authorized_user
+                    user = Auth.token_auth.current_user()
                 try:
                     metadata[i] = Metadata.getvalue(dataset=dataset, key=i, user=user)
                 except MetadataNotFound:

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1027,7 +1027,6 @@ class ApiBase(Resource):
                     authorized_user: Optional[User] = Auth.token_auth.current_user()
                     user = authorized_user
                 try:
-                    self.logger.info("Accessing {!r} ({!r}) as {}", i, native_key, user)
                     metadata[i] = Metadata.getvalue(dataset=dataset, key=i, user=user)
                 except MetadataNotFound:
                     metadata[i] = None

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -821,51 +821,34 @@ class Metadata(Database.Base):
     # the "server" namespace, and are strictly controlled by keyword path:
     # e.g., "server.deleted", "server.archived";
     #
-    # Metadata keys within the "user" namespace allow exposure of user-specific
-    # configuration data through the Dataset metadata API; for example, a
-    # client can ask whether a specific dataset has been "favorited" by the
-    # authenticated user (TBD) and the allowable access settings (currently
-    # private and public).
-    #
-    # Metadata keys intended for use by the dashboard client are in the
-    # "dashboard" namespace. While these can be modified by any API client, the
-    # separate namespace provides some protection against accidental
-    # modifications that might break dashboard semantics. This is an "open"
-    # namespace, allowing the dashboard to define and manage any keys it needs
-    # within the "dashboard.*" hierarchy.
+    # The "dashboard" and "user" namespaces can be written by an authenticated
+    # client to track external metadata. The difference is that "dashboard" key
+    # values are visible to all clients with READ access to the dataset, while
+    # the "user" namespace is visible only to clients authenticated to the user
+    # that wrote the data. That is, "dashboard.seen" is a global dashboard
+    # metadata property visible to all users, while "user.favorite" is visible
+    # only to the specific user that wrote the value; each authenticated user
+    # may have its own unique "user.favorite" value.
     #
     # The following class constants define the set of currently available
     # metadata keys, where the "open" namespaces are represented by the
-    # syntax "user.*".
+    # syntax "dashboard.*" and "user.*" which allow clients to control the
+    # key names using a "dotted path" notation like "dashboard.seen" or
+    # "dashboard.contact.email".
 
-    # DASHBOARD is arbitrary data saved on behalf of the dashboard client; the
-    # reserved namespace differs from "user" only in that reserving a primary
-    # key for the "well known" dashboard client offers some protection against
-    # key name collisions.
+    # DASHBOARD is arbitrary data saved on behalf of the dashboard client as a
+    # JSON document. Writing these keys requires ownership of the referenced
+    # dataset, and the data is visible to all clients with READ access to the
+    # dataset.
     #
     # {"dashboard.seen": True}
     DASHBOARD = "dashboard.*"
 
     # USER is arbitrary data saved with the dataset on behalf of an
-    # authenticated user, as a JSON document.
-    #
-    # Note that the hierarchical key management in the getvalue and setvalue
-    # static methods (used consistently by the API layer) allow client code
-    # to interact with these either as a complete JSON document ("user") or
-    # as a full dotted key path ("user.contact.name.first") or at any JSON
-    # layer between.
-    #
-    # API keyword validation uses the trailing ".*" here to indicate that only
-    # the first element of the path should be validated, allowing the client
-    # a completely uninterpreted namespace below that.
-    #
-    # Metadata in the "user" namespace is user-specific; it will always be set
-    # and accessed using the authenticated user ID. That is, different users
-    # will see their own "user" namespace keys for any given dataset.
-    #
-    # TODO: ?? It occurs to me that we could allow "user" metadata rows without
-    # a user_id, which could act as a "default" for all users examining the
-    # dataset -- I'm not entirely sure this is a good model.
+    # authenticated user, as a JSON document. Writing these keys requires READ
+    # access to the referenced dataset, and are visible only to clients that
+    # are authenticated as the user which set them. Each user can have its own
+    # unique value for these keys, for example "user.favorite".
     #
     # {"user.favorite": True}
     USER_NATIVE_KEY = "user"
@@ -997,7 +980,7 @@ class Metadata(Database.Base):
         Returns:
             native SQL key name ("user")
         """
-        return key.lower().split(".").pop(0)
+        return key.lower().split(".")[0]
 
     @staticmethod
     def is_key_path(key: str, valid: List[str]) -> bool:
@@ -1007,7 +990,7 @@ class Metadata(Database.Base):
         valid. If the key is a dotted path and the first element plus a
         trailing ".*" is in the list, then this is an open key namespace where
         any subsequent path is acceptable: e.g., "user.*" allows "user", or
-        "user.contact", "user.contact.name", etc.
+        "user.favorite", "user.notes.status", etc.
 
         Args:
             key: metadata key path
@@ -1040,16 +1023,28 @@ class Metadata(Database.Base):
         level Metadata object. The full JSON value of a top level key can be
         acquired directly using `Metadata.get(dataset, key)`
 
-        E.g., for "user.contact.name" with the dataset's Metadata value for the
-        "user" key as {"contact": {"name": "Dave", "email": "d@example.com"}},
-        this would return "Dave", whereas Metadata.get(dataset, "user") would
-        return the entire user key JSON, such as
-        {"user" {"contact": {"name": "Dave", "email": "d@example.com}}}
+        For example, if the metadata database has
+
+            "dashboard": {
+                    "contact": {
+                        "name": "dave",
+                        "email": "d@example.com"
+                    }
+                }
+
+        then Metadata.get(dataset, "dashboard.contact.name") would return
+
+            "Dave"
+
+        whereas Metadata.get(dataset, "dashboard") would return the entire user
+        key JSON, such as
+
+            {"dashboard" {"contact": {"name": "Dave", "email": "d@example.com}}}
 
         Args:
             dataset: associated dataset
             key: hierarchical key path to fetch
-            user:
+            user: User-specific key value (used only for "user." namespace)
 
         Returns:
             Value of the key path
@@ -1171,9 +1166,9 @@ class Metadata(Database.Base):
         """
         try:
             meta = __class__._query(dataset, key, user).first()
-        except SQLAlchemyError:
+        except SQLAlchemyError as e:
             Metadata.logger.exception("Can't get {}>>{} from DB", dataset, key)
-            raise MetadataSqlError("getting", dataset, key)
+            raise MetadataSqlError("getting", dataset, key) from e
         else:
             if meta is None:
                 raise MetadataNotFound(dataset, key)

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -872,7 +872,7 @@ class Metadata(Database.Base):
     USER = USER_NATIVE_KEY + ".*"
 
     # DELETION timestamp for dataset based on user settings and system
-    # settings at time the dataset is created.
+    # settings when the dataset is created.
     #
     # {"server.deletion": "2021-12-25"}
     DELETION = "server.deletion"
@@ -936,8 +936,6 @@ class Metadata(Database.Base):
 
     dataset = relationship("Dataset", back_populates="metadatas", single_parent=True)
     user = relationship("User", back_populates="dataset_metadata", single_parent=True)
-
-    # __table_args__ = (UniqueConstraint("user", "key"), {})
 
     @validates("key")
     def validate_key(self, _, value: Any) -> str:

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -29,6 +29,12 @@ class User(Database.Base):
     role = Column(Enum(Roles), unique=False, nullable=True)
     auth_tokens = relationship("ActiveTokens", backref="users")
 
+    # NOTE: this relationship defines a `user` property in `Metadata`
+    # that refers to the parent `User` object.
+    dataset_metadata = relationship(
+        "Metadata", back_populates="user", cascade="all, delete-orphan"
+    )
+
     def __str__(self):
         return f"User, id: {self.id}, username: {self.username}"
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -386,7 +386,7 @@ def provide_metadata(attach_dataset):
     """
     drb = Dataset.query(name="drb")
     test = Dataset.query(name="test")
-    Metadata.setvalue(dataset=drb, key="user.contact", value="me@example.com")
+    Metadata.setvalue(dataset=drb, key="dashboard.contact", value="me@example.com")
     Metadata.setvalue(dataset=drb, key=Metadata.DELETION, value="2022-12-25")
     Metadata.setvalue(
         dataset=drb,
@@ -397,7 +397,7 @@ def provide_metadata(attach_dataset):
             "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
         },
     )
-    Metadata.setvalue(dataset=test, key="user.contact", value="you@example.com")
+    Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
     Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
 
 

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -19,19 +19,19 @@ class TestMetadata:
         # See if we can create a metadata row
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         assert ds.metadatas == []
-        m = Metadata.create(key="user", value=True, dataset=ds)
+        m = Metadata.create(key="dashboard", value=True, dataset=ds)
         assert m is not None
         assert ds.metadatas == [m]
 
         # Try to get it back
-        m1 = Metadata.get(ds, "user")
+        m1 = Metadata.get(ds, "dashboard")
         assert m1.key == m.key
         assert m1.value == m.value
         assert m.id == m1.id
         assert m.dataset_ref == m1.dataset_ref
 
         # Check the str()
-        assert "test(1)|frodo|fio>>user" == str(m)
+        assert "test(1)|frodo|fio>>dashboard" == str(m)
 
         # Try to get a metadata key that doesn't exist
         with pytest.raises(MetadataNotFound) as exc:
@@ -50,33 +50,33 @@ class TestMetadata:
 
         # Try to create a key without a value
         with pytest.raises(MetadataMissingKeyValue):
-            Metadata(key="user")
+            Metadata(key="dashboard")
 
         # Try to add a duplicate metadata key
         with pytest.raises(MetadataDuplicateKey) as exc:
-            m1 = Metadata(key="user", value="IRRELEVANT")
+            m1 = Metadata(key="dashboard", value="IRRELEVANT")
             m1.add(ds)
-        assert exc.value.key == "user"
+        assert exc.value.key == "dashboard"
         assert exc.value.dataset == ds
         assert ds.metadatas == [m]
 
         # Try to add a Metadata key to something that's not a dataset
         with pytest.raises(DatasetBadParameterType) as exc:
-            m1 = Metadata(key="user", value="DONTCARE")
+            m1 = Metadata(key="dashboard", value="DONTCARE")
             m1.add("foobar")
         assert exc.value.bad_value == "foobar"
         assert exc.value.expected_type == Dataset.__name__
 
         # Try to create a Metadata with a bad value for the dataset
         with pytest.raises(DatasetBadParameterType) as exc:
-            m1 = Metadata.create(key="user", value="TRUE", dataset=[ds])
+            m1 = Metadata.create(key="dashboard", value="TRUE", dataset=[ds])
         assert exc.value.bad_value == [ds]
         assert exc.value.expected_type == Dataset.__name__
 
         # Try to update the metadata key
         m.value = "False"
         m.update()
-        m1 = Metadata.get(ds, "user")
+        m1 = Metadata.get(ds, "dashboard")
         assert m.id == m1.id
         assert m.dataset_ref == m1.dataset_ref
         assert m.key == m1.key
@@ -85,27 +85,27 @@ class TestMetadata:
         # Delete the key and make sure its gone
         m.delete()
         with pytest.raises(MetadataNotFound) as exc:
-            Metadata.get(ds, "user")
+            Metadata.get(ds, "dashboard")
         assert exc.value.dataset == ds
-        assert exc.value.key == "user"
+        assert exc.value.key == "dashboard"
         assert ds.metadatas == []
 
     def test_metadata_remove(self, db_session, create_user):
         """Test that we can remove a Metadata key"""
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         assert ds.metadatas == []
-        m = Metadata(key="user", value="TRUE")
+        m = Metadata(key="dashboard", value="TRUE")
         m.add(ds)
         assert ds.metadatas == [m]
 
-        Metadata.remove(ds, "user")
+        Metadata.remove(ds, "dashboard")
         assert ds.metadatas == []
         with pytest.raises(MetadataNotFound) as exc:
-            Metadata.get(ds, "user")
+            Metadata.get(ds, "dashboard")
         assert exc.value.dataset == ds
-        assert exc.value.key == "user"
+        assert exc.value.key == "dashboard"
 
-        Metadata.remove(ds, "user")
+        Metadata.remove(ds, "dashboard")
         assert ds.metadatas == []
 
 
@@ -113,63 +113,109 @@ class TestMetadataNamespace:
     def test_get_bad_syntax(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.getvalue(ds, "user..foo")
+            Metadata.getvalue(ds, "dashboard..foo")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "user..foo"
-        assert str(exc.value) == "Metadata key 'user..foo' is not supported"
+        assert exc.value.key == "dashboard..foo"
+        assert str(exc.value) == "Metadata key 'dashboard..foo' is not supported"
+
+    def test_user_metadata(self, db_session, create_user, create_drb_user):
+        """Various tests on user-mapped Metadata keys"""
+        # See if we can create a metadata row
+        ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
+        assert ds.metadatas == []
+        t = Metadata.create(key="user", value=True, dataset=ds, user=create_user)
+        assert t is not None
+        assert ds.metadatas == [t]
+        assert create_user.dataset_metadata == [t]
+
+        d = Metadata.create(key="user", value=False, dataset=ds, user=create_drb_user)
+        assert d is not None
+        assert ds.metadatas == [t, d]
+        assert create_user.dataset_metadata == [t]
+        assert create_drb_user.dataset_metadata == [d]
+
+        g = Metadata.create(key="user", value="text", dataset=ds)
+        assert g is not None
+        assert ds.metadatas == [t, d, g]
+        assert create_user.dataset_metadata == [t]
+        assert create_drb_user.dataset_metadata == [d]
+
+        assert Metadata.get(key="user", dataset=ds).value == "text"
+        assert Metadata.get(key="user", dataset=ds, user=create_user).value is True
+        assert Metadata.get(key="user", dataset=ds, user=create_drb_user).value is False
+
+        Metadata.remove(key="user", dataset=ds, user=create_drb_user)
+        assert create_drb_user.dataset_metadata == []
+        assert create_user.dataset_metadata == [t]
+        assert ds.metadatas == [t, g]
+
+        Metadata.remove(key="user", dataset=ds)
+        assert create_user.dataset_metadata == [t]
+        assert ds.metadatas == [t]
+
+        Metadata.remove(key="user", dataset=ds, user=create_user)
+        assert create_user.dataset_metadata == []
+        assert ds.metadatas == []
+
+        # Peek under the carpet to look for orphaned metadata objects linked
+        # to the Dataset
+        metadata = (
+            Database.db_session.query(Metadata).filter_by(dataset_ref=ds.id).first()
+        )
+        assert metadata is None
 
     def test_set_bad_syntax(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.setvalue(ds, "user.foo.", "irrelevant")
+            Metadata.setvalue(ds, "dashboard.foo.", "irrelevant")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "user.foo."
-        assert str(exc.value) == "Metadata key 'user.foo.' is not supported"
+        assert exc.value.key == "dashboard.foo."
+        assert str(exc.value) == "Metadata key 'dashboard.foo.' is not supported"
 
     def test_set_bad_characters(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.setvalue(ds, "user.*!foo", "irrelevant")
+            Metadata.setvalue(ds, "dashboard.*!foo", "irrelevant")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "user.*!foo"
-        assert str(exc.value) == "Metadata key 'user.*!foo' is not supported"
+        assert exc.value.key == "dashboard.*!foo"
+        assert str(exc.value) == "Metadata key 'dashboard.*!foo' is not supported"
 
     def test_get_novalue(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
-        assert Metadata.getvalue(ds, "user.email") is None
-        assert Metadata.getvalue(ds, "user") is None
+        assert Metadata.getvalue(ds, "dashboard.email") is None
+        assert Metadata.getvalue(ds, "dashboard") is None
 
     def test_get_bad_path(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
-        Metadata.setvalue(ds, "user.contact", "hello")
+        Metadata.setvalue(ds, "dashboard.contact", "hello")
         with pytest.raises(MetadataBadStructure) as exc:
-            Metadata.getvalue(ds, "user.contact.email")
+            Metadata.getvalue(ds, "dashboard.contact.email")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "user.contact.email"
+        assert exc.value.key == "dashboard.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'user.contact.email' in test(1)|frodo|fio is not a JSON object"
+            == "Key 'contact' value for 'dashboard.contact.email' in test(1)|frodo|fio is not a JSON object"
         )
 
     def test_set_bad_path(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
-        Metadata.setvalue(ds, "user.contact", "hello")
+        Metadata.setvalue(ds, "dashboard.contact", "hello")
         with pytest.raises(MetadataBadStructure) as exc:
-            Metadata.setvalue(ds, "user.contact.email", "me@example.com")
+            Metadata.setvalue(ds, "dashboard.contact.email", "me@example.com")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "user.contact.email"
+        assert exc.value.key == "dashboard.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'user.contact.email' in test(1)|frodo|fio is not a JSON object"
+            == "Key 'contact' value for 'dashboard.contact.email' in test(1)|frodo|fio is not a JSON object"
         )
 
     def test_get_outer_path(self, db_session, create_user):
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
-        Metadata.setvalue(ds, "user.value.hello.english", "hello")
-        Metadata.setvalue(ds, "user.value.hello.espanol", "hola")
-        assert Metadata.getvalue(ds, "user.value") == {
+        Metadata.setvalue(ds, "dashboard.value.hello.english", "hello")
+        Metadata.setvalue(ds, "dashboard.value.hello.espanol", "hola")
+        assert Metadata.getvalue(ds, "dashboard.value") == {
             "hello": {"english": "hello", "espanol": "hola"}
         }
 
@@ -177,12 +223,12 @@ class TestMetadataNamespace:
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         Metadata.setvalue(
             ds,
-            "user.contact",
+            "dashboard.contact",
             {"email": "me@example.com", "name": {"first": "My", "last": "Name"}},
         )
-        assert Metadata.getvalue(ds, "user.contact.email") == "me@example.com"
-        assert Metadata.getvalue(ds, "user.contact.name.first") == "My"
-        assert Metadata.getvalue(ds, "user.contact.name") == {
+        assert Metadata.getvalue(ds, "dashboard.contact.email") == "me@example.com"
+        assert Metadata.getvalue(ds, "dashboard.contact.name.first") == "My"
+        assert Metadata.getvalue(ds, "dashboard.contact.name") == {
             "first": "My",
             "last": "Name",
         }
@@ -191,12 +237,12 @@ class TestMetadataNamespace:
         ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
         Metadata.setvalue(
             ds,
-            "user.contact",
+            "dashboard.contact",
             {"email": "me@example.com", "name": {"first": "My", "last": "Name"}},
         )
-        assert Metadata.getvalue(ds, "user.contact.email") == "me@example.com"
-        assert Metadata.getvalue(ds, "user.contact.name.first") == "My"
-        assert Metadata.getvalue(ds, "user.contact.name") == {
+        assert Metadata.getvalue(ds, "dashboard.contact.email") == "me@example.com"
+        assert Metadata.getvalue(ds, "dashboard.contact.name.first") == "My"
+        assert Metadata.getvalue(ds, "dashboard.contact.name") == {
             "first": "My",
             "last": "Name",
         }
@@ -211,3 +257,23 @@ class TestMetadataNamespace:
         # to the deleted Dataset
         metadata = Database.db_session.query(Metadata).filter_by(dataset_ref=id).first()
         assert metadata is None
+
+    def test_setgetvalue_user(self, db_session, create_user, create_drb_user):
+        ds = Dataset.create(owner=create_user.username, controller="frodo", name="fio")
+        Metadata.setvalue(dataset=ds, key="user.contact", value="Barney")
+        Metadata.setvalue(
+            dataset=ds, key="user.contact", value="Fred", user=create_user
+        )
+        Metadata.setvalue(
+            dataset=ds, key="user.contact", value="Wilma", user=create_drb_user
+        )
+
+        assert Metadata.getvalue(dataset=ds, user=None, key="user") == {
+            "contact": "Barney"
+        }
+        assert Metadata.getvalue(dataset=ds, user=create_user, key="user") == {
+            "contact": "Fred"
+        }
+        assert Metadata.getvalue(dataset=ds, user=create_drb_user, key="user") == {
+            "contact": "Wilma"
+        }

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -117,7 +117,6 @@ class TestDatasetsMetadata:
         response = query_get_as(
             "drb",
             {
-                "name": "drb",
                 "metadata": ["dashboard.seen", "server.deletion", "dataset.access"],
             },
             "drb",
@@ -133,7 +132,6 @@ class TestDatasetsMetadata:
         response = query_get_as(
             "drb",
             {
-                "name": "drb",
                 "metadata": "dashboard.seen,server.deletion,dataset.access",
             },
             "drb",
@@ -185,8 +183,8 @@ class TestDatasetsMetadata:
 
     def test_get_unauth(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "metadata": [
                     "dashboard.seen",
                     "server.deletion,dataset.access",
@@ -292,10 +290,8 @@ class TestDatasetsMetadata:
 
     def test_put_noauth(self, query_get_as, query_put_as):
         response = query_put_as(
-            {
-                "name": "fio_1",
-                "metadata": {"dashboard.seen": False, "dashboard.saved": True},
-            },
+            "fio_1",
+            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
             None,
             HTTPStatus.UNAUTHORIZED,
         )
@@ -313,10 +309,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {"dashboard.saved": True, "dashboard.seen": False}
         response = query_get_as(
-            "drb",
-            {"metadata": "dashboard,dataset.access"},
-            "drb",
-            HTTPStatus.OK,
+            "drb", {"metadata": "dashboard,dataset.access"}, "drb", HTTPStatus.OK
         )
         assert response.json == {
             "dashboard": {"contact": "me@example.com", "saved": True, "seen": False},
@@ -338,32 +331,29 @@ class TestDatasetsMetadata:
 
     def test_put_user(self, query_get_as, query_put_as):
         response = query_put_as(
-            {"name": "fio_1", "metadata": {"user.favorite": True, "user.tag": "AWS"}},
+            "fio_1",
+            {"metadata": {"user.favorite": True, "user.tag": "AWS"}},
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {"user.favorite": True, "user.tag": "AWS"}
         response = query_put_as(
-            {"name": "fio_1", "metadata": {"user.favorite": False, "user.tag": "RHEL"}},
+            "fio_1",
+            {"metadata": {"user.favorite": False, "user.tag": "RHEL"}},
             "test",
             HTTPStatus.OK,
         )
         assert response.json == {"user.favorite": False, "user.tag": "RHEL"}
         response = query_put_as(
-            {"name": "fio_1", "metadata": {"user.favorite": False, "user.tag": "BAD"}},
+            "fio_1",
+            {"metadata": {"user.favorite": False, "user.tag": "BAD"}},
             None,
             HTTPStatus.UNAUTHORIZED,
         )
 
-        response = query_get_as(
-            {"name": "fio_1", "metadata": "user"}, "drb", HTTPStatus.OK
-        )
+        response = query_get_as("fio_1", {"metadata": "user"}, "drb", HTTPStatus.OK)
         assert response.json == {"user": {"favorite": True, "tag": "AWS"}}
-        response = query_get_as(
-            {"name": "fio_1", "metadata": "user"}, "test", HTTPStatus.OK
-        )
+        response = query_get_as("fio_1", {"metadata": "user"}, "test", HTTPStatus.OK)
         assert response.json == {"user": {"favorite": False, "tag": "RHEL"}}
-        response = query_get_as(
-            {"name": "fio_1", "metadata": "user"}, None, HTTPStatus.OK
-        )
+        response = query_get_as("fio_1", {"metadata": "user"}, None, HTTPStatus.OK)
         assert response.json == {"user": None}

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -23,20 +23,24 @@ class TestDatasetsMetadata:
         def query_api(
             dataset: str, payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = self.token(client, server_config, username)
+            headers = None
+            if username:
+                token = self.token(client, server_config, username)
+                headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
-                headers={"authorization": f"bearer {token}"},
+                headers=headers,
                 query_string=payload,
             )
             assert response.status_code == expected_status
 
             # We need to log out to avoid "duplicate auth token" errors on the
             # "put" test which does a PUT followed by two GETs.
-            client.post(
-                f"{server_config.rest_uri}/logout",
-                headers={"authorization": f"bearer {token}"},
-            )
+            if username:
+                client.post(
+                    f"{server_config.rest_uri}/logout",
+                    headers={"authorization": f"bearer {token}"},
+                )
             return response
 
         return query_api
@@ -57,20 +61,24 @@ class TestDatasetsMetadata:
         def query_api(
             dataset: str, payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = self.token(client, server_config, username)
+            headers = None
+            if username:
+                token = self.token(client, server_config, username)
+                headers = {"authorization": f"bearer {token}"}
             response = client.put(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
-                headers={"authorization": f"bearer {token}"},
+                headers=headers,
                 json=payload,
             )
             assert response.status_code == expected_status
 
             # We need to log out to avoid "duplicate auth token" errors on the
             # test case which does a PUT followed by two GETs.
-            client.post(
-                f"{server_config.rest_uri}/logout",
-                headers={"authorization": f"bearer {token}"},
-            )
+            if username:
+                client.post(
+                    f"{server_config.rest_uri}/logout",
+                    headers={"authorization": f"bearer {token}"},
+                )
             return response
 
         return query_api
@@ -109,12 +117,8 @@ class TestDatasetsMetadata:
         response = query_get_as(
             "drb",
             {
-                "metadata": [
-                    "dashboard.seen",
-                    "server.deletion",
-                    "dataset.access",
-                    "user.contact",
-                ]
+                "name": "drb",
+                "metadata": ["dashboard.seen", "server.deletion", "dataset.access"],
             },
             "drb",
             HTTPStatus.OK,
@@ -123,13 +127,15 @@ class TestDatasetsMetadata:
             "dashboard.seen": None,
             "server.deletion": "2022-12-25",
             "dataset.access": "private",
-            "user.contact": "me@example.com",
         }
 
     def test_get2(self, query_get_as):
         response = query_get_as(
             "drb",
-            {"metadata": "dashboard.seen,server.deletion,dataset.access,user"},
+            {
+                "name": "drb",
+                "metadata": "dashboard.seen,server.deletion,dataset.access",
+            },
             "drb",
             HTTPStatus.OK,
         )
@@ -137,7 +143,6 @@ class TestDatasetsMetadata:
             "dashboard.seen": None,
             "server.deletion": "2022-12-25",
             "dataset.access": "private",
-            "user": {"contact": "me@example.com"},
         }
 
     def test_get3(self, query_get_as):
@@ -147,8 +152,8 @@ class TestDatasetsMetadata:
                 "metadata": [
                     "dashboard.seen",
                     "server.deletion,dataset.access",
-                    "user",
-                ]
+                    "user.favorite",
+                ],
             },
             "drb",
             HTTPStatus.OK,
@@ -157,10 +162,10 @@ class TestDatasetsMetadata:
             "dashboard.seen": None,
             "server.deletion": "2022-12-25",
             "dataset.access": "private",
-            "user": {"contact": "me@example.com"},
+            "user.favorite": None,
         }
 
-    def test_get_unauth(self, query_get_as):
+    def test_get_private_noauth(self, query_get_as):
         response = query_get_as(
             "drb",
             {
@@ -178,12 +183,30 @@ class TestDatasetsMetadata:
             == "User test is not authorized to READ a resource owned by drb with private access"
         )
 
+    def test_get_unauth(self, query_get_as):
+        response = query_get_as(
+            {
+                "name": "drb",
+                "metadata": [
+                    "dashboard.seen",
+                    "server.deletion,dataset.access",
+                    "user",
+                ],
+            },
+            None,
+            HTTPStatus.UNAUTHORIZED,
+        )
+        assert (
+            response.json["message"]
+            == "Unauthenticated client is not authorized to READ a resource owned by drb with private access"
+        )
+
     def test_get_bad_query(self, query_get_as):
         response = query_get_as(
             "drb",
             {
                 "controller": "foobar",
-                "metadata": "dashboard.seen,server.deletion,dataset.access,user",
+                "metadata": "dashboard.seen,server.deletion,dataset.access",
             },
             "drb",
             HTTPStatus.BAD_REQUEST,
@@ -267,6 +290,20 @@ class TestDatasetsMetadata:
             == "User test is not authorized to UPDATE a resource owned by drb with public access"
         )
 
+    def test_put_noauth(self, query_get_as, query_put_as):
+        response = query_put_as(
+            {
+                "name": "fio_1",
+                "metadata": {"dashboard.seen": False, "dashboard.saved": True},
+            },
+            None,
+            HTTPStatus.UNAUTHORIZED,
+        )
+        assert (
+            response.json["message"]
+            == "Unauthenticated client is not authorized to UPDATE a resource owned by drb with public access"
+        )
+
     def test_put(self, query_get_as, query_put_as):
         response = query_put_as(
             "drb",
@@ -282,7 +319,7 @@ class TestDatasetsMetadata:
             HTTPStatus.OK,
         )
         assert response.json == {
-            "dashboard": {"saved": True, "seen": False},
+            "dashboard": {"contact": "me@example.com", "saved": True, "seen": False},
             "dataset.access": "private",
         }
 
@@ -298,3 +335,35 @@ class TestDatasetsMetadata:
             "dashboard.seen": False,
             "dataset.access": "private",
         }
+
+    def test_put_user(self, query_get_as, query_put_as):
+        response = query_put_as(
+            {"name": "fio_1", "metadata": {"user.favorite": True, "user.tag": "AWS"}},
+            "drb",
+            HTTPStatus.OK,
+        )
+        assert response.json == {"user.favorite": True, "user.tag": "AWS"}
+        response = query_put_as(
+            {"name": "fio_1", "metadata": {"user.favorite": False, "user.tag": "RHEL"}},
+            "test",
+            HTTPStatus.OK,
+        )
+        assert response.json == {"user.favorite": False, "user.tag": "RHEL"}
+        response = query_put_as(
+            {"name": "fio_1", "metadata": {"user.favorite": False, "user.tag": "BAD"}},
+            None,
+            HTTPStatus.UNAUTHORIZED,
+        )
+
+        response = query_get_as(
+            {"name": "fio_1", "metadata": "user"}, "drb", HTTPStatus.OK
+        )
+        assert response.json == {"user": {"favorite": True, "tag": "AWS"}}
+        response = query_get_as(
+            {"name": "fio_1", "metadata": "user"}, "test", HTTPStatus.OK
+        )
+        assert response.json == {"user": {"favorite": False, "tag": "RHEL"}}
+        response = query_get_as(
+            {"name": "fio_1", "metadata": "user"}, None, HTTPStatus.OK
+        )
+        assert response.json == {"user": None}


### PR DESCRIPTION
PBENCH-645

This change re-purposes the `user.*` Dataset Metadata namespace as a per-user key space, where each authenticated client with READ access to a given dataset will be able to write independent metadata attached to that dataset. (Only the owner has UPDATE access to change the "global" metadata keys in the "dashboard.*" namespace.)

At the Metadata internal class level, methods now allow specifying a `User` to associate each item of metadata. At the API level, the user is always the authenticated user (or None for only global metadata).

An unauthenticated client can ask for `user.*` keys, but the value will always be None as authenticated clients will never create global values for the `user.*` namespace and unauthenticated clients can't ever set metadata values.