### PR TITLE
Ensure use of `localhost` when stopping Redis

### DIFF
--- a/lib/pbench/agent/tool_meister_stop.py
+++ b/lib/pbench/agent/tool_meister_stop.py
@@ -65,6 +65,10 @@ class RedisServer(RedisServerCommon):
             )
         except FileNotFoundError:
             pass
+        else:
+            # Since this Redis server is locally managed, communication to it
+            # will always be through the "localhost" interface.
+            self.host = "localhost"
 
     def locally_managed(self) -> bool:
         return self.pid_file is not None

--- a/lib/pbench/agent/tool_meister_stop.py
+++ b/lib/pbench/agent/tool_meister_stop.py
@@ -66,8 +66,9 @@ class RedisServer(RedisServerCommon):
         except FileNotFoundError:
             pass
         else:
-            # Since this Redis server is locally managed, communication to it
-            # will always be through the "localhost" interface.
+            # The redis.pid file exists in the "tm" directory, which means this
+            # Redis server is locally managed.  Communication with it will
+            # always be through the "localhost" interface.
             self.host = "localhost"
 
     def locally_managed(self) -> bool:
@@ -290,7 +291,7 @@ def main():
     parser.add_argument(
         "--redis-server",
         dest="redis_server",
-        default=os.environ.get("PBENCH_REDIS_SERVER", None),
+        default=os.environ.get("PBENCH_REDIS_SERVER", ""),
         help=(
             "Use an existing Redis server specified by <hostname>:<port>;"
             " implies the use of an existing Tool Data Sink and Tool Meisters"

--- a/lib/pbench/test/unit/agent/test_tool_meister_stop.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister_stop.py
@@ -20,7 +20,7 @@ class TestRedisServer:
         rs = RedisServer("", rundir, "notme.example.com")
         assert (
             rs.locally_managed()
-        ), "Populated run directory did not result in a 'locally managed' RedisServer instance"
+        ), "RedisServer incorrectly inferred a non-locally managed instance from a run directory with a 'tm/redis.pid' file"
         assert (
             rs.host == "localhost"
         ), f"Expected 'RedisServer.host' to be 'localhost', got '{rs.host}'"
@@ -34,7 +34,7 @@ class TestRedisServer:
         rs = RedisServer(f"{rs_host}:4343", rundir, "notme.example.com")
         assert (
             not rs.locally_managed()
-        ), "Empty run directory still resulting in a 'locally managed' RedisServer instance"
+        ), "RedisServer incorrectly inferred a locally managed instance from an empty run directory"
         assert (
             rs.host == "redis.example.com"
         ), f"Expected 'RedisServer.host' to be '{rs_host}', got '{rs.host}'"

--- a/lib/pbench/test/unit/agent/test_tool_meister_stop.py
+++ b/lib/pbench/test/unit/agent/test_tool_meister_stop.py
@@ -1,0 +1,40 @@
+"""Tests for the Tool Meister "stop" module.
+"""
+from pbench.agent.tool_meister_stop import RedisServer
+
+
+class TestRedisServer:
+    """Verify the RedisServer class use by Tool Meister "stop"."""
+
+    def test_locally_managed(self, tmp_path):
+        # Locally managed means we have a run directory, ...
+        rundir = tmp_path / "run-dir"
+        rundir.mkdir()
+        # ... with a "tm" sub-directory, ...
+        tmdir = rundir / "tm"
+        tmdir.mkdir()
+        # ... containing a "redis.pid" file.
+        pidfile = tmdir / "redis.pid"
+        pidfile.write_text("12345")
+
+        rs = RedisServer("", rundir, "notme.example.com")
+        assert (
+            rs.locally_managed()
+        ), "Populated run directory did not result in a 'locally managed' RedisServer instance"
+        assert (
+            rs.host == "localhost"
+        ), f"Expected 'RedisServer.host' to be 'localhost', got '{rs.host}'"
+
+    def test_not_locally_managed(self, tmp_path):
+        # Empty benchmark run directory indicates not locally managed.
+        rundir = tmp_path / "empty-run-dir"
+        rundir.mkdir()
+
+        rs_host = "redis.example.com"
+        rs = RedisServer(f"{rs_host}:4343", rundir, "notme.example.com")
+        assert (
+            not rs.locally_managed()
+        ), "Empty run directory still resulting in a 'locally managed' RedisServer instance"
+        assert (
+            rs.host == "redis.example.com"
+        ), f"Expected 'RedisServer.host' to be '{rs_host}', got '{rs.host}'"


### PR DESCRIPTION
When `pbench-tool-meister-stop` is invoked where the Redis server was created locally by `pbench-tool-meister-start`, we always want to use the `localhost` IP address to talk to it.

Fixes issue #2861.