### PR TITLE
Allow changing the dataset resource name and deletion date

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -45,6 +45,10 @@ class PbenchServerConfig(PbenchConfig):
     for the pbench server environment.
     """
 
+    # Define a fallback default for dataset maximum retention, which we expect
+    # to be defined in pbench-server-default.cfg.
+    MAXIMUM_RETENTION_DAYS = 3650
+
     def __init__(self, cfg_name):
         super().__init__(cfg_name)
 
@@ -160,6 +164,24 @@ class PbenchServerConfig(PbenchConfig):
     @property
     def rest_uri(self):
         return self._get_conf("pbench-server", "rest_uri")
+
+    @property
+    def max_retention_period(self) -> timedelta:
+        """
+        Produce a timedelta representing the number of days the server allows
+        a dataset to be retained.
+
+        Returns
+            delta time representing retention period
+        """
+        try:
+            retention_days = int(
+                self._get_conf("pbench-server", "maximum-dataset-retention-days")
+            )
+        except (NoOptionError, NoSectionError):
+            retention_days = self.MAXIMUM_RETENTION_DAYS
+
+        return timedelta(days=retention_days)
 
     def _get_conf(self, section, option):
         """

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -26,9 +26,11 @@ class Database:
 
     @staticmethod
     def init_db(server_config, logger):
-        # Attach the logger to the base class for models to find
+        # Attach the logger and server config object to the base class for
+        # database models to find
         if logger and not hasattr(Database.Base, "logger"):
             Database.Base.logger = logger
+            Database.Base.config = server_config
 
         # WARNING:
         # Make sure all the models are imported before this function gets called

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -1124,7 +1124,9 @@ class Metadata(Database.Base):
                 or len(value) > __class__.MAX_NAME_LEN
                 or len(value) < __class__.MIN_NAME_LEN
             ):
-                raise MetadataBadValue(dataset, key, value, "UTF-8 string")
+                raise MetadataBadValue(
+                    dataset, key, value, "UTF-8 string of 1 to 32 characters"
+                )
 
             try:
                 value.encode("utf-8", errors="strict")

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -1125,7 +1125,10 @@ class Metadata(Database.Base):
                 or len(value) < __class__.MIN_NAME_LEN
             ):
                 raise MetadataBadValue(
-                    dataset, key, value, "UTF-8 string of 1 to 32 characters"
+                    dataset,
+                    key,
+                    value,
+                    f"UTF-8 string of {__class__.MIN_NAME_LEN} to {__class__.MAX_NAME_LEN} characters",
                 )
 
             try:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -203,6 +203,26 @@ class MetadataBadStructure(MetadataError):
         return f"Key {self.element!r} value for {self.key!r} in {self.dataset} is not a JSON object"
 
 
+class MetadataBadValue(MetadataError):
+    """
+    An unsupported value was specified for a special metadata key
+
+    The error text will identify the metadata key that was specified and the
+    actual and expected value type.
+    """
+
+    def __init__(self, dataset: "Dataset", key: str, value: str, expected: str):
+        super().__init__(dataset, key)
+        self.value = value
+        self.expected = expected
+
+    def __str__(self) -> str:
+        return (
+            f"Metadata key {self.key!r} value {self.value!r} for dataset "
+            f"{self.dataset} must be a {self.expected}"
+        )
+
+
 class MetadataKeyError(DatasetError):
     """
     A base class for metadata key errors in the context of Metadata errors
@@ -235,24 +255,6 @@ class MetadataBadKey(MetadataKeyError):
 
     def __str__(self) -> str:
         return f"Metadata key {self.key!r} is not supported"
-
-
-class MetadataBadValue(MetadataError):
-    """
-    An unsupported value was specified for a special metadata key
-
-    The error text will identify the metadata key that was specified and the
-    actual and expected value type.
-    """
-
-    def __init__(self, dataset: "Dataset", key: str, value: str, expected: str):
-        self.name = dataset.name
-        self.key = key
-        self.value = value
-        self.expected = expected
-
-    def __str__(self) -> str:
-        return f"Metadata key {self.key!r} value {self.value!r} for dataset {self.name!r} must be a {self.expected}"
 
 
 class MetadataProtectedKey(MetadataKeyError):
@@ -1166,7 +1168,7 @@ class Metadata(Database.Base):
             meta.value = meta_value
             meta.update()
         else:
-            meta = Metadata.create(
+            Metadata.create(
                 dataset=dataset, key=native_key, value=meta_value, user=user
             )
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -381,7 +381,9 @@ def provide_metadata(attach_dataset):
     """
     drb = Dataset.query(name="drb")
     Metadata.setvalue(dataset=drb, key="dashboard.contact", value="me@example.com")
