### PR TITLE
Clarify "tarball" vs "dataset" in FileTree

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -88,6 +88,6 @@ class DatasetsDelete(ElasticBulkBase):
         if summary["failure"] == 0:
             self.logger.info("Deleting dataset {} file system representation", dataset)
             file_tree = FileTree(self.config, self.logger)
-            file_tree.delete(dataset.name)
+            file_tree.delete(dataset.resource_id)
             self.logger.info("Deleting dataset {} PostgreSQL representation", dataset)
             dataset.delete()

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -13,10 +13,11 @@ from pbench.server.api.auth import Auth
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetDuplicate,
+    DatasetNotFound,
     Metadata,
     States,
 )
-from pbench.server.filetree import DatasetNotFound, FileTree
+from pbench.server.filetree import FileTree
 from pbench.server.utils import UtcTimeHelper, filesize_bytes
 
 

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -484,6 +484,7 @@ class Controller:
             elif file.is_file() and Dataset.is_tarball(file):
                 tarball = Tarball(file, self)
                 self.tarballs[tarball.name] = tarball
+                self.datasets[tarball.resource_id] = tarball
                 if tarball.check_unpacked(self.incoming):
                     tarball.check_results(self.results)
 
@@ -755,7 +756,7 @@ class FileTree:
         """
         return dataset_id in self.datasets
 
-    def __getitem__(self, dataset: str) -> Tarball:
+    def __getitem__(self, dataset_id: str) -> Tarball:
         """
         Direct access to a dataset Tarball object by dataset ID (MD5).
 
@@ -818,7 +819,7 @@ class FileTree:
             if file.is_dir() and file.name != FileTree.TEMPORARY:
                 self._add_controller(file)
 
-    def find_dataset(self, dataset: str) -> Tarball:
+    def find_dataset(self, dataset_id: str) -> Tarball:
         """
         Given the resource ID of a dataset, search the ARCHIVE tree for a
         controller with a matching dataset results MD5 value. This will build

--- a/lib/pbench/server/filetree.py
+++ b/lib/pbench/server/filetree.py
@@ -737,8 +737,8 @@ class FileTree:
         NOTE: both _discover_unpacked() and _discover_results() rely on the
         results of _discover_archive(), which must run first.
 
-        Full discovery is not required before adding or deleting a dataset, or
-        attempting to locate a dataset with find_dataset().
+        Full discovery is not required in order to find, create, or delete a
+        specific dataset.
         """
         self._discover_controllers()
 
@@ -885,7 +885,7 @@ class FileTree:
 
         Args:
             controller: associated controller name
-            tarball: dataset tarball path
+            tarfile: dataset tarball path
 
         Returns
             Tarball object

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -98,8 +98,8 @@ class TestDatasetsDelete:
         def fake_constructor(self, options: PbenchServerConfig, logger: Logger):
             pass
 
-        def fake_delete(self, name: str) -> None:
-            TestDatasetsDelete.tarball_deleted = name
+        def fake_delete(self, dataset_id: str) -> None:
+            TestDatasetsDelete.tarball_deleted = dataset_id
 
         TestDatasetsDelete.tarball_deleted = None
         monkeypatch.setattr(FileTree, "__init__", fake_constructor)
@@ -141,7 +141,7 @@ class TestDatasetsDelete:
         assert response.status_code == expected_status
         if expected_status == HTTPStatus.OK:
             assert response.json == {"ok": 31, "failure": 0}
-            assert TestDatasetsDelete.tarball_deleted == owner
+            assert TestDatasetsDelete.tarball_deleted == ds.resource_id
 
             # On success, the Dataset should be gone
             with pytest.raises(DatasetNotFound):

--- a/lib/pbench/test/unit/server/test_file_tree.py
+++ b/lib/pbench/test/unit/server/test_file_tree.py
@@ -218,7 +218,7 @@ class TestFileTree:
         controller = tarball.controller
 
         assert tree.controllers == {controller.name: controller}
-        assert tree.datasets == {tarball.name: tarball}
+        assert tree.datasets == {md5: tarball}
 
         # It hasn't been unpacked
         assert tarball.unpacked is None
@@ -234,7 +234,7 @@ class TestFileTree:
         assert exc.value.tarball == "foobar"
 
         # Unpack the dataset, creating INCOMING and RESULTS links
-        tree.unpack(dataset_name)
+        tree.unpack(md5)
         assert tarball.unpacked == controller.incoming / tarball.name
         assert tarball.results_link == controller.results / tarball.name
 
@@ -315,8 +315,8 @@ class TestFileTree:
         assert results_link.is_symlink()
         assert results_link.samefile(incoming_dir)
 
-        assert tree.datasets[dataset_name].unpacked == incoming_dir
-        assert tree.datasets[dataset_name].results_link == results_link
+        assert tree.datasets[md5].unpacked == incoming_dir
+        assert tree.datasets[md5].results_link == results_link
 
         # Re-discover, with all the files in place, and compare
         newtree = FileTree(server_config, make_logger)


### PR DESCRIPTION
PBENCH-769

With the recent change to make tarball MD5 the authoritative "resource id" for datasets, the ambiguity in `FileTree` classes between "tarball" and "dataset" becomes more important. A planned change to allow altering the dataset resource name for display will compound the problem since tarball names are immutable but will no longer match the dataset name.

This change attempts to more clearly separate the two concepts, while redefining the primary access into the file tree to use the resource ID of a dataset, which is the tarball MD5 value and therefore easily accessible in both models.