### PR TITLE
Correct installation path for Server RPM build

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -48,7 +48,7 @@ install-python3-setup: install-bin install-lib
 	mkdir -p ${DESTDIR}/python3
 	${COPY} requirements.txt ${DESTDIR}
 	(cd ..; SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py install --prefix=${DESTDIR}/python3)
-	${COPY} $(addprefix ${DESTDIR}/python3/bin/, pbench-config pbench-server ${click-scripts}) ${BINDIR}/
+	${COPY} $(addprefix ${DESTDIR}/python3/local/bin/, pbench-config pbench-server ${click-scripts}) ${BINDIR}/
 	${RM} -r ${DESTDIR}/python3
 	${COPY} ../lib/pbench ${LIBDIR}/
 	${RM} -r $$(find ${LIBDIR} -name __pycache__) ${LIBDIR}/pbench/test ${LIBDIR}/pbench/agent ${LIBDIR}/pbench/cli/agent


### PR DESCRIPTION
`python3 setup.py install --prefix=...` adds `local` to the installation path.

I believe this issue is only in Fedora-36.