### PR TITLE
Quote the screenit variable in pbench-fio

### DIFF
--- a/agent/bench-scripts/pbench-fio
+++ b/agent/bench-scripts/pbench-fio
@@ -596,14 +596,14 @@ function fio_run_job() {
 	if [ -n "${clients}" ]; then
 		for client in "${client_names[@]}"; do
 			local bash_c_cmd="${benchmark} --server=,${client_ports[${client}]} > client-result.txt 2> client-result.err"
-			local screen_it="screen -L -Logfile fio-server.screen.log -dmS fio-server bash -c ${bash_c_cmd}"
+			local screen_it="screen -L -Logfile fio-server.screen.log -dmS fio-server bash -c '${bash_c_cmd}'"
 			if pbench-is-local ${client}; then
 				debug_log "killing any old local fio processes and starting new a fio process for the local client"
 				killall ${benchmark} > /dev/null 2>&1
-				(cd ${benchmark_results_dir} && ${screen_it})
+				(cd ${benchmark_results_dir} && eval "${screen_it}")
 			else
 				debug_log "killing any old fio processes, creating directories, and starting new a fio process on remote client ${client}:${client_ports[${client}]}"
-				ssh ${ssh_opts} ${client} "killall ${benchmark} > /dev/null 2>&1; mkdir -p ${benchmark_results_dir} && cd ${benchmark_results_dir} && ${screen_it}"
+				ssh ${ssh_opts} ${client} "killall ${benchmark} > /dev/null 2>&1; mkdir -p ${benchmark_results_dir} && cd ${benchmark_results_dir} && eval \"${screen_it}\""
 			fi
 		done
 		debug_log "waiting for fio process(server) to start on the remote clients"


### PR DESCRIPTION
Without the quotation the execution is failing on the localhost as the
"bash -c ..." receives multiple arguments which results in executing
only "fio" without the remaining arguments.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>