### PR TITLE
Delete the epel role from pbench_agent_install.yml

### DIFF
--- a/agent/ansible/pbench_agent_install.yml
+++ b/agent/ansible/pbench_agent_install.yml
@@ -9,7 +9,6 @@
     pbench_configuration_environment: "{{ cenv | default('production') }}"
 
   roles:
-    - epel_repo_install
     - pbench_repo_install
     - pbench_agent_install
     - pbench_agent_config


### PR DESCRIPTION
It should not be part of the installation: it is part of the preparation of the hosts and therefore belongs in a different playbook.