### PR TITLE
Enhancements to the CI pipeline, part 1

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -157,12 +157,12 @@ centos-7-% centos-8-%: _PROMETHEUS_RPMS = \
 
 # Tagging targets
 #
-# Available tags values are "latest", "alpha", "beta", "major", and "major-minor"
+# Available tags values are "latest", "alpha", "beta", "ci", "major", and "major-minor".
 # "major" produces a tag of "v<Major>-latest", and "major-minor" produces a tag
 # of "v<Major>.<Minor>-latest".
 #
 # See the `tagit` script for details.
-_TAG_TYPES = latest alpha beta major major-minor
+_TAG_TYPES = latest alpha beta ci major major-minor
 $(_TAG_TYPES:%=tag-%): tag-%: $(_DEFAULT_DISTROS:%=%-tag-%)
 
 

--- a/build.sh
+++ b/build.sh
@@ -60,8 +60,8 @@ export PATH=${HOME}/.local/bin:${PATH}
 python3 -m pip install --user -r lint-requirements.txt
 
 # If this script is run in a container and the user in the container doesn't
-# match the owner of the Git checkout, then Git objects; these config settings
-# prevent the complaints.
+# match the owner of the Git checkout, then Git issues an error; these config
+# settings avoid the problem.
 GITTOP=$(git rev-parse --show-toplevel 2>&1 | head -n 1)
 if [[ ${GITTOP} =~ "fatal: unsafe repository ('/home/root/pbench'" ]] ; then
 	git config --global --add safe.directory /home/root/pbench

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,112 @@
+#!/bin/bash -e
+
+# This script drives the various tasks involved in testing and building the
+# various artifacts for the Pbench product.  It is intended to be run from the
+# root directory of a Git branch checkout.
+
+# The following variables will normally be defined as credentials in the Jenkins
+# environment.  For developer use of this script, they should be defined in the
+# shell environment; otherwise, they will be given default values, here.
+#
+#  COPR_CONFIG - the path to the configuration file for the COPR account
+#  PODMAN_USR - the username for the container registry account
+#  PODMAN_PSW - the password for the container registry account
+#
+PODMAN_USR=${PODMAN_USR-"pbench+mr_jenkins"}
+PODMAN_PSW=${PODMAN_PSW-${DEFAULT_PODMAN_PASSWORD}}
+COPR_CONFIG=${COPR_CONFIG:-"${HOME}/.config/copr"}
+
+
+# Function to read an initialization/configuration file and print the value of
+# the specified key in the specified section.  Borrowed from
+# https://stackoverflow.com/questions/49399984/parsing-ini-file-in-bash/49400353
+function getIni() {
+  local f=${1}  # Initialization/configuration file name
+  local s=${2}  # Section name
+  local o=${3}  # Option name
+
+  if [[ ! -r ${f} ]]; then
+    echo "Missing or bad COPR config file:  ${f}" >&2
+    exit 1
+  fi
+
+  local rv=$(awk '/^\[.*\]$/{obj=$0}/=/{print obj $0}' ${f} | \
+    sed -En "/${s}]${o}/s/^.*=[[:space:]]*//p" | \
+    tail -n 1)
+
+  if [[ -z ${rv} ]]; then
+    echo "Missing '${o}' in COPR config file, '${f}'" >&2
+    exit 1
+  fi
+
+  echo ${rv}
+}
+
+
+COPR_USER=$(getIni ${COPR_CONFIG} copr-cli username)
+COPR_URL=$(getIni ${COPR_CONFIG} copr-cli copr_url)
+
+if [[ ${COPR_URL} =~ "copr.fedorainfracloud.org" ]]; then
+  URL_PREFIX=https://download.copr.fedorainfracloud.org/results/${COPR_USER}
+elif [[ ${COPR_URL} =~ "copr.devel.redhat.com" ]]; then
+  URL_PREFIX=http://coprbe.devel.redhat.com/results/${COPR_USER}
+else
+  echo "Unexpected COPR_URL: '${COPR_URL}'" >&2
+  exit 1
+fi
+
+# Install the linter requirements and add them to the PATH.
+export PATH=${HOME}/.local/bin:${PATH}
+python3 -m pip install --user -r lint-requirements.txt
+
+# If this script is run in a container and the user in the container doesn't
+# match the owner of the Git checkout, then Git objects; these config settings
+# prevent the complaints.
+GITTOP=$(git rev-parse --show-toplevel 2>&1 | head -n 1)
+if [[ ${GITTOP} =~ "fatal: unsafe repository ('/home/root/pbench'" ]] ; then
+	git config --global --add safe.directory /home/root/pbench
+	git config --global --add safe.directory /home/root/pbench/agent/stockpile
+	GITTOP=$(git rev-parse --show-toplevel)
+fi
+
+# Install the Dashboard dependencies, including the linter's dependencies and
+# the unit test dependencies.
+( cd dashboard && npm install )
+
+# Test for code style and lint
+black --check .
+flake8 .
+( cd dashboard && npx eslint "src/**" --max-warnings 0 )
+
+# Run unit tests
+tox                                     # Agent and Server unit tests and legacy tests
+( cd dashboard && CI=true npm test )    # Dashboard unit tests
+
+# Build Agent and Server RPMs (Server RPM includes the Dashboard) on COPR
+( cd agent/rpm && make COPR_USER=${COPR_USER} COPR_CONFIG=${COPR_CONFIG} copr-ci )
+( cd server/rpm && make COPR_USER=${COPR_USER} COPR_CONFIG=${COPR_CONFIG} copr-ci )
+
+# The following steps don't work inside the CI container, so just declare
+# victory now.  (Building a container inside a container requires a
+# specially-configured and/or -invoked container, and we don't have that
+# arranged, yet.)
+exit 0
+
+################################################################################
+#  Future extensions
+################################################################################
+
+# Need to log into the registry to access the Server base image, etc.
+podman login -u="${PODMAN_USR}" -p="${PODMAN_PSW}" quay.io
+
+# Build the Agent container images and the Pbench-in-a-Can Server image
+( cd agent/containers/images && \
+  make COPR_USER=${COPR_USER} URL_PREFIX=${URL_PREFIX} TEST=ci \
+  )
+server/pbenchinacan/container-build.sh
+
+# Push the Agent and Server container images to the container registry.
+( cd agent/containers/images && \
+  make COPR_USER=${COPR_USER} URL_PREFIX=${URL_PREFIX} TEST=ci tag-ci push-ci \
+  )
+podman push quay.io/pbench/pbenchinacan-pbenchserver

