### PR TITLE
`pbench-specjbb2005` now handles commented props

### DIFF
--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -277,12 +277,12 @@ trap "interrupt" INT QUIT TERM
 
 # edit the jbb properties file to match user's options
 > ${benchmark_run_dir}/SPECjbb.props.sed
-printf "s/input.jvm_instances=.*/input.jvm_instances=$nr_jvms/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf "s/input.measurement_seconds=.*/input.measurement_seconds=$runtime/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf "s/input.starting_number_warehouses=.*/input.starting_number_warehouses=$start_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf "s/input.increment_number_warehouses=.*/input.increment_number_warehouses=$inc_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf "s/input.ending_number_warehouses=.*/input.ending_number_warehouses=$stop_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-sed -f ${benchmark_run_dir}/SPECjbb.props.sed ${specjbb2005_dir}/SPECjbb.props > ${benchmark_run_dir}/SPECjbb.props
+printf -- "s/#?input.jvm_instances=.*/input.jvm_instances=$nr_jvms/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
+printf -- "s/#?input.measurement_seconds=.*/input.measurement_seconds=$runtime/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
+printf -- "s/#?input.starting_number_warehouses=.*/input.starting_number_warehouses=$start_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
+printf -- "s/#?input.increment_number_warehouses=.*/input.increment_number_warehouses=$inc_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
+printf -- "s/#?input.ending_number_warehouses=.*/input.ending_number_warehouses=$stop_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
+sed -E -f ${benchmark_run_dir}/SPECjbb.props.sed ${specjbb2005_dir}/SPECjbb.props > ${benchmark_run_dir}/SPECjbb.props
 if [ $? -ne 0 ]; then
 	printf "\t${benchmark}: unable to create the SPECjbb.props file (\"${benchmark_run_dir}/SPECjbb.props\")\n\n"
 	exit 1

--- a/agent/bench-scripts/pbench-specjbb2005
+++ b/agent/bench-scripts/pbench-specjbb2005
@@ -276,17 +276,16 @@ fi
 trap "interrupt" INT QUIT TERM
 
 # edit the jbb properties file to match user's options
-> ${benchmark_run_dir}/SPECjbb.props.sed
-printf -- "s/#?input.jvm_instances=.*/input.jvm_instances=$nr_jvms/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf -- "s/#?input.measurement_seconds=.*/input.measurement_seconds=$runtime/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf -- "s/#?input.starting_number_warehouses=.*/input.starting_number_warehouses=$start_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf -- "s/#?input.increment_number_warehouses=.*/input.increment_number_warehouses=$inc_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-printf -- "s/#?input.ending_number_warehouses=.*/input.ending_number_warehouses=$stop_warehouses/\n" >> ${benchmark_run_dir}/SPECjbb.props.sed
-sed -E -f ${benchmark_run_dir}/SPECjbb.props.sed ${specjbb2005_dir}/SPECjbb.props > ${benchmark_run_dir}/SPECjbb.props
+cp ${specjbb2005_dir}/SPECjbb.props ${benchmark_run_dir}/SPECjbb.props
 if [ $? -ne 0 ]; then
 	printf "\t${benchmark}: unable to create the SPECjbb.props file (\"${benchmark_run_dir}/SPECjbb.props\")\n\n"
 	exit 1
 fi
+printf "input.jvm_instances=$nr_jvms\n" >> ${benchmark_run_dir}/SPECjbb.props
+printf "input.measurement_seconds=$runtime\n" >> ${benchmark_run_dir}/SPECjbb.props
+printf "input.starting_number_warehouses=$start_warehouses\n" >> ${benchmark_run_dir}/SPECjbb.props
+printf "input.increment_number_warehouses=$inc_warehouses\n" >> ${benchmark_run_dir}/SPECjbb.props
+printf "input.ending_number_warehouses=$stop_warehouses\n" >> ${benchmark_run_dir}/SPECjbb.props
 cp ${specjbb2005_dir}/SPECjbb_config.props ${benchmark_run_dir}/
 if [ $? -ne 0 ]; then
 	printf "\t${benchmark}: unable to copy SPECjbb_config.props file from \"${specjbb2005_dir}\"\n\n"

--- a/agent/bench-scripts/test-bin/java
+++ b/agent/bench-scripts/test-bin/java
@@ -22,16 +22,25 @@ nr_jvms = None
 start = None
 inc = None
 stop = None
+runtime = None
 with open("SPECjbb.props", "r") as fp:
     for line in fp:
+        if not line.startswith("input."):
+            continue
+        val_str = line.split("=", 1)[1]
+        if val_str == "_bad_\n":
+            continue
+        val = int(val_str)
         if line.startswith("input.jvm_instances="):
-            nr_jvms = int(line.split("=", 1)[1])
+            nr_jvms = val
         if line.startswith("input.starting_number_warehouses="):
-            start = int(line.split("=", 1)[1])
+            start = val
         if line.startswith("input.increment_number_warehouses="):
-            inc = int(line.split("=", 1)[1])
+            inc = val
         if line.startswith("input.ending_number_warehouses="):
-            stop = int(line.split("=", 1)[1])
+            stop = val
+        if line.startswith("input.measurement_seconds="):
+            runtime = val
 
 tgt_dir = "SPECjbbSingleJVM" if nr_jvms == 1 else f"SPECjbbMultiJVM.{jvm_id:03d}"
 res_dir = Path("results") / tgt_dir
@@ -39,6 +48,6 @@ res_dir.mkdir()
 with open(res_dir / f"SPECjbb.{jvm_id:03d}.raw", "w") as fp:
     for i in range(start, stop + 1, inc):
         print("Timing Measurement began")
