### PR TITLE
Work around for rpmlint incompatibilities

### DIFF
--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -42,7 +42,8 @@ srpm: spec patches tarball
 spec: rpm-dirs ${prog}.spec.j2
 	if [ -e ./seqno ] ;then expr ${seqno} + 1 > ./seqno ;fi
 	jinja2 ${prog}.spec.j2 -D version=${VERSION} -D gdist=g${sha1} -D seqno=${seqno} > ${RPMSPEC}/${prog}.spec
-	rpmlint --rpmlintrc ${PBENCHTOP}/utils/rpmlint ${RPMSPEC}/${prog}.spec
+	cp ${PBENCHTOP}/utils/rpmlint ${RPMSPEC}/pbench-common.rpmlintrc
+	XDG_CONFIG_HOME=${PBENCHTOP}/utils rpmlint ${RPMSPEC}/${prog}.spec
 
 .PHONY: patches
 patches: rpm-dirs


### PR DESCRIPTION
Starting with `rpmlint` 2.0.0, the `--file` option was changed to `--rpmlintrc`.  The first encounter with this version of `rpmlint` came with Fedora 36, but will likely show up soon in other distributions.

To work around this change, we take advantage of two behaviors of `rpmlint`, one from the pre-2.0.0 version and one from the new version.

For pre-2.0.0, we set the `XDG_CONFIG_HOME` to `${PBENCH_TOP}/utils` so that our `rpmlint` file containing the configuration we want is found.

For 2.0.0 and later, we copy our `rpmlint` file to a `pbench-common.rpmlintrc` along side the build location of the .spec file.