### PR TITLE
Tweak container builds for CentOS Stream 9

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -1,4 +1,5 @@
 {% set is_centos_8 = true if image_name == 'centos' and image_rev == '8' else false %}
+{% set is_centos_9 = true if image_name == 'centos' and image_rev == '9' else false %}
 {% set image_tag = 'stream' + image_rev if image_name == 'centos' else image_rev %}
 # {{ distro_name }} pbench-agent base image
 FROM {{ image_repo }}/{{ image_name }}:{{ image_tag }}
@@ -17,8 +18,12 @@ RUN \
 {% if image_name == 'centos' %}
     {{ pkgmgr }} install -y --setopt=tsflags=nodocs https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ image_rev }}.noarch.rpm && \
 {% endif %}
-    {{ pkgmgr }} install -y --setopt=tsflags=nodocs {% if is_centos_8 %}--enablerepo powertools glibc-locale-source {% endif %} pbench-agent && \
-{% if is_centos_8 %}
+    {{ pkgmgr }} install -y --setopt=tsflags=nodocs \
+        {% if is_centos_8 %}--enablerepo powertools {% endif %} \
+        {% if is_centos_9 %}--enablerepo crb {% endif %} \
+        {% if is_centos_8 or is_centos_9 %} glibc-locale-source {% endif %} \
+        pbench-agent && \
+{% if is_centos_8 or is_centos_9 %}
     localedef -i en_US -f UTF-8 en_US.UTF-8 && \
 {% endif %}
     {{ pkgmgr }} -y clean all && \

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -2,9 +2,11 @@
 FROM pbench-agent-base-{{ distro }}:{{ tag }}
 
 {% if kind in ('tools', 'all') %}
+{% if distro.startswith('fedora') or distro == 'centos-7' or distro == 'centos-8' %}
 COPY ./{{ distro }}-pcp.repo /etc/yum.repos.d/pcp.repo
 {% if distro.startswith('centos') %}
 COPY ./{{ distro }}-prometheus.repo /etc/yum.repos.d/prometheus.repo
+{% endif %}
 {% endif %}
 {% endif %}
 
@@ -14,7 +16,11 @@ COPY ./{{ distro }}-prometheus.repo /etc/yum.repos.d/prometheus.repo
 #        Kubernetes or RHV environments.
 {% set pkgmgr = 'yum' if distro == 'centos-7' else 'dnf' %}
 RUN {{ pkgmgr }} install -y --setopt=tsflags=nodocs \
+        {% if distro == 'centos-9' %}--enablerepo crb \
+        {% else %}
         {% if distro == 'centos-8' %}--enablerepo powertools {% endif %} \
-        {% if kind in ('tools', 'all') %}--enablerepo pcp-rpm-release {% endif %}{{ rpms }} && \
+        {% if kind in ('tools', 'all') %}--enablerepo pcp-rpm-release {% endif %} \
+        {% endif %}
+        {{ rpms }} && \
     {{ pkgmgr }} -y clean all && \
     rm -rf /var/cache/{{ pkgmgr }}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -70,16 +70,6 @@ _PCP_RPMS = \
 	pcp-system-tools \
 	pcp-zeroconf
 
-# These are the lists of Prometheus RPMs -- the packages are the same, but they
-# have different names in the different distributions -- so we have two lists
-# keyed by the distro name.
-_centos_PROMETHEUS_RPMS = \
-    node_exporter \
-    prometheus2
-_fedora_PROMETHEUS_RPMS = \
-    golang-github-prometheus-node-exporter \
-    golang-github-prometheus
-
 # The list of RPMs which provide the various tools we offer.
 # Not intended to be overridden with an environment variable.
 # Please keep the lists sorted.
@@ -96,7 +86,7 @@ _TOOL_RPMS = \
 	${_PCP_RPMS} \
 	perf \
 	procps-ng \
-	${_${DIST_NAME}_PROMETHEUS_RPMS} \
+	${_PROMETHEUS_RPMS} \
 	strace \
 	tcpdump \
 	trace-cmd
@@ -153,6 +143,15 @@ $(_DISTROS:%=%-tm): %-tm: pkgmgr-clean %-tool-meister-tagged
 # for DIST_NAME and DIST_VERSION, respectively.
 %: DIST_NAME = $(wordlist 1, 1, $(subst -, ,$*))
 %: DIST_VERSION = $(wordlist 2, 2, $(subst -, ,$*))
+
+# These are the lists of Prometheus RPMs -- the packages are the same, but they
+# have different names in the different distributions
+fedora-% centos-9-%: _PROMETHEUS_RPMS = \
+    golang-github-prometheus-node-exporter \
+    golang-github-prometheus
+centos-7-% centos-8-%: _PROMETHEUS_RPMS = \
+    node_exporter \
+    prometheus2
 
 
 # Tagging targets
@@ -212,11 +211,13 @@ $(_TAG_TYPES:%=push-%): push-%: $(_DEFAULT_DISTROS:%=%-push-%)
 %-tools-tagged: %-tools %-tags.lis
 	./apply-tags pbench-agent-tools-$* $*-tags.lis
 
-# Add an additional dependency for centos-%-tools targets (this .repo file is
-# not required on Fedora).
-$(_ALL_centos_VERSIONS:%=%-tools): centos-%-tools: centos-%-prometheus.repo
+# CentOS 7 & 8 (but not 9) require an additional .repo file for Prometheus for
+# the tools container; analogously, they as well as Fedora require an additional
+# .repo file for PCP.
+centos-7-tools centos-8-tools: centos-%-tools: centos-%-prometheus.repo
+$(_ALL_fedora_VERSIONS:%=%-tools) centos-7-tools centos-8-tools: %-tools: %-pcp.repo
 
-%-tools: %-base-tagged %-tools.Dockerfile %-pcp.repo %-tags.lis
+%-tools: %-base-tagged %-tools.Dockerfile %-tags.lis
 	./build-image tools $* $*-tags.lis
 
 %-tools.Dockerfile: Dockerfile.layered.j2 %-tags.lis

--- a/server/containers/images/Dockerfile.base.j2
+++ b/server/containers/images/Dockerfile.base.j2
@@ -10,6 +10,9 @@ RUN \
 {% if distro_image.startswith('centos') %}
     {{ pkgmgr }} install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ distro_image.split(':', 1)[1] }}.noarch.rpm && \
 {% endif %}
-    {{ pkgmgr }} install -y {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %}--enablerepo copr-pbench pbench-server && \
+    {{ pkgmgr }} install -y \
+        {% if distro_image == 'centos:8' %}--enablerepo PowerTools {% endif %} \
+        {% if distro_image == 'centos:9' %}--enablerepo crb {% endif %} \
+        --enablerepo copr-pbench pbench-server && \
     {{ pkgmgr }} -y clean all && \
     rm -rf /var/cache/yum


### PR DESCRIPTION
CentOS Stream 9 has new requirements for where we pull RPMs from, particularly for PCP and Prometheus.  This PR makes the changes required to build the Agent container images for `centos-9`.