### PR TITLE
GET API for /datasets/inventory/ to access dataset artifacts

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -18,6 +18,7 @@ from pbench.server.api.auth import Auth
 from pbench.server.api.resources.datasets_daterange import DatasetsDateRange
 from pbench.server.api.resources.datasets_list import DatasetsList
 from pbench.server.api.resources.datasets_metadata import DatasetsMetadata
+from pbench.server.api.resources.datasets_inventory import DatasetsInventory
 from pbench.server.api.resources.endpoint_configure import EndpointConfig
 from pbench.server.api.resources.graphql_api import GraphQL
 from pbench.server.api.resources.query_apis.datasets.datasets_contents import (
@@ -87,6 +88,11 @@ def register_endpoints(api, app, config):
     api.add_resource(
         DatasetsMetadata,
         f"{base_uri}/datasets/metadata/<string:dataset>",
+        resource_class_args=(config, logger),
+    )
+    api.add_resource(
+        DatasetsInventory,
+        f"{base_uri}/datasets/inventory/<string:dataset>/<path:path>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -6,7 +6,7 @@ from flask.wrappers import Request, Response
 from flask import send_file
 
 import os
-from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
+from pbench.server import PbenchServerConfig
 from pbench.server.api.resources import (
     APIAbort,
     API_AUTHORIZATION,

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from logging import Logger
-from pathlib import Path
 
 from flask import send_file
 from flask.wrappers import Response
@@ -58,15 +57,15 @@ class DatasetsInventory(ApiBase):
         dataset = params.uri["dataset"]
         path = params.uri["path"]
 
+        file_tree = FileTree(self.config, self.logger)
         try:
-            file_tree = FileTree(self.config, self.logger)
             tarball = file_tree.find_dataset(dataset.name)
-            dataset_location = tarball.unpacked
         except TarballNotFound as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
+        dataset_location = tarball.unpacked
         if dataset_location is None:
             raise APIAbort(HTTPStatus.NOT_FOUND, "The dataset is not unpacked")
-        file_path = dataset_location / Path(path)
+        file_path = dataset_location / path
         if file_path.is_file():
             return send_file(file_path)
         elif file_path.exists():

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,0 +1,80 @@
+from http import HTTPStatus
+from logging import Logger
+from pathlib import Path
+
+from flask.wrappers import Request, Response
+from flask import send_file
+
+import os
+from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
+from pbench.server.api.resources import (
+    APIAbort,
+    API_AUTHORIZATION,
+    API_METHOD,
+    API_OPERATION,
+    ApiBase,
+    ApiParams,
+    ApiSchema,
+    ParamType,
+    Parameter,
+    Schema,
+)
+
+from pbench.server.filetree import DatasetNotFound, FileTree
+
+
+class DatasetsInventory(ApiBase):
+    """
+    API class to retrieve files in a byte strean of a unpacked dataset.
+    """
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            ApiSchema(
+                API_METHOD.GET,
+                API_OPERATION.READ,
+                uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True)
+                ),
+                authorization=API_AUTHORIZATION.DATASET,
+            ),
+        )
+
+    def return_send_file(self, file_path):
+        return send_file(file_path)
+
+    def _get(self, params: ApiParams, request: Request) -> Response:
+        """
+        Get the values of client-accessible dataset and retrun the byte stream of the requested file .
+
+        Args:
+            params: Flask's URI parameter dictionary with dataset name
+            request: The original Request object containing query parameters
+
+        GET /api/v1/datasets/inventory/{dataset}/{path}
+        """
+
+        dataset = params.uri["dataset"]
+        path = params.uri["path"]
+
+        # Validate the authenticated user's authorization for the combination
+        # of "owner" and "access".
+
+        self._check_authorization(
+            str(dataset.owner_id), dataset.access, API_OPERATION.READ
+        )
+        try:
+            file_tree = FileTree(self.config, self.logger)
+            dataset_location = file_tree.find_inventory(dataset.name)
+            file_path = Path(os.path.join(dataset_location, Path(path)))
+            if file_path.is_file():
+                return self.return_send_file(file_path)
+            else:
+                raise APIAbort(
+                    HTTPStatus.NOT_FOUND, "File is not present in the given path"
+                )
+
+        except DatasetNotFound as e:
+            raise APIAbort(HTTPStatus.NOT_FOUND, str(e))

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -942,24 +942,3 @@ class FileTree:
         del self.datasets[dataset_id]
         del self.tarballs[name]
         self._clean_empties(tarball.controller_name)
