### PR TITLE
Expose tarball metadata.log values through API

### DIFF
--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -291,9 +291,9 @@ class Upload(Resource):
             #
             # NOTE: The full metadata.log (as a JSON object with section names
             # as the top level key) will be stored as a Metadata key using the
-            # name "dataset". For retrieval, the "dataset" key represents a
-            # JSON mapping of the Dataset SQL object, but will be enhanced with
-            # the parsed metadata.log values as well. (IS THIS TOO CONFUSING?)
+            # reserved internal key "metalog". For retrieval, the "dataset" key
+            # provides a JSON mapping of the Dataset SQL object, enhanced with
+            # the dataset's "metalog" Metadata key value.
             #
             # NOTE: we're setting the Dataset "created" timestamp here, but it
             # won't be committed to the database until the "advance" operation

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -286,8 +286,9 @@ class Upload(Resource):
             # Now that we have the tarball, extract the dataset timestamp from
             # the metadata.log file.
             #
-            # If this fails, the metadata.log is missing or corrupt and we'll
-            # abort the upload with an erorr.
+            # If the metadata.log is missing or corrupt, or doesn't contain the
+            # "date" property in the "pbench" section, the resulting exception
+            # will cause the upload to fail with an error.
             #
             # NOTE: The full metadata.log (as a JSON object with section names
             # as the top level key) will be stored as a Metadata key using the

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -645,7 +645,7 @@ class Dataset(Database.Base):
         including non-private primary SQL columns and the `metadata.log` data
         from the metadata table.
 
-        This mapping provides the basis of the "dataset.*" metadata namespace
+        This mapping provides the basis of the "dataset" metadata namespace
         for the API.
 
         Returns

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -651,6 +651,10 @@ class Dataset(Database.Base):
         Returns
             Dictionary representation of the DB object
         """
+        try:
+            metadata_log = Metadata.get(self, Metadata.METALOG).value
+        except MetadataNotFound:
+            metadata_log = None
         return {
             "access": self.access,
             "created": self.created.isoformat() if self.created else None,
@@ -659,6 +663,7 @@ class Dataset(Database.Base):
             "state": str(self.state),
             "transition": self.transition.isoformat(),
             "uploaded": self.uploaded.isoformat(),
+            Metadata.METALOG: metadata_log,
         }
 
     def __str__(self) -> str:
@@ -813,8 +818,11 @@ class Metadata(Database.Base):
 
     # "Native" keys are the value of the PostgreSQL "key" column in the SQL
     # table. We support hierarchical nested keys of the form "server.indexed",
-    # but the first element of any nested key path must be one of these:
-    NATIVE_KEYS = [DASHBOARD, SERVER, USER]
+    # but the first element of any nested key path must be one of these. The
+    # METALOG key is special, representing the Metadata table portion of the
+    # DATASET
+    METALOG = "metalog"
+    NATIVE_KEYS = [DASHBOARD, METALOG, SERVER, USER]
 
     # DELETION timestamp for dataset based on user settings and system
     # settings when the dataset is created.

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -237,7 +237,7 @@ class Tarball:
         except Exception as exc:
             raise MetadataError(self.tarball_path, exc)
 
-    def get_metadata(self) -> Optional[JSONOBJECT]:
+    def get_metadata(self) -> JSONOBJECT:
         """
         Fetch the values in metadata.log from the tarball, and return a JSON
         document organizing the metadata by section.
@@ -245,18 +245,13 @@ class Tarball:
         The information is unpacked and processed once, and cached.
 
         Returns:
-            A parsed ConfigParser of `metadata.log`
+            A JSON representation of the dataset `metadata.log`
         """
         if not self.metadata:
-            try:
-                data = self.extract(f"{self.name}/metadata.log")
-                metadata = ConfigParser()
-                metadata.read_string(data)
-                self.metadata = {
-                    s: dict(metadata.items(s)) for s in metadata.sections()
-                }
-            except Exception as e:
-                self.logger.exception("{} metadata extraction: {}", self.name, e)
+            data = self.extract(f"{self.name}/metadata.log")
+            metadata = ConfigParser()
+            metadata.read_string(data)
+            self.metadata = {s: dict(metadata.items(s)) for s in metadata.sections()}
         return self.metadata
 
     def unpack(self, incoming: Path, results: Path):

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -257,7 +257,6 @@ class Tarball:
                 }
             except Exception as e:
                 self.logger.exception("{} metadata extraction: {}", self.name, e)
-                pass
         return self.metadata
 
     def unpack(self, incoming: Path, results: Path):

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -380,7 +380,6 @@ def provide_metadata(attach_dataset):
     confusion.)
     """
     drb = Dataset.query(name="drb")
-    test = Dataset.query(name="test")
     Metadata.setvalue(dataset=drb, key="dashboard.contact", value="me@example.com")
     Metadata.setvalue(dataset=drb, key=Metadata.DELETION, value="2022-12-25")
     Metadata.setvalue(
@@ -406,6 +405,7 @@ def provide_metadata(attach_dataset):
         },
     )
 
+    test = Dataset.query(name="test")
     Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
     Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
     Metadata.create(

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -392,8 +392,6 @@ def provide_metadata(attach_dataset):
             "unit-test.v6.run-toc.2020-05": ["random_md5_string1"],
         },
     )
-    Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
-    Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
     Metadata.create(
         dataset=drb,
         key=Metadata.METALOG,
@@ -407,6 +405,9 @@ def provide_metadata(attach_dataset):
             "run": {"controller": "node1.example.com"},
         },
     )
