### PR TITLE
Expand and generalize metadata namespace

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -322,12 +322,11 @@ def convert_json(value: JSONOBJECT, parameter: "Parameter") -> JSONOBJECT:
             if parameter.keywords:
                 bad = []
                 for k in value.keys():
-                    if parameter.keywords:
-                        if parameter.key_path:
-                            if not Metadata.is_key_path(k, parameter.keywords):
-                                bad.append(k)
-                        elif k not in parameter.keywords:
+                    if parameter.key_path:
+                        if not Metadata.is_key_path(k, parameter.keywords):
                             bad.append(k)
+                    elif k not in parameter.keywords:
+                        bad.append(k)
                 if bad:
                     raise KeywordError(
                         parameter, f"JSON key{'s' if len(bad) > 1 else ''}", bad

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -17,6 +17,7 @@ from pbench.server.api.resources import (
 from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import (
     Dataset,
+    Metadata,
     MetadataError,
 )
 
@@ -42,7 +43,8 @@ class DatasetsList(ApiBase):
                     "metadata",
                     ParamType.LIST,
                     element_type=ParamType.KEYWORD,
-                    keywords=ApiBase.METADATA,
+                    keywords=Metadata.METADATA_KEYS,
+                    key_path=True,
                     string_list=",",
                 ),
             ),

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -34,7 +34,8 @@ class DatasetsMetadata(ApiBase):
             "metadata",
             ParamType.LIST,
             element_type=ParamType.KEYWORD,
-            keywords=ApiBase.METADATA,
+            keywords=Metadata.METADATA_KEYS,
+            key_path=True,
             string_list=",",
         ),
     )
@@ -50,6 +51,7 @@ class DatasetsMetadata(ApiBase):
                     ParamType.JSON,
                     keywords=Metadata.USER_UPDATEABLE_METADATA,
                     required=True,
+                    key_path=True,
                 ),
             ),
             role=API_OPERATION.UPDATE,
@@ -145,7 +147,7 @@ class DatasetsMetadata(ApiBase):
             role = API_OPERATION.UPDATE
         else:
             for k in metadata.keys():
-                if Metadata.get_native_key(k) != Metadata.USER_NATIVE_KEY:
+                if Metadata.get_native_key(k) != Metadata.USER:
                     role = API_OPERATION.UPDATE
         self._check_authorization(
             str(dataset.owner_id), dataset.access, check_role=role
@@ -155,7 +157,7 @@ class DatasetsMetadata(ApiBase):
         for k, v in metadata.items():
             native_key = Metadata.get_native_key(k)
             user: Optional[User] = None
-            if native_key == Metadata.USER_NATIVE_KEY:
+            if native_key == Metadata.USER:
                 user = Auth.token_auth.current_user()
             try:
                 Metadata.setvalue(key=k, value=v, dataset=dataset, user=user)

--- a/lib/pbench/server/api/resources/query_apis/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_detail.py
@@ -9,7 +9,11 @@ from pbench.server.api.resources.query_apis import (
     ElasticBase,
     PostprocessError,
 )
-from pbench.server.database.models.datasets import DatasetNotFound, MetadataError
+from pbench.server.database.models.datasets import (
+    DatasetNotFound,
+    Metadata,
+    MetadataError,
+)
 
 
 class DatasetsDetail(ElasticBase):
@@ -33,7 +37,9 @@ class DatasetsDetail(ElasticBase):
                     "metadata",
                     ParamType.LIST,
                     element_type=ParamType.KEYWORD,
-                    keywords=ElasticBase.METADATA,
+                    keywords=Metadata.METADATA_KEYS,
+                    key_path=True,
+                    string_list=",",
                 ),
             ),
         )

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -789,7 +789,7 @@ class Metadata(Database.Base):
     DASHBOARD = "dashboard"
 
     # DATASET is a "virtual" key namespace representing the columns of the
-    # Dataset SQL table. Through Dataset.as_json() we allow the colums to be
+    # Dataset SQL table. Through Dataset.as_dict() we allow the columns to be
     # accessed as a normal metadata key namespace.
     #
     # {"dataset.created": "3000-03-30T03:30:30.303030+00:00"}

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -3,7 +3,7 @@ import datetime
 import enum
 from pathlib import Path
 import re
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from sqlalchemy import Column, DateTime, Enum, event, ForeignKey, Integer, JSON, String
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
@@ -639,6 +639,28 @@ class Dataset(Database.Base):
 
         return dataset
 
