### PR TITLE
Provide a server configuration option mechanism

### DIFF
--- a/docs/API/V1/README.md
+++ b/docs/API/V1/README.md
@@ -8,6 +8,14 @@ Once you know the hostname of a Pbench Server, you can ask for the API
 configuration using the [endpoints](endpoints.md) API. This will report the
 server's version and a list of all API end points supported by the server.
 
+## Pbench Server configuration settings
+
+Some aspects of Pbench Server operation can be controlled by a user holding the
+`ADMIN` [role](../access_model.md) through the
+[server configuration](./server_config.md) API, including disabling the Pbench
+Server API while the server is undergoing maintenance, and setting a banner
+message accessible to clients.
+
 ## Pbench Server resources
 
 ### Datasets

--- a/docs/API/V1/README.md
+++ b/docs/API/V1/README.md
@@ -13,7 +13,7 @@ server's version and a list of all API end points supported by the server.
 Some aspects of Pbench Server operation can be controlled by a user holding the
 `ADMIN` [role](../access_model.md) through the
 [server configuration](./server_config.md) API, including disabling the Pbench
-Server API while the server is undergoing maintenance, and setting a banner
+Server API while the server is undergoing maintenance and setting a banner
 message accessible to clients.
 
 ## Pbench Server resources

--- a/docs/API/V1/contents.md
+++ b/docs/API/V1/contents.md
@@ -47,6 +47,12 @@ The authenticated client does not have READ access to the specified dataset.
 Either the `<dataset>` or the relative `<path>` within the dataset does not
 exist.
 
+`503`   **SERVICE UNAVAILABLE** \
+The server has been disabled using the `server-state` server configuration
+setting in the [server configuration](./server_config.md) API. The response
+body is an `application/json` document describing the current server state,
+a message, and optional JSON data provided by the system administrator.
+
 ## Response body
 
 The `application/json` response body consists of a JSON object describing the

--- a/docs/API/V1/inventory.md
+++ b/docs/API/V1/inventory.md
@@ -49,6 +49,12 @@ The `<path>` refers to a directory. Use
 `/api/v1/dataset/contents/<dataset><path>` to request a JSON response document
 describing the directory contents.
 
+`503`   **SERVICE UNAVAILABLE** \
+The server has been disabled using the `server-state` server configuration
+setting in the [server configuration](./server_config.md) API. The response
+body is an `application/json` document describing the current server state,
+a message, and optional JSON data provided by the system administrator.
+
 ## Response body
 
 The `application/octet-stream` response body is the raw byte stream contents of

--- a/docs/API/V1/list.md
+++ b/docs/API/V1/list.md
@@ -87,6 +87,12 @@ by `owner` or `access=private`.
 The client asked to filter `access=private` datasets for an `owner` for which
 the client does not have READ access.
 
+`503`   **SERVICE UNAVAILABLE** \
+The server has been disabled using the `server-state` server configuration
+setting in the [server configuration](./server_config.md) API. The response
+body is an `application/json` document describing the current server state,
+a message, and optional JSON data provided by the system administrator.
+
 ## Response body
 
 The `application/json` response body contains a list of objects which describe

--- a/docs/API/V1/server_config.md
+++ b/docs/API/V1/server_config.md
@@ -1,0 +1,253 @@
+# `GET /api/v1/server/configuration[/][{key}]`
+
+This API returns an `application/json` document describing the the Pbench Server
+configuration settings. When the `{key}` parameter is specified, the API will
+return the specific named server configuration setting. When `{key}` is omitted,
+all server configuration settings will be returned.
+
+## Query parameters
+
+None.
+
+## Request headers
+
+`authorization: bearer` token [_optional_] \
+*Bearer* schema authorization may be specified, but is not required to `GET`
+server configuration settings.
+
+## Response headers
+
+`content-type: application/json` \
+The return is a serialized JSON object with the requested server configuration
+settings.
+
+## Response status
+
+`400`   **BAD REQUEST** \
+The specified `{key}` value (see [settings](#server-configuration-settings))
+is unknown.
+
+## Response body
+
+The `application/json` response body is a JSON document containing the requested
+server configuration setting key and value or, if no `{key}` was specified, all
+supported server configuration settings.
+
+When you use [PUT](#put-apiv1serverconfigurationkey) to modify one or more server
+configuration settings, the response body will look the same, showing the new
+value of each modified server configuration setting.
+
+### Examples
+
+```
+GET /api/v1/server/configuration/dataset-lifetime
+{
+    "dataset-lifetime": "4"
+}
+
+GET /api/v1/server/configuration/
+{
+    "dataset-lifetime": "4",
+    "server-banner": {
+        "message": "Server will be down for maintenance on Tuesday!",
+        "contact": "admin@lab.example.com"
+    }
+    "server-state": {
+        "status": "readonly",
+        "message": "rebuilding index ... back to normal soon"
+    }
+}
+```
+
+# `PUT /api/v1/server/configuration[/][{key}]`
+
+This API allows a user holding the `ADMIN` role to modify server configuration
+settings. When the `{key}` parameter is specified, the API will modify a single
+named configuration setting. When `{key}` is omitted, the `application/json`
+request body can be used to modify multiple configuration settings at once.
+
+## Query parameters
+
+`value`    string \
+When a single configuration setting is specified with `{key}` in the URI, you
+can specify a string value for the parameter using this query parameter without
+an `application/json` request body. You cannot specify complex JSON configuration
+settings this way. For example, `PUT /api/v1/server/configuration/key?value=1`.
+
+## Request body
+
+When specifying a non-string value for a server configuration setting, or when
+specifying multiple configuration settings, the data to be set is specified in
+an `application/json` request body.
+
+You can specify a single `{key}` value on the URI and then specify the value
+using a `value` field in the `application/json` request body instead of using
+the `value` query parameter. You can do this even if the value is a simple
+string, although it's more useful when you need to specify a JSON object value.
+For example,
+
+```
+PUT /api/v1/server/configuration/server-state
+{
+    "value": {"status": "enabled"}
+}
+```
+
+If you omit the `{key}` value from the URI, specify all configuration settings
+you wish to change in the `application/json` request body. You can specify a
+single server configuration setting, or all server configuration settings at
+once. For example,
+
+```
+PUT /api/v1/server/configuration/
+{
+    "server-state": {"status": "disabled", "message": "down for maintenance"},
+    "server-banner": {"message": "Days of 100% uptime: 0"}
+}
+```
+
+## Request headers
+
+`authorization: bearer` token [_optional_] \
+*Bearer* schema authorization is required to change any server configuration
+settings. The authenticated user must have `ADMIN` role.
+
+## Response headers
+
+`content-type: application/json` \
+The return is a serialized JSON object with information about the selected
+datasets.
+
+## Response status
+
+`401`   **UNAUTHORIZED** \
+The client did not provide an authentication token.
+
+`403`   **FORBIDDEN** \
+The client's authentication token does not correspond to a user with `ADMIN`
+role.
+
+## Response body
+
+Just as in [GET](#get-apiv1serverconfigurationkey), the `application/json`
+response body will be a JSON object showing the current (new) value of the
+modified server configuration settings.
+
+## Server configuration settings
+
+### dataset-lifetime
+
+The value for the `dataset-lifetime` server configuration setting is the *maximum*
+number of days a dataset can be retained on the server. When each dataset is
+uploaded to the server, a "deletion date" represented by the dataset
+[metadata](../metadata.md) key `server.deletion` is calculated based on this
+value and user preferences (which may specify a shorter lifetime, but not a
+longer lifetime). When a dataset has remained on the server past the
+`server.deletion` date, it may be removed automatically by the server to
+conserve space.
+
+The number of days is specified as an string representing an integer, optionally
+followed by a space and `day` or `days`. For example, "4" or "4 days" or "4 day"
+are equivalent.
+
+```
+{
+    "dataset-lifetime": "4"
+}
+```
+
+### server-banner
+
+This server configuration setting allows a server administrator to set an
+informational message that can be retrieved and displayed by any client, for
+example as a banner on a UI. The value s a JSON object, containing at least
+a `message` field.
+
+Any additional JSON data may be provided, and will be returned uninterpreted
+when a client requests it with `GET /api/v1/server/configuration/server-banner`.
+
+For example,
+
+```
+{
+    "server-banner": {
+        "message": "The server will be down for 2 hours on Monday, July 41st",
+        "contact": {
+            "email": "admin@pbench.example.com",
+            "phone": "(555) 555-5555",
+            "hours": ["8:00 EST", "17:00 EST"]
+        },
+        "statistics": {
+            "datasets": 50000,
+            "hours-up": 2.3,
+            "users": 26.4
+        }
+    }
+}
+```
+
+### server-state
+
+This server configuration setting allows a server administrator to control
+the operating state of the server remotely. As for
+[`server-banner`](#server-banner), the value is a JSON object, and any JSON
+fields passed in to the server will be returned to a client, however the
+following fields have special meaning:
+
+**`status`** \
+The operating status of the server.
+
+* `enabled`: Normal operation.
+* `disabled`: Most server API endpoints will fail with the **503** (service
+unavailable) HTTP status. However a few endpoints are always allowed:
+  * [login](./login.md) because only an authenticated user with `ADMIN` role
+    can modify server configuration settings;
+  * [logout](./logout.md) for consistency;
+  * [endpoints](./endpoints.md) for server configuration information;
+  * [server_configuration](./server_config.md) to allow re-enabling the server
+    or modifying the banner.
+* `readonly`: The server will respond to `GET` requests for information, but will return **503** (service unavailable) for any attempt to modify server state. (With the same exceptions as listed above for `disabled`.)
+
+**`message`** \
+A message to explain downtime. This is required when the `status` is `disabled`
+or `readonly` and optional otherwise. Note that a `message` when the `status`
+is `enabled` won't normally be seen, unless a client asks for the `server-state`
+configuration setting. The `server-banner` configuration setting is generally
+more appropriate under normal operating conditions.
+
+When the `status` is `disabled` or `readonly`, and an API call fails with **503**
+(service unavailable), the full JSON object will be returned as the
+`application/json` error response body. A `message` key in an error response is
+a standard convention, and many clients will display this as an explanation for
+the failure. The client also has access to any additional information provided
+in the `server-state` JSON object including the `status`.
+
+## Response body
+
+The `application/json` response body for `PUT` is exactly the same as for
+[`GET`](#response-body) when the same server configuration settings are
+requested, showing only the server configuration settings that were changed
+in the `PUT`.
+
+```
+PUT /api/v1/server/configuration/dataset-lifetime?value=4
+
+{
+    "dataset-lifetime": "4"
+}
+```
+
+or 
+
+```
+PUT /api/v1/server/configuration
+{
+    "dataset-lifetime": "4 days",
+    "server-state": {"status": "enabled"}
+}
+
+{
+    "dataset-lifetime": "4",
+    "server-state": {"status": "enabled"}
+}
+```

--- a/docs/API/V1/server_config.md
+++ b/docs/API/V1/server_config.md
@@ -133,24 +133,31 @@ The `application/json` response body for `PUT` is exactly the same as for
 requested, showing only the server configuration settings that were changed
 in the `PUT`.
 
+_This request:_
 ```
 PUT /api/v1/server/configuration/dataset-lifetime?value=4
+```
 
-RESPONSE={
+_returns this response:_
+```
+{
     "dataset-lifetime": "4"
 }
 ```
 
-or 
 
+_And this request:_
 ```
 PUT /api/v1/server/configuration
-REQUEST={
+{
     "dataset-lifetime": "4 days",
     "server-state": {"status": "enabled"}
 }
+```
 
-RESPONSE={
+_returns this response:_
+```
+{
     "dataset-lifetime": "4",
     "server-state": {"status": "enabled"}
 }
@@ -196,7 +203,7 @@ For example, the following are examples of valid banners:
 ```
 {
     "server-banner": {
-        "message": "I have nothing to say"
+        "message": "Have a Happy Pbench Day"
     }
 }
 ```
@@ -223,7 +230,7 @@ For example, the following are examples of valid banners:
 
 This server configuration setting allows a server administrator to control
 the operating state of the server remotely. As for
-[`server-banner`](#server-banner), the value is a JSON object, and any JSON
+[`server-banner`](#server-banner), the value is a JSON object and any JSON
 fields passed in to the server will be returned to a client, however the
 following fields have special meaning:
 
@@ -247,11 +254,11 @@ or `readonly` and optional otherwise.
 
 When the server status is `disabled`, or when it's `readonly` and a client
 tries to modify some data through the API, the server will fail the request
-with a `503` (service unavailable) error, and return the full `server-state`
-JSON object as the `application/json` error response body. The `message` key in
-an error response is a standard convention, and many clients will display this
-as an explanation for the failure. The client will also have access to any
-additional information provided in the `server-state` JSON object.
+with a `503` (service unavailable) error. It will return an `application/json`
+error response payload containing the full `server-state` JSON object. The
+`message` key in an error response is a standard convention, and many clients
+will display this as an explanation for the failure. The client will also have
+access to any additional information provided in the `server-state` JSON object.
 
 Note that you can set a `message` when the `status` is `enabled` but it won't
 be reported to a client unless a client asks for the `server-state`

--- a/docs/API/V1/server_config.md
+++ b/docs/API/V1/server_config.md
@@ -114,8 +114,8 @@ settings. The authenticated user must have `ADMIN` role.
 ## Response headers
 
 `content-type: application/json` \
-The response body is a serialized JSON object with information about the selected
-server configuration settings.
+The response body is a serialized JSON object with the selected server
+configuration settings.
 
 ## Response status
 
@@ -230,8 +230,8 @@ For example, the following are examples of valid banners:
 
 This server configuration setting allows a server administrator to control
 the operating state of the server remotely. As for
-[`server-banner`](#server-banner), the value is a JSON object and any JSON
-fields passed in to the server will be returned to a client, however the
+[`server-banner`](#server-banner), the value is a JSON object, and any JSON
+fields passed in to the server will be returned to a client. The
 following fields have special meaning:
 
 **`status`** \

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -166,7 +166,7 @@ class PbenchServerConfig(PbenchConfig):
         return self._get_conf("pbench-server", "rest_uri")
 
     @property
-    def max_retention_period(self) -> timedelta:
+    def max_retention_period(self) -> int:
         """
         Produce a timedelta representing the number of days the server allows
         a dataset to be retained.
@@ -180,8 +180,7 @@ class PbenchServerConfig(PbenchConfig):
             )
         except (NoOptionError, NoSectionError):
             retention_days = self.MAXIMUM_RETENTION_DAYS
-
-        return timedelta(days=retention_days)
+        return retention_days
 
     def _get_conf(self, section, option):
         """

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -36,6 +36,7 @@ from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetai
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch
+from pbench.server.api.resources.server_configuration import ServerConfiguration
 from pbench.server.api.resources.upload_api import Upload
 from pbench.server.api.resources.users_api import Login, Logout, RegisterUser, UserAPI
 from pbench.server.database import init_db
@@ -163,6 +164,12 @@ def register_endpoints(api, app, config):
         RegisterUser,
         f"{base_uri}/register",
         endpoint="register",
+        resource_class_args=(config, logger),
+    )
+    api.add_resource(
+        ServerConfiguration,
+        f"{base_uri}/server/configuration",
+        f"{base_uri}/server/configuration/<string:key>",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -170,6 +170,7 @@ def register_endpoints(api, app, config):
         ServerConfiguration,
         f"{base_uri}/server/configuration",
         f"{base_uri}/server/configuration/<string:key>",
+        strict_slashes=False,
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -169,8 +169,9 @@ def register_endpoints(api, app, config):
     api.add_resource(
         ServerConfiguration,
         f"{base_uri}/server/configuration",
+        f"{base_uri}/server/configuration/",
         f"{base_uri}/server/configuration/<string:key>",
-        strict_slashes=False,
+        endpoint="server_configuration",
         resource_class_args=(config, logger),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -67,8 +67,8 @@ class UnauthorizedAccess(APIAbort):
 
 class UnauthorizedAdminAccess(UnauthorizedAccess):
     """
-    A refinement of the Unauthorized exception where ADMIN access is required
-    as we can't describe a resource owner and access.
+    A refinement of the UnauthorizedAccess exception where ADMIN access is
+    required and we have no associated resource owner and access.
     """
 
     def __init__(

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -77,7 +77,13 @@ class UnauthorizedAdminAccess(UnauthorizedAccess):
         operation: "API_OPERATION",
         http_status: int = HTTPStatus.FORBIDDEN,
     ):
-        super().__init__(user, operation, None, None, http_status=http_status)
+        super().__init__(
+            user=user,
+            operation=operation,
+            owner=None,
+            access=None,
+            http_status=http_status,
+        )
 
     def __str__(self) -> str:
         return f"{'User ' + self.user.username if self.user else 'Unauthenticated client'} is not authorized to {self.operation.name} a server administrative resource"
@@ -953,9 +959,7 @@ class ApiSchema:
         Returns
             The values for username and access policy to use for authorization.
         """
-        if self.authorization == API_AUTHORIZATION.ADMIN:
-            return ApiAuthorization(type=self.authorization, role=self.operation)
-        elif self.authorization == API_AUTHORIZATION.DATASET:
+        if self.authorization == API_AUTHORIZATION.DATASET:
             ds = self.get_param_by_type(ParamType.DATASET, params)
             if ds:
                 return ApiAuthorization(
@@ -974,6 +978,8 @@ class ApiSchema:
                 access=access.value,
                 role=self.operation,
             )
+        elif self.authorization == API_AUTHORIZATION.ADMIN:
+            return ApiAuthorization(type=self.authorization, role=self.operation)
         return None
 
 

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -12,6 +12,7 @@ from pbench.server.api.resources import (
     API_METHOD,
     APIAbort,
     API_OPERATION,
+    ApiAuthorization,
     ApiBase,
     ApiParams,
     ApiSchema,
@@ -148,7 +149,14 @@ class DatasetsMetadata(ApiBase):
             for k in metadata.keys():
                 if Metadata.get_native_key(k) != Metadata.USER:
                     role = API_OPERATION.UPDATE
-        self._check_authorization(str(dataset.owner_id), dataset.access, role)
+        self._check_authorization(
+            ApiAuthorization(
+                API_AUTHORIZATION.USER_ACCESS,
+                role,
+                str(dataset.owner_id),
+                dataset.access,
+            )
+        )
 
         # Validate the metadata key values in a separate pass so that we can
         # fail before committing any changes to the database.

--- a/lib/pbench/server/api/resources/server_configuration.py
+++ b/lib/pbench/server/api/resources/server_configuration.py
@@ -1,0 +1,152 @@
+from http import HTTPStatus
+from logging import Logger
+
+from flask.json import jsonify
+from flask.wrappers import Request, Response
+
+from pbench.server import PbenchServerConfig
+from pbench.server.api.resources import (
+    API_AUTHORIZATION,
+    API_METHOD,
+    APIAbort,
+    API_OPERATION,
+    ApiBase,
+    ApiParams,
+    ApiSchema,
+    MissingParameters,
+    ParamType,
+    Parameter,
+    Schema,
+)
+from pbench.server.database.models.server_config import (
+    ServerConfig,
+    ServerConfigBadValue,
+    ServerConfigError,
+)
+
+
+class ServerConfiguration(ApiBase):
+    """
+    API class to retrieve and mutate Dataset metadata.
+    """
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            ApiSchema(
+                API_METHOD.PUT,
+                API_OPERATION.UPDATE,
+                uri_schema=Schema(
+                    Parameter("key", ParamType.KEYWORD, keywords=ServerConfig.KEYS)
+                ),
+                # TODO: We aspire to be flexible about how a config option is
+                # specified on a PUT. While the "config" parameter is specifically
+                # intended to support a full JSON body that sets or updates all
+                # options at once, for individual options using the "value"
+                # query parameter is probably easier... but the "value" body
+                # parameter also allows specifying the value in a body.
+                #
+                #   PUT /server/configuration/dataset-lifetime?value=2y
+                #   PUT /server/configuration/dataset-lifetime
+                #       {"value": "2y"}
+                #   PUT /server/configuration/dataset-lifetime ???
+                #       {"config": {"dataset-lifetime": "2y"}}
+                #
+                # Some options may not make sense: need to think about this.
+                query_schema=Schema(Parameter("value", ParamType.STRING)),
+                body_schema=Schema(
+                    Parameter("config", ParamType.JSON, keywords=ServerConfig.KEYS),
+                    Parameter("value", ParamType.JSON),
+                ),
+                authorization=API_AUTHORIZATION.ADMIN,
+            ),
+            ApiSchema(
+                API_METHOD.GET,
+                API_OPERATION.READ,
+                uri_schema=Schema(
+                    Parameter("key", ParamType.KEYWORD, keywords=ServerConfig.KEYS)
+                ),
+                authorization=API_AUTHORIZATION.NONE,
+            ),
+            always_enabled=True,
+        )
+
+    def _get(self, params: ApiParams, request: Request) -> Response:
+        """
+        Get the values of server configuration parameters.
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+
+        GET /api/v1/server/configuration?key=config1&key=config2
+        """
+
+        key = params.uri.get("key")
+        try:
+            if key:
+                s = ServerConfig.get(key)
+                return jsonify({key: s.value if s else None})
+            else:
+                return jsonify(ServerConfig.get_all())
+        except ServerConfigError as e:
+            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
+
+    def _put(self, params: ApiParams, _) -> Response:
+        """
+        Set or modify the values of server configuration keys.
+
+        PUT /api/v1/server/configuration
+        {
+            "config": {
+                "dataset-lifetime": 10,
+                "server-state": "running"
+            }
+        }
+
+        PUT /api/v1/server/configuration/dataset-lifetime?value=10
+
+        PUT /api/v1/server/configuration/dataset-lifetime
+        {
+            "value": "10"
+        }
+        """
+
+        try:
+            key = params.uri["key"]
+            try:
+                value = params.query["value"]
+            except KeyError:
+                try:
+                    value = params.body["value"]
+                except KeyError:
+                    raise APIAbort(
+                        HTTPStatus.BAD_REQUEST,
+                        "Incorrect value specification for key {key!r}",
+                    )
+            try:
+                ServerConfig.set(key=key, value=value)
+                return jsonify({key: value})
+            except ServerConfigBadValue as e:
+                raise APIAbort(HTTPStatus.BAD_REQUEST, str(e))
+            except ServerConfigError as e:
+                raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
+        except KeyError:
+            pass
+
+        try:
+            config = params.body["config"]
+        except KeyError:
+            raise MissingParameters(["config"])
+
+        failures = []
+        for k, v in config.items():
+            try:
+                ServerConfig.set(key=k, value=v)
+            except ServerConfigError as e:
+                self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))
+                failures.append(k)
+        if failures:
+            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
+        return jsonify(ServerConfig.get_all())

--- a/lib/pbench/server/api/resources/server_configuration.py
+++ b/lib/pbench/server/api/resources/server_configuration.py
@@ -72,10 +72,6 @@ class ServerConfiguration(ApiBase):
         """
         Get the values of server configuration parameters.
 
-        Args:
-            params: API parameters
-            request: The original Request object containing query parameters
-
         GET /api/v1/server/configuration/{key}
             return the value of a single configuration parameter
 
@@ -83,6 +79,13 @@ class ServerConfiguration(ApiBase):
 
         GET /api/v1/server/configuration
             return all configuration parameters
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+
+        Returns:
+            HTTP Response object
         """
 
         key = params.uri.get("key")
@@ -93,7 +96,101 @@ class ServerConfiguration(ApiBase):
             else:
                 return jsonify(ServerConfig.get_all())
         except ServerConfigError as e:
-            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
+            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e)) from e
+
+    def put_key(self, params: ApiParams) -> Response:
+        """
+        Implement the PUT operation when a system configuration setting key is
+        specified on the URI as /system/configuration/{key}.
+
+        A single system config setting is set by naming the config key in the
+        URI and specifying a value using either the "value" query parameter or
+        a "value" key in a JSON request body.
+
+        We'll complain about JSON request body parameters that are "shadowed"
+        by the "value" query parameter and might represent client confusion.
+        We won't complain about unnecessary JSON request body keys if we find
+        the "value" in the request body as those would normally have been
+        ignored by schema validation.
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+
+        Returns:
+            HTTP Response object
+        """
+
+        key = params.uri.get("key")
+        if key:
+            # If we have a key in the URL, then we need a "value" for it, which
+            # we can take either from a query parameter or from the JSON
+            # request payload.
+            value = params.query.get("value")
+            if value:
+                # If we got the value from the query parameter, complain about
+                # any JSON request body keys
+                if params.body:
+                    raise APIAbort(
+                        HTTPStatus.BAD_REQUEST,
+                        "Redundant parameters specified in the JSON request body: "
+                        f"{sorted(params.body.keys())!r}",
+                    )
+            else:
+                value = params.body.get("value")
+                if not value:
+                    raise APIAbort(
+                        HTTPStatus.BAD_REQUEST,
+                        f"No value found for key system configuration key {key!r}",
+                    )
+
+            try:
+                ServerConfig.set(key=key, value=value)
+                return jsonify({key: value})
+            except ServerConfigBadValue as e:
+                raise APIAbort(HTTPStatus.BAD_REQUEST, str(e)) from e
+            except ServerConfigError as e:
+                raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e)) from e
+
+    def put_body(self, params: ApiParams) -> Response:
+        """
+        Allow setting the value of multiple system configuration settings with
+        a single PUT by specifying a JSON request body with key/value pairs.
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+
+        Returns:
+            HTTP Response object
+        """
+        badkeys = []
+        for k, v in params.body.items():
+            if k not in ServerConfig.KEYS:
+                badkeys.append(k)
+
+        if badkeys:
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST,
+                f"Unrecognized configuration parameters {sorted(badkeys)!r} specified: valid parameters are {sorted(ServerConfig.KEYS)!r}",
+            )
+
+        failures = []
+        response = {}
+        fail_status = HTTPStatus.BAD_REQUEST
+        for k, v in params.body.items():
+            try:
+                c = ServerConfig.set(key=k, value=v)
+                response[c.key] = c.value
+            except ServerConfigBadValue as e:
+                failures.append(str(e))
+            except ServerConfigError as e:
+                fail_status = HTTPStatus.INTERNAL_SERVER_ERROR
+                self.logger.warning(str(e))
+                failures.append(str(e))
+        if failures:
+            raise APIAbort(fail_status, message=", ".join(failures))
+        return jsonify(response)
 
     def _put(self, params: ApiParams, _) -> Response:
         """
@@ -111,76 +208,16 @@ class ServerConfiguration(ApiBase):
         {
             "value": "10"
         }
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+
+        Returns:
+            HTTP Response object
         """
 
-        # First, we check for the ways to set an individual config setting by
-        # naming the config key on the URI and specifying a value either with
-        # the "value" either as a query parameter or in the JSON request body.
-        #
-        # We'll complain about JSON request body parameters that are "shadowed"
-        # by the URI or query parameter and might represent client confusion.
-        keydup = set()
-        key = params.uri.get("key")
-        if key:
-            # If we have a key in the URL, the we need a "value" for it, which
-            # we can take either from a query parameter or from the JSON
-            # request payload.
-            if params.body and list(params.body.keys()) != ["value"]:
-                keydup.update(params.body.keys())
-            value = params.query.get("value")
-            if value:
-                if params.body:
-                    keydup.update(params.body.keys())
-            else:
-                value = params.body.get("value")
-                if not value:
-                    raise APIAbort(
-                        HTTPStatus.BAD_REQUEST,
-                        f"No value found for key system configuration key {key!r}",
-                    )
-
-            if len(keydup) > 0:
-                raise APIAbort(
-                    HTTPStatus.BAD_REQUEST,
-                    f"Redundant parameters specified in the JSON request body: {sorted(keydup)!r}",
-                )
-
-            try:
-                ServerConfig.set(key=key, value=value)
-                return jsonify({key: value})
-            except ServerConfigBadValue as e:
-                raise APIAbort(HTTPStatus.BAD_REQUEST, str(e))
-            except ServerConfigError as e:
-                raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e))
-
+        if params.uri:
+            return self.put_key(params)
         else:
-            # If we get here, we didn't get "key" from the URI, so we're expecting
-            # a JSON request body with key/value pairs, potentially for multiple
-            # config options.
-            badkeys = []
-            for k, v in params.body.items():
-                if k not in ServerConfig.KEYS:
-                    badkeys.append(k)
-
-            if badkeys:
-                raise APIAbort(
-                    HTTPStatus.BAD_REQUEST,
-                    f"Unrecognized configuration parameters {sorted(badkeys)!r} specified: valid parameters are {sorted(ServerConfig.KEYS)!r}",
-                )
-
-            failures = []
-            response = {}
-            fail_status = HTTPStatus.BAD_REQUEST
-            for k, v in params.body.items():
-                try:
-                    c = ServerConfig.set(key=k, value=v)
-                    response[c.key] = c.value
-                except ServerConfigBadValue as e:
-                    failures.append(str(e))
-                except ServerConfigError as e:
-                    fail_status = HTTPStatus.INTERNAL_SERVER_ERROR
-                    self.logger.warning(str(e))
-                    failures.append(str(e))
-            if failures:
-                raise APIAbort(fail_status, message=", ".join(failures))
-            return jsonify(response)
+            return self.put_body(params)

--- a/lib/pbench/server/api/resources/server_configuration.py
+++ b/lib/pbench/server/api/resources/server_configuration.py
@@ -126,7 +126,10 @@ class ServerConfiguration(ApiBase):
         except KeyError:
             # This "isn't possible" given the Flask mapping rules, but try
             # to report it gracefully instead of letting the KeyError fly.
-            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, f"Found URI parameters {sorted(params.uri)} not including 'key'")
+            raise APIAbort(
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                f"Found URI parameters {sorted(params.uri)} not including 'key'",
+            )
 
         # If we have a key in the URL, then we need a "value" for it, which
         # we can take either from a query parameter or from the JSON

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -17,6 +17,7 @@ from pbench.server.database.models.datasets import (
     Metadata,
     States,
 )
+from pbench.server.database.models.server_config import ServerConfig
 from pbench.server.filetree import FileTree
 from pbench.server.utils import UtcTimeHelper, filesize_bytes
 
@@ -59,6 +60,9 @@ class Upload(Resource):
 
     @Auth.token_auth.login_required()
     def put(self, filename: str):
+        disabled = ServerConfig.get_disabled()
+        if disabled:
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
 
         # Used to record what steps have been completed during the upload, and
         # need to be undone on failure

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -6,6 +6,7 @@ from flask_bcrypt import check_password_hash
 from email_validator import EmailNotValidError
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
 from typing import NamedTuple
+from pbench.server.database.models.server_config import ServerConfig
 from pbench.server.database.models.users import User
 from pbench.server.database.models.active_tokens import ActiveTokens
 from pbench.server.api.auth import Auth
@@ -45,6 +46,10 @@ class RegisterUser(Resource):
                     }
         To get the auth token user has to perform the login action
         """
+        disabled = ServerConfig.get_disabled()
+        if disabled:
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
+
         # get the post data
         user_data = request.get_json()
         if not user_data:
@@ -377,6 +382,10 @@ class UserAPI(Resource):
                         "message": "failure message"
                     }
         """
+        disabled = ServerConfig.get_disabled(readonly=True)
+        if disabled:
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
+
         result = self.get_valid_target_user(target_username, "GET")
         if not result.target_user:
             abort(result.http_status, message=result.http_message)
@@ -416,6 +425,10 @@ class UserAPI(Resource):
                         "message": "failure message"
                     }
         """
+        disabled = ServerConfig.get_disabled()
+        if disabled:
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
+
         user_payload = request.get_json()
         if not user_payload:
             self.logger.warning("Invalid json object: {}", request.url)
@@ -487,6 +500,10 @@ class UserAPI(Resource):
                         "message": "failure message"
                     }
         """
+        disabled = ServerConfig.get_disabled()
+        if disabled:
+            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
+
         result = self.get_valid_target_user(target_username, "DELETE")
         if not result.target_user:
             abort(result.http_status, message=result.http_message)

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -30,6 +30,7 @@ class Database:
         # database models to find
         if logger and not hasattr(Database.Base, "logger"):
             Database.Base.logger = logger
+        if server_config and not hasattr(Database.Base, "server_config"):
             Database.Base.config = server_config
 
         # WARNING:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -13,8 +13,8 @@ from sqlalchemy.types import TypeDecorator
 
 from pbench.server.database.database import Database
 from pbench.server.database.models.server_config import (
+    OPTION_DATASET_LIFETIME,
     ServerConfig,
-    ServerConfigOptions,
 )
 from pbench.server.database.models.users import User
 
@@ -1131,9 +1131,7 @@ class Metadata(Database.Base):
             except date_parser.ParserError as p:
                 raise MetadataBadValue(dataset, key, value, "date/time") from p
 
-            max_retention = ServerConfig.get(
-                key=ServerConfigOptions.MAXIMUM_DATASET_LIFETIME.key
-            )
+            max_retention = ServerConfig.get(key=OPTION_DATASET_LIFETIME)
             maximum = dataset.uploaded + datetime.timedelta(
                 days=int(max_retention.value)
             )

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -12,6 +12,10 @@ from sqlalchemy.orm import relationship, validates, Query
 from sqlalchemy.types import TypeDecorator
 
 from pbench.server.database.database import Database
+from pbench.server.database.models.server_config import (
+    ServerConfig,
+    ServerConfigOptions,
+)
 from pbench.server.database.models.users import User
 
 
@@ -1127,7 +1131,12 @@ class Metadata(Database.Base):
             except date_parser.ParserError as p:
                 raise MetadataBadValue(dataset, key, value, "date/time") from p
 
-            maximum = dataset.uploaded + __class__.config.max_retention_period
+            max_retention = ServerConfig.get(
+                key=ServerConfigOptions.MAXIMUM_DATASET_LIFETIME.key
+            )
+            maximum = dataset.uploaded + datetime.timedelta(
+                days=int(max_retention.value)
+            )
             if target > maximum:
                 raise MetadataBadValue(
                     dataset, key, value, f"date/time before {maximum:%Y-%m-%d}"

--- a/lib/pbench/server/database/models/server_config.py
+++ b/lib/pbench/server/database/models/server_config.py
@@ -1,0 +1,388 @@
+from enum import Enum
+import re
+from typing import Callable, Optional
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.sql.sqltypes import JSON
+from pbench.server import JSONOBJECT, JSONVALUE
+
+from pbench.server.database.database import Database
+
+
+class ServerConfigError(Exception):
+    """
+    This is a base class for errors reported by the ServerConfig class. It is
+    never raised directly, but may be used in "except" clauses.
+    """
+
+    pass
+
+
+class ServerConfigSqlError(ServerConfigError):
+    """
+    SQLAlchemy errors reported through ServerConfig operations.
+
+    The exception will identify the base name of the Elasticsearch index,
+    along with the operation being attempted; the __cause__ will specify the
+    original SQLAlchemy exception.
+    """
+
+    def __init__(self, operation: str, name: str, cause: str):
+        self.operation = operation
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Error {self.operation} index {self.name!r}: {self.cause}"
+
+
+class ServerConfigDuplicate(ServerConfigError):
+    """
+    Attempt to commit a duplicate ServerConfig.
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Duplicate config setting {self.name!r}: {self.cause}"
+
+
+class ServerConfigNullKey(ServerConfigError):
+    """
+    Attempt to commit a ServerConfig with an empty key.
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Missing key value in {self.name!r}: {self.cause}"
+
+
+class ServerConfigMissingKey(ServerConfigError):
+    """
+    Attempt to set a ServerConfig with an empty key.
+    """
+
+    def __str__(self) -> str:
+        return "Missing key name"
+
+
+class ServerConfigBadKey(ServerConfigError):
+    """
+    Attempt to commit a ServerConfig with a bad key.
+    """
+
+    def __init__(self, key: str):
+        self.key = key
+
+    def __str__(self) -> str:
+        return f"Configuration key {self.key!r} is unknown"
+
+
+class ServerConfigBadValue(ServerConfigError):
+    """
+    Attempt to assign a bad value to a server configuration option
+    """
+
+    def __init__(self, key: str, value: JSONVALUE):
+        self.key = key
+        self.value = value
+
+    def __str__(self) -> str:
+        return f"Unsupported value for configuration key {self.key!r} ({self.value!r})"
+
+
+# Formal timedelta syntax is "[D day[s], ][H]H:MM:SS[.UUUUUU]"; without an
+# external package we have no standard way to parse or format timedelta
+# strings. Additionally for "lifetime" we don't care about fractional days,
+# so we simpify by accepting "D[[ ]day[s]]".
+_TIMEDELTA_FORMAT = re.compile(r"(?P<days>\d{1,9})(?:\s*day(?:s)?)?")
+
+
+def validate_lifetime(key: str, value: JSONVALUE) -> JSONVALUE:
+    v = str(value)
+    check = _TIMEDELTA_FORMAT.fullmatch(v)
+    if check:
+        days = check.group("days")
+    else:
+        raise ServerConfigBadValue(key, value)
+    return days
+
+
+# Formal "state" syntax is a JSON object with boolean "enabled" key and a
+# "message" string describing why the server isn't enabled. The "message" is
+# required only if the "enable" flag is false. For example,
+#
+# {"status": "enabled"}
+#
+# or
+#
+# {"status": "disabled", "message": "Down for maintanance"}
+#
+# or
+#
+# {"status": "readonly", "message": "Available for queries but no changes allowed"}
+#
+# Additional fields can be set by an administrator and will be retained and
+# reported when the state is queried or when an API call fails because the
+# state isn't enabled.
+STATE_STATUS_KEY = "status"
+STATE_MESSAGE_KEY = "message"
+STATE_STATUS_KEYWORD_DISABLED = "disabled"
+STATE_STATUS_KEYWORD_ENABLED = "enabled"
+STATE_STATUS_KEYWORD_READONLY = "readonly"
+STATE_STATUS_KEYWORDS = [
+    STATE_STATUS_KEYWORD_DISABLED,
+    STATE_STATUS_KEYWORD_ENABLED,
+    STATE_STATUS_KEYWORD_READONLY,
+]
+
+
+def validate_server_state(key: str, value: JSONVALUE) -> JSONVALUE:
+    try:
+        status = value[STATE_STATUS_KEY].lower()
+    except (KeyError, SyntaxError, TypeError):
+        raise ServerConfigBadValue(key, value)
+    if status not in STATE_STATUS_KEYWORDS:
+        raise ServerConfigBadValue(key, value)
+
+    # canonicalize the status value by lowercasing it
+    value[STATE_STATUS_KEY] = status
+    if status != STATE_STATUS_KEYWORD_ENABLED and STATE_MESSAGE_KEY not in value:
+        raise ServerConfigBadValue(key, value)
+    return value
+
+
+# A set of string values, including a message for users that can be displayed
+# as a banner in a client. This must include a "message" and may also include
+# other fields such as administrator contacts, maintenance schedule.
+BANNER_MESSAGE_KEY = "message"
+
+
+def validate_server_banner(key: str, value: JSONVALUE) -> JSONVALUE:
+    if not isinstance(value, dict) or BANNER_MESSAGE_KEY not in value:
+        raise ServerConfigBadValue(key, value)
+    return value
+
+
+class ServerConfigOptions(Enum):
+    MAXIMUM_DATASET_LIFETIME = ("dataset-lifetime", validate_lifetime)
+    SERVER_BANNER = ("server-banner", validate_server_banner)
+    SERVER_STATE = ("server-state", validate_server_state)
+
+    def __init__(self, key: str, validator: Callable[[str, JSONVALUE], JSONVALUE]):
+        self.key = key
+        self.validator = validator
+
+    @classmethod
+    def lookup(cls, key: str) -> "ServerConfigOptions":
+        if not key:
+            raise ServerConfigMissingKey()
+        k = key.lower()
+        for x in cls:
+            if k == x.key:
+                return x
+        else:
+            raise ServerConfigBadKey(k)
+
+    @staticmethod
+    def validate(key: str, value: JSONVALUE) -> JSONVALUE:
+        option = ServerConfigOptions.lookup(key)
+        return option.validator(key, value)
+
+
+class ServerConfig(Database.Base):
+    """
+    A framework to manage Pbench configuration settings. This is a simple
+    key-value store that can be used flexibly to manage runtime configuration.
+
+    Columns:
+        id      Generated unique ID of table row
+        key     Configuration key name
+        value   Configuration key value
+    """
+
+    KEYS = sorted([s.key for s in ServerConfigOptions])
+
+    __tablename__ = "serverconfig"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    key = Column(String(255), unique=True, index=True, nullable=False)
+    value = Column(JSON, index=False, nullable=True)
+
+    @staticmethod
+    def _default(key: str) -> JSONVALUE:
+        if key == ServerConfigOptions.MAXIMUM_DATASET_LIFETIME.key:
+            return str(__class__.config.max_retention_period)
+        elif key == ServerConfigOptions.SERVER_STATE.key:
+            return {STATE_STATUS_KEY: STATE_STATUS_KEYWORD_ENABLED}
+        else:
+            return None
+
+    @staticmethod
+    def create(key: str, value: JSONVALUE) -> "ServerConfig":
+        """
+        A simple factory method to construct a new ServerConfig setting and
+        add it to the database.
+
+        Args:
+            key: config setting key
+            value: config setting value
+
+        Returns:
+            A new ServerConfig object initialized with the parameters and added
+            to the database.
+        """
+
+        v = ServerConfigOptions.validate(key, value)
+        config = ServerConfig(key=key, value=v)
+        config.add()
+        return config
+
+    @staticmethod
+    def get(key: str, use_default: bool = True) -> "ServerConfig":
+        """
+        Return a ServerConfig object with the specified key name. For
+        example, SererConfig.get("max-lifetime").
+
+        If the key has no definition, a default value will optionally
+        be provided.
+
+        Args:
+            key: Base index name
+            use_default: If the DB value is None, subsitute a default
+
+        Raises:
+            ServerConfigSqlError: problem interacting with Database
+
+        Returns:
+            ServerConfig object with the specified key name or None
+        """
+        try:
+            config = Database.db_session.query(ServerConfig).filter_by(key=key).first()
+            if config is None and use_default:
+                config = ServerConfig(key=key, value=__class__._default(key))
+        except SQLAlchemyError as e:
+            raise ServerConfigSqlError("finding", key, str(e))
+        return config
+
+    @staticmethod
+    def set(key: str, value: JSONVALUE) -> "ServerConfig":
+        """
+        Update a ServerConfig key with the specified value. For
+        example, SererConfig.set("max-lifetime").
+
+        Args:
+            key: Base index name
+
+        Raises:
+            ServerConfigSqlError: problem interacting with Database
+            ServerConfigNotFound: the specified template doesn't exist
+
+        Returns:
+            ServerConfig object with the specified key name
+        """
+
+        v = ServerConfigOptions.validate(key, value)
+        config = __class__.get(key, use_default=False)
+        if config:
+            config.value = v
+            config.update()
+        else:
+            config = __class__.create(key=key, value=v)
+        return config
+
+    @staticmethod
+    def get_disabled(readonly: bool = False) -> Optional[JSONOBJECT]:
+        """
+        Determine whether the current 'server-state' setting disallows the
+        requested access. By default we check for WRITE access, which
+        can be overridden by specifying 'readonly=True'
+
+        Args:
+            readonly: Caller requires only read access to the server API.
+
+        Returns:
+            None if the server is enabled. If the server is disabled for the
+            requested access, the entire JSON value is returned and should be
+            reported to a caller.
+        """
+        state = __class__.get(key=ServerConfigOptions.SERVER_STATE.key)
+        if state:
+            value = state.value
+            status = value[STATE_STATUS_KEY]
+            if status == "disabled" or status == "readonly" and not readonly:
+                return value
+        return None
+
+    @staticmethod
+    def get_all() -> JSONOBJECT:
+        """
+        Return all server config settings as a JSON object
+        """
+        configs = Database.db_session.query(ServerConfig).all()
+        db = {c.key: c.value for c in configs}
+        return {k: db[k] if k in db else __class__._default(k) for k in __class__.KEYS}
+
+    def __str__(self) -> str:
+        """
+        Return a string representation of the key-value pair
+
+        Returns:
+            string representation
+        """
+        return f"{self.key}: {self.value!r}"
+
+    def _decode(self, exception: IntegrityError) -> Exception:
+        """
+        Decode a SQLAlchemy IntegrityError to look for a recognizable UNIQUE
+        or NOT NULL constraint violation. Return the original exception if
+        it doesn't match.
+
+        Args:
+            exception: An IntegrityError to decode
+
+        Returns:
+            a more specific exception, or the original if decoding fails
+        """
+        # Postgres engine returns (code, message) but sqlite3 engine only
+        # returns (message); so always take the last element.
+        cause = exception.orig.args[-1]
+        if cause.find("UNIQUE constraint") != -1:
+            return ServerConfigDuplicate(self.key, cause)
+        elif cause.find("NOT NULL constraint") != -1:
+            return ServerConfigNullKey(self.key, cause)
+        return exception
+
+    def add(self):
+        """
+        Add the ServerConfig object to the database
+        """
+        try:
+            Database.db_session.add(self)
+            Database.db_session.commit()
+        except IntegrityError as e:
+            Database.db_session.rollback()
+            raise self._decode(e)
+        except Exception as e:
+            Database.db_session.rollback()
+            raise ServerConfigSqlError("adding", self.key, str(e))
+
+    def update(self):
+        """
+        Update the database row with the modified version of the
+        ServerConfig object.
+        """
+        try:
+            Database.db_session.commit()
+        except IntegrityError as e:
+            Database.db_session.rollback()
+            raise self._decode(e)
+        except Exception as e:
+            Database.db_session.rollback()
+            raise ServerConfigSqlError("updating", self.key, str(e))

--- a/lib/pbench/server/database/models/server_config.py
+++ b/lib/pbench/server/database/models/server_config.py
@@ -114,9 +114,11 @@ def validate_lifetime(key: str, value: JSONVALUE) -> JSONVALUE:
     return days
 
 
-# Formal "state" syntax is a JSON object with boolean "enabled" key and a
-# "message" string describing why the server isn't enabled. The "message" is
-# required only if the "enable" flag is false. For example,
+# Formal "state" syntax is a JSON object with a "status" key designating the
+# current server status ("enabled", "disabled", or "readonly" to allow read
+# access but not modification of resources), and a "message" string
+# describing why the server isn't enabled. The "message" is required only if
+# the "status" isn't "enabled". For example,
 #
 # {"status": "enabled"}
 #
@@ -187,8 +189,7 @@ class ServerConfigOptions(Enum):
         for x in cls:
             if k == x.key:
                 return x
-        else:
-            raise ServerConfigBadKey(k)
+        raise ServerConfigBadKey(k)
 
     @staticmethod
     def validate(key: str, value: JSONVALUE) -> JSONVALUE:

--- a/lib/pbench/test/unit/server/database/test_server_config_db.py
+++ b/lib/pbench/test/unit/server/database/test_server_config_db.py
@@ -270,9 +270,7 @@ class TestServerConfig:
     def test_construct_duplicate(self):
         """Test server config parameter constructor"""
         ServerConfig.create(key="dataset-lifetime", value=1)
-        self.check_session(
-            committed=[FakeRow(id=1, key="dataset-lifetime", value="1")]
-        )
+        self.check_session(committed=[FakeRow(id=1, key="dataset-lifetime", value="1")])
         with pytest.raises(ServerConfigDuplicate) as e:
             self.session.raise_on_commit = IntegrityError(
                 statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
@@ -280,8 +278,7 @@ class TestServerConfig:
             ServerConfig.create(key="dataset-lifetime", value=2)
         assert str(e).find("dataset-lifetime") != -1
         self.check_session(
-            committed=[FakeRow(id=1, key="dataset-lifetime", value="1")],
-            rolledback=1
+            committed=[FakeRow(id=1, key="dataset-lifetime", value="1")], rolledback=1
         )
 
     def test_construct_null(self):
@@ -307,9 +304,7 @@ class TestServerConfig:
     def test_update(self):
         """Test that we can update an existing configuration setting"""
         config = ServerConfig.create(key="dataset-lifetime", value="2")
-        self.check_session(
-            committed=[FakeRow(id=1, key="dataset-lifetime", value="2")]
-        )
+        self.check_session(committed=[FakeRow(id=1, key="dataset-lifetime", value="2")])
         config.value = "5"
         config.update()
         self.check_session(committed=[FakeRow(id=1, key="dataset-lifetime", value="5")])

--- a/lib/pbench/test/unit/server/database/test_server_config_db.py
+++ b/lib/pbench/test/unit/server/database/test_server_config_db.py
@@ -1,56 +1,309 @@
-import pytest
+from typing import Dict, List, Optional
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from pbench.server.database.database import Database
 from pbench.server.database.models.server_config import (
     ServerConfig,
     ServerConfigBadKey,
     ServerConfigBadValue,
     ServerConfigDuplicate,
     ServerConfigMissingKey,
+    ServerConfigNullKey,
 )
 
 
+# NOTE: the SQLAlchemy mock infrastructure here is specific to the ServerConfig
+# class, but it could "easily" (with substantial effort) be generalized to
+# become a shared mock platform for DB operation testing, including across
+# multiple DB tables (e.g., by maintaining a dict of session commit lists by
+# database table name)
+
+
+class FakeDBOrig:
+    """
+    A simple mocked replacement for SQLAlchemy's engine "origin" object in
+    exceptions.
+    """
+
+    def __init__(self, arg: str):
+        """
+        Create an 'orig' object
+
+        Args:
+            arg:    A text string passing information about the engine's
+                    SQL query.
+        """
+        self.args = [arg]
+
+
+class FakeRow:
+    """
+    Maintain an internal "database row" copy that we can use to verify the
+    committed records and compare active proxy values against the committed DB
+    rows.
+    """
+
+    def __init__(self, id, key, value):
+        self.id = id
+        self.key = key
+        self.value = value
+
+    def __eq__(self, entity) -> bool:
+        return (
+            isinstance(entity, __class__)
+            and self.id == entity.id
+            and self.key == entity.key
+            and self.value == entity.value
+        )
+
+    def __gt__(self, entity) -> bool:
+        return self.id > entity.id
+
+    def __lt__(self, entity) -> bool:
+        return self.id < entity.id
+
+
+class FakeQuery:
+    """
+    Model the SQLAlchemy query operations by reducing the list of known
+    committed DB values based on filter expressions.
+    """
+
+    def __init__(self, session: "FakeSession"):
+        """
+        Set up the query using a copy of the full list of known DB objects.
+
+        Args:
+            session: The associated fake session object
+        """
+        self.selected = list(session.known.values())
+        self.session = session
+
+    def all(self) -> List[ServerConfig]:
+        """
+        Return all selected records
+        """
+        return self.selected
+
+    def filter_by(self, **kwargs) -> "FakeQuery":
+        """
+        Reduce the list of matching DB objects by matching against the two
+        main columns.
+
+        Args:
+            kwargs: Standard SQLAlchemy signature
+                key: if present, select by key
+                value: if present, select by value
+
+        Returns:
+            The query so filters can be chained
+        """
+        for s in self.selected:
+            if "key" in kwargs and s.key != kwargs["key"]:
+                self.selected.remove(s)
+            if "value" in kwargs and s.key != kwargs["value"]:
+                self.selected.remove(s)
+        return self
+
+    def first(self) -> Optional[ServerConfig]:
+        """
+        Return the first match, or None if there are none left.
+        """
+        return self.selected[0] if self.selected else None
+
+
+class FakeSession:
+    """
+    Mock a SQLAlchemy Session for testing.
+    """
+
+    def __init__(self):
+        """
+        Initialize the context of the session
+        """
+        self.id = 1
+        self.added: List[ServerConfig] = []
+        self.known: Dict[int, ServerConfig] = {}
+        self.committed: Dict[int, FakeRow] = {}
+        self.rolledback = 0
+        self.queries: List[FakeQuery] = []
+        self.raise_on_commit: Optional[Exception] = None
+
+    def query(self, *entities, **kwargs) -> FakeQuery:
+        """
+        Perform a mocked query on the session, setting up the query context
+        and returning it
+
+        Args:
+            entities: The SQLAlchemy entities on which we're operating
+            kwargs: Additional SQLAlchemy parameters
+
+        Returns:
+            A mocked query object
+        """
+        q = FakeQuery(self)
+        self.queries.append(q)
+        return q
+
+    def add(self, config: ServerConfig):
+        """
+        Add a DB object to a list for testing
+
+        Args:
+            config: A server configuration setting object
+        """
+        self.added.append(config)
+
+    def commit(self):
+        """
+        Mock a commit operation on the DB session. If the 'raise_on_commit'
+        property has been set, "fail" by raising the exception. Otherwise,
+        mock a commit by updating any cached "committed" values if the "known"
+        proxy objects have changed, and record any new "added" objects.
+        """
+        if self.raise_on_commit:
+            raise self.raise_on_commit
+        for k in self.known:
+            if self.committed[k].value != self.known[k].value:
+                self.committed[k].value = self.known[k].value
+        for a in self.added:
+            a.id = self.id
+            self.id += 1
+            self.known[a.id] = a
+            self.committed[a.id] = FakeRow(id=a.id, key=a.key, value=a.value)
+        self.added = []
+        self.deleted = []
+
+    def rollback(self):
+        """
+        Just record that rollback was called, since we always raise an error
+        before changing anything during the mocked commit.
+        """
+        self.rolledback += 1
+
+
 class TestServerConfig:
-    def test_bad_key(self, db_session):
+    session = None
+
+    def check_session(self, added=[], queries=0, committed=[], rolledback=0):
+        """
+        Encapsulate the common checks we want to make after running test cases.
+
+        Args:
+            added: A list of object proxies we expect to have been added (but
+                not yet committed)
+            queries: A count of queries we expect to have been made
+            committed: A set of objects we expect to have been committed
+            rolledback: True if we expect rollback to have been called
+        """
+        session = self.session
+        assert session
+        assert len(session.queries) == queries
+        assert len(session.added) == len(added)
+        xlated = [
+            a
+            for a in session.added
+            for k in added
+            if a.key == k.key and a.value == k.value
+        ]
+        assert session.added == xlated
+        assert sorted(list(session.committed.values())) == sorted(committed)
+        assert session.rolledback == rolledback
+
+    @pytest.fixture(autouse=True, scope="function")
+    def fake_db(self, monkeypatch, server_config):
+        """
+        Fixture to mock a DB session for testing.
+
+        We patch the SQLAlchemy db_session to our fake session. We also store a
+        server configuration object on the Database.Base. (TODO: I was unable
+        to monkeypatch this due to the odd context of our base object
+        modifications during DB initialization; this is "unsatisfying" but
+        shouldn't be a problem)
+        """
+        self.session = FakeSession()
+        with monkeypatch.context() as m:
+            m.setattr(Database, "db_session", self.session)
+            Database.Base.config = server_config
+            yield
+
+    def test_bad_key(self):
         """Test server config parameter key validation"""
         with pytest.raises(ServerConfigBadKey) as exc:
             ServerConfig.create(key="not-a-key", value="no-no")
         assert str(exc.value) == "Configuration key 'not-a-key' is unknown"
 
-    def test_construct(self, db_session):
+    def test_construct(self):
         """Test server config parameter constructor"""
         config = ServerConfig(key="dataset-lifetime", value="2")
         assert config.key == "dataset-lifetime"
         assert config.value == "2"
         assert str(config) == "dataset-lifetime: '2'"
+        self.check_session()
 
-    def test_create(self, db_session):
+    def test_create(self):
         """Test server config parameter creation"""
         config = ServerConfig.create(key="dataset-lifetime", value="2")
         assert config.key == "dataset-lifetime"
         assert config.value == "2"
         assert str(config) == "dataset-lifetime: '2'"
+        self.check_session(committed=[FakeRow(id=1, key="dataset-lifetime", value="2")])
 
-    def test_construct_duplicate(self, db_session):
+    def test_construct_duplicate(self):
         """Test server config parameter constructor"""
         ServerConfig.create(key="dataset-lifetime", value=1)
+        self.session.raise_on_commit = IntegrityError(
+            statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
+        )
         with pytest.raises(ServerConfigDuplicate) as e:
             ServerConfig.create(key="dataset-lifetime", value=2)
         assert str(e).find("dataset-lifetime") != -1
+        self.check_session(
+            committed=[FakeRow(id=1, key="dataset-lifetime", value="1")],
+            added=[FakeRow(id=None, key="dataset-lifetime", value="2")],
+            rolledback=1,
+        )
 
-    def test_get(self, db_session):
+    def test_construct_null(self):
+        """Test server config parameter constructor"""
+        self.session.raise_on_commit = IntegrityError(
+            statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
+        )
+        with pytest.raises(ServerConfigNullKey):
+            ServerConfig.create(key="dataset-lifetime", value=2)
+        self.check_session(
+            added=[FakeRow(id=None, key="dataset-lifetime", value="2")],
+            rolledback=1,
+        )
+
+    def test_get(self):
         """Test that we can retrieve what we set"""
         config = ServerConfig.create(key="dataset-lifetime", value="2")
         result = ServerConfig.get(key="dataset-lifetime")
         assert config == result
+        self.check_session(
+            committed=[FakeRow(id=1, key="dataset-lifetime", value="2")], queries=1
+        )
 
-    def test_update(self, db_session):
+    def test_update(self):
+        """Test that we can update an existing configuration setting"""
         config = ServerConfig.create(key="dataset-lifetime", value="2")
         config.value = "5"
         config.update()
+        self.check_session(committed=[FakeRow(id=1, key="dataset-lifetime", value="5")])
         result = ServerConfig.get(key="dataset-lifetime")
         assert config == result
+        self.check_session(
+            committed=[FakeRow(id=1, key="dataset-lifetime", value="5")], queries=1
+        )
 
-    def test_set(self, db_session):
+    def test_set(self):
+        """
+        Test that we can use set both to create and update configuration
+        settings
+        """
         config = ServerConfig.set(key="dataset-lifetime", value="40 days")
         result = ServerConfig.get(key="dataset-lifetime")
         assert config == result
@@ -59,11 +312,18 @@ class TestServerConfig:
         result = ServerConfig.get(key="dataset-lifetime")
         assert result.value == "120"
 
-    def test_missing(self, db_session):
+        # NOTE: each `get` does a query, plus each `set` checks whether the
+        # key already exists: 2 get + 2 set == 4 queries
+        self.check_session(
+            committed=[FakeRow(id=1, key="dataset-lifetime", value="120")], queries=4
+        )
+
+    def test_missing(self):
+        """Check that 'create' complains about a missing key"""
         with pytest.raises(ServerConfigMissingKey):
             ServerConfig.create(key=None, value=None)
 
-    def test_get_all_default(self, db_session):
+    def test_get_all_default(self):
         """
         Test get_all when no values have been set. It should return all the
         defined keys, but with None values.
@@ -74,7 +334,7 @@ class TestServerConfig:
             "server-banner": None,
         }
 
-    def test_get_all(self, db_session):
+    def test_get_all(self):
         """
         Set values and make sure they're all reported correctly
         """
@@ -99,7 +359,7 @@ class TestServerConfig:
             ("1 day", "1"),
         ],
     )
-    def test_lifetimes(self, db_session, value, expected):
+    def test_lifetimes(self, value, expected):
         """
         Test some lifetimes that should be OK
         """
@@ -120,7 +380,7 @@ class TestServerConfig:
             "1 days, 10:15:20",
         ],
     )
-    def test_bad_lifetimes(self, db_session, value):
+    def test_bad_lifetimes(self, value):
         """
         Test some lifetime values that aren't legal
         """
@@ -159,7 +419,7 @@ class TestServerConfig:
             ),
         ],
     )
-    def test_create_state_and_banner(self, db_session, key, value):
+    def test_create_state_and_banner(self, key, value):
         """Test server state and banner setting"""
         config = ServerConfig.create(key=key, value=value)
         assert config.key == key
@@ -179,7 +439,7 @@ class TestServerConfig:
             {"status": "disabled", "banner": "'disabled' requires a message'"},
         ],
     )
-    def test_bad_state(self, db_session, value):
+    def test_bad_state(self, value):
         """
         A "server-state" value must include at least "status" and if the value
         isn't "enabled" must also contain "message"
@@ -189,7 +449,7 @@ class TestServerConfig:
         assert exc.value.value == value
 
     @pytest.mark.parametrize("value", [1, True, "yes", ["a", "b"], {"banner": "xyzzy"}])
-    def test_bad_banner(self, db_session, value):
+    def test_bad_banner(self, value):
         """
         A "server-banner" value must include at least "message"
         """

--- a/lib/pbench/test/unit/server/database/test_server_config_db.py
+++ b/lib/pbench/test/unit/server/database/test_server_config_db.py
@@ -1,0 +1,199 @@
+import pytest
+
+from pbench.server.database.models.server_config import (
+    ServerConfig,
+    ServerConfigBadKey,
+    ServerConfigBadValue,
+    ServerConfigDuplicate,
+    ServerConfigMissingKey,
+)
+
+
+class TestServerConfig:
+    def test_bad_key(self, db_session):
+        """Test server config parameter key validation"""
+        with pytest.raises(ServerConfigBadKey) as exc:
+            ServerConfig.create(key="not-a-key", value="no-no")
+        assert str(exc.value) == "Configuration key 'not-a-key' is unknown"
+
+    def test_construct(self, db_session):
+        """Test server config parameter constructor"""
+        config = ServerConfig(key="dataset-lifetime", value="2")
+        config.add()
+        assert config.key == "dataset-lifetime"
+        assert config.value == "2"
+        assert "dataset-lifetime: '2'" == str(config)
+
+    def test_create(self, db_session):
+        """Test server config parameter creation"""
+        config = ServerConfig.create(key="dataset-lifetime", value="2")
+        assert config.key == "dataset-lifetime"
+        assert config.value == "2"
+        assert "dataset-lifetime: '2'" == str(config)
+
+    def test_construct_duplicate(self, db_session):
+        """Test server config parameter constructor"""
+        ServerConfig.create(key="dataset-lifetime", value=1)
+        with pytest.raises(ServerConfigDuplicate) as e:
+            ServerConfig.create(key="dataset-lifetime", value=2)
+        assert str(e).find("dataset-lifetime") != -1
+
+    def test_get(self, db_session):
+        """Test that we can retrieve what we set"""
+        config = ServerConfig.create(key="dataset-lifetime", value="2")
+        result = ServerConfig.get(key="dataset-lifetime")
+        assert config == result
+
+    def test_update(self, db_session):
+        config = ServerConfig.create(key="dataset-lifetime", value="2")
+        config.value = "5"
+        config.update()
+        result = ServerConfig.get(key="dataset-lifetime")
+        assert config == result
+
+    def test_set(self, db_session):
+        config = ServerConfig.set(key="dataset-lifetime", value="40 days")
+        result = ServerConfig.get(key="dataset-lifetime")
+        assert config == result
+        assert config.value == "40"
+        ServerConfig.set(key="dataset-lifetime", value=120)
+        result = ServerConfig.get(key="dataset-lifetime")
+        assert result.value == "120"
+
+    def test_missing(self, db_session):
+        with pytest.raises(ServerConfigMissingKey):
+            ServerConfig.create(key=None, value=None)
+
+    def test_get_all_default(self, db_session):
+        """
+        Test get_all when no values have been set. It should return all the
+        defined keys, but with None values.
+        """
+        assert ServerConfig.get_all() == {
+            "dataset-lifetime": "3650",
+            "server-state": {"status": "enabled"},
+            "server-banner": None,
+        }
+
+    def test_get_all(self, db_session):
+        """
+        Set values and make sure they're all reported correctly
+        """
+        ServerConfig.create(key="dataset-lifetime", value="2")
+        ServerConfig.create(key="server-state", value={"status": "enabled"})
+        ServerConfig.create(key="server-banner", value={"message": "Mine"})
+        assert ServerConfig.get_all() == {
+            "dataset-lifetime": "2",
+            "server-state": {"status": "enabled"},
+            "server-banner": {"message": "Mine"},
+        }
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (2, "2"),
+            ("4", "4"),
+            ("999999999", "999999999"),
+            ("10 days", "10"),
+            ("1day", "1"),
+            ("1       days", "1"),
+            ("1 day", "1"),
+        ],
+    )
+    def test_lifetimes(self, db_session, value, expected):
+        """
+        Test some lifetimes that should be OK
+        """
+        config = ServerConfig.create(key="dataset-lifetime", value=value)
+        assert config.value == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "string",
+            ["list"],
+            ("tuple"),
+            {"dict": "ionary"},
+            "1d",
+            "1da",
+            "9999999999",
+            "1 daysies",
+            "1 days, 10:15:20",
+        ],
+    )
+    def test_bad_lifetimes(self, db_session, value):
+        """
+        Test some lifetime values that aren't legal
+        """
+        with pytest.raises(ServerConfigBadValue) as exc:
+            ServerConfig.create(key="dataset-lifetime", value=value)
+        assert exc.value.value == value
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("server-state", {"status": "enabled"}),
+            ("server-state", {"status": "enabled", "message": "All OK"}),
+            (
+                "server-state",
+                {
+                    "status": "disabled",
+                    "message": "Not so good",
+                    "up_again": "tomorrow",
+                },
+            ),
+            (
+                "server-state",
+                {
+                    "status": "readonly",
+                    "message": "Look but don't touch",
+                    "reason": "rebuilding",
+                },
+            ),
+            (
+                "server-banner",
+                {"message": "Perf & Scale Pbench server", "contact": "Call Pete"},
+            ),
+            (
+                "server-banner",
+                {"message": "You should see this", "url": "http://nowhere"},
+            ),
+        ],
+    )
+    def test_create_state_and_banner(self, db_session, key, value):
+        """Test server state and banner setting"""
+        config = ServerConfig.create(key=key, value=value)
+        assert config.key == key
+        assert config.value == value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            1,
+            4.000,
+            True,
+            "yes",
+            ["a", "b"],
+            {"banner": "Must have 'status' key"},
+            {"status": "nonsense", "message": "This uses a bad 'status' value"},
+            {"status": "disabled", "banner": "'disabled' requires a message'"},
+        ],
+    )
+    def test_bad_state(self, db_session, value):
+        """
+        A "server-state" value must include at least "status" and if the value
+        isn't "enabled" must also contain "message"
+        """
+        with pytest.raises(ServerConfigBadValue) as exc:
+            ServerConfig.create(key="server-state", value=value)
+        assert exc.value.value == value
+
+    @pytest.mark.parametrize("value", [1, True, "yes", ["a", "b"], {"banner": "xyzzy"}])
+    def test_bad_banner(self, db_session, value):
+        """
+        A "server-banner" value must include at least "message"
+        """
+        with pytest.raises(ServerConfigBadValue) as exc:
+            ServerConfig.create(key="server-banner", value=value)
+        assert exc.value.value == value

--- a/lib/pbench/test/unit/server/database/test_server_config_db.py
+++ b/lib/pbench/test/unit/server/database/test_server_config_db.py
@@ -19,17 +19,16 @@ class TestServerConfig:
     def test_construct(self, db_session):
         """Test server config parameter constructor"""
         config = ServerConfig(key="dataset-lifetime", value="2")
-        config.add()
         assert config.key == "dataset-lifetime"
         assert config.value == "2"
-        assert "dataset-lifetime: '2'" == str(config)
+        assert str(config) == "dataset-lifetime: '2'"
 
     def test_create(self, db_session):
         """Test server config parameter creation"""
         config = ServerConfig.create(key="dataset-lifetime", value="2")
         assert config.key == "dataset-lifetime"
         assert config.value == "2"
-        assert "dataset-lifetime: '2'" == str(config)
+        assert str(config) == "dataset-lifetime: '2'"
 
     def test_construct_duplicate(self, db_session):
         """Test server config parameter constructor"""

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -59,6 +59,7 @@ class TestEndpointConfig:
                 "login": f"{uri}/login",
                 "logout": f"{uri}/logout",
                 "register": f"{uri}/register",
+                "server_configuration": f"{uri}/server/configuration",
                 "upload": f"{uri}/upload",
                 "user": f"{uri}/user",
             },
@@ -111,6 +112,10 @@ class TestEndpointConfig:
                 "login": {"template": f"{uri}/login", "params": {}},
                 "logout": {"template": f"{uri}/logout", "params": {}},
                 "register": {"template": f"{uri}/register", "params": {}},
+                "server_configuration": {
+                    "template": f"{uri}/server/configuration/{{key}}",
+                    "params": {"key": {"type": "string"}},
+                },
                 "upload": {
                     "template": f"{uri}/upload/{{filename}}",
                     "params": {"filename": {"type": "string"}},

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -1,7 +1,13 @@
 from http import HTTPStatus
+import logging
+from nis import match
 
 import pytest
 import requests
+from pbench.server.api.resources import APIAbort, ApiParams
+from pbench.server.api.resources.server_configuration import ServerConfiguration
+
+from pbench.server.database.models.server_config import ServerConfig
 
 
 class TestServerConfiguration:
@@ -78,6 +84,16 @@ class TestServerConfiguration:
             "server-state": {"status": "enabled"},
             "server-banner": None,
         }
+
+    def test_put_bad_uri_key(self, server_config):
+        """
+        A shape of things to come: one true unit test to confirm proper
+        handling of a condition that ought to be impossible through Flask
+        routing.
+        """
+        put = ServerConfiguration(server_config, logging.getLogger("test"))
+        with pytest.raises(APIAbort, match=r"Found URI parameters \['foo', 'plugh'\]"):
+            put._put_key(ApiParams(uri={"plugh": "xyzzy", "foo": "bar"}))
 
     def test_put_missing_value(self, query_put):
         """

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -1,0 +1,220 @@
+from http import HTTPStatus
+
+import pytest
+import requests
+
+
+class TestServerConfiguration:
+    @pytest.fixture()
+    def query_get(self, client, server_config):
+        """
+        Helper fixture to perform the API query and validate an expected
+        return status.
+
+        Args:
+            client: Flask test API client fixture
+            server_config: Pbench config fixture
+        """
+
+        def query_api(
+            key: str, expected_status: HTTPStatus = HTTPStatus.OK
+        ) -> requests.Response:
+            k = f"/{key}" if key else ""
+            response = client.get(f"{server_config.rest_uri}/server/configuration{k}")
+            assert response.status_code == expected_status
+            return response
+
+        return query_api
+
+    @pytest.fixture()
+    def query_put(self, client, server_config, pbench_admin_token):
+        """
+        Helper fixture to perform the API query and validate an expected
+        return status.
+
+        Args:
+            client: Flask test API client fixture
+            server_config: Pbench config fixture
+            pbench_admin_token: Provide an admin authentication token
+        """
+
+        def query_api(
+            key: str,
+            expected_status: HTTPStatus = HTTPStatus.OK,
+            token: str = pbench_admin_token,
+            **kwargs,
+        ) -> requests.Response:
+            k = f"/{key}" if key else ""
+            response = client.put(
+                f"{server_config.rest_uri}/server/configuration{k}",
+                headers={"authorization": f"bearer {token}"},
+                **kwargs,
+            )
+            assert response.status_code == expected_status
+            return response
+
+        return query_api
+
+    def test_get_bad_keys(self, query_get):
+        response = query_get("xyzzy", HTTPStatus.BAD_REQUEST)
+        assert response.json == {
+            "message": "Unrecognized keyword ['xyzzy'] given for parameter key; allowed keywords are ['dataset-lifetime', 'server-banner', 'server-state']"
+        }
+
+    def test_get1(self, query_get):
+        response = query_get("dataset-lifetime")
+        assert response.json == {"dataset-lifetime": "3650"}
+
+    def test_get_all(self, query_get):
+        response = query_get(None, HTTPStatus.OK)
+        assert response.json == {
+            "dataset-lifetime": "3650",
+            "server-state": {"status": "enabled"},
+            "server-banner": None,
+        }
+
+    def test_put_missing_key(self, query_put):
+        """
+        Test behavior when JSON payload does not contain all required keys.
+        """
+        response = query_put(json={}, key=None, expected_status=HTTPStatus.BAD_REQUEST)
+        assert response.json.get("message") == "Missing required parameters: config"
+
+    def test_put_bad_key(self, query_put):
+        response = query_put(key="fookey", expected_status=HTTPStatus.BAD_REQUEST)
+        assert response.json == {
+            "message": "Unrecognized keyword ['fookey'] given for parameter key; allowed keywords are ['dataset-lifetime', 'server-banner', 'server-state']"
+        }
+
+    def test_put_bad_keys(self, query_put):
+        response = query_put(
+            key=None,
+            json={"config": {"fookey": "bar"}},
+            expected_status=HTTPStatus.BAD_REQUEST,
+        )
+        assert response.json == {
+            "message": "Unrecognized JSON key ['fookey'] given for parameter config; allowed keywords are ['dataset-lifetime', 'server-banner', 'server-state']"
+        }
+
+    @pytest.mark.parametrize(
+        "key,value",
+        [
+            ("dataset-lifetime", "14 years"),
+            ("server-banner", {"banner": None}),
+            ("server-state", "running"),
+            ("server-state", {"status": "disabled"}),
+        ],
+    )
+    def test_bad_value(self, query_put, key, value):
+        response = query_put(
+            key=key, expected_status=HTTPStatus.BAD_REQUEST, json={"value": value}
+        )
+        assert (
+            f"Unsupported value for configuration key '{key}'"
+            in response.json["message"]
+        )
+
+    def test_put_param(self, query_put):
+        response = query_put(key="dataset-lifetime", query_string={"value": "2"})
+        assert response.json == {"dataset-lifetime": "2"}
+
+    def test_put_value(self, query_put):
+        response = query_put(key="dataset-lifetime", json={"value": "2"})
+        assert response.json == {"dataset-lifetime": "2"}
+
+    def test_put_value_unauth(self, query_put):
+        response = query_put(
+            key="dataset-lifetime",
+            token="",
+            json={"value": "4 days"},
+            expected_status=HTTPStatus.UNAUTHORIZED,
+        )
+        assert response.json == {
+            "message": "Unauthenticated client is not authorized to UPDATE a server administrative resource"
+        }
+
+    def test_put_value_user(self, query_put, pbench_token):
+        response = query_put(
+            key="dataset-lifetime",
+            token=pbench_token,
+            json={"value": "4 days"},
+            expected_status=HTTPStatus.FORBIDDEN,
+        )
+        assert response.json == {
+            "message": "User drb is not authorized to UPDATE a server administrative resource"
+        }
+
+    def test_put_config(self, query_get, query_put):
+        response = query_put(
+            key=None,
+            expected_status=HTTPStatus.OK,
+            json={
+                "config": {
+                    "dataset-lifetime": "2",
+                    "server-state": {"status": "enabled"},
+                }
+            },
+        )
+        assert response.json == {
+            "dataset-lifetime": "2",
+            "server-state": {"status": "enabled"},
+            "server-banner": None,
+        }
+        response = query_get({}, HTTPStatus.OK)
+        assert response.json == {
+            "dataset-lifetime": "2",
+            "server-state": {"status": "enabled"},
+            "server-banner": None,
+        }
+
+    def test_disable_api(self, server_config, client, query_put, create_drb_user):
+        query_put(
+            key="server-state",
+            expected_status=HTTPStatus.OK,
+            json={
+                "value": {
+                    "status": "disabled",
+                    "message": "Disabled for testing",
+                    "contact": "test@example.com",
+                }
+            },
+        )
+        response = client.get(f"{server_config.rest_uri}/datasets/list")
+        assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+        assert response.json == {
+            "contact": "test@example.com",
+            "status": "disabled",
+            "message": "Disabled for testing",
+        }
+
+    def test_disable_api_readonly(
+        self, server_config, client, query_put, pbench_token, more_datasets
+    ):
+        query_put(
+            key="server-state",
+            expected_status=HTTPStatus.OK,
+            json={
+                "value": {
+                    "status": "readonly",
+                    "message": "Limited for testing",
+                    "contact": "test@example.com",
+                }
+            },
+        )
+        response = client.get(
+            f"{server_config.rest_uri}/datasets/list?owner=drb",
+            headers={"authorization": f"Bearer {pbench_token}"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert response.json["total"] == 2
+        response = client.put(
+            f"{server_config.rest_uri}/datasets/metadata/drb",
+            headers={"authorization": f"Bearer {pbench_token}"},
+            json={"metadata": {"dataset.name": "Test"}},
+        )
+        assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+        assert response.json == {
+            "status": "readonly",
+            "message": "Limited for testing",
+            "contact": "test@example.com",
+        }

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -68,9 +68,9 @@ class TestServerConfiguration:
     @pytest.mark.parametrize("key", (None, ""))
     def test_get_all(self, query_get, key):
         """
-        We use a triple Flask mapping so that both /server/configuration and
-        /server/configuration/ should be mapped to "get all"; test that both
-        work.
+        We use a trailing-slash-insensitive URI mapping so that both
+        /server/configuration and /server/configuration/ should be mapped to
+        "get all"; test that both paths work.
         """
         response = query_get(key)
         assert response.json == {

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -1,13 +1,10 @@
 from http import HTTPStatus
 import logging
-from nis import match
 
 import pytest
 import requests
 from pbench.server.api.resources import APIAbort, ApiParams
 from pbench.server.api.resources.server_configuration import ServerConfiguration
-
-from pbench.server.database.models.server_config import ServerConfig
 
 
 class TestServerConfiguration:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-psycopg2
+psycopg2-binary
 pyesbulk>=2.0.1
 PyJwt
 python-dateutil

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-psycopg2-binary
+psycopg2
 pyesbulk>=2.0.1
 PyJwt
 python-dateutil


### PR DESCRIPTION
PBENCH-759

Add a key/value store for server-wide configuration settings. To start, we implement three settings: the maximum dataset retention in days, the current server state, and a "banner" object that can be displayed by clients to inform users of issues, maintenance plans, etc.

The retention period default is taken from the `pbench-server.cfg` file. The default server state is "enabled". There is no default banner.

When the server is `disabled`, most API operations will fail with `SERVICE_UNAVAILABLE`/503, returning a message which can be configured along with the server state. Specific APIs can be excluded from the shutdown, specifically the `/api/v1/server/configuration` API that will allow it to be enabled again. (We also allow login and logout, since an ADMIN user needs to authenticate in order to change the settings.) When the server state is `readonly`, API operations that don't change server state are allowed as usual, but modification is disallowed.

* The `dataset-lifetime` key has a value in days. The validator will accept integer days, a string numeric value, or a string with the standard ISO delta format "<n> day[s]".
* The 'server-state' key value is a JSON object with the following keys:
  * `state` has keyword values of `enabled`, `disabled`, or `readonly`, the latter allowing APIs to read server data, but no changes
  * `message` is required if the `state` is `disabled` or `readonly`, and should provide an explanation.
  * Any additional keys are stored and returned unchanged (and uninterpreted) by a `GET`, or when the state causes an API to report failure with 503 (`SERVICE_UNAVAILABLE`)
* The `server-banner` key value is a JSON object with the following keys:
  * `message` is required
  * Any additional keys are stored and returned unchanged (and uninterpreted) by a `GET`

For example,

```
{
    "dataset-lifetime": "200",
    "server-state": {"status": "enabled"},
    "server-banner": {
        "message": "Down 2022-09-01 for maintenance",
        "contact": "labadmin@example.com"
    },
}
```