### PR TITLE
PBENCH-667: Use URI parameterization where reasonable

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -66,7 +66,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         DatasetsDelete,
-        f"{base_uri}/datasets/delete",
+        f"{base_uri}/datasets/delete/<string:dataset>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -101,7 +101,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         DatasetsPublish,
-        f"{base_uri}/datasets/publish",
+        f"{base_uri}/datasets/publish/<string:dataset>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -56,7 +56,7 @@ def register_endpoints(api, app, config):
 
     api.add_resource(
         DatasetsContents,
-        f"{base_uri}/datasets/contents",
+        f"{base_uri}/datasets/contents/<string:dataset>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -32,8 +32,10 @@ class DatasetsContents(IndexMapBase):
             ApiSchema(
                 API_METHOD.POST,
                 API_OPERATION.READ,
+                uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True)
+                ),
                 body_schema=Schema(
-                    Parameter("name", ParamType.DATASET, required=True),
                     Parameter("parent", ParamType.STRING, required=True),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,
@@ -53,7 +55,6 @@ class DatasetsContents(IndexMapBase):
 
         EXAMPLE:
         {
-            "dataset": <dataset reference>
             "parent": '/1-default'
         }
         """

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -36,7 +36,9 @@ class DatasetsDelete(ElasticBulkBase):
             ApiSchema(
                 API_METHOD.POST,
                 API_OPERATION.DELETE,
-                body_schema=Schema(Parameter("name", ParamType.DATASET, required=True)),
+                uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True)
+                ),
                 authorization=API_AUTHORIZATION.DATASET,
             ),
             action="delete",

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -29,8 +29,10 @@ class DatasetsPublish(ElasticBulkBase):
             ApiSchema(
                 API_METHOD.POST,
                 API_OPERATION.UPDATE,
+                uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True)
+                ),
                 body_schema=Schema(
-                    Parameter("name", ParamType.DATASET, required=True),
                     Parameter("access", ParamType.ACCESS, required=True),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -21,9 +21,9 @@ class TestDatasetsContents(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=DatasetsContents(client.config, client.logger),
-            pbench_endpoint="/datasets/contents",
+            pbench_endpoint="/datasets/contents/drb",
             elastic_endpoint="/_search",
-            payload={"name": "drb", "parent": "/1-default"},
+            payload={"parent": "/1-default"},
             index_from_metadata="run-toc",
         )
 
@@ -473,16 +473,12 @@ class TestDatasetsContents(Commons):
         indices = self.cls_obj.get_index(drb, self.index_from_metadata)
         assert indices == "unit-test.v6.run-toc.2020-05"
 
-    @pytest.mark.parametrize("name", ("wrong", "", None))
+    @pytest.mark.parametrize("name", ("wrong", ""))
     def test_missing_name(self, client, server_config, pbench_token, name):
-        if name is None:
-            del self.payload["name"]
-            expected_status = HTTPStatus.BAD_REQUEST
-        else:
-            self.payload["name"] = name
-            expected_status = HTTPStatus.NOT_FOUND
+        expected_status = HTTPStatus.NOT_FOUND
+        incorrect_endpoint = self.pbench_endpoint.rsplit("/", 1)[0] + "/" + name
         response = client.post(
-            f"{server_config.rest_uri}{self.pbench_endpoint}",
+            incorrect_endpoint,
             headers={"Authorization": "Bearer " + pbench_token},
             json=self.payload,
         )

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -20,7 +20,6 @@ class TestDatasetsDelete:
     constructor and `post` service.
     """
 
-    PAYLOAD = {"name": "drb"}
     tarball_deleted = None
 
     def fake_elastic(self, monkeypatch, map: JSON, partial_fail: bool):
@@ -124,8 +123,6 @@ class TestDatasetsDelete:
         """
         self.fake_elastic(monkeypatch, get_document_map, False)
         self.fake_filetree(monkeypatch)
-        payload = self.PAYLOAD.copy()
-        payload["name"] = owner
 
         is_admin = build_auth_header["header_param"] == HeaderTypes.VALID_ADMIN
         if not HeaderTypes.is_valid(build_auth_header["header_param"]):
@@ -136,9 +133,8 @@ class TestDatasetsDelete:
             expected_status = HTTPStatus.OK
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete",
+            f"{server_config.rest_uri}/datasets/delete/{owner}",
             headers=build_auth_header["header"],
-            json=payload,
         )
         assert response.status_code == expected_status
         if expected_status == HTTPStatus.OK:
@@ -171,9 +167,8 @@ class TestDatasetsDelete:
         self.fake_filetree(monkeypatch)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete",
+            f"{server_config.rest_uri}/datasets/delete/drb",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
         )
 
         # Verify the report and status
@@ -194,13 +189,9 @@ class TestDatasetsDelete:
         """
         Check the delete API if the dataset doesn't exist.
         """
-        payload = self.PAYLOAD.copy()
-        payload["name"] = "badwolf"
-
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete",
+            f"{server_config.rest_uri}/datasets/delete/badwolf",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=payload,
         )
 
         # Verify the report and status
@@ -228,9 +219,8 @@ class TestDatasetsDelete:
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete",
+            f"{server_config.rest_uri}/datasets/delete/drb",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
         )
 
         # Verify the failure

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -19,7 +19,7 @@ class TestDatasetsPublish:
     constructor and `post` service.
     """
 
-    PAYLOAD = {"name": "drb", "access": "public"}
+    PAYLOAD = {"access": "public"}
 
     def fake_elastic(self, monkeypatch, map: JSON, partial_fail: bool):
         """
@@ -113,8 +113,6 @@ class TestDatasetsPublish:
         user (managed by the build_auth_header fixture).
         """
         self.fake_elastic(monkeypatch, get_document_map, False)
-        payload = self.PAYLOAD.copy()
-        payload["name"] = owner
 
         is_admin = build_auth_header["header_param"] == HeaderTypes.VALID_ADMIN
         if not HeaderTypes.is_valid(build_auth_header["header_param"]):
@@ -125,9 +123,9 @@ class TestDatasetsPublish:
             expected_status = HTTPStatus.OK
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish",
+            f"{server_config.rest_uri}/datasets/publish/{owner}",
             headers=build_auth_header["header"],
-            json=payload,
+            json=self.PAYLOAD,
         )
         assert response.status_code == expected_status
         if expected_status == HTTPStatus.OK:
