### PR TITLE
Configure "python" token -  backport to b0.71

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -8,60 +8,86 @@ URL:            https://github.com/distributed-system-analysis/pbench
 Source0:        pbench-agent-%{version}.tar.gz
 Buildarch:      noarch
 
-# EPEL provides ansible (a curated set of roles with a dependency on ansible-core)
-# on RHEL 8 and RHEL9. Only CentOS-Stream seems to not have an ansible package
-# available.
 
-%if 0%{?centos} >= 8
-Requires:  ansible-core
+# RHEL7, RHEL9 (and CentOS-Stream-9) and the Fedoras provide a python3 package
+# through the standard distro repos.
+# RHEL8 (and CentOS-Stream-8) provide python36, python38 and python39 as modules.
+# We stick with python39 for them for now.
+# N.B. The condition catches both RHEL8 and CentOS-Stream-8)
+%if 0%{?rhel} == 8
+
+Requires:  python39
+# This is used by the shebang processor
+%define __python3 /usr/bin/python3.9
+%define __python_name python39
+
 %else
-Requires:  ansible
+
+Requires:  python3
+%define __python_name python3
+
 %endif
 
+
+# RHEL7 is a special case: it does not conform to the (slightly) more
+# general pattern of the rest
 
 %if 0%{?rhel} == 7
-Requires:  python3, python3-pip
-%endif
 
-# This condition will be true on a CentOS-Stream-8 system as well
-%if 0%{?rhel} == 8
-Requires:  python36, python3-pip
 # RPMs for modules in requirements.txt
-Requires:  python3-cffi, python3-click, python3-requests
-# RPMs for module dependencies
-Requires:  python3-docutils, python3-psutil
-%endif
+Requires: python3-pip, python3-requests
+# RPMS for module dependencies
+Requires: python3-psutil
 
-# This condition will be true on a CentOS-Stream-9 system as well
-%if 0%{?rhel} == 9
-Requires:  python3-pip
+# RHEL7 also does not define __python3 - we need it for installing
+# requirements through pip so we define it here
+%define __python3 /usr/bin/python3
+
+%else
+
 # RPMs for modules in requirements.txt
-Requires:  python3-cffi, python3-requests
-# RPMs for module dependencies
-Requires:  python3-docutils, python3-psutil
+Requires: %{__python_name}-pip, %{__python_name}-cffi, %{__python_name}-requests
+# RPMS for module dependencies
+Requires: %{__python_name}-psutil
+
 %endif
 
+# docutils is not available for RHEL7 - it is also *only* available as
+# `python3-docutil's on everything else, which is not good for
+# RHEL8/CentOS Stream 8 where we would want `python39-docutils', but
+# this does not exist. We need to handle it specially: check for
+# RHEL9/CentOS Stream 9 OR Fedora
 
+%if 0%{?rhel} > 8 || 0%{?fedora} != 0
+Requires: python3-docutils
+%endif
+
+# additional packages that Fedora builds but the RHELs don't
 %if 0%{?fedora} != 0
-Requires:  python3, python3-pip
 # RPMs for modules in requirements.txt
-Requires:  python3-bottle, python3-cffi, python3-click, python3-daemon
-Requires:  python3-jinja2, python3-redis, python3-requests, python3-sh
+Requires:  python3-bottle, python3-click, python3-daemon
+Requires:  python3-jinja2, python3-redis, python3-sh
+%endif
 
 %if 0%{?fedora} >= 36
 Requires: python3-ifaddr
 %endif
 
-# RPMs for module dependencies
-Requires:  python3-psutil
-%endif
-
+# Common requirements
 Requires:  perl, perl-Data-UUID, perl-JSON, perl-JSON-XS
 Requires:  perl-Time-HiRes
 
 Requires:  bc, bzip2, hostname, iproute, iputils, net-tools, numactl
 Requires:  openssh-clients, openssh-server, procps-ng, psmisc, redis
 Requires:  rpmdevtools, rsync, screen, sos, tar, xz
+
+# The condition here should be 7 OR 8.4 OR 8.5 but we don't have a way to deal with minor versions.
+# The resulting RPM will NOT work on RHEL8.[45].
+%if 0%{?rhel} == 7
+Requires:  ansible
+%else
+Requires:  ansible-core
+%endif
 
 Obsoletes: pbench <= 0.34
 Conflicts: pbench <= 0.34
@@ -98,8 +124,7 @@ if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;f
 %post
 
 # Install python dependencies
-python3 -m pip install --upgrade pip 2>&1 > /%{installdir}/pip3-upgrade.log
-python3 -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
+%{__python3} -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
 
 # link the pbench profile, so it'll automatically be sourced on login
 ln -sf /%{installdir}/profile /etc/profile.d/pbench-agent.sh


### PR DESCRIPTION
This PR is a backport of #2925 to b0.71. It supersedes PR #2902 which is closed.