--- a/dashboard/.eslintignore
+++ b/dashboard/.eslintignore
@@ -1,0 +1,5 @@
+*.css
+*.ico
+*.jpg
+*.less
+*.svg

--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -21,5 +21,10 @@
     ],
     "rules": {
         "react/prop-types": 0
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -47,13 +47,21 @@
     "eject": "react-scripts eject",
     "server": "node server",
     "start": "react-app-rewired start",
-    "test": "react-app-rewired test"
+    "test": "react-scripts test"
   },
   "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
+    ]
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.[t|j]sx?$": "babel-jest"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!@patternfly)/"
     ]
   },
   "browserslist": {

--- a/dashboard/src/App.test.js
+++ b/dashboard/src/App.test.js
@@ -1,8 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { Provider } from "react-redux";
+import store from "store/store";
+import React from 'react';
+
+const AppWrapper = () => {
+  return (
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+};
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  render(<AppWrapper />);
+  const linkElement = screen.getByText('Explore');
   expect(linkElement).toBeInTheDocument();
 });

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -1,24 +1,33 @@
 pipeline {
     agent { label 'pbench' }
     environment {
-        IMAGE_ROLE="ci"
+        // COPR_CONFIG=credentials('cce995d4-0bfc-44d8-b4fb-cf5641a56639')  // External COPR
+        COPR_CONFIG=credentials('6fe4042e-8e9e-43d4-b0cf-909459c8c6fb')     // Internal COPR
+        EXTRA_PODMAN_SWITCHES="--pull=always -e=COV_REPORT_XML=yes -e=PODMAN*"
         IMAGE_KIND="fedora"
         IMAGE_REPO="quay.io/pbench"
-        EXTRA_PODMAN_SWITCHES="--pull=always -e COV_REPORT_XML=yes"
+        IMAGE_ROLE="ci"
         NO_COLORS=0
+        PODMAN=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
         PY_COLORS=0
         TERM='dumb'
     }
     stages {
         stage('Linting & Unit Tests') {
             steps {
+                // If we don't have a sequence number file left over from a
+                // previous run, then create one.
+                sh 'if [[ ! -e agent/rpm/seqno ]] ; then echo "1" > agent/rpm/seqno ; fi'
+                sh 'if [[ ! -e server/rpm/seqno ]] ; then echo "1" > server/rpm/seqno ; fi'
+
                 // If there is somehow a symlink left over from a previous run's
                 // Cobertura processing, remove it, because it seems to confuse
                 // the coverage data collection.
                 sh 'rm -fv pbench'
 
-                echo 'Linting, pytest-based unit tests, and legacy unit tests'
-                sh 'jenkins/run tox'
+                // Run the "build" (lint, unit tests, RPM builds, etc.) in a
+                // container.
+                sh 'jenkins/run ./build.sh'
             }
         }
         stage('Agent Python3.6 Check') {

--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -71,7 +71,27 @@ RUN \
         `# Base command used by CI unit test jobs` \
         `#` \
         tox \
-    && \
+        `#` \
+        `# Required for running various linters` \
+        `#` \
+        black \
+        npm \
+        python3-flake8 \
+        `#` \
+        `# Required for building RPMs` \
+        `#` \
+        python3-jinja2-cli \
+        rpmlint \
+        http://hdn.corp.redhat.com/rhel8-csb/RPMS/noarch/redhat-internal-cert-install-0.1-25.el7.noarch.rpm \
+        `#` \
+        `# Required for building containers` \
+        `#` \
+        buildah \
+        copr-cli \
+        podman \
+        && \
+    python3 -m pip install --upgrade pip \
+        && \
     `#` \
     `# Save space in the container image.` \
     `#` \

--- a/jenkins/run
+++ b/jenkins/run
@@ -51,12 +51,18 @@ if [ "${git_dir}" != "$(pwd)/.git" ]; then
     GIT_BASE_VOLUME="--volume ${git_common_dir}:${git_common_dir}:z"
 fi
 
+if [[ -n ${COPR_CONFIG} ]]; then
+    COPR_CONFIG_VOLUME="--volume ${COPR_CONFIG}:${HOME_DIR}/.config/copr:z"
+fi
+
 _image=${IMAGE:-${_image_repo}/pbench-${_image_role}-${_image_kind}:${_branch_name}}
 
 podman run \
     --userns=keep-id \
-    --volume $(pwd):${HOME_DIR}/pbench:z \
     --volume ${HOME_DIR} \
+    --volume ${HOME_DIR}/.config \
+    ${COPR_CONFIG_VOLUME} \
+    --volume $(pwd):${HOME_DIR}/pbench:z \
     ${GIT_BASE_VOLUME} \
     -w ${HOME_DIR}/pbench \
     --env HOME=${HOME_DIR} \

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -1,6 +1,23 @@
 # Makefile for generating a source RPM and optional local RPM
 # for the Pbench server.
 
+# To limit the builds to certain chroots or exclude certain chroots
+# from building, add entries of the form
+#    "--chroot centos-stream-9-x86_64"
+# or
+#    "--exclude-chroot centos-stream-9-x86_64"
+# to the CHROOTS variable below.
+# Multiple such entries can be added to be passed as options to
+# `copr-cli build'.  By default, we build every chroot configured for
+# the project.
+# N.B. `copr-cli' flags an error if the value of a `--chroot' or
+# `--exclude-chroot' option is not configured in the project.
+# E.g. to build the RHEL9 chroots only:
+# CHROOTS = --chroot centos-stream-9-x86_64 \
+#           --chroot centos-stream-9-aarch64 \
+#           --chroot epel-9-x86_64 \
+#           --chroot epel-9-aarch64
+CHROOTS = --chroot rhel-9.dev-x86_64
 component = server
 subcomps = server web-server
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,11 @@ setenv =
     SKIP_GENERATE_AUTHORS = 1
     SKIP_WRITE_GIT_CHANGELOG = 1
 deps =
-    -r{toxinidir}/lint-requirements.txt
     -r{toxinidir}/agent/requirements.txt
     -r{toxinidir}/agent/test-requirements.txt
     -r{toxinidir}/server/requirements.txt
     -r{toxinidir}/server/test-requirements.txt
 commands =
-    black --check .
-    flake8 .
     bash -c "{toxinidir}/exec-unittests {envdir} {posargs}"
 whitelist_externals =
     bash

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -17,6 +17,9 @@ prog = pbench-${component}
 VERSION := $(file < ${PBENCHTOP}/${component}/VERSION)
 TBDIR = ${TMPDIR}/${prog}-${VERSION}
 
+# This can be overridden by specifying it on the command line.
+COPR_CONFIG = ${HOME}/.config/copr
+
 RPMDIRS = BUILD BUILDROOT SPECS SOURCES SRPMS RPMS
 
 RPMSRC = ${HOME}/rpmbuild/SOURCES
@@ -76,10 +79,10 @@ else
 _copr_user = ${USER}
 endif
 
-COPR_TARGETS = copr copr-test
+COPR_TARGETS = copr copr-test copr-ci
 .PHONY: ${COPR_TARGETS}
 ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
-	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
+	copr-cli --config ${COPR_CONFIG} build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 .PHONY: distclean
 distclean:


### PR DESCRIPTION
This PR is the first installment in a series of enhancements to the Pbench CI pipeline.  The goal is to have the CI perform lint and style checks, run unit tests, build RPMs, build containers, and run functional tests for each of the Agent, Server, and Dashboard.  This PR provides the first several of those, up through building RPMs for the Agent and Server (the Dashboard is expected to be deployed using a different mechanism).  It also enables the Cobertura report to find and display the source lines!

For convenience, this PR consists of a series of commits, but they should be squashed into a single commit when it is merged (NOTE:  this PR is now based on #2938 and #2939, so their respective commits will appear in this PR until they are merged):
- enhancements to the CI pipeline
- tweaks to the CI dockerfile, adding dependencies of the extended pipeline features
- tweaks to the Dashboard environment for running ESLint
- tweaks to the Server RPM build to limit its default build to RHEL-9
- tweaks to the Dashboard code to make it pass ESlint

Highlights of the changes:
- Add a new top-level file, `build.sh` which executes the steps outlined above.  The CI executes this script in the CI container via the `jenkins/run` command.  The intention is that developers should be able to run the script as well, either natively or via a `jenkins/run` command in their own environment.  The script does the following:
  - extract credentials from environment variables and from a local COPR config file
  - install the Python and Node.js requirements for running the Agent, Server, and Dashboard linters and the Dashboard unit tests
  - run the various linters
  - run the various unit tests
  - use COPR (either the internal or the external one) to build the RPMs for the Agent and the Server
  - declare victory (there is latent code for building and pushing the Agent container images and the Pbench Server-in-a-Can container images, but it doesn't work inside the CI container, currently)
- Add support for a "CI" tag for building Agent containers, to keep them separate from the normally published containers.
- Add some configuration files for ESLint, the Dashboard lint program.
- Make some tweaks to the Dashboard files to enable them to pass the lint checks and unit tests.  (I'm hoping that these will come in via another PR from the Dashboard folks...but, if that doesn't happen, then they are here, so that the pipeline won't fail.)
- Tweak the Jenkins pipeline definition:
  - add environment variables/secrets for the credentials for accessing COPR and the container registry
  - alphabetize the environment variable list, now that it is long
  - change the invocation from running `tox` directly to running the new `build.sh` script
  - add (and remove) a symlink which enables the Cobertura report to find the sources properly
- Remove the responsibility for running the Python linters from Tox, now that it is handled by `build.sh`, and add to the dependences for the linters in the CI container image definition.
- Add the dependencies for building the RPMs and container images to the CI container image definition.
- Modify the `jenkins/run` script to add a mapping for the COPR config file from the Jenkins secret file (or the user's file) to the conventional file inside the container.  Also, add a volume for the `${HOME}/.config` directory (so the `npm` install inside the container can write it), and reorder the volume options in the container invocation from top to bottom (i.e., `${HOME}` first, then `${HOME}/.config`, and so on).
- Tweak the Server RPM makefile to set the default build to (only) RHEL-9.
- Change the common RPM makefile to explicitly specify a COPR config file for credentials, and add a `copr-ci` target.