-
-    def find_inventory(self, dataset: str) -> Path:
-        """
-        Given the name of a dataset,search the INCOMING tree directory for
-        the dataset and return its relative path.
-
-        Args:
-            dataset: The name of a dataset that might exist somewhere in the
-                file tree
-
-        Raises:
-            DatasetNotFound: the INCOMING tree does not contain a dataset ,either
-            it is not unpacked or dataset is not found .
-
-        Returns:
-            A Path of the dataset directory.
-        """
-        for dirs in self.incoming_root.rglob("*"):
-            if dirs.name == dataset:
-                return dirs.absolute()
-        raise DatasetNotFound(dataset)

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -942,3 +942,24 @@ class FileTree:
         del self.datasets[dataset_id]
         del self.tarballs[name]
         self._clean_empties(tarball.controller_name)
+
+    def find_inventory(self, dataset: str) -> Path:
+        """
+        Given the name of a dataset,search the INCOMING tree directory for
+        the dataset and return its relative path.
+
+        Args:
+            dataset: The name of a dataset that might exist somewhere in the
+                file tree
+
+        Raises:
+            DatasetNotFound: the INCOMING tree does not contain a dataset ,either
+            it is not unpacked or dataset is not found .
+
+        Returns:
+            A Path of the dataset directory.
+        """
+        for dirs in self.incoming_root.rglob("*"):
+            if dirs.name == dataset:
+                return dirs.absolute()
+        raise DatasetNotFound(dataset)

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -8,8 +8,9 @@ from pathlib import Path
 import pytest
 import requests
 
-from _typeshed.wsgi import WSGIEnvironment
-from flask.wrappers import Response
+if t.TYPE_CHECKING:
+    from _typeshed.wsgi import WSGIEnvironment
+    from flask.wrappers import Response
 
 from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -105,8 +105,12 @@ class TestDatasetsAccess:
         monkeypatch.setattr(Path, "is_file", lambda self: False)
         monkeypatch.setattr(Path, "exists", lambda self: True)
 
-        response = query_get_as("fio_2", "test", HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "1-default")
-        assert response.json == {"message": "The specified path does not refers to a regular file"}
+        response = query_get_as(
+            "fio_2", "test", HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "1-default"
+        )
+        assert response.json == {
+            "message": "The specified path does not refers to a regular file"
+        }
 
     def test_not_a_file(self, query_get_as, monkeypatch):
         monkeypatch.setattr(FileTree, "find_dataset", self.mock_find_dataset)
@@ -115,7 +119,6 @@ class TestDatasetsAccess:
 
         response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "1-default")
         assert response.json == {"message": "File is not present in the given path"}
-
 
     def test_dataset_in_given_path(self, query_get_as, monkeypatch):
         monkeypatch.setattr(FileTree, "find_dataset", self.mock_find_dataset)

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -8,6 +8,9 @@ from pathlib import Path
 import pytest
 import requests
 
