### PR TITLE
Add example playbook to open ports for redis/TDS

### DIFF
--- a/agent/ansible/pbench_agent_tool_meister_firewall.yml
+++ b/agent/ansible/pbench_agent_tool_meister_firewall.yml
@@ -1,0 +1,7 @@
+---
+- name: open ports for redis and tool data sink
+  hosts: controllers
+  remote_user: root
+
+  roles:
+    - pbench_firewall_open_ports


### PR DESCRIPTION
It uses the pbench_firewall_open_ports role from the Galaxy
pbench agent collection.