### PR TITLE
Handle response payloads which are not JSON in generate_token.py

### DIFF
--- a/lib/pbench/cli/agent/commands/generate_token.py
+++ b/lib/pbench/cli/agent/commands/generate_token.py
@@ -1,5 +1,7 @@
 """pbench-generate-token"""
 
+from json import JSONDecodeError
+
 import click
 import requests
 
@@ -30,7 +32,11 @@ class GenerateToken(BaseCommand):
         except requests.exceptions.ConnectionError as exc:
             raise RuntimeError(f"Cannot connect to '{uri}'") from exc
 
-        payload = response.json()
+        try:
+            payload = response.json()
+        except JSONDecodeError:
+            payload = {"message": response.text}
+
         if response.ok:
             click.echo(payload["auth_token"])
             return 0

--- a/lib/pbench/cli/agent/commands/generate_token.py
+++ b/lib/pbench/cli/agent/commands/generate_token.py
@@ -37,7 +37,7 @@ class GenerateToken(BaseCommand):
         except JSONDecodeError:
             payload = {"message": response.text}
 
-        if response.ok:
+        if response.ok and "auth_token" in payload:
             click.echo(payload["auth_token"])
             return 0
 


### PR DESCRIPTION
While the server responds to requests with a JSON payload, even for errors, not all responses come from the server.  (E.g., in the event that the server is unresponsive (e.g., because it's not running), the proxy will respond with a `408/Request Timeout`.)  This PR adds a little bit of defense to `generate_token.py` where we decode the response payload.

@dbutenhof, can you give this a try?

Fixes #2839.