### PR TITLE
Fix Cobertura source lines report

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -12,6 +12,11 @@ pipeline {
     stages {
         stage('Linting & Unit Tests') {
             steps {
+                // If there is somehow a symlink left over from a previous run's
+                // Cobertura processing, remove it, because it seems to confuse
+                // the coverage data collection.
+                sh 'rm -fv pbench'
+
                 echo 'Linting, pytest-based unit tests, and legacy unit tests'
                 sh 'jenkins/run tox'
             }
@@ -25,6 +30,14 @@ pipeline {
     }
     post {
         success {
+            // This symlink somehow allows the Cobertura plug-in to find the
+            // sources referenced in the coverage report.  However, the presence
+            // of this link inside the container seems to confuse the coverage
+            // data collection, so we create it here and then remove it after
+            // generating the report. (We use the -f option just in case there's
+            // an old one hanging around.)
+            sh 'ln -sTf lib/pbench pbench'
+
             // Note that jenkins/run-pytests is executed inside the container
             // while the Cobertura plug-in is executed natively, so this poses
             // a challenge in terms of finding the coverage report file; we
@@ -41,7 +54,7 @@ pipeline {
                 onlyStable: false,
                 sourceEncoding: 'ASCII',
                 zoomCoverageChart: false])
-            sh 'rm cov/report.xml'
+            sh 'rm cov/report.xml pbench'
         }
     }
 }


### PR DESCRIPTION
[As requested](https://github.com/distributed-system-analysis/pbench/pull/2935#pullrequestreview-1033455167) in #2935, here's a separate PR which restores the source lines display to working order in the Cobertura coverage report in the Jenkins job.

Note that this modification leaves unchanged the complaints in the log about sources _outside_ the Pbench project, and the coverage report still shows them...hopefully these can be addressed in a future PR.