### PR TITLE
Use the "epel" chroot for "Rocky Linux"

### DIFF
--- a/agent/ansible/pbench/agent/roles/pbench_repo_install/vars/main.yml
+++ b/agent/ansible/pbench/agent/roles/pbench_repo_install/vars/main.yml
@@ -1,9 +1,13 @@
 ---
-distro: "{{ 'centos-stream' if ansible_distribution == 'CentOS' and ansible_distribution_major_version > '7'
-          else
-            'epel' if ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS'
-          else
-            'fedora' if ansible_distribution == 'Fedora'
-          else
-            '' }}"
-distrodir: "{{ distro }}-{{ ansible_distribution_major_version }}-$basearch"
+# Map distribution name to COPR chroot
+copr_chroots:
+  RedHat: epel
+  Fedora: fedora
+  CentOS: centos-stream
+  Rocky: epel
+
+# CentOS 7 is an exception
+copr_distro: "{{ 'epel' if ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
+                 else
+                     copr_chroots[ansible_distribution] }}"
+distrodir: "{{ copr_distro }}-{{ ansible_distribution_major_version }}-$basearch"


### PR DESCRIPTION
Set up a map with the `ansible_distribution' value  as key and the
COPR chroot name as value. Use the map to calculate the final
component of the baseurl field in the repo file (except for CentOS 7
which is one-of-a-kind).

The map can be extended easily for other distros, RHEL clones or
otherwise.