+
+    Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
+    Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
     Metadata.create(
         dataset=test,
         key=Metadata.METALOG,

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -394,6 +394,32 @@ def provide_metadata(attach_dataset):
     )
     Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
     Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
+    Metadata.create(
+        dataset=drb,
+        key=Metadata.METALOG,
+        value={
+            "pbench": {
+                "date": "2020-02-15T00:00:00",
+                "config": "test1",
+                "script": "unit-test",
+                "name": "drb",
+            },
+            "run": {"controller": "node1.example.com"},
+        },
+    )
+    Metadata.create(
+        dataset=test,
+        key=Metadata.METALOG,
+        value={
+            "pbench": {
+                "date": "2002-05-16T00:00:00",
+                "config": "test2",
+                "script": "unit-test",
+                "name": "test",
+            },
+            "run": {"controller": "node2.example.com"},
+        },
+    )
 
 
 @pytest.fixture()

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -51,6 +51,7 @@ class TestDatasets:
             "state": "Uploading",
             "transition": "1970-01-01T00:00:00+00:00",
             "uploaded": "1970-01-01T00:00:00+00:00",
+            "metalog": None,
         }
 
     def test_dataset_survives_user(self, db_session, create_user):
@@ -63,6 +64,31 @@ class TestDatasets:
         User.delete(username=user.username)
         ds1 = Dataset.query(name="fio")
         assert ds1 == ds
+
+    def test_dataset_metadata_log(self, db_session, create_user, provide_metadata):
+        """
+        Test that `as_dict` provides the mocked metadata.log contents along
+        with the Dataset object.
+        """
+        ds1 = Dataset.query(name="drb")
+        assert ds1.as_dict() == {
+            "access": "private",
+            "created": "2020-02-15T00:00:00+00:00",
+            "name": "drb",
+            "owner": "drb",
+            "state": "Uploading",
+            "transition": "1970-01-01T00:42:00+00:00",
+            "uploaded": "2022-01-01T00:00:00+00:00",
+            "metalog": {
+                "pbench": {
+                    "config": "test1",
+                    "date": "2020-02-15T00:00:00",
+                    "name": "drb",
+                    "script": "unit-test",
+                },
+                "run": {"controller": "node1.example.com"},
+            },
+        }
 
     def test_construct_bad_owner(self, db_session):
         """Test with a non-existent username"""
@@ -124,6 +150,7 @@ class TestDatasets:
             "state": "Uploaded",
             "transition": "2525-08-25T15:25:00+00:00",
             "uploaded": "2525-05-25T15:15:00+00:00",
+            "metalog": None,
         }
 
     def test_advanced_bad_state(self, db_session, create_user):

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -123,6 +123,15 @@ class TestInternalMetadata:
             "state": "Uploading",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
+            "metalog": {
+                "pbench": {
+                    "config": "test1",
+                    "date": "2020-02-15T00:00:00",
+                    "name": "drb",
+                    "script": "unit-test",
+                },
+                "run": {"controller": "node1.example.com"},
+            },
         }
 
     def test_dataset_keys(self, provide_metadata):
@@ -131,6 +140,10 @@ class TestInternalMetadata:
         assert metadata == "Uploading"
         metadata = Metadata.getvalue(ds, "dataset.transition")
         assert metadata == "1970-01-01T00:42:00+00:00"
+        metadata = Metadata.getvalue(ds, "dataset.metalog.run")
+        assert metadata == {"controller": "node1.example.com"}
+        metadata = Metadata.getvalue(ds, "dataset.metalog.pbench.name")
+        assert metadata == "drb"
         metadata = Metadata.getvalue(ds, "dataset.nosuchkey")
         assert metadata is None
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -155,6 +155,15 @@ class TestDatasetsMetadata:
                 "state": "Uploading",
                 "transition": "1970-01-01T00:42:00+00:00",
                 "uploaded": "2022-01-01T00:00:00+00:00",
+                "metalog": {
+                    "pbench": {
+                        "config": "test1",
+                        "date": "2020-02-15T00:00:00",
+                        "name": "drb",
+                        "script": "unit-test",
+                    },
+                    "run": {"controller": "node1.example.com"},
+                },
             },
         }
 

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -16,7 +16,6 @@ from pbench.server.database.models.datasets import (
     States,
 )
 from pbench.server.filetree import FileTree
-from pbench.server.utils import UtcTimeHelper
 from pbench.test.unit.server.test_user_auth import login_user, register_user
 
 
@@ -126,9 +125,7 @@ class TestUpload:
                 TestUpload.tarball_deleted = self.name
 
             def get_metadata(self):
-                return {
-                    "pbench": {"date": UtcTimeHelper.from_string("2002-05-16").utc_time}
-                }
+                return {"pbench": {"date": "2002-05-16T00:00:00"}}
 
         class FakeFileTree(FileTree):
             def __init__(self, options: PbenchServerConfig, logger: Logger):


### PR DESCRIPTION
PBENCH-682

The filetree code was already parsing metadata.log in order to obtain the "created" timestamp. This PR formalizes that a bit, converting the entire config hierarchy (sections/settings) as a JSONOBJECT, which is persisted in SQL as a "metalog" key value for the dataset.

The "metalog" key value is exposed as a key in the "dataset" namespace, so that `/datasets/list?metadata=dataset` will return it as part of the JSON representation of the primary Dataset SQL row. As with any other metadata namespace, segments can be addressed directly, e.g., `dataset.metalog.run.controller`.

NOTE: I'm not deeply in love with the name "metalog"; however I didn't want to use the obvious "metadata" as it'll all appear nested inside the outer "metadata" key. I'm open to alternate suggestions!

Resolves #2600 