-        fp.write(f"test{i} -- 42 * {i}\n")
+        fp.write(f"test{i} -- 42 * {i} - {runtime}\n")
         print("Timing Measurement ended")
 sys.exit(0)

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-56.pre
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-56.pre
@@ -9,11 +9,11 @@ _dir="${_testtmp}/specjbb2005"
 mkdir ${_dir} || exit 1
 touch ${_dir}/SPECjbb.props || exit 1
 # 2. a properties file containing the 5 properties that will be replaced
-printf "input.jvm_instances=_replace_\n" >> ${_dir}/SPECjbb.props
-printf "input.measurement_seconds=_replace_\n" >> ${_dir}/SPECjbb.props
-printf "input.starting_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
-printf "input.increment_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
-printf "#input.ending_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
+printf "input.jvm_instances=_bad_\n" >> ${_dir}/SPECjbb.props
+printf "input.measurement_seconds=_bad_\n" >> ${_dir}/SPECjbb.props
+printf "input.starting_number_warehouses=_bad_\n" >> ${_dir}/SPECjbb.props
+printf "input.increment_number_warehouses=_bad_\n" >> ${_dir}/SPECjbb.props
+printf "#input.ending_number_warehouses=_bad_\n" >> ${_dir}/SPECjbb.props
 # 3. a properties file for the configuration of SPECjbb, the contents of which
 #    is ignored, but its presence is expected
 touch ${_dir}/SPECjbb_config.props || exit 1

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-56.pre
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-56.pre
@@ -13,7 +13,7 @@ printf "input.jvm_instances=_replace_\n" >> ${_dir}/SPECjbb.props
 printf "input.measurement_seconds=_replace_\n" >> ${_dir}/SPECjbb.props
 printf "input.starting_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
 printf "input.increment_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
-printf "input.ending_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
+printf "#input.ending_number_warehouses=_replace_\n" >> ${_dir}/SPECjbb.props
 # 3. a properties file for the configuration of SPECjbb, the contents of which
 #    is ignored, but its presence is expected
 touch ${_dir}/SPECjbb_config.props || exit 1

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-56.txt
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-56.txt
@@ -81,7 +81,6 @@ Timing Measurement ended
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/8-warehouses:8/sample1/SPECjbb.raw
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/8-warehouses:8/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb.props
-/var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb.props.sed
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb_config.props
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/jvm-1-worker.txt
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-56_1900.01.01T00.00.00/metadata.log
@@ -182,6 +181,11 @@ user_script = specjbb2005
 
 --- specjbb2005_test-56_1900.01.01T00.00.00/metadata.log file contents
 +++ specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb.props file contents
+input.jvm_instances=_bad_
+input.measurement_seconds=_bad_
+input.starting_number_warehouses=_bad_
+input.increment_number_warehouses=_bad_
+#input.ending_number_warehouses=_bad_
 input.jvm_instances=1
 input.measurement_seconds=30
 input.starting_number_warehouses=1

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-56.txt
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-56.txt
@@ -181,3 +181,10 @@ iteration_name = 8-warehouses:8
 user_script = specjbb2005
 
 --- specjbb2005_test-56_1900.01.01T00.00.00/metadata.log file contents
++++ specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb.props file contents
+input.jvm_instances=1
+input.measurement_seconds=30
+input.starting_number_warehouses=1
+input.increment_number_warehouses=1
+input.ending_number_warehouses=8
+--- specjbb2005_test-56_1900.01.01T00.00.00/SPECjbb.props file contents

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-57.txt
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-57.txt
@@ -36,7 +36,6 @@ Timing Measurement ended
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/3-warehouses:23/sample1/SPECjbb.raw
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/3-warehouses:23/sample1/tools-default
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb.props
-/var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb.props.sed
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb_config.props
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/jvm-1-worker.txt
 /var/tmp/pbench-test-bench/pbench-agent/specjbb2005_test-57_1900.01.01T00.00.00/jvm-2-worker.txt
@@ -95,6 +94,11 @@ user_script = specjbb2005
 
 --- specjbb2005_test-57_1900.01.01T00.00.00/metadata.log file contents
 +++ specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb.props file contents
+input.jvm_instances=_bad_
+input.measurement_seconds=_bad_
+input.starting_number_warehouses=_bad_
+input.increment_number_warehouses=_bad_
+#input.ending_number_warehouses=_bad_
 input.jvm_instances=2
 input.measurement_seconds=30
 input.starting_number_warehouses=13

--- a/agent/bench-scripts/tests/pbench-specjbb2005/test-57.txt
+++ b/agent/bench-scripts/tests/pbench-specjbb2005/test-57.txt
@@ -94,3 +94,10 @@ iteration_name = 3-warehouses:23
 user_script = specjbb2005
 
 --- specjbb2005_test-57_1900.01.01T00.00.00/metadata.log file contents
++++ specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb.props file contents
+input.jvm_instances=2
+input.measurement_seconds=30
+input.starting_number_warehouses=13
+input.increment_number_warehouses=5
+input.ending_number_warehouses=23
+--- specjbb2005_test-57_1900.01.01T00.00.00/SPECjbb.props file contents

--- a/agent/bench-scripts/unittests
+++ b/agent/bench-scripts/unittests
@@ -160,6 +160,7 @@ function _dump_logs {
     if [[ ! -z "${rundir}" ]]; then
         _dump_file ${rundir} metadata.log
         _dump_file ${rundir} user-benchmark-summary.json
+        _dump_file ${rundir} SPECjbb.props
         (
         if cd ${_testdir}/${rundir} > /dev/null 2>&1 ;then
             for f in $(find . -name '*.cmd' 2> /dev/null | sort); do


### PR DESCRIPTION
If the `SPECjbb.props` file has a commented out line we now uncomment it to ensure the requested behaviors take effect.