+from _typeshed.wsgi import WSGIEnvironment
+from flask.wrappers import Response
+
 from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 from pbench.server.filetree import FileTree

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 import pytest
 import requests
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import PbenchServerConfig
 from pbench.server.api.resources.datasets_inventory import DatasetsInventory
 from pbench.server.filetree import FileTree
 from pathlib import Path

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -1,0 +1,99 @@
+from http import HTTPStatus
+
+import pytest
+import requests
+
+from pbench.server import JSON, PbenchServerConfig
+from pbench.server.api.resources.datasets_inventory import DatasetsInventory
+from pbench.server.filetree import FileTree
+from pathlib import Path
+from pbench.server.database.models.datasets import Dataset, DatasetNotFound
+
+
+class TestDatasetsAccess:
+    @pytest.fixture()
+    def query_get_as(self, client, server_config, more_datasets, provide_metadata):
+        """
+        Helper fixture to perform the API query and validate an expected
+        return status.
+
+        Args:
+            client: Flask test API client fixture
+            server_config: Pbench config fixture
+            more_datasets: Dataset construction fixture
+            provide_metadata: Dataset metadata fixture
+        """
+
+        def query_api(
+            dataset: str, username: str, expected_status: HTTPStatus, path: str
+        ) -> requests.Response:
+            headers = None
+            try:
+                dataset = Dataset.query(name=dataset).resource_id
+            except DatasetNotFound:
+                dataset = dataset  # Allow passing deliberately bad value
+            if username:
+                token = self.token(client, server_config, username)
+                headers = {"authorization": f"bearer {token}"}
+            response = client.get(
+                f"{server_config.rest_uri}/datasets/inventory/{dataset}/{path}",
+                headers=headers,
+            )
+            assert response.status_code == expected_status
+
+            # We need to log out to avoid "duplicate auth token" errors on the
+            # "put" test which does a PUT followed by two GETs.
+            if username:
+                client.post(
+                    f"{server_config.rest_uri}/logout",
+                    headers={"authorization": f"bearer {token}"},
+                )
+            return response
+
+        return query_api
+
+    def token(self, client, config: PbenchServerConfig, user: str) -> str:
+        response = client.post(
+            f"{config.rest_uri}/login",
+            json={"username": user, "password": "12345"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        data = response.json
+        assert data["auth_token"]
+        return data["auth_token"]
+
+    def mock_find_inventory(self, dataset):
+        return "/dataset1/"
+
+    def mock_send_file(self, file_path):
+        return {"status": "OK"}
+
+    def test_get_no_dataset(self, query_get_as):
+        with pytest.raises(Exception) as exc:
+            response = query_get_as(
+                "foobar", "drb", HTTPStatus.BAD_REQUEST, "metadata.log"
+            )
+            assert response.json == {"message": "Dataset 'foobar' not found"}
+
+    def test_dataset_not_present(self, query_get_as):
+        response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "metadata.log")
+        assert response.json == {
+            "message": "The dataset named 'fio_2' is not present in the file tree"
+        }
+
+    def test_not_a_file(self, query_get_as, monkeypatch):
+        monkeypatch.setattr(FileTree, "find_inventory", self.mock_find_inventory)
+        monkeypatch.setattr(Path, "is_file", lambda self: False)
+        response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "1-default")
+
+        assert response.json == {"message": "File is not present in the given path"}
+
+    def test_dataset_in_given_path(self, query_get_as, monkeypatch):
+
+        monkeypatch.setattr(FileTree, "find_inventory", self.mock_find_inventory)
+        monkeypatch.setattr(Path, "is_file", lambda self: True)
+        monkeypatch.setattr(DatasetsInventory, "return_send_file", self.mock_send_file)
+
+        response = query_get_as("fio_1", "drb", HTTPStatus.OK, "1-default/default.csv")
+        print(response)
+        assert response.status_code == HTTPStatus.OK

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -12,15 +12,13 @@ if TYPE_CHECKING:
     from _typeshed.wsgi import WSGIEnvironment
     from flask.wrappers import Response
 
-from pbench.server import PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 from pbench.server.filetree import FileTree
-from pbench.test.unit.server.conftest import generic_password
 
 
 class TestDatasetsAccess:
     @pytest.fixture()
