### PR TITLE
Fix pbench-register-tool-set argument handling

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.18.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.18.txt
@@ -1,0 +1,17 @@
++++ Running test-11.18 pbench-register-tool-set light
+"vmstat" tool is now registered for host "testhost.example.com" in group "default"
+--- Finished test-11.18 pbench-register-tool-set (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/vmstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/vmstat:
+--interval=3
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "testhost.example.com" in group "default"
+--- pbench.log file contents

--- a/agent/util-scripts/pbench-register-tool-set
+++ b/agent/util-scripts/pbench-register-tool-set
@@ -134,7 +134,6 @@ while true; do
 		exit 0
 		;;
 	--)
-		shift
 		break
 		;;
 	esac

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -389,6 +389,7 @@ declare -A tools=(
     [test-11.15]="pbench-register-tool-set"
     [test-11.16]="pbench-register-tool-set"
     [test-11.17]="pbench-register-tool-set"
+    [test-11.18]="pbench-register-tool-set"
     [test-17]="test-tm-start-bad-group"
     [test-18]="test-tm-stop-bad-group"
     [test-19]="test-tool-trigger"
@@ -475,7 +476,7 @@ declare -A options=(
     [test-11.15]="--remotes=@non-existent-file"
     [test-11.16]="--remotes=@${_testdir}/tmp/good-remote-file"
     [test-11.17]="--remotes=@${_testdir}/tmp/empty-remote-file"
-
+    [test-11.18]="light"
     # pbench-move-results
     [test-20]="--help"
     # pbench-move-results - no args, nothing to do


### PR DESCRIPTION
Fixes #2903

Invoking pbench-register-tool-set with a named toolset argument, e.g.

   pbench-register-tool-set light

ignores the named argument, and substitutes the default tool set,
resulting in a deprecation warning and registration of the default
tool set.

The option-handling code does one extra shift of the argument list
falling off the end. The fix just eliminates the extra shift.

Also add a simple unit test for this case.