### PR TITLE
Fix rpmlint breakage

### DIFF
--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -42,7 +42,7 @@ srpm: spec patches tarball
 spec: rpm-dirs ${prog}.spec.j2
 	if [ -e ./seqno ] ;then expr ${seqno} + 1 > ./seqno ;fi
 	jinja2 ${prog}.spec.j2 -D version=${VERSION} -D gdist=g${sha1} -D seqno=${seqno} > ${RPMSPEC}/${prog}.spec
-	rpmlint --rpmlintrc ${PBENCHTOP}/utils/rpmlint ${RPMSPEC}/${prog}.spec
+	rpmlint --file ${PBENCHTOP}/utils/rpmlint ${RPMSPEC}/${prog}.spec
 
 .PHONY: patches
 patches: rpm-dirs


### PR DESCRIPTION
PBENCH-765

Changes were made to conform to Fedora 36 rpmlint changes to use `--rpmlintrc` instead of `--file`, but this breaks the other platforms.

Revert that change. Supporting Python3.10 and Fedora 36 is an ongoing challenge, but breaking existing platforms doesn't move us forward.