### PR TITLE
Addendum to PR #2904: add more tests

### DIFF
--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.19.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.19.txt
@@ -1,0 +1,17 @@
++++ Running test-11.19 pbench-register-tool-set -- light
+"vmstat" tool is now registered for host "testhost.example.com" in group "default"
+--- Finished test-11.19 pbench-register-tool-set (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-default
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/vmstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-default/testhost.example.com/vmstat:
+--interval=3
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "testhost.example.com" in group "default"
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.20.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.20.txt
@@ -1,0 +1,17 @@
++++ Running test-11.20 pbench-register-tool-set --group=foo light
+"vmstat" tool is now registered for host "testhost.example.com" in group "foo"
+--- Finished test-11.20 pbench-register-tool-set (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com/vmstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com/vmstat:
+--interval=3
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "testhost.example.com" in group "foo"
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.21.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.21.txt
@@ -1,0 +1,17 @@
++++ Running test-11.21 pbench-register-tool-set --group=foo -- light
+"vmstat" tool is now registered for host "testhost.example.com" in group "foo"
+--- Finished test-11.21 pbench-register-tool-set (status=0)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/pbench.log
+/var/tmp/pbench-test-utils/pbench/tmp
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com
+/var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com/vmstat
+=== /var/tmp/pbench-test-utils/pbench/tools-v1-foo/testhost.example.com/vmstat:
+--interval=3
+--- pbench tree state
++++ pbench.log file contents
+[debug][1900-01-01T00:00:00.000000] tool_opts: "--interval=3"
+[info][1900-01-01T00:00:00.000000] "vmstat" tool is now registered for host "testhost.example.com" in group "foo"
+--- pbench.log file contents

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.22.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.22.txt
@@ -1,0 +1,7 @@
++++ Running test-11.22 pbench-register-tool-set --group=foo nonexistenttoolset
+ERROR: failed to fetch tool set, nonexistenttoolset-tool-set, from the pbench-agent configuration file
+--- Finished test-11.22 pbench-register-tool-set (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/gold/pbench-register-tool-set/test-11.23.txt
+++ b/agent/util-scripts/gold/pbench-register-tool-set/test-11.23.txt
@@ -1,0 +1,7 @@
++++ Running test-11.23 pbench-register-tool-set  -- --group=foo light
+ERROR: failed to fetch tool set, --group=foo-tool-set, from the pbench-agent configuration file
+--- Finished test-11.23 pbench-register-tool-set (status=1)
++++ pbench tree state
+/var/tmp/pbench-test-utils/pbench
+/var/tmp/pbench-test-utils/pbench/tmp
+--- pbench tree state

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -390,6 +390,11 @@ declare -A tools=(
     [test-11.16]="pbench-register-tool-set"
     [test-11.17]="pbench-register-tool-set"
     [test-11.18]="pbench-register-tool-set"
+    [test-11.19]="pbench-register-tool-set"
+    [test-11.20]="pbench-register-tool-set"
+    [test-11.21]="pbench-register-tool-set"
+    [test-11.22]="pbench-register-tool-set"
+    [test-11.23]="pbench-register-tool-set"
     [test-17]="test-tm-start-bad-group"
     [test-18]="test-tm-stop-bad-group"
     [test-19]="test-tool-trigger"
@@ -477,6 +482,11 @@ declare -A options=(
     [test-11.16]="--remotes=@${_testdir}/tmp/good-remote-file"
     [test-11.17]="--remotes=@${_testdir}/tmp/empty-remote-file"
     [test-11.18]="light"
+    [test-11.19]="-- light"
+    [test-11.20]="--group=foo light"
+    [test-11.21]="--group=foo -- light"
+    [test-11.22]="--group=foo nonexistenttoolset"
+    [test-11.23]=" -- --group=foo light"
     # pbench-move-results
     [test-20]="--help"
     # pbench-move-results - no args, nothing to do
@@ -537,6 +547,8 @@ declare -A expected_status=(
     [test-11.11]=1
     [test-11.15]=1
     [test-11.17]=1
+    [test-11.22]=1
+    [test-11.23]=1
     [test-17]=1
     [test-18]=1
     [test-22]=1


### PR DESCRIPTION
Following a comment by @dbutenhof on PR #2904 (actually, its sibling back-porting to b0.71), this PR adds a few more tests for `pbench-register-tool-set'.