+    def as_dict(self) -> Dict[str, Any]:
+        """
+        Return a dict representing the extended public view of the dataset,
+        including non-private primary SQL columns and the `metadata.log` data
+        from the metadata table.
+
+        This mapping provides the basis of the "dataset.*" metadata namespace
+        for the API.
+
+        Returns
+            Dictionary representation of the DB object
+        """
+        return {
+            "access": self.access,
+            "created": self.created.isoformat() if self.created else None,
+            "name": self.name,
+            "owner": self.owner.username,
+            "state": str(self.state),
+            "transition": self.transition.isoformat(),
+            "uploaded": self.uploaded.isoformat(),
+        }
+
     def __str__(self) -> str:
         """
         Return a string representation of the dataset
@@ -735,11 +757,6 @@ class Metadata(Database.Base):
 
     __tablename__ = "dataset_metadata"
 
-    # "Native" keys are the value of the PostgreSQL "key" column in the SQL
-    # table. We support hierarchical nested keys of the form "server.indexed",
-    # but the first element of any nested key path must be one of these:
-    NATIVE_KEYS = ["dashboard", "server", "user"]
-
     # +++ Standard Metadata keys:
     #
     # Metadata accessible through the API comes from both the parent Dataset
@@ -762,12 +779,6 @@ class Metadata(Database.Base):
     # metadata property visible to all users, while "user.favorite" is visible
     # only to the specific user that wrote the value; each authenticated user
     # may have its own unique "user.favorite" value.
-    #
-    # The following class constants define the set of currently available
-    # metadata keys, where the "open" namespaces are represented by the
-    # syntax "dashboard.*" and "user.*" which allow clients to control the
-    # key names using a "dotted path" notation like "dashboard.seen" or
-    # "dashboard.contact.email".
 
     # DASHBOARD is arbitrary data saved on behalf of the dashboard client as a
     # JSON document. Writing these keys requires ownership of the referenced
@@ -775,7 +786,21 @@ class Metadata(Database.Base):
     # dataset.
     #
     # {"dashboard.seen": True}
-    DASHBOARD = "dashboard.*"
+    DASHBOARD = "dashboard"
+
+    # DATASET is a "virtual" key namespace representing the columns of the
+    # Dataset SQL table. Through Dataset.as_json() we allow the colums to be
+    # accessed as a normal metadata key namespace.
+    #
+    # {"dataset.created": "3000-03-30T03:30:30.303030+00:00"}
+    DATASET = "dataset"
+
+    # SERVER is an internally maintained key namespace for additional metadata
+    # relating to the server's management of datasets. The information here is
+    # accessible to callers, but can't be changed.
+    #
+    # {"server.deletion": "3030-03-30T03:30:30.303030+00:00"}
+    SERVER = "server"
 
     # USER is arbitrary data saved with the dataset on behalf of an
     # authenticated user, as a JSON document. Writing these keys requires READ
@@ -784,8 +809,12 @@ class Metadata(Database.Base):
     # unique value for these keys, for example "user.favorite".
     #
     # {"user.favorite": True}
-    USER_NATIVE_KEY = "user"
-    USER = USER_NATIVE_KEY + ".*"
+    USER = "user"
+
+    # "Native" keys are the value of the PostgreSQL "key" column in the SQL
+    # table. We support hierarchical nested keys of the form "server.indexed",
+    # but the first element of any nested key path must be one of these:
+    NATIVE_KEYS = [DASHBOARD, SERVER, USER]
 
     # DELETION timestamp for dataset based on user settings and system
     # settings when the dataset is created.
@@ -829,13 +858,7 @@ class Metadata(Database.Base):
     USER_UPDATEABLE_METADATA = [DASHBOARD, USER]
 
     # Metadata keys that are accessible to clients
-    USER_METADATA = USER_UPDATEABLE_METADATA + [DELETION]
-
-    # Metadata keys that are for internal use only
-    INTERNAL_METADATA = [REINDEX, ARCHIVED, TARBALL_PATH, INDEX_MAP]
-
-    # All supported Metadata keys
-    METADATA_KEYS = USER_METADATA + INTERNAL_METADATA
+    METADATA_KEYS = sorted(USER_UPDATEABLE_METADATA + [DATASET, SERVER])
 
     # NOTE: the ECMA JSON specification allows JSON "names" (keys) to be any
     # string, though most implementations and schemas enforce or recommend
@@ -919,11 +942,18 @@ class Metadata(Database.Base):
     def is_key_path(key: str, valid: List[str]) -> bool:
         """
         Determine whether 'key' is a valid Metadata key path using the list
