### PR TITLE
Avoid verify_common_bench_script_options in linpack pre-check

### DIFF
--- a/agent/bench-scripts/pbench-linpack
+++ b/agent/bench-scripts/pbench-linpack
@@ -118,7 +118,6 @@ while true; do
 		;;
 	esac
 done
-verify_common_bench_script_options ${tool_group} ${sysinfo}
 
 function pre_check {
 	# Invoke the linpack driver to perform a pre-check that it will be able to
@@ -138,6 +137,8 @@ if [[ ${pre_check_only} -ne 0 ]]; then
 	pre_check ${@}
 	exit ${?}
 fi
+
+verify_common_bench_script_options ${tool_group} ${sysinfo}
 
 linpack_ver="$(pbench-config version ${benchmark})"
 if [[ -z "${linpack_ver}" ]]; then


### PR DESCRIPTION
The verify_common_bench_script_options fails when tools are not
configured locally, which is usually the case of remote --pre-check-only

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>