### PR TITLE
Add numactl to agent dependencies

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -46,7 +46,7 @@ Requires:  python3-psutil
 Requires:  perl, perl-Data-UUID, perl-JSON, perl-JSON-XS
 Requires:  perl-Time-HiRes
 
-Requires:  bc, bzip2, hostname, iproute, iputils, net-tools
+Requires:  bc, bzip2, hostname, iproute, iputils, net-tools, numactl
 Requires:  openssh-clients, openssh-server, procps-ng, psmisc, redis
 Requires:  rpmdevtools, rsync, screen, sos, tar, xz
 


### PR DESCRIPTION
PBENCH-737

numactl is required by pbench-uperf and by pbench-linpack
and the numastat tool.