### PR TITLE
Move towards embedded URL parameters: metadata

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -86,7 +86,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         DatasetsMetadata,
-        f"{base_uri}/datasets/metadata",
+        f"{base_uri}/datasets/metadata/<string:dataset>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -27,7 +27,6 @@ class DatasetsMetadata(ApiBase):
     """
 
     GET_SCHEMA = Schema(
-        Parameter("name", ParamType.STRING, required=True),
         Parameter(
             "metadata",
             ParamType.LIST,
@@ -42,7 +41,7 @@ class DatasetsMetadata(ApiBase):
             config,
             logger,
             Schema(
-                Parameter("name", ParamType.STRING, required=True),
+                Parameter("dataset", ParamType.STRING, required=True),
                 Parameter(
                     "metadata",
                     ParamType.JSON,
@@ -57,23 +56,15 @@ class DatasetsMetadata(ApiBase):
         """
         Get the values of client-accessible dataset metadata keys.
 
-        NOTE: This does not rely on a JSON payload to identify the dataset and
-        desired metadata keys. While in theory there's no restriction on
-        passing a request payload to GET, the venerable (obsolete) Javascript
-        requests package doesn't support it, and Elasticsearch allows POST as
-        well as GET for queries because many clients can't support a payload on
-        GET. In this case, we're going to experiment with an alternative, using
-        query parameters.
-
         Args:
-            json_data: Ignored because GET has no JSON payload
+            json_data: Flask's URI parameter dictionary with dataset name
             request: The original Request object containing query parameters
 
         GET /api/v1/datasets/metadata?name=dname&metadata=dashboard.seen,server.deletion
         """
 
+        name = json_data.get("dataset")
         json = self._validate_query_params(request, self.GET_SCHEMA)
-        name = json.get("name")
         keys = json.get("metadata")
 
         try:
@@ -123,7 +114,7 @@ class DatasetsMetadata(ApiBase):
             "user": {"cloud": "AWS", "contact": "json.carter@mars.org}
         ]
         """
-        name = json_data["name"]
+        name = json_data["dataset"]
         metadata = json_data["metadata"]
 
         try:

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -218,7 +218,9 @@ class TestDatasetsMetadata:
         Note that Pbench will silently ignore any additional keys that are
         specified but not required.
         """
-        response = client.put(f"{server_config.rest_uri}/datasets/metadata/drb")
+        response = client.put(
+            f"{server_config.rest_uri}/datasets/metadata/drb", json={}
+        )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == "Missing required parameters: metadata"
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -203,12 +203,14 @@ class TestDatasetsMetadata:
         )
         assert response.json == {"message": "Unknown URL query keys: controller,plugh"}
 
-    def test_put_missing_json_object(self, client, server_config, pbench_token):
+    @pytest.mark.parametrize(
+        "uri", ("/datasets/metadata/", "/datasets/metadata"))
+    def test_put_missing_uri_param(self, client, server_config, pbench_token, uri):
         """
         Test behavior when no dataset name is given on the URI. (NOTE that
         Flask automatically handles this with a NOT_FOUND response.)
         """
-        response = client.put(f"{server_config.rest_uri}/datasets/metadata/")
+        response = client.put(f"{server_config.rest_uri}{uri}")
         assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_put_missing_key(self, client, server_config, pbench_token):

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -203,8 +203,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {"message": "Unknown URL query keys: controller,plugh"}
 
-    @pytest.mark.parametrize(
-        "uri", ("/datasets/metadata/", "/datasets/metadata"))
+    @pytest.mark.parametrize("uri", ("/datasets/metadata/", "/datasets/metadata"))
     def test_put_missing_uri_param(self, client, server_config, pbench_token, uri):
         """
         Test behavior when no dataset name is given on the URI. (NOTE that

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -1,12 +1,9 @@
 from http import HTTPStatus
-import itertools
 
 import pytest
 import requests
 
 from pbench.server import JSON, PbenchServerConfig
-from pbench.server.api.resources import ParamType
-from pbench.server.api.resources.datasets_metadata import DatasetsMetadata
 
 
 class TestDatasetsMetadata:
@@ -24,11 +21,11 @@ class TestDatasetsMetadata:
         """
 
         def query_api(
-            payload: JSON, username: str, expected_status: HTTPStatus
+            dataset: str, payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
             token = self.token(client, server_config, username)
             response = client.get(
-                f"{server_config.rest_uri}/datasets/metadata",
+                f"{server_config.rest_uri}/datasets/metadata/{dataset}",
                 headers={"authorization": f"bearer {token}"},
                 query_string=payload,
             )
@@ -58,11 +55,11 @@ class TestDatasetsMetadata:
         """
 
         def query_api(
-            payload: JSON, username: str, expected_status: HTTPStatus
+            dataset: str, payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
             token = self.token(client, server_config, username)
             response = client.put(
-                f"{server_config.rest_uri}/datasets/metadata",
+                f"{server_config.rest_uri}/datasets/metadata/{dataset}",
                 headers={"authorization": f"bearer {token}"},
                 json=payload,
             )
@@ -90,10 +87,8 @@ class TestDatasetsMetadata:
 
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(
-            {
-                "name": "foobar",
-                "metadata": ["dashboard.seen", "dashboard.saved"],
-            },
+            "foobar",
+            {"metadata": ["dashboard.seen", "dashboard.saved"]},
             "drb",
             HTTPStatus.BAD_REQUEST,
         )
@@ -101,10 +96,8 @@ class TestDatasetsMetadata:
 
     def test_get_bad_keys(self, query_get_as):
         response = query_get_as(
-            {
-                "name": "drb",
-                "metadata": ["xyzzy", "plugh", "dataset.owner", "dataset.access"],
-            },
+            "drb",
+            {"metadata": ["xyzzy", "plugh", "dataset.owner", "dataset.access"]},
             "drb",
             HTTPStatus.BAD_REQUEST,
         )
@@ -114,14 +107,14 @@ class TestDatasetsMetadata:
 
     def test_get1(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "metadata": [
                     "dashboard.seen",
                     "server.deletion",
                     "dataset.access",
                     "user.contact",
-                ],
+                ]
             },
             "drb",
             HTTPStatus.OK,
@@ -135,10 +128,8 @@ class TestDatasetsMetadata:
 
     def test_get2(self, query_get_as):
         response = query_get_as(
-            {
-                "name": "drb",
-                "metadata": "dashboard.seen,server.deletion,dataset.access,user",
-            },
+            "drb",
+            {"metadata": "dashboard.seen,server.deletion,dataset.access,user"},
             "drb",
             HTTPStatus.OK,
         )
@@ -151,13 +142,13 @@ class TestDatasetsMetadata:
 
     def test_get3(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "metadata": [
                     "dashboard.seen",
                     "server.deletion,dataset.access",
                     "user",
-                ],
+                ]
             },
             "drb",
             HTTPStatus.OK,