-    Metadata.setvalue(dataset=drb, key=Metadata.DELETION, value="2022-12-25")
+    Metadata.setvalue(
+        dataset=drb, key=Metadata.DELETION, value="2022-12-25 00:00-04:00"
+    )
     Metadata.setvalue(
         dataset=drb,
         key="server.index-map",
@@ -407,7 +409,9 @@ def provide_metadata(attach_dataset):
 
     test = Dataset.query(name="test")
     Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
-    Metadata.setvalue(dataset=test, key=Metadata.DELETION, value="2023-01-25")
+    Metadata.setvalue(
+        dataset=test, key=Metadata.DELETION, value="1979-11-01T00:00+00:00"
+    )
     Metadata.create(
         dataset=test,
         key=Metadata.METALOG,

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -384,7 +384,7 @@ class TestMetadataNamespace:
             Metadata.setvalue(ds, "dataset.name", "")
         assert (
             str(exc.value)
-            == "Metadata key 'dataset.name' value '' for dataset 'drb' must be a string"
+            == "Metadata key 'dataset.name' value '' for dataset drb(3)|drb must be a string"
         )
         assert Metadata.getvalue(ds, "dataset.name") == name
 
@@ -401,11 +401,11 @@ class TestMetadataNamespace:
         [
             (
                 "Not a date",
-                "Metadata key 'server.deletion' value 'Not a date' for dataset 'drb' must be a date/time",
+                "Metadata key 'server.deletion' value 'Not a date' for dataset drb(3)|drb must be a date/time",
             ),
             (
                 "2040-12-25",
-                "Metadata key 'server.deletion' value '2040-12-25' for dataset 'drb' must be a date/time before 2031-12-30",
+                "Metadata key 'server.deletion' value '2040-12-25' for dataset drb(3)|drb must be a date/time before 2031-12-30",
             ),
         ],
     )

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -367,7 +367,13 @@ class TestMetadataNamespace:
 
     @pytest.mark.parametrize(
         "value",
-        ["Symbols like $ and _ and @", "MY_DATA", "123456", "Shift to the left"],
+        [
+            "Symbols like $ and _ and @",
+            "MY_DATA",
+            "123456",
+            "La palabra año incluye unicode",
+            "Shift to the left",
+        ],
     )
     def test_mutable_dataset(self, attach_dataset, value):
         """
@@ -379,7 +385,7 @@ class TestMetadataNamespace:
 
     @pytest.mark.parametrize(
         "value",
-        ["", b"\xe8", "This is a really long name that exceeds the maximum length"],
+        ["", True, 1, "This is a really long name that exceeds the maximum length"],
     )
     def test_mutable_dataset_bad(self, attach_dataset, value):
         """
@@ -391,7 +397,7 @@ class TestMetadataNamespace:
             Metadata.setvalue(ds, "dataset.name", value)
         assert (
             str(exc.value)
-            == f"Metadata key 'dataset.name' value {value!r} for dataset drb(3)|drb must be a UTF-8 string"
+            == f"Metadata key 'dataset.name' value {value!r} for dataset drb(3)|drb must be a UTF-8 string of 1 to 32 characters"
         )
         assert Metadata.getvalue(ds, "dataset.name") == name
 

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -8,6 +8,7 @@ from pbench.server.database.models.datasets import (
     Metadata,
     DatasetBadParameterType,
     MetadataBadStructure,
+    MetadataBadValue,
     MetadataNotFound,
     MetadataBadKey,
     MetadataMissingKeyValue,
@@ -152,7 +153,7 @@ class TestInternalMetadata:
         ds = Dataset.query(name="drb")
         metadata = Metadata.getvalue(ds, "server")
         assert metadata == {
-            "deletion": "2022-12-25",
+            "deletion": "2022-12-25T04:00:00+00:00",
             "index-map": {
                 "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
                 "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
@@ -163,7 +164,7 @@ class TestInternalMetadata:
     def test_server_keys(self, provide_metadata):
         ds = Dataset.query(name="drb")
         metadata = Metadata.getvalue(ds, "server.deletion")
-        assert metadata == "2022-12-25"
+        assert metadata == "2022-12-25T04:00:00+00:00"
         metadata = Metadata.getvalue(ds, "server.index-map")
         assert metadata == {
             "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
@@ -363,3 +364,61 @@ class TestMetadataNamespace:
         assert Metadata.getvalue(dataset=ds, user=user1, key="user") == {
             "contact": "Wilma"
         }
+
+    @pytest.mark.parametrize("value", ["This is a name", True, 1.0, ["a", "b"]])
+    def test_mutable_dataset(self, attach_dataset, value):
+        """
+        Try setting a few valid names.
+        """
+        ds = Dataset.query(name="drb")
+        Metadata.setvalue(ds, "dataset.name", value)
+        assert Metadata.getvalue(ds, "dataset")["name"] == str(value)
+
+    def test_mutable_dataset_bad(self, attach_dataset):
+        """
+        Test the reaction to a "bad" (empty) string name.
+        """
+        ds = Dataset.query(name="drb")
+        name = ds.name
+        with pytest.raises(MetadataBadValue) as exc:
+            Metadata.setvalue(ds, "dataset.name", "")
+        assert (
+            str(exc.value)
+            == "Metadata key 'dataset.name' value '' for dataset 'drb' must be a string"
+        )
+        assert Metadata.getvalue(ds, "dataset.name") == name
+
+    def test_mutable_server(self, server_config, attach_dataset):
+        """
+        Set the dataset deletion time to a valid date/time string
+        """
+        ds = Dataset.query(name="drb")
+        Metadata.setvalue(ds, "server.deletion", "1979-12-29 08:00-04:00")
+        assert Metadata.getvalue(ds, "server.deletion") == "1979-12-29T12:00:00+00:00"
+
+    @pytest.mark.parametrize(
+        "value,message",
+        [
+            (
+                "Not a date",
+                "Metadata key 'server.deletion' value 'Not a date' for dataset 'drb' must be a date/time",
+            ),
+            (
+                "2040-12-25",
+                "Metadata key 'server.deletion' value '2040-12-25' for dataset 'drb' must be a date/time before 2031-12-30",
+            ),
+        ],
+    )
+    def test_mutable_server_bad(self, server_config, attach_dataset, value, message):
+        """
+        Try out some invalid deletion time values.
+
+        The value must be a valid date/time string, and it must be within the
+        server's maximum retention threshold from the dataset's upload time.
+        """
+        ds = Dataset.query(name="drb")
+        deletion = Metadata.getvalue(ds, "server.deletion")
+        with pytest.raises(MetadataBadValue) as exc:
+            Metadata.setvalue(ds, "server.deletion", value)
+        assert str(exc.value) == message
+        assert Metadata.getvalue(ds, "server.deletion") == deletion

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -323,7 +323,7 @@ class TestDatasetsDetail(Commons):
             },
             "serverMetadata": {
                 "dashboard.seen": None,
-                "server.deletion": "2022-12-25T04:00:00+00:00",
+                "server.deletion": "2022-12-26",
             },
         }
         assert expected == res_json

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -321,7 +321,10 @@ class TestDatasetsDetail(Commons):
                 "toc-prefix": "fio_rhel8_kvm_perf43_preallocfull_nvme_run4_iothread_isolcpus_2020.04.29T12.49.13",
                 "toolsgroup": "default",
             },
-            "serverMetadata": {"dashboard.seen": None, "server.deletion": "2022-12-25"},
+            "serverMetadata": {
+                "dashboard.seen": None,
+                "server.deletion": "2022-12-25T04:00:00+00:00",
+            },
         }
         assert expected == res_json
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -134,7 +134,7 @@ class TestDatasetsMetadata:
         assert response.json == {
             "dashboard.seen": None,
             "server": {
-                "deletion": "2022-12-25T04:00:00+00:00",
+                "deletion": "2022-12-26",
                 "index-map": {
                     "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
                     "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
@@ -155,7 +155,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {
             "dashboard.seen": None,
-            "server.deletion": "2022-12-25T04:00:00+00:00",
+            "server.deletion": "2022-12-26",
             "dataset": {
                 "access": "private",
                 "created": "2020-02-15T00:00:00+00:00",
@@ -191,7 +191,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {
             "dashboard.seen": None,
-            "server.deletion": "2022-12-25T04:00:00+00:00",
+            "server.deletion": "2022-12-26",
             "dataset.access": "private",
             "user.favorite": None,
         }

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -134,7 +134,7 @@ class TestDatasetsMetadata:
         assert response.json == {
             "dashboard.seen": None,
             "server": {
-                "deletion": "2022-12-25",
+                "deletion": "2022-12-25T04:00:00+00:00",
                 "index-map": {
                     "unit-test.v6.run-data.2020-08": ["random_md5_string1"],
                     "unit-test.v5.result-data-sample.2020-08": ["random_document_uuid"],
@@ -155,7 +155,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {
             "dashboard.seen": None,
-            "server.deletion": "2022-12-25",
+            "server.deletion": "2022-12-25T04:00:00+00:00",
             "dataset": {
                 "access": "private",
                 "created": "2020-02-15T00:00:00+00:00",
@@ -191,7 +191,7 @@ class TestDatasetsMetadata:
         )
         assert response.json == {
             "dashboard.seen": None,
-            "server.deletion": "2022-12-25",
+            "server.deletion": "2022-12-25T04:00:00+00:00",
             "dataset.access": "private",
             "user.favorite": None,
         }
@@ -296,7 +296,7 @@ class TestDatasetsMetadata:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed namespaces are ['dashboard', 'user']"
+            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed namespaces are ['dashboard', 'dataset.name', 'server.deletion', 'user']"
         }
 
     def test_put_reserved_metadata(self, client, server_config, attach_dataset):
@@ -306,7 +306,7 @@ class TestDatasetsMetadata:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed namespaces are ['dashboard', 'user']"
+            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed namespaces are ['dashboard', 'dataset.name', 'server.deletion', 'user']"
         }
 
     def test_put_nowrite(self, query_get_as, query_put_as):

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -403,9 +403,7 @@ class TestUpload:
         assert dataset.created.isoformat() == "2002-05-16T00:00:00+00:00"
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
         assert Metadata.getvalue(dataset, "dashboard") is None
-        assert (
-            Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-01T00:00:00+00:00"
-        )
+        assert Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-02"
         assert self.filetree_created
         assert dataset.name in self.filetree_created
 


### PR DESCRIPTION
PBENCH-749

Having changed the API to use the unique tarball MD5 as the formal resource ID, we're free to allow users to select more meaningfull resource names for filtering and display.

This PR adds a layer allowing the owner of a dataset to use the metadata PUT API to alter the dataset.name and server.deletion metadata keys with basic validity checking:
- The name value must be a UTF-8 string from 1 to 32 characters
- The deletion value must be a valid date/time string that does not exceed the server's maximum dataset lifetime from the dataset's upload timestamp.