### PR TITLE
Enhancements to the CI pipeline (Part 1, Take 2)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+
+# This script drives the various tasks involved in testing and building the
+# various artifacts for the Pbench product.  It is intended to be run from the
+# root directory of a Git branch checkout.
+
+
+# Install the linter requirements and add them to the PATH.
+export PATH=${HOME}/.local/bin:${PATH}
+python3 -m pip install --user -r lint-requirements.txt
+
+# If this script is run in a container and the user in the container doesn't
+# match the owner of the Git checkout, then Git issues an error; these config
+# settings avoid the problem.
+GITTOP=$(git rev-parse --show-toplevel 2>&1 | head -n 1)
+if [[ ${GITTOP} =~ "fatal: unsafe repository ('/home/root/pbench'" ]] ; then
+	git config --global --add safe.directory /home/root/pbench
+	git config --global --add safe.directory /home/root/pbench/agent/stockpile
+	GITTOP=$(git rev-parse --show-toplevel)
+fi
+
+# Install the Dashboard dependencies, including the linter's dependencies and
+# the unit test dependencies.
+( cd dashboard && npm install )
+
+# Test for code style and lint
+black --check .
+flake8 .
+( cd dashboard && npx eslint "src/**" --max-warnings 0 )
+
+# Run unit tests
+tox                                     # Agent and Server unit tests and legacy tests
+( cd dashboard && CI=true npm test )    # Dashboard unit tests
+
+exit 0

--- a/dashboard/.eslintignore
+++ b/dashboard/.eslintignore
@@ -1,0 +1,5 @@
+*.css
+*.ico
+*.jpg
+*.less
+*.svg

--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -21,5 +21,10 @@
     ],
     "rules": {
         "react/prop-types": 0
+    },
+    "settings": {
+        "react": {
+            "version": "detect"
+        }
     }
 }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -47,13 +47,21 @@
     "eject": "react-scripts eject",
     "server": "node server",
     "start": "react-app-rewired start",
-    "test": "react-app-rewired test"
+    "test": "react-scripts test"
   },
   "proxy": "http://localhost:3001",
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
+    ]
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.[t|j]sx?$": "babel-jest"
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!@patternfly)/"
     ]
   },
   "browserslist": {

--- a/dashboard/src/App.test.js
+++ b/dashboard/src/App.test.js
@@ -1,8 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { Provider } from "react-redux";
+import store from "store/store";
+import React from 'react';
+
+const AppWrapper = () => {
+  return (
+    <Provider store={store}>
+      <App />
+    </Provider>
+  );
+};
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
+  render(<AppWrapper />);
+  const linkElement = screen.getByText('Explore');
   expect(linkElement).toBeInTheDocument();
 });

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -17,8 +17,8 @@ pipeline {
                 // the coverage data collection.
                 sh 'rm -fv pbench'
 
-                echo 'Linting, pytest-based unit tests, and legacy unit tests'
-                sh 'jenkins/run tox'
+                // Run the "build" (lint, unit tests, etc.) in a container.
+                sh 'jenkins/run ./build.sh'
             }
         }
         stage('Agent Python3.6 Check') {

--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -68,10 +68,11 @@ RUN \
         parallel \
         time \
         `#` \
-        `# Base command used by CI unit test jobs` \
+        `# Commands for running unit test jobs` \
         `#` \
+        npm \
         tox \
-    && \
+        && \
     `#` \
     `# Save space in the container image.` \
     `#` \

--- a/jenkins/run
+++ b/jenkins/run
@@ -55,8 +55,9 @@ _image=${IMAGE:-${_image_repo}/pbench-${_image_role}-${_image_kind}:${_branch_na
 
 podman run \
     --userns=keep-id \
-    --volume $(pwd):${HOME_DIR}/pbench:z \
     --volume ${HOME_DIR} \
+    --volume ${HOME_DIR}/.config \
+    --volume $(pwd):${HOME_DIR}/pbench:z \
     ${GIT_BASE_VOLUME} \
     -w ${HOME_DIR}/pbench \
     --env HOME=${HOME_DIR} \

--- a/tox.ini
+++ b/tox.ini
@@ -22,14 +22,11 @@ setenv =
     SKIP_GENERATE_AUTHORS = 1
     SKIP_WRITE_GIT_CHANGELOG = 1
 deps =
-    -r{toxinidir}/lint-requirements.txt
     -r{toxinidir}/agent/requirements.txt
     -r{toxinidir}/agent/test-requirements.txt
     -r{toxinidir}/server/requirements.txt
     -r{toxinidir}/server/test-requirements.txt
 commands =
-    black --check .
-    flake8 .
     bash -c "{toxinidir}/exec-unittests {envdir} {posargs}"
 whitelist_externals =
     bash


### PR DESCRIPTION
PBENCH-694

This PR is the second try at the first installment in a series of enhancements to the Pbench CI pipeline. The goal is to have the CI perform lint and style checks, run unit tests, build RPMs, build containers, and run functional tests for each of the Agent, Server, and Dashboard. This PR provides the first of those, running lint and style checks as well as unit tests for the Agent, Server, and Dashboard.  (This PR is a split of #2935, deferring the building of RPMs and subsequent stages to a subsequent PR.)

For convenience, this PR consists of a series of commits, but they should be squashed into a single commit when it is merged:
- enhancements to the CI pipeline
- tweaks to the CI dockerfile, adding dependencies of the extended pipeline features
- tweaks to the Dashboard environment for running ESLint
- tweaks to the Dashboard code to make it pass ESlint

Highlights of the changes:
- Add a new top-level script file, `build.sh`, which executes the steps outlined above. The CI executes this script in the CI container via the `jenkins/run` command. The intention is that developers should be able to run this script as well, either natively or via a `jenkins/run` command in their own environment. The script does the following:
  - install the Python and Node.js requirements for running the Agent, Server, and Dashboard linters and the Dashboard unit tests
  - run the various linters
  - run the various unit tests
  - and it will be extended in the future with additional capabilities
- Add some configuration files for ESLint, the Dashboard lint program.
- Make some tweaks to the Dashboard files to enable them to pass the lint checks and unit tests. (I'm hoping that these will come in via another PR from the Dashboard folks...but, if that doesn't happen, then they are here, so that the pipeline won't fail.)
- Tweak the Jenkins pipeline definition to change the invocation from running `tox` directly to running the new `build.sh` script
- Remove the responsibility for running the Python linters from Tox, now that it is handled by `build.sh`.
- Modify the `jenkins/run` script to add a volume for the `${HOME}/.config` directory (so the `npm` install inside the container can write it), and reorder the volume options in the container invocation from top to bottom (i.e., `${HOME}` first, then `${HOME}/.config`, and so on).
