### PR TITLE
Use `major.minor` version in COPR repo name

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -28,8 +28,10 @@
 #     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile" files
 #
 
+_PBENCH_TOP := $(shell git rev-parse --show-toplevel)
+
 # Include definition of _DISTROS
-include ../utils/utils.mk
+include ${_PBENCH_TOP}/utils/utils.mk
 
 # By default we only build images for x86_64 architectures.
 _ARCH = x86_64

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -50,7 +50,7 @@ URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 # the final repo name would be "pbench-test".
 TEST =
 _TEST_SUFFIX = $(if $(TEST),-$(TEST),"")
-_PBENCH_REPO_NAME = pbench${_TEST_SUFFIX}
+_PBENCH_REPO_NAME = pbench-$(shell grep -oE '[0-9]+\.[0-9]+' ${_PBENCH_TOP}/agent/VERSION)${_TEST_SUFFIX}
 
 # By default we use the pbench Quay.io organization for the image
 # repository.  You can override this default using an environment

--- a/agent/containers/images/gen-tags-from-rpm
+++ b/agent/containers/images/gen-tags-from-rpm
@@ -29,7 +29,7 @@ name="${4}"
 # Ensure we only consider the pbench-agent RPM's version string from the
 # target repo.
 url="${url_prefix}/${name}/${dist}-${arch}"
-version_string="$(yum list -q --repofrompath pbench,"${url}" pbench-agent.noarch 2>/dev/null | awk 'FNR==2{print $2}')"
+version_string="$(yum list -q --repofrompath ${name},"${url}" pbench-agent.noarch 2>/dev/null | awk 'FNR==2{print $2}')"
 if [[ -z "${version_string}" ]]; then
     printf -- "Failed to fetch pbench-agent.noarch version string from '%s'\n" "${url}" >&2
     exit 1

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -105,7 +105,7 @@ submodules:
 ${subcomps}:
 	make -C ${PBENCHTOP}/$@ DESTDIR=${TBDIR}/$@ install
 
-$(RPMSRPM)/$(prog)-$(version)-$(seqno)g$(sha1).src.rpm: srpm
+$(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm: srpm
 
 ifdef COPR_USER
 _copr_user = ${COPR_USER}
@@ -115,7 +115,7 @@ endif
 
 COPR_TARGETS = copr copr-test
 .PHONY: ${COPR_TARGETS}
-${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)g$(sha1).src.rpm
+${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 # Determine the present working directory relative to ${PBENCHTOP} so that we

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -105,7 +105,7 @@ submodules:
 ${subcomps}:
 	make -C ${PBENCHTOP}/$@ DESTDIR=${TBDIR}/$@ install
 
-$(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm: srpm
+$(RPMSRPM)/$(prog)-$(version)-$(seqno)g$(sha1).src.rpm: srpm
 
 ifdef COPR_USER
 _copr_user = ${COPR_USER}
@@ -115,7 +115,7 @@ endif
 
 COPR_TARGETS = copr copr-test
 .PHONY: ${COPR_TARGETS}
-${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
+${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)g$(sha1).src.rpm
 	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 # Determine the present working directory relative to ${PBENCHTOP} so that we

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -27,6 +27,7 @@ include ${PBENCHTOP}/utils/utils.mk
 
 prog = pbench-${component}
 VERSION := $(shell cat ${PBENCHTOP}/${component}/VERSION)
+MAJORMINOR := $(shell grep -oE '[0-9]+\.[0-9]+' ${PBENCHTOP}/${component}/VERSION)
 TBDIR = ${TMPDIR}/${prog}-${VERSION}
 
 # If we are building for a distro, use a distro-specific suffix on the build and
@@ -116,7 +117,7 @@ endif
 COPR_TARGETS = copr copr-test
 .PHONY: ${COPR_TARGETS}
 ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
-	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
+	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench-$(MAJORMINOR),$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
 # Determine the present working directory relative to ${PBENCHTOP} so that we
 # can find it inside the container, where the source tree might be in a


### PR DESCRIPTION
PBENCH-823

The COPR rules are such that you can only have one RPM for a given chroot per repository.  So you can't have a `pbench-agent` `0.69.*` and a `pbench-agent` `0.71.*` RPM available at the same time.