-    def query_get_as(self, client, server_config, more_datasets):
+    def query_get_as(self, client, server_config, more_datasets, pbench_token):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -32,14 +30,13 @@ class TestDatasetsAccess:
         """
 
         def query_api(
-            dataset: str, username: str, expected_status: HTTPStatus, path: str
+            dataset: str, expected_status: HTTPStatus, path: str
         ) -> requests.Response:
             try:
                 dataset_id = Dataset.query(name=dataset).resource_id
             except DatasetNotFound:
                 dataset_id = dataset  # Allow passing deliberately bad value
-            token = self.token(client, server_config, username)
-            headers = {"authorization": f"bearer {token}"}
+            headers = {"authorization": f"bearer {pbench_token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/inventory/{dataset_id}/{path}",
                 headers=headers,
@@ -48,16 +45,6 @@ class TestDatasetsAccess:
             return response
 
         return query_api
-
-    def token(self, client, config: PbenchServerConfig, user: str) -> str:
-        response = client.post(
-            f"{config.rest_uri}/login",
-            json={"username": user, "password": generic_password},
-        )
-        assert response.status_code == HTTPStatus.OK
-        data = response.json
-        assert data["auth_token"]
-        return data["auth_token"]
 
     def mock_send_file(
         self,
@@ -84,14 +71,20 @@ class TestDatasetsAccess:
 
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(
-            "nonexistent-dataset", "drb", HTTPStatus.NOT_FOUND, "metadata.log"
+            "nonexistent-dataset", HTTPStatus.NOT_FOUND, "metadata.log"
         )
         assert response.json == {"message": "Dataset 'nonexistent-dataset' not found"}
 
-    def test_dataset_not_present(self, query_get_as, monkeypatch):
-        response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "metadata.log")
+    def test_dataset_not_present(self, query_get_as):
+        response = query_get_as("fio_2", HTTPStatus.NOT_FOUND, "metadata.log")
         assert response.json == {
             "message": "The dataset tarball named 'fio_2' is not present in the file tree"
+        }
+
+    def test_unauthorized_access(self, query_get_as):
+        response = query_get_as("test", HTTPStatus.FORBIDDEN, "metadata.log")
+        assert response.json == {
+            "message": "User drb is not authorized to READ a resource owned by test with private access"
         }
 
     def test_dataset_is_not_unpacked(self, query_get_as, monkeypatch):
@@ -102,7 +95,8 @@ class TestDatasetsAccess:
             return Tarball
 
         monkeypatch.setattr(FileTree, "find_dataset", mock_find_not_unpacked)
-        response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "1-default")
+
+        response = query_get_as("fio_2", HTTPStatus.NOT_FOUND, "1-default")
         assert response.json == {"message": "The dataset is not unpacked"}
 
     def test_path_is_directory(self, query_get_as, monkeypatch):
@@ -110,9 +104,7 @@ class TestDatasetsAccess:
         monkeypatch.setattr(Path, "is_file", lambda self: False)
         monkeypatch.setattr(Path, "exists", lambda self: True)
 
-        response = query_get_as(
-            "fio_2", "test", HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "1-default"
-        )
+        response = query_get_as("fio_2", HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "1-default")
         assert response.json == {
             "message": "The specified path does not refer to a regular file"
         }
@@ -122,7 +114,7 @@ class TestDatasetsAccess:
         monkeypatch.setattr(Path, "is_file", lambda self: False)
         monkeypatch.setattr(Path, "exists", lambda self: False)
 
-        response = query_get_as("fio_2", "test", HTTPStatus.NOT_FOUND, "1-default")
+        response = query_get_as("fio_2", HTTPStatus.NOT_FOUND, "1-default")
         assert response.json == {
             "message": "The specified path does not refer to a file"
         }
@@ -132,5 +124,5 @@ class TestDatasetsAccess:
         monkeypatch.setattr(Path, "is_file", lambda self: True)
         monkeypatch.setattr(werkzeug.utils, "send_file", self.mock_send_file)
 
-        response = query_get_as("fio_1", "drb", HTTPStatus.OK, "1-default/default.csv")
+        response = query_get_as("fio_2", HTTPStatus.OK, "1-default/default.csv")
         assert response.status_code == HTTPStatus.OK

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -83,8 +83,8 @@ class TestEndpointConfig:
                     "template": f"{uri}/datasets/inventory/{{dataset}}/{{path}}",
                     "params": [
                         {"name": "dataset", "type": "string"},
-                        {"name": "path", "type": "path"}
-                    ]
+                        {"name": "path", "type": "path"},
+                    ],
                 },
                 "datasets_list": {"template": f"{uri}/datasets/list", "params": {}},
                 "datasets_mappings": {

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -45,6 +45,7 @@ class TestEndpointConfig:
                 "datasets_daterange": f"{uri}/datasets/daterange",
                 "datasets_delete": f"{uri}/datasets/delete",
                 "datasets_detail": f"{uri}/datasets/detail",
+                "datasets_inventory": f"{uri}/datasets/inventory",
                 "datasets_list": f"{uri}/datasets/list",
                 "datasets_mappings": f"{uri}/datasets/mappings",
                 "datasets_metadata": f"{uri}/datasets/metadata",
@@ -77,6 +78,13 @@ class TestEndpointConfig:
                 "datasets_detail": {
                     "template": f"{uri}/datasets/detail/{{dataset}}",
                     "params": {"dataset": {"type": "string"}},
+                },
+                "datasets_inventory": {
+                    "template": f"{uri}/datasets/inventory/{{dataset}}/{{path}}",
+                    "params": [
+                        {"name": "dataset", "type": "string"},
+                        {"name": "path", "type": "path"}
+                    ]
                 },
                 "datasets_list": {"template": f"{uri}/datasets/list", "params": {}},
                 "datasets_mappings": {

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -81,10 +81,7 @@ class TestEndpointConfig:
                 },
                 "datasets_inventory": {
                     "template": f"{uri}/datasets/inventory/{{dataset}}/{{path}}",
-                    "params": [
-                        {"name": "dataset", "type": "string"},
-                        {"name": "path", "type": "path"},
-                    ],
+                    "params": {"dataset": {"type": "string"}, "path": {"type": "path"}},
                 },
                 "datasets_list": {"template": f"{uri}/datasets/list", "params": {}},
                 "datasets_mappings": {


### PR DESCRIPTION
Define Pbench server API to access dataset artifacts (including tarball)

PBENCH-625

Add a new `/datasets/inventory/` API to return the files as byte stream for the specified `dataset` with the `path` as URI parameters.