### PR TITLE
Improve handling of key validation errors

### DIFF
--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -165,7 +165,7 @@ class DatasetsMetadata(ApiBase):
         # Now update the metadata, which may occur in multiple SQL operations
         # across namespaces. Make a best attempt to update all even if we
         # encounter an unexpected error.
-        fail_count = 0
+        fail = False
         for k, v in metadata.items():
             native_key = Metadata.get_native_key(k)
             user: Optional[User] = None
@@ -175,9 +175,9 @@ class DatasetsMetadata(ApiBase):
                 Metadata.setvalue(key=k, value=v, dataset=dataset, user=user)
             except MetadataError as e:
                 self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))
-                fail_count += 1
+                fail = True
 
-        if fail_count:
+        if fail:
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
         results = self._get_dataset_metadata(dataset, list(metadata.keys()))
         return jsonify(results)

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -21,6 +21,7 @@ from pbench.server.api.resources import (
 )
 from pbench.server.database.models.datasets import (
     Metadata,
+    MetadataBadValue,
     MetadataError,
 )
 from pbench.server.database.models.users import User
@@ -149,7 +150,22 @@ class DatasetsMetadata(ApiBase):
                     role = API_OPERATION.UPDATE
         self._check_authorization(str(dataset.owner_id), dataset.access, role)
 
+        # Validate the metadata key values in a separate pass so that we can
+        # fail before committing any changes to the database.
         failures = []
+        for k, v in metadata.items():
+            try:
+                Metadata.validate(dataset=dataset, key=k, value=v)
+            except MetadataBadValue as e:
+                failures.append(str(e))
+
+        if failures:
+            raise APIAbort(HTTPStatus.BAD_REQUEST, ", ".join(failures))
+
+        # Now update the metadata, which may occur in multiple SQL operations
+        # across namespaces. Make a best attempt to update all even if we
+        # encounter an unexpected error.
+        fail_count = 0
         for k, v in metadata.items():
             native_key = Metadata.get_native_key(k)
             user: Optional[User] = None
@@ -159,8 +175,9 @@ class DatasetsMetadata(ApiBase):
                 Metadata.setvalue(key=k, value=v, dataset=dataset, user=user)
             except MetadataError as e:
                 self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))
-                failures.append(k)
-        if failures:
+                fail_count += 1
+
+        if fail_count:
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
         results = self._get_dataset_metadata(dataset, list(metadata.keys()))
         return jsonify(results)

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -1144,15 +1144,6 @@ class Metadata(Database.Base):
         "a.b.c" a value of "bar", and then query "a", you'll get back
         "a": {"b": {"c": "bar"}}}
 
-        We handle two keys specially:
-
-            dataset.name: The primary resource name of a dataset, which can be
-                modified by the dataset's owner.
-            server.deletion: The expected automatic deletion date of the
-                dataset. It can be modified by the owner so long as the new
-                value is a valid date that falls within the maximum server
-                retention period from the dataset's upload timestamp.
-
         Args:
             dataset: Associated Dataset
             key: Lookup key (including hierarchical dotted paths)
@@ -1163,11 +1154,11 @@ class Metadata(Database.Base):
         keys = key.lower().split(".")
         native_key = keys.pop(0)
         found = True
+        v = __class__.validate(dataset, key, value)
 
         # Setting the dataset name is a direct modification to the Dataset SQL
         # column, so do that first and exit without touching the Metadata
         # table.
-        v = __class__.validate(dataset, key, value)
         if key == __class__.DATASET_NAME:
             dataset.name = v
             dataset.update()


### PR DESCRIPTION
PBENCH-837

Setting the "dataset.name" and "server.deletion" keys can produce validation errors which the `PUT /datasets/metadata` API wasn't properly handling, so that the attempt fails with `INTERNAL_SERVER_ERROR` instead of `BAD_REQUEST`.

Add logic to pre-validate so that on validation failure we can fail before modifying any metadata values.

(FYI: I also experimented with the alternative of wrapping the key setting loop in a nested SQLAlchemy transaction that could be cleanly unrolled on error. I didn't manage to get that to work, but it's probably something we should consider trying again later.)