@@ -152,7 +150,7 @@ class TestDatasetsPublish:
         self.fake_elastic(monkeypatch, get_document_map, True)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish",
+            f"{server_config.rest_uri}/datasets/publish/drb",
             headers={"authorization": f"Bearer {pbench_token}"},
             json=self.PAYLOAD,
         )
@@ -176,13 +174,11 @@ class TestDatasetsPublish:
         """
         Check the publish API if the dataset doesn't exist.
         """
-        payload = self.PAYLOAD.copy()
-        payload["name"] = "badwolf"
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish",
+            f"{server_config.rest_uri}/datasets/publish/badwolf",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=payload,
+            json=self.PAYLOAD,
         )
 
         # Verify the report and status
@@ -210,7 +206,7 @@ class TestDatasetsPublish:
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish",
+            f"{server_config.rest_uri}/datasets/publish/drb",
             headers={"authorization": f"Bearer {pbench_token}"},
             json=self.PAYLOAD,
         )

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -45,7 +45,7 @@ class TestEndpointConfig:
                 # a trailing "/" here; for example, /datasets/mappings/
                 # corresponds to /datasets/mappings/<string:dataset_view>";
                 # see endpoint_configure.py for more detail.
-                "datasets_contents": f"{uri}/datasets/contents",
+                "datasets_contents": f"{uri}/datasets/contents/",
                 "datasets_daterange": f"{uri}/datasets/daterange",
                 "datasets_delete": f"{uri}/datasets/delete/",
                 "datasets_detail": f"{uri}/datasets/detail/",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -53,7 +53,7 @@ class TestEndpointConfig:
                 "datasets_mappings": f"{uri}/datasets/mappings/",
                 "datasets_metadata": f"{uri}/datasets/metadata/",
                 "datasets_namespace": f"{uri}/datasets/namespace/",
-                "datasets_publish": f"{uri}/datasets/publish",
+                "datasets_publish": f"{uri}/datasets/publish/",
                 "datasets_search": f"{uri}/datasets/search",
                 "datasets_values": f"{uri}/datasets/values/",
                 "elasticsearch": f"{uri}/elasticsearch",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -47,7 +47,7 @@ class TestEndpointConfig:
                 # see endpoint_configure.py for more detail.
                 "datasets_contents": f"{uri}/datasets/contents",
                 "datasets_daterange": f"{uri}/datasets/daterange",
-                "datasets_delete": f"{uri}/datasets/delete",
+                "datasets_delete": f"{uri}/datasets/delete/",
                 "datasets_detail": f"{uri}/datasets/detail/",
                 "datasets_list": f"{uri}/datasets/list",
                 "datasets_mappings": f"{uri}/datasets/mappings/",


### PR DESCRIPTION
This PR addresses the remaining items for our efforts to move the resource (dataset name) from a JSON payload to the URI parameter. 

\
Commit_1: Add the dataset resource name to the URI as `/datasets/delete/<dataset>` PBENCH-673
Old: 
```
POST /datasets/delete
{name: <dataset_name>}
```
New: 
```
POST /datasets/delete/<dataset_name>
```

\
Commit_2: Add the dataset resource name to the URI as `/datasets/publish/<dataset>` PBENCH-674
Old: 
```
POST /datasets/publish
{"name": <dataset_name>, "access": <public/private>}
```
New: 
```
POST /datasets/publish/<dataset_name>
{"access": <public/private>}
```

\
Commit_3: Add the dataset resource name to the URI as `/datasets/contents/<dataset>` PBENCH-675
Old: 
```
POST /datasets/contents
{"name": <dataset_name>, "parent": <dataset_parent_name>}
```
New: 
```
POST /datasets/contents/<dataset_name>
{ "parent": <dataset_parent_name>}
```