-        specified in 'valid'. If the specified key is in the list, then it's
-        valid. If the key is a dotted path and the first element plus a
-        trailing ".*" is in the list, then this is an open key namespace where
-        any subsequent path is acceptable: e.g., "user.*" allows "user", or
-        "user.favorite", "user.notes.status", etc.
+        specified in 'valid'. If the "native" key (first element of a dotted
+        path) is in the list, then it's valid.
+
+        NOTE: we only validate the "native" key of the path. The "dashboard"
+        and "user" namespaces are completely open for any subsidiary keys the
+        caller desires. The "dataset" and "server" namespaces are internally
+        defined by Pbench, and can't be modified by the client, however a query
+        for a metadata key that's not defined will simply return None. This
+        seems preferable to building a complicated multi-level keyword path
+        validator and provides a degree of version independence. (That is, if
+        we add "server.nextgenkey" a query for that key on a previous server
+        version will return None rather than failing in validation.)
 
         Args:
             key: metadata key path
@@ -940,8 +970,8 @@ class Metadata(Database.Base):
         # Disallow ".." and trailing "."
         if "" in path:
             return False
-        # Check for open namespace match
-        if path[0] + ".*" not in valid:
+        # Check for namespace match
+        if path[0] not in valid:
             return False
         # Check that all open namespace keys are valid symbols
         return bool(re.fullmatch(Metadata._valid_key_charset, k))
@@ -986,11 +1016,14 @@ class Metadata(Database.Base):
             raise MetadataBadKey(key)
         keys = key.lower().split(".")
         native_key = keys.pop(0)
-        try:
-            meta = Metadata.get(dataset, native_key, user)
-        except MetadataNotFound:
-            return None
-        value = meta.value
+        if native_key == "dataset":
+            value = dataset.as_dict()
+        else:
+            try:
+                meta = Metadata.get(dataset, native_key, user)
+            except MetadataNotFound:
+                return None
+            value = meta.value
         name = native_key
         for i in keys:
             # If we have a nested key, and the `value` at this level isn't

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -15,7 +15,7 @@ from pbench.server.database.models.datasets import (
 )
 
 
-class TestMetadata:
+class TestGetSetMetadata:
     def test_metadata(self, db_session, create_user):
         """Various tests on Metadata keys"""
         # See if we can create a metadata row
@@ -109,6 +109,53 @@ class TestMetadata:
 
         Metadata.remove(ds, "dashboard")
         assert ds.metadatas == []
+
+
+class TestInternalMetadata:
+    def test_dataset_full(self, provide_metadata):
+        ds = Dataset.query(name="drb")
+        metadata = Metadata.getvalue(ds, "dataset")
+        assert metadata == {
+            "access": "private",
+            "created": "2020-02-15T00:00:00+00:00",
+            "name": "drb",
+            "owner": "drb",
+            "state": "Uploading",
+            "transition": "1970-01-01T00:42:00+00:00",
+            "uploaded": "2022-01-01T00:00:00+00:00",
+        }
+
+    def test_dataset_keys(self, provide_metadata):
+        ds = Dataset.query(name="drb")
+        metadata = Metadata.getvalue(ds, "dataset.state")
+        assert metadata == "Uploading"
+        metadata = Metadata.getvalue(ds, "dataset.transition")
+        assert metadata == "1970-01-01T00:42:00+00:00"
+        metadata = Metadata.getvalue(ds, "dataset.nosuchkey")
+        assert metadata is None
+
+    def test_server_full(self, provide_metadata):
+        ds = Dataset.query(name="drb")
+        metadata = Metadata.getvalue(ds, "server")
+        assert metadata == {
+            "deletion": "2022-12-25",
+            "index-map": {
+                "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
+                "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
+                "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
+            },
+        }
+
+    def test_server_keys(self, provide_metadata):
+        ds = Dataset.query(name="drb")
+        metadata = Metadata.getvalue(ds, "server.deletion")
+        assert metadata == "2022-12-25"
+        metadata = Metadata.getvalue(ds, "server.index-map")
+        assert metadata == {
+            "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
+            "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
+            "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
+        }
 
 
 class TestMetadataNamespace:

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -156,6 +156,8 @@ class TestInternalMetadata:
             "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
             "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
         }
