### PR TITLE
Remove minor redundancy in datasets mappings

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -144,7 +144,8 @@ class IndexMapBase(ElasticBase):
                 self.get_aggregatable_fields(v, f"{prefix}{f}.", result)
         return result
 
-    def get_mappings(self, document: JSON) -> JSON:
+    @staticmethod
+    def get_mappings(document: JSON) -> JSON:
         """
         Utility function to return ES mappings by querying the Template
         database against a given index.

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -115,6 +115,7 @@ class DatasetsMappings(ApiBase):
             return jsonify(result)
         except TemplateNotFound:
             self.logger.exception(
-                "Document template {} not found in the database.", index["index"]
+                "Document template for index {} not found in the database",
+                index["index"],
             )
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -113,9 +113,6 @@ class DatasetsMappings(ApiBase):
 
             # construct response object
             return jsonify(result)
-        except TemplateNotFound:
-            self.logger.exception(
-                "Document template for index {} not found in the database",
-                index["index"],
-            )
+        except TemplateNotFound as e:
+            self.logger.exception(str(e))
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -15,7 +15,7 @@ from pbench.server.api.resources import (
 )
 
 from pbench.server.api.resources.query_apis.datasets import IndexMapBase
-from pbench.server.database.models.template import Template, TemplateNotFound
+from pbench.server.database.models.template import TemplateNotFound
 
 
 class DatasetsMappings(ApiBase):
@@ -103,10 +103,7 @@ class DatasetsMappings(ApiBase):
 
         index = IndexMapBase.ES_INTERNAL_INDEX_NAMES[json_data["dataset_view"]]
         try:
-            index_name = index["index"]
-            template = Template.find(index_name)
-            mappings = template.mappings
-
+            mappings = IndexMapBase.get_mappings(index)
             result = {}
             for property in mappings["properties"]:
                 if "properties" in mappings["properties"][property]:
@@ -118,6 +115,6 @@ class DatasetsMappings(ApiBase):
             return jsonify(result)
         except TemplateNotFound:
             self.logger.exception(
-                "Document template {} not found in the database.", index_name
+                "Document template {} not found in the database.", index["index"]
             )
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/lib/pbench/server/database/models/template.py
+++ b/lib/pbench/server/database/models/template.py
@@ -55,7 +55,7 @@ class TemplateNotFound(TemplateError):
         self.name = name
 
     def __str__(self) -> str:
-        return f"No template {self.name!r}"
+        return f"Document template for index {self.name!r} not found in the database"
 
 
 class TemplateDuplicate(TemplateError):

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
@@ -1,20 +1,5 @@
 from http import HTTPStatus
 
-import pytest
-from sqlalchemy.exc import DatabaseError
-
-from pbench.server.database.models.template import Template
-
-
-@pytest.fixture()
-def database_error(monkeypatch):
-    def raise_db_error(name: str):
-        raise DatabaseError("DB Error")
-
-    with monkeypatch.context() as m:
-        m.setattr(Template, "find", raise_db_error)
-        yield
-
 
 class TestDatasetsMappings:
     """
@@ -48,7 +33,6 @@ class TestDatasetsMappings:
                     "tar-ball-creation-timestamp",
                     "toc-prefix",
                 ],
-                "authorization": ["access", "owner"],
                 "host_tools_info": [
                     "hostname",
                     "hostname-f",
@@ -120,7 +104,7 @@ class TestDatasetsMappings:
                 == "Unrecognized keyword ['bad_data_object_view'] given for parameter dataset_view; allowed keywords are ['contents', 'iterations', 'summary', 'timeseries']"
             )
 
-    def test_with_db_error(self, client, server_config, database_error):
+    def test_with_db_error(self, client, server_config):
         """
         Check the index mappings API if there is an error connecting to sql database.
         """


### PR DESCRIPTION
Remove bit of redundancy in `dataset_mappings` for getting ES mapping properties.