@@ -171,13 +162,13 @@ class TestDatasetsMetadata:
 
     def test_get_unauth(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "metadata": [
                     "dashboard.seen",
                     "server.deletion,dataset.access",
                     "user",
-                ],
+                ]
             },
             "test",
             HTTPStatus.FORBIDDEN,
@@ -189,8 +180,8 @@ class TestDatasetsMetadata:
 
     def test_get_bad_query(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "controller": "foobar",
                 "metadata": "dashboard.seen,server.deletion,dataset.access,user",
             },
@@ -201,8 +192,8 @@ class TestDatasetsMetadata:
 
     def test_get_bad_query_2(self, query_get_as):
         response = query_get_as(
+            "drb",
             {
-                "name": "drb",
                 "controller": "foobar",
                 "plugh": "xyzzy",
                 "metadata": ["dashboard.seen", "server.deletion", "dataset.access"],
@@ -214,94 +205,36 @@ class TestDatasetsMetadata:
 
     def test_put_missing_json_object(self, client, server_config, pbench_token):
         """
-        Test behavior when no JSON payload is given
+        Test behavior when no dataset name is given on the URI. (NOTE that
+        Flask automatically handles this with a NOT_FOUND response.)
         """
-        response = client.put(f"{server_config.rest_uri}/datasets/metadata")
-        assert response.status_code == HTTPStatus.BAD_REQUEST
-        assert response.json.get("message") == "Invalid request payload"
+        response = client.put(f"{server_config.rest_uri}/datasets/metadata/")
+        assert response.status_code == HTTPStatus.NOT_FOUND
 
-    def test_put_missing_keys(self, client, server_config, pbench_token):
+    def test_put_missing_key(self, client, server_config, pbench_token):
         """
         Test behavior when JSON payload does not contain all required keys.
 
         Note that Pbench will silently ignore any additional keys that are
         specified but not required.
-
-        TODO: This is mostly copied from commons.py; ideally these would be
-        refactored into a common "superclass" analagous to ApiBase as Commons
-        is to ElasticBase.
         """
-        classobject = DatasetsMetadata(client.config, client.logger)
-
-        def missing_key_helper(keys):
-            response = client.post(
-                f"{server_config.rest_uri}/datasets/metadata",
-                json=keys,
-            )
-            assert response.status_code == HTTPStatus.BAD_REQUEST
-            missing = sorted(set(required_keys) - set(keys))
-            assert (
-                response.json.get("message")
-                == f"Missing required parameters: {','.join(missing)}"
-            )
-
-        parameter_items = classobject.schema.parameters.items()
-
-        required_keys = [
-            key for key, parameter in parameter_items if parameter.required
-        ]
-
-        all_combinations = []
-        for r in range(1, len(parameter_items) + 1):
-            for item in itertools.combinations(parameter_items, r):
-                tmp_req_keys = [key for key, parameter in item if parameter.required]
-                if tmp_req_keys != required_keys:
-                    all_combinations.append(item)
-
-        for items in all_combinations:
-            keys = {}
-            for key, parameter in items:
-                if parameter.type is ParamType.ACCESS:
-                    keys[key] = "public"
-                elif parameter.type is ParamType.DATE:
-                    keys[key] = "2020"
-                elif parameter.type is ParamType.LIST:
-                    keys[key] = []
-                elif parameter.type is ParamType.KEYWORD:
-                    keys[key] = parameter.keywords[0]
-                else:
-                    keys[key] = "foobar"
-
-            missing_key_helper(keys)
-
-        # Test in case all of the required keys are missing and some
-        # random non-existent key is present in the payload
-        if required_keys:
-            missing_key_helper({"notakey": None})
+        response = client.put(f"{server_config.rest_uri}/datasets/metadata/drb")
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json.get("message") == "Missing required parameters: metadata"
 
     def test_put_no_dataset(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata",
-            json={
-                "controller": "node",
-                "name": "foobar",
-                "metadata": {"dashboard.seen": True, "dashboard.saved": False},
-            },
+            f"{server_config.rest_uri}/datasets/metadata/foobar",
+            json={"metadata": {"dashboard.seen": True, "dashboard.saved": False}},
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {"message": "Dataset 'foobar' not found"}
 
     def test_put_bad_keys(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata",
+            f"{server_config.rest_uri}/datasets/metadata/drb",
             json={
-                "controller": "node",
-                "name": "drb",
-                "metadata": {
-                    "xyzzy": "private",
-                    "what": "sup",
-                    "dashboard.saved": True,
-                },
+                "metadata": {"xyzzy": "private", "what": "sup", "dashboard.saved": True}
             },
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -311,12 +244,8 @@ class TestDatasetsMetadata:
 
     def test_put_reserved_metadata(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata",
-            json={
-                "controller": "node",
-                "name": "drb",
-                "metadata": {"dataset.access": "private"},
-            },
+            f"{server_config.rest_uri}/datasets/metadata/drb",
+            json={"metadata": {"dataset.access": "private"}},
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
@@ -325,10 +254,8 @@ class TestDatasetsMetadata:
 
     def test_put_nowrite(self, query_get_as, query_put_as):
         response = query_put_as(
-            {
-                "name": "fio_1",
-                "metadata": {"dashboard.seen": False, "dashboard.saved": True},
-            },
+            "fio_1",
+            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
             "test",
             HTTPStatus.FORBIDDEN,
         )
@@ -339,19 +266,15 @@ class TestDatasetsMetadata:
 
     def test_put(self, query_get_as, query_put_as):
         response = query_put_as(
-            {
-                "name": "drb",
-                "metadata": {"dashboard.seen": False, "dashboard.saved": True},
-            },
+            "drb",
+            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {"dashboard.saved": True, "dashboard.seen": False}
         response = query_get_as(
-            {
-                "name": "drb",
-                "metadata": "dashboard,dataset.access",
-            },
+            "drb",
+            {"metadata": "dashboard,dataset.access"},
             "drb",
             HTTPStatus.OK,
         )
@@ -362,10 +285,8 @@ class TestDatasetsMetadata:
 
         # Try a second GET, returning "dashboard" fields separately:
         response = query_get_as(
-            {
-                "name": "drb",
-                "metadata": ["dashboard.seen", "dashboard.saved", "dataset.access"],
-            },
+            "drb",
+            {"metadata": ["dashboard.seen", "dashboard.saved", "dataset.access"]},
             "drb",
             HTTPStatus.OK,
         )

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -51,7 +51,7 @@ class TestEndpointConfig:
                 "datasets_detail": f"{uri}/datasets/detail",
                 "datasets_list": f"{uri}/datasets/list",
                 "datasets_mappings": f"{uri}/datasets/mappings/",
-                "datasets_metadata": f"{uri}/datasets/metadata",
+                "datasets_metadata": f"{uri}/datasets/metadata/",
                 "datasets_namespace": f"{uri}/datasets/namespace/",
                 "datasets_publish": f"{uri}/datasets/publish",
                 "datasets_search": f"{uri}/datasets/search",


### PR DESCRIPTION
PBENCH-669

We started out with all parameters in a JSON request payload to `POST` operations following Elasticsearch conventions. While some new APIs have used both query parameters and embedded Flask URL parameters, there are older APIs that should be retrofitted to that model.

In this PR, I'm addressing `/datasets/metadata` (which seems like a good place to start as the Overview page is on the cusp of using it).

In particular, we'll now `GET`|`PUT` `http://<server>/api/v1/datasets/metadata/<name>`. rather than specifying the dataset name with `?name=<name>`.