+        metadata = Metadata.getvalue(ds, "server.webbwantsthistest")
+        assert metadata is None
 
 
 class TestMetadataNamespace:

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -180,7 +180,7 @@ class TestDatasetsList:
             HTTPStatus.BAD_REQUEST,
         )
         assert response.json == {
-            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard.*', 'dataset.access', 'dataset.created', 'dataset.owner', 'dataset.uploaded', 'server.deletion', 'user.*']"
+            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard', 'dataset', 'server', 'user']"
         }
 
     def test_get_unknown_keys(self, query_as):

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -110,21 +110,28 @@ class TestDatasetsMetadata:
             HTTPStatus.BAD_REQUEST,
         )
         assert response.json == {
-            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard.*', 'dataset.access', 'dataset.created', 'dataset.owner', 'dataset.uploaded', 'server.deletion', 'user.*']"
+            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard', 'dataset', 'server', 'user']"
         }
 
     def test_get1(self, query_get_as):
         response = query_get_as(
             "drb",
             {
-                "metadata": ["dashboard.seen", "server.deletion", "dataset.access"],
+                "metadata": ["dashboard.seen", "server", "dataset.access"],
             },
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {
             "dashboard.seen": None,
-            "server.deletion": "2022-12-25",
+            "server": {
+                "deletion": "2022-12-25",
+                "index-map": {
+                    "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
+                    "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
+                    "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
+                },
+            },
             "dataset.access": "private",
         }
 
@@ -132,7 +139,7 @@ class TestDatasetsMetadata:
         response = query_get_as(
             "drb",
             {
-                "metadata": "dashboard.seen,server.deletion,dataset.access",
+                "metadata": "dashboard.seen,server.deletion,dataset",
             },
             "drb",
             HTTPStatus.OK,
@@ -140,7 +147,15 @@ class TestDatasetsMetadata:
         assert response.json == {
             "dashboard.seen": None,
             "server.deletion": "2022-12-25",
-            "dataset.access": "private",
+            "dataset": {
+                "access": "private",
+                "created": "2020-02-15T00:00:00+00:00",
+                "name": "drb",
+                "owner": "drb",
+                "state": "Uploading",
+                "transition": "1970-01-01T00:42:00+00:00",
+                "uploaded": "2022-01-01T00:00:00+00:00",
+            },
         }
 
     def test_get3(self, query_get_as):
@@ -263,7 +278,7 @@ class TestDatasetsMetadata:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed keywords are ['dashboard.*', 'user.*']"
+            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed namespaces are ['dashboard', 'user']"
         }
 
     def test_put_reserved_metadata(self, client, server_config, attach_dataset):
@@ -273,7 +288,7 @@ class TestDatasetsMetadata:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed keywords are ['dashboard.*', 'user.*']"
+            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed namespaces are ['dashboard', 'user']"
         }
 
     def test_put_nowrite(self, query_get_as, query_put_as):

--- a/lib/pbench/test/unit/server/test_schema.py
+++ b/lib/pbench/test/unit/server/test_schema.py
@@ -414,8 +414,8 @@ class TestParameter:
         "listtype,keys,path,value",
         (
             (ParamType.ACCESS, None, False, ["sauron", "PRIVATE"]),
-            (ParamType.INT, None, ["a", "b"]),
-            (ParamType.INT, None, {"dict": "is-not-a-list-either"}),
+            (ParamType.INT, None, False, ["a", "b"]),
+            (ParamType.INT, None, False, {"dict": "is-not-a-list-either"}),
             (ParamType.KEYWORD, ["Yes", "No"], False, ["maybe", "nO"]),
             (ParamType.KEYWORD, ["me"], True, ["me."]),
             (ParamType.KEYWORD, ["me"], True, ["me..foo"]),


### PR DESCRIPTION
PBENCH-448

This allows API clients to access the entire "dataset" and "server" key namespaces just like "user" and "dashboard"; e.g., to ask for "dataset" to get all the dataset SQL columns as a JSON document.

This also paves the way to adding a full representation of the agent's metadata.log metadata without requiring a specific defined and validated key path for each item.