### PR TITLE
Correct CentOS 7 container builds, update defaults

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -1,6 +1,6 @@
 {% set is_centos_8 = true if image_name == 'centos' and image_rev == '8' else false %}
 {% set is_centos_9 = true if image_name == 'centos' and image_rev == '9' else false %}
-{% set image_tag = 'stream' + image_rev if image_name == 'centos' else image_rev %}
+{% set image_tag = 'stream' + image_rev if image_name == 'centos' and image_rev != '7' else image_rev %}
 # {{ distro_name }} pbench-agent base image
 FROM {{ image_repo }}/{{ image_name }}:{{ image_tag }}
 

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -110,15 +110,16 @@ _ADV_TMPL = _ALL_${d}_VERSIONS := $(foreach v,${_NUMBERS},${d}-${v}) # template 
 $(foreach d,${_ALL_DISTRO_NAMES},$(eval $(call _ADV_TMPL, ${d})))  # set _ALL_centos_VERSIONS, etc.
 _DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
 
-# By default we only build images for the following distributions.  (At the time
-# of this writing, centos-9 has no support in packagecloud.io, so it is omitted.)
-_DEFAULT_DISTROS = centos-8 fedora-34 fedora-35
+# By default we only build images for the following distributions.
+_DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35
 
-# By default we won't build the Tool Data Sink and Tool Meister images
+# By default we build the Tool Data Sink and Tool Meister images as well.
 all: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
 
+# Convenience target to only build the Tool Data Sink images.
 tds: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)
 
+# Convenience target to only build the Tool Meister images.
 tm: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 
 #+


### PR DESCRIPTION
We have restored the ability to build CentOS 7-based containers.

The default container distributions supported are now CentOS 7 (restored), CentOS 8 (no change), CentOS 9 (added), and Fedora 35 (no change).  We removed Fedora 34 which recently was declared EOL.