### PR TITLE
Generalize the "dashboard" namespace

### DIFF
--- a/dashboard/src/actions/overviewActions.js
+++ b/dashboard/src/actions/overviewActions.js
@@ -3,6 +3,14 @@ import * as TYPES from "./types";
 import API from "../utils/axiosInstance";
 import { constructToast } from "./toastActions";
 
+const DATASET_ACCESS = "dataset.access"
+const DATASET_CREATED = "dataset.created"
+const DATASET_OWNER = "dataset.owner"
+const DASHBOARD_SAVED = "global.dashboard.saved"
+const DASHBOARD_SEEN = "global.dashboard.seen"
+const SERVER_DELETION = "server.deletion"
+const USER_FAVORITE = "user.dashboard.favorite"
+
 export const getDatasets = () => async (dispatch, getState) => {
   try {
     dispatch({ type: TYPES.LOADING });
@@ -10,13 +18,13 @@ export const getDatasets = () => async (dispatch, getState) => {
     const username = getState().userAuth.loginDetails.username;
 
     const params = new URLSearchParams();
-    params.append("metadata", "dataset.created");
-    params.append("metadata", "dataset.owner");
-    params.append("metadata", "dataset.access");
-    params.append("metadata", "server.deletion");
-    params.append("metadata", "dashboard.saved");
-    params.append("metadata", "dashboard.seen");
-    params.append("metadata", "user.favorite");
+    params.append("metadata", DATASET_CREATED);
+    params.append("metadata", DATASET_OWNER);
+    params.append("metadata", DATASET_ACCESS);
+    params.append("metadata", SERVER_DELETION);
+    params.append("metadata", DASHBOARD_SAVED);
+    params.append("metadata", DASHBOARD_SEEN);
+    params.append("metadata", USER_FAVORITE);
 
     params.append("owner", username);
 
@@ -36,10 +44,10 @@ export const getDatasets = () => async (dispatch, getState) => {
         });
 
         const savedRuns = data.filter(
-          (item) => item.metadata["dashboard.saved"]
+          (item) => item.metadata[DASHBOARD_SAVED]
         );
         const newRuns = data.filter(
-          (item) => !item.metadata["dashboard.saved"]
+          (item) => !item.metadata[DASHBOARD_SAVED]
         );
 
         dispatch({
@@ -64,9 +72,9 @@ export const getDatasets = () => async (dispatch, getState) => {
 };
 
 const metaDataActions = {
-  save: "dashboard.saved",
-  read: "dashboard.seen",
-  favorite: "user.favorite",
+  save: DASHBOARD_SAVED,
+  read: DASHBOARD_SEEN,
+  favorite: USER_FAVORITE,
 };
 /**
  * Function which return a thunk to be passed to a Redux dispatch() call

--- a/docs/API/V1/list.md
+++ b/docs/API/V1/list.md
@@ -102,7 +102,8 @@ display purposes and must not be assumed to be unique or definitive.
 * `metadata`: If additional metadata was requested, it will appear as a nested
 JSON object in this field.
 
-For example, the query `GET http://host/api/v1/datasets/list?metadata=user.favorite`
+For example, the query
+`GET http://host/api/v1/datasets/list?metadata=user.dashboard.favorite`
 might return:
 
 ```json
@@ -110,12 +111,12 @@ might return:
     {
         "name": "pbench-fio_config_2022-06-29:00:00:00",
         "resource_id": "07f0a9cb817e258a54dbf3444abcd3aa",
-        "metadata": {"user.favorite": true}
+        "metadata": {"user.dashboard.favorite": true}
     },
     {
         "name": "the dataset I created for fun",
         "resource_id": "8322d8043755ccd33dc6d7091d1f9ff9",
-        "metadata": {"user.favorite": false}
+        "metadata": {"user.dashboard.favorite": false}
     }
 ]
 ```

--- a/docs/API/metadata.md
+++ b/docs/API/metadata.md
@@ -112,9 +112,9 @@ within this namespace to any valid JSON values (string, number, boolean, list,
 or nested objects) for retrieval later. All clients with read access to the
 dataset will see the same values.
 
-The recommended best practice is to assign a project sub-key that will be unique
-and avoid collisions between distinct clients. The Pbench Dashboard project,
-for example, will store all client metadata under the `global.dashboard`
+The recommended best practice is to select a project sub-key that will be unique
+and minimize the risk of collisions between various clients. The Pbench Dashboard
+project, for example, will store all client metadata under the `global.dashboard`
 sub-namespace, for example `global.dashboard.seen`. A hypothetical client named
 "clienta" might use `global.clienta`, for example `global.clienta.configuration`.
 
@@ -137,9 +137,9 @@ sub-resource as long as the client has READ access to the dataset. See
 [Access model](./access_model.md) for general information about the Pbench
 Server access controls.
 
-The recommended best practice is to assign a project sub-key that will be unique
-and avoid collisions between distinct clients. The Pbench Dashboard project,
-for example, will store all client metadata under the `user.dashboard`
+The recommended best practice is to select a project sub-key that will be unique
+to minimize the risk of collisions between various clients. The Pbench Dashboard
+project, for example, will store all client metadata under the `user.dashboard`
 sub-namespace, for example `user.dashboard.favorite`. A hypothetical client
 named "clienta" might use `user.clienta`, for example `user.clienta.configuration`.
 

--- a/docs/API/metadata.md
+++ b/docs/API/metadata.md
@@ -23,19 +23,24 @@ based on the owner's retention policy and the server administrator's retention
 policy along with some other internal management context. The expected deletion
 date is accessible under the `server` metadata key namespace.
 
-Clients can also set arbitrary metadata through the "dashboard" and "user"
+Clients can also set arbitrary metadata through the "global" and "user"
 metadata namespaces:
-* The "dashboard" namespace can only be modified by the owner of the dataset,
+* The "global" namespace can only be modified by the owner of the dataset,
 and is visible to anyone with read access to the dataset.
 * The "user" namespace is private to each authenticated user, and even if you
 don't own a dataset you can set your own private "user" metadata to help you
 categorize that dataset and to find it again.
 
 Metadata namespaces are hierarchical, and are exposed as nested JSON objects.
-You can address an entire namespace, e.g., `dashboard` or `dataset` and
+You can address an entire namespace, e.g., `global` or `dataset` and
 retrieve the entire JSON object, or you can address nested objects or values
-using a dotted metadata key path like `dashboard.contact.email` or
+using a dotted metadata key path like `global.contact.email` or
 `dataset.metalog.pbench.script`.
+
+By convention, a Pbench Server client should create a sub-namespace to minimize
+the risk of key collisions within the `global` and `user` namespaces. The
+Pbench Dashboard client, for example, uses `global.dashboard.seen` and
+`user.dashboard.favorite`.
 
 For example, given the following hypothetical `user` JSON value:
 
@@ -58,11 +63,11 @@ would return the entire JSON value. In addition:
 There are currently four metadata namespaces.
 
 * The `dataset` and `server` namespaces are defined and managed by Pbench.
-* The `dashboard` namespace allows an authenticated client to define an
+* The `global` namespace allows an authenticated client to define an
 arbitrary nested set of JSON objects associated with a specific dataset
 owned by the authenticated user.
-* The `user` namespace is similar to `dashboard` in structure. The difference
-is that where metadata in the `dashboard` namespace can only be modified by the
+* The `user` namespace is similar to `global` in structure. The difference
+is that where metadata in the `global` namespace can only be modified by the
 owner of the dataset and is visible to all clients with read access to the
 dataset, any authenticated user can set arbitrary values in the `user`
 namespace and those values are visible only to the user who set them. Other

--- a/docs/API/metadata.md
+++ b/docs/API/metadata.md
@@ -104,13 +104,19 @@ received based on user profile preferences and server configuration; but it can
 be modified by the owner of the dataset, as long as the new timestamp remains
 within the maximum allowed server data retention period.
 
-### Dashboard namespace
+### Global namespace
 
 The server will never modify or directly interpret values in this namespace. An
 authenticated client representing the owner of a dataset can set any keys
 within this namespace to any valid JSON values (string, number, boolean, list,
 or nested objects) for retrieval later. All clients with read access to the
 dataset will see the same values.
+
+The recommended best practice is to assign a project sub-key that will be unique
+and avoid collisions between distinct clients. The Pbench Dashboard project,
+for example, will store all client metadata under the `global.dashboard`
+sub-namespace, for example `global.dashboard.seen`. A hypothetical client named
+"clienta" might use `global.clienta`, for example `global.clienta.configuration`.
 
 __NOTE__: The server will in the future be able to use these values to filter
 the selected datasets for [datasets/list](V1/list.md).
@@ -130,6 +136,12 @@ dataset. Any authenticated client has UPDATE and DELETE access to this private
 sub-resource as long as the client has READ access to the dataset. See
 [Access model](./access_model.md) for general information about the Pbench
 Server access controls.
+
+The recommended best practice is to assign a project sub-key that will be unique
+and avoid collisions between distinct clients. The Pbench Dashboard project,
+for example, will store all client metadata under the `user.dashboard`
+sub-namespace, for example `user.dashboard.favorite`. A hypothetical client
+named "clienta" might use `user.clienta`, for example `user.clienta.configuration`.
 
 An unauthenticated client can neither set nor retrieve any `user` namespace
 values; such a client will always see the `user` namespace as empty.

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -81,7 +81,7 @@ class DatasetsMetadata(ApiBase):
             params: API parameters
             request: The original Request object containing query parameters
 
-        GET /api/v1/datasets/metadata?name=dname&metadata=dashboard.seen,server.deletion
+        GET /api/v1/datasets/metadata?name=dname&metadata=global.seen,server.deletion
         """
 
         dataset = params.uri["dataset"]
@@ -102,7 +102,7 @@ class DatasetsMetadata(ApiBase):
         {
             "name": "datasetname",
             "metadata": [
-                "dashboard.seen": True,
+                "global.seen": True,
                 "user": {"favorite": True}
             ]
         }
@@ -116,7 +116,7 @@ class DatasetsMetadata(ApiBase):
         e.g., for the above query,
 
         [
-            "dashboard.seen": True,
+            "global.seen": True,
             "user": {"favorite": False}
         ]
         """

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -792,22 +792,23 @@ class Metadata(Database.Base):
     # the "server" namespace, and are strictly controlled by keyword path:
     # e.g., "server.deleted", "server.archived";
     #
-    # The "dashboard" and "user" namespaces can be written by an authenticated
-    # client to track external metadata. The difference is that "dashboard" key
+    # The "global" and "user" namespaces can be written by an authenticated
+    # client to track external metadata. The difference is that "global" key
     # values are visible to all clients with READ access to the dataset, while
     # the "user" namespace is visible only to clients authenticated to the user
-    # that wrote the data. That is, "dashboard.seen" is a global dashboard
-    # metadata property visible to all users, while "user.favorite" is visible
-    # only to the specific user that wrote the value; each authenticated user
-    # may have its own unique "user.favorite" value.
+    # that wrote the data. Both are represented as arbitrarily nested JSON
+    # objects accessible at any level by a dotted key path. For example, for a
+    # value of "global": {"favorite": true, "mine": {"contact": "me"}}, the
+    # value of key path "global" is the entire object, "global.favorite" is
+    # true, "global.mine" is {"contact": "me"}, and "global.mind.contact" is
+    # "me".
 
-    # DASHBOARD is arbitrary data saved on behalf of the dashboard client as a
-    # JSON document. Writing these keys requires ownership of the referenced
-    # dataset, and the data is visible to all clients with READ access to the
-    # dataset.
+    # GLOBAL provides an open metadata namespace allowing a client which is
+    # authenticated as the owner of the dataset to define arbitrary metadata
+    # accessible to all users.
     #
-    # {"dashboard.seen": True}
-    DASHBOARD = "dashboard"
+    # {"global.dashboard.seen": True}
+    GLOBAL = "global"
 
     # DATASET is a "virtual" key namespace representing the columns of the
     # Dataset SQL table. Through Dataset.as_dict() we allow the columns to be
@@ -828,13 +829,15 @@ class Metadata(Database.Base):
     # {"server.deletion": "3030-03-30T03:30:30.303030+00:00"}
     SERVER = "server"
 
-    # USER is arbitrary data saved with the dataset on behalf of an
-    # authenticated user, as a JSON document. Writing these keys requires READ
-    # access to the referenced dataset, and are visible only to clients that
-    # are authenticated as the user which set them. Each user can have its own
-    # unique value for these keys, for example "user.favorite".
+    # USER provides an open metadata namespace allowing a client which is
+    # authenticated to define arbitrary metadata accessible only to that
+    # authenticated user. Writing 'user' keys requires only READ access to the
+    # referenced dataset, but the value set is visible only to clients that are
+    # authenticated as the user which set them. Each user can have its own
+    # unique value for these keys, for example "user.favorite". Unauthenticated
+    # clients can neither set nor read metadata in the USER namespace.
     #
-    # {"user.favorite": True}
+    # {"user.dashboard.favorite": True}
     USER = "user"
 
     # "Native" keys are the value of the PostgreSQL "key" column in the SQL
@@ -843,7 +846,7 @@ class Metadata(Database.Base):
     # METALOG key is special, representing the Metadata table portion of the
     # DATASET
     METALOG = "metalog"
-    NATIVE_KEYS = [DASHBOARD, METALOG, SERVER, USER]
+    NATIVE_KEYS = [GLOBAL, METALOG, SERVER, USER]
 
     # DELETION timestamp for dataset based on user settings and system
     # settings when the dataset is created.
@@ -885,12 +888,12 @@ class Metadata(Database.Base):
 
     # Metadata keys that clients can update
     #
-    # NOTE: the entire "dashboard" and "user" namespaces are writable, but only
+    # NOTE: the entire "global" and "user" namespaces are writable, but only
     # specific keys in the "dataset" and "server" namespaces can be modified.
-    USER_UPDATEABLE_METADATA = [DASHBOARD, DATASET_NAME, DELETION, USER]
+    USER_UPDATEABLE_METADATA = [DATASET_NAME, DELETION, GLOBAL, USER]
 
     # Metadata keys that clients can read
-    METADATA_KEYS = sorted([DASHBOARD, DATASET, SERVER, USER])
+    METADATA_KEYS = sorted([DATASET, GLOBAL, SERVER, USER])
 
     # NOTE: the ECMA JSON specification allows JSON "names" (keys) to be any
     # string, though most implementations and schemas enforce or recommend
@@ -939,8 +942,8 @@ class Metadata(Database.Base):
         for the referenced Dataset.
 
         NOTE: use this only for raw first-level Metadata keys, not dotted
-        paths like "dashboard.seen", which will fail key validation. Instead,
-        use the higher-level `set` helper.
+        paths like "global.seen", which will fail key validation. Instead,
+        use the higher-level `setvalue` helper.
 
         Args:
             dataset: Associated Dataset
@@ -984,7 +987,7 @@ class Metadata(Database.Base):
         specified in 'valid'. If the "native" key (first element of a dotted
         path) is in the list, then it's valid.
 
-        NOTE: we only validate the "native" key of the path. The "dashboard"
+        NOTE: we only validate the "native" key of the path. The "global"
         and "user" namespaces are completely open for any subsidiary keys the
         caller desires. The "dataset" and "server" namespaces are internally
         defined by Pbench, and can't be modified by the client, however a query
@@ -1027,21 +1030,21 @@ class Metadata(Database.Base):
 
         For example, if the metadata database has
 
-            "dashboard": {
+            "global": {
                     "contact": {
                         "name": "dave",
                         "email": "d@example.com"
                     }
                 }
 
-        then Metadata.get(dataset, "dashboard.contact.name") would return
+        then Metadata.get(dataset, "global.contact.name") would return
 
             "Dave"
 
-        whereas Metadata.get(dataset, "dashboard") would return the entire user
+        whereas Metadata.get(dataset, "global") would return the entire user
         key JSON, such as
 
-            {"dashboard" {"contact": {"name": "Dave", "email": "d@example.com}}}
+            {"global" {"contact": {"name": "Dave", "email": "d@example.com}}}
 
         Args:
             dataset: associated dataset
@@ -1079,7 +1082,9 @@ class Metadata(Database.Base):
     @staticmethod
     def validate(dataset: Dataset, key: str, value: Any) -> Any:
         """
-        Validate a key value. We have two special cases:
+        Create or modify an existing metadata value. This method supports
+        hierarchical dotted paths like "global.seen" and should be used in
+        most contexts where client-visible metadata paths are used.
 
         1) For 'dataset.name', we require a UTF-8 encoded string of 1 to 32
            characters.

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -800,7 +800,7 @@ class Metadata(Database.Base):
     # objects accessible at any level by a dotted key path. For example, for a
     # value of "global": {"favorite": true, "mine": {"contact": "me"}}, the
     # value of key path "global" is the entire object, "global.favorite" is
-    # true, "global.mine" is {"contact": "me"}, and "global.mind.contact" is
+    # true, "global.mine" is {"contact": "me"}, and "global.mine.contact" is
     # "me".
 
     # GLOBAL provides an open metadata namespace allowing a client which is

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -380,7 +380,7 @@ def provide_metadata(attach_dataset):
     confusion.)
     """
     drb = Dataset.query(name="drb")
-    Metadata.setvalue(dataset=drb, key="dashboard.contact", value="me@example.com")
+    Metadata.setvalue(dataset=drb, key="global.contact", value="me@example.com")
     Metadata.setvalue(
         dataset=drb, key=Metadata.DELETION, value="2022-12-25 00:00-04:00"
     )
@@ -408,7 +408,7 @@ def provide_metadata(attach_dataset):
     )
 
     test = Dataset.query(name="test")
-    Metadata.setvalue(dataset=test, key="dashboard.contact", value="you@example.com")
+    Metadata.setvalue(dataset=test, key="global.contact", value="you@example.com")
     Metadata.setvalue(
         dataset=test, key=Metadata.DELETION, value="1979-11-01T00:00+00:00"
     )

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -23,19 +23,19 @@ class TestGetSetMetadata:
         # See if we can create a metadata row
         ds = Dataset.query(name="drb")
         assert ds.metadatas == []
-        m = Metadata.create(key="dashboard", value=True, dataset=ds)
+        m = Metadata.create(key="global", value=True, dataset=ds)
         assert m is not None
         assert ds.metadatas == [m]
 
         # Try to get it back
-        m1 = Metadata.get(ds, "dashboard")
+        m1 = Metadata.get(ds, "global")
         assert m1.key == m.key
         assert m1.value == m.value
         assert m.id == m1.id
         assert m.dataset_ref == m1.dataset_ref
 
         # Check the str()
-        assert "drb(3)|drb>>dashboard" == str(m)
+        assert "drb(3)|drb>>global" == str(m)
 
         # Try to get a metadata key that doesn't exist
         with pytest.raises(MetadataNotFound) as exc:
@@ -54,33 +54,33 @@ class TestGetSetMetadata:
 
         # Try to create a key without a value
         with pytest.raises(MetadataMissingKeyValue):
-            Metadata(key="dashboard")
+            Metadata(key="global")
 
         # Try to add a duplicate metadata key
         with pytest.raises(MetadataDuplicateKey) as exc:
-            m1 = Metadata(key="dashboard", value="IRRELEVANT")
+            m1 = Metadata(key="global", value="IRRELEVANT")
             m1.add(ds)
-        assert exc.value.key == "dashboard"
+        assert exc.value.key == "global"
         assert exc.value.dataset == ds
         assert ds.metadatas == [m]
 
         # Try to add a Metadata key to something that's not a dataset
         with pytest.raises(DatasetBadParameterType) as exc:
-            m1 = Metadata(key="dashboard", value="DONTCARE")
+            m1 = Metadata(key="global", value="DONTCARE")
             m1.add("foobar")
         assert exc.value.bad_value == "foobar"
         assert exc.value.expected_type == Dataset.__name__
 
         # Try to create a Metadata with a bad value for the dataset
         with pytest.raises(DatasetBadParameterType) as exc:
-            m1 = Metadata.create(key="dashboard", value="TRUE", dataset=[ds])
+            m1 = Metadata.create(key="global", value="TRUE", dataset=[ds])
         assert exc.value.bad_value == [ds]
         assert exc.value.expected_type == Dataset.__name__
 
         # Try to update the metadata key
         m.value = "False"
         m.update()
-        m1 = Metadata.get(ds, "dashboard")
+        m1 = Metadata.get(ds, "global")
         assert m.id == m1.id
         assert m.dataset_ref == m1.dataset_ref
         assert m.key == m1.key
@@ -89,27 +89,27 @@ class TestGetSetMetadata:
         # Delete the key and make sure its gone
         m.delete()
         with pytest.raises(MetadataNotFound) as exc:
-            Metadata.get(ds, "dashboard")
+            Metadata.get(ds, "global")
         assert exc.value.dataset == ds
-        assert exc.value.key == "dashboard"
+        assert exc.value.key == "global"
         assert ds.metadatas == []
 
     def test_metadata_remove(self, attach_dataset):
         """Test that we can remove a Metadata key"""
         ds = Dataset.query(name="test")
         assert ds.metadatas == []
-        m = Metadata(key="dashboard", value="TRUE")
+        m = Metadata(key="global", value="TRUE")
         m.add(ds)
         assert ds.metadatas == [m]
 
-        Metadata.remove(ds, "dashboard")
+        Metadata.remove(ds, "global")
         assert ds.metadatas == []
         with pytest.raises(MetadataNotFound) as exc:
-            Metadata.get(ds, "dashboard")
+            Metadata.get(ds, "global")
         assert exc.value.dataset == ds
-        assert exc.value.key == "dashboard"
+        assert exc.value.key == "global"
 
-        Metadata.remove(ds, "dashboard")
+        Metadata.remove(ds, "global")
         assert ds.metadatas == []
 
 
@@ -179,10 +179,10 @@ class TestMetadataNamespace:
     def test_get_bad_syntax(self, attach_dataset):
         ds = Dataset.query(name="drb")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.getvalue(ds, "dashboard..foo")
+            Metadata.getvalue(ds, "global..foo")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "dashboard..foo"
-        assert str(exc.value) == "Metadata key 'dashboard..foo' is not supported"
+        assert exc.value.key == "global..foo"
+        assert str(exc.value) == "Metadata key 'global..foo' is not supported"
 
     def test_user_metadata(self, attach_dataset):
         """Various tests on user-mapped Metadata keys"""
@@ -249,55 +249,55 @@ class TestMetadataNamespace:
     def test_set_bad_syntax(self, attach_dataset):
         ds = Dataset.query(name="drb")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.setvalue(ds, "dashboard.foo.", "irrelevant")
+            Metadata.setvalue(ds, "global.foo.", "irrelevant")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "dashboard.foo."
-        assert str(exc.value) == "Metadata key 'dashboard.foo.' is not supported"
+        assert exc.value.key == "global.foo."
+        assert str(exc.value) == "Metadata key 'global.foo.' is not supported"
 
     def test_set_bad_characters(self, attach_dataset):
         ds = Dataset.query(name="drb")
         with pytest.raises(MetadataBadKey) as exc:
-            Metadata.setvalue(ds, "dashboard.*!foo", "irrelevant")
+            Metadata.setvalue(ds, "global.*!foo", "irrelevant")
         assert exc.type == MetadataBadKey
-        assert exc.value.key == "dashboard.*!foo"
-        assert str(exc.value) == "Metadata key 'dashboard.*!foo' is not supported"
+        assert exc.value.key == "global.*!foo"
+        assert str(exc.value) == "Metadata key 'global.*!foo' is not supported"
 
     def test_get_novalue(self, attach_dataset):
         ds = Dataset.query(name="drb")
-        assert Metadata.getvalue(ds, "dashboard.email") is None
-        assert Metadata.getvalue(ds, "dashboard") is None
+        assert Metadata.getvalue(ds, "global.email") is None
+        assert Metadata.getvalue(ds, "global") is None
 
     def test_get_bad_path(self, attach_dataset):
         ds = Dataset.query(name="drb")
-        Metadata.setvalue(ds, "dashboard.contact", "hello")
+        Metadata.setvalue(ds, "global.contact", "hello")
         with pytest.raises(MetadataBadStructure) as exc:
-            Metadata.getvalue(ds, "dashboard.contact.email")
+            Metadata.getvalue(ds, "global.contact.email")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "dashboard.contact.email"
+        assert exc.value.key == "global.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'dashboard.contact.email' in drb(3)|drb is not a JSON object"
+            == "Key 'contact' value for 'global.contact.email' in drb(3)|drb is not a JSON object"
         )
 
     def test_set_bad_path(self, attach_dataset):
         ds = Dataset.query(name="drb")
-        Metadata.setvalue(ds, "dashboard.contact", "hello")
+        Metadata.setvalue(ds, "global.contact", "hello")
         with pytest.raises(MetadataBadStructure) as exc:
-            Metadata.setvalue(ds, "dashboard.contact.email", "me@example.com")
+            Metadata.setvalue(ds, "global.contact.email", "me@example.com")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "dashboard.contact.email"
+        assert exc.value.key == "global.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'dashboard.contact.email' in drb(3)|drb is not a JSON object"
+            == "Key 'contact' value for 'global.contact.email' in drb(3)|drb is not a JSON object"
         )
 
     def test_get_outer_path(self, attach_dataset):
         ds = Dataset.query(name="drb")
-        Metadata.setvalue(ds, "dashboard.value.hello.english", "hello")
-        Metadata.setvalue(ds, "dashboard.value.hello.espanol", "hola")
-        assert Metadata.getvalue(ds, "dashboard.value") == {
+        Metadata.setvalue(ds, "global.value.hello.english", "hello")
+        Metadata.setvalue(ds, "global.value.hello.espanol", "hola")
+        assert Metadata.getvalue(ds, "global.value") == {
             "hello": {"english": "hello", "espanol": "hola"}
         }
 
@@ -305,12 +305,12 @@ class TestMetadataNamespace:
         ds = Dataset.query(name="drb")
         Metadata.setvalue(
             ds,
-            "dashboard.contact",
+            "global.contact",
             {"email": "me@example.com", "name": {"first": "My", "last": "Name"}},
         )
-        assert Metadata.getvalue(ds, "dashboard.contact.email") == "me@example.com"
-        assert Metadata.getvalue(ds, "dashboard.contact.name.first") == "My"
-        assert Metadata.getvalue(ds, "dashboard.contact.name") == {
+        assert Metadata.getvalue(ds, "global.contact.email") == "me@example.com"
+        assert Metadata.getvalue(ds, "global.contact.name.first") == "My"
+        assert Metadata.getvalue(ds, "global.contact.name") == {
             "first": "My",
             "last": "Name",
         }
@@ -319,12 +319,12 @@ class TestMetadataNamespace:
         ds = Dataset.query(name="drb")
         Metadata.setvalue(
             ds,
-            "dashboard.contact",
+            "global.contact",
             {"email": "me@example.com", "name": {"first": "My", "last": "Name"}},
         )
-        assert Metadata.getvalue(ds, "dashboard.contact.email") == "me@example.com"
-        assert Metadata.getvalue(ds, "dashboard.contact.name.first") == "My"
-        assert Metadata.getvalue(ds, "dashboard.contact.name") == {
+        assert Metadata.getvalue(ds, "global.contact.email") == "me@example.com"
+        assert Metadata.getvalue(ds, "global.contact.name.first") == "My"
+        assert Metadata.getvalue(ds, "global.contact.name") == {
             "first": "My",
             "last": "Name",
         }

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -201,7 +201,7 @@ class TestDatasetsDetail(Commons):
             "user": "drb",
             "start": "2020-08",
             "end": "2020-10",
-            "metadata": ["dashboard.seen", "server.deletion"],
+            "metadata": ["global.seen", "server.deletion"],
         }
 
         response_payload = {
@@ -322,7 +322,7 @@ class TestDatasetsDetail(Commons):
                 "toolsgroup": "default",
             },
             "serverMetadata": {
-                "dashboard.seen": None,
+                "global.seen": None,
                 "server.deletion": "2022-12-26",
             },
         }

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -180,7 +180,7 @@ class TestDatasetsList:
             HTTPStatus.BAD_REQUEST,
         )
         assert response.json == {
-            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard', 'dataset', 'server', 'user']"
+            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dataset', 'global', 'server', 'user']"
         }
 
     def test_get_unknown_keys(self, query_as):

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -105,7 +105,7 @@ class TestDatasetsMetadata:
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(
             "foobar",
-            {"metadata": ["dashboard.seen", "dashboard.saved"]},
+            {"metadata": ["global.seen", "global.saved"]},
             "drb",
             HTTPStatus.NOT_FOUND,
         )
@@ -119,20 +119,20 @@ class TestDatasetsMetadata:
             HTTPStatus.BAD_REQUEST,
         )
         assert response.json == {
-            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dashboard', 'dataset', 'server', 'user']"
+            "message": "Unrecognized list values ['plugh', 'xyzzy'] given for parameter metadata; expected ['dataset', 'global', 'server', 'user']"
         }
 
     def test_get1(self, query_get_as):
         response = query_get_as(
             "drb",
             {
-                "metadata": ["dashboard.seen", "server", "dataset.access"],
+                "metadata": ["global.seen", "server", "dataset.access"],
             },
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {
-            "dashboard.seen": None,
+            "global.seen": None,
             "server": {
                 "deletion": "2022-12-26",
                 "index-map": {
@@ -148,13 +148,13 @@ class TestDatasetsMetadata:
         response = query_get_as(
             "drb",
             {
-                "metadata": "dashboard.seen,server.deletion,dataset",
+                "metadata": "global.seen,server.deletion,dataset",
             },
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {
-            "dashboard.seen": None,
+            "global.seen": None,
             "server.deletion": "2022-12-26",
             "dataset": {
                 "access": "private",
@@ -181,7 +181,7 @@ class TestDatasetsMetadata:
             "drb",
             {
                 "metadata": [
-                    "dashboard.seen",
+                    "global.seen",
                     "server.deletion,dataset.access",
                     "user.favorite",
                 ],
@@ -190,7 +190,7 @@ class TestDatasetsMetadata:
             HTTPStatus.OK,
         )
         assert response.json == {
-            "dashboard.seen": None,
+            "global.seen": None,
             "server.deletion": "2022-12-26",
             "dataset.access": "private",
             "user.favorite": None,
@@ -201,7 +201,7 @@ class TestDatasetsMetadata:
             "drb",
             {
                 "metadata": [
-                    "dashboard.seen",
+                    "global.seen",
                     "server.deletion,dataset.access",
                     "user",
                 ]
@@ -219,7 +219,7 @@ class TestDatasetsMetadata:
             "drb",
             {
                 "metadata": [
-                    "dashboard.seen",
+                    "global.seen",
                     "server.deletion,dataset.access",
                     "user",
                 ],
@@ -237,7 +237,7 @@ class TestDatasetsMetadata:
             "drb",
             {
                 "controller": "foobar",
-                "metadata": "dashboard.seen,server.deletion,dataset.access",
+                "metadata": "global.seen,server.deletion,dataset.access",
             },
             "drb",
             HTTPStatus.BAD_REQUEST,
@@ -250,7 +250,7 @@ class TestDatasetsMetadata:
             {
                 "controller": "foobar",
                 "plugh": "xyzzy",
-                "metadata": ["dashboard.seen", "server.deletion", "dataset.access"],
+                "metadata": ["global.seen", "server.deletion", "dataset.access"],
             },
             "drb",
             HTTPStatus.BAD_REQUEST,
@@ -282,7 +282,7 @@ class TestDatasetsMetadata:
     def test_put_no_dataset(self, client, server_config, attach_dataset):
         response = client.put(
             f"{server_config.rest_uri}/datasets/metadata/foobar",
-            json={"metadata": {"dashboard.seen": True, "dashboard.saved": False}},
+            json={"metadata": {"global.seen": True, "global.saved": False}},
         )
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.json == {"message": "Dataset 'foobar' not found"}
@@ -291,12 +291,12 @@ class TestDatasetsMetadata:
         response = client.put(
             f"{server_config.rest_uri}/datasets/metadata/drb",
             json={
-                "metadata": {"xyzzy": "private", "what": "sup", "dashboard.saved": True}
+                "metadata": {"xyzzy": "private", "what": "sup", "global.saved": True}
             },
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed namespaces are ['dashboard', 'dataset.name', 'server.deletion', 'user']"
+            "message": "Unrecognized JSON keys ['what', 'xyzzy'] given for parameter metadata; allowed namespaces are ['dataset.name', 'global', 'server.deletion', 'user']"
         }
 
     def test_put_reserved_metadata(self, client, server_config, attach_dataset):
@@ -306,13 +306,13 @@ class TestDatasetsMetadata:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json == {
-            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed namespaces are ['dashboard', 'dataset.name', 'server.deletion', 'user']"
+            "message": "Unrecognized JSON key ['dataset.access'] given for parameter metadata; allowed namespaces are ['dataset.name', 'global', 'server.deletion', 'user']"
         }
 
     def test_put_nowrite(self, query_get_as, query_put_as):
         response = query_put_as(
             "fio_1",
-            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
+            {"metadata": {"global.seen": False, "global.saved": True}},
             "test",
             HTTPStatus.FORBIDDEN,
         )
@@ -324,7 +324,7 @@ class TestDatasetsMetadata:
     def test_put_noauth(self, query_get_as, query_put_as):
         response = query_put_as(
             "fio_1",
-            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
+            {"metadata": {"global.seen": False, "global.saved": True}},
             None,
             HTTPStatus.UNAUTHORIZED,
         )
@@ -402,29 +402,29 @@ class TestDatasetsMetadata:
     def test_put(self, query_get_as, query_put_as):
         response = query_put_as(
             "drb",
-            {"metadata": {"dashboard.seen": False, "dashboard.saved": True}},
+            {"metadata": {"global.seen": False, "global.saved": True}},
             "drb",
             HTTPStatus.OK,
         )
-        assert response.json == {"dashboard.saved": True, "dashboard.seen": False}
+        assert response.json == {"global.saved": True, "global.seen": False}
         response = query_get_as(
-            "drb", {"metadata": "dashboard,dataset.access"}, "drb", HTTPStatus.OK
+            "drb", {"metadata": "global,dataset.access"}, "drb", HTTPStatus.OK
         )
         assert response.json == {
-            "dashboard": {"contact": "me@example.com", "saved": True, "seen": False},
+            "global": {"contact": "me@example.com", "saved": True, "seen": False},
             "dataset.access": "private",
         }
 
-        # Try a second GET, returning "dashboard" fields separately:
+        # Try a second GET, returning "global" fields separately:
         response = query_get_as(
             "drb",
-            {"metadata": ["dashboard.seen", "dashboard.saved", "dataset.access"]},
+            {"metadata": ["global.seen", "global.saved", "dataset.access"]},
             "drb",
             HTTPStatus.OK,
         )
         assert response.json == {
-            "dashboard.saved": True,
-            "dashboard.seen": False,
+            "global.saved": True,
+            "global.seen": False,
             "dataset.access": "private",
         }
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -341,7 +341,13 @@ class TestDatasetsMetadata:
         """
         put = query_put_as(
             "drb",
-            {"metadata": {"global.dashboard.c": 1, "dataset.name": 1, "global.dashboard.test": "A"}},
+            {
+                "metadata": {
+                    "global.dashboard.c": 1,
+                    "dataset.name": 1,
+                    "global.dashboard.test": "A",
+                }
+            },
             "drb",
             HTTPStatus.BAD_REQUEST,
         )

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -341,7 +341,7 @@ class TestDatasetsMetadata:
         """
         put = query_put_as(
             "drb",
-            {"metadata": {"dashboard.c": 1, "dataset.name": 1, "dashboard.test": "A"}},
+            {"metadata": {"global.dashboard.c": 1, "dataset.name": 1, "global.dashboard.test": "A"}},
             "drb",
             HTTPStatus.BAD_REQUEST,
         )
@@ -353,14 +353,14 @@ class TestDatasetsMetadata:
         # verify that the values didn't change
         get = query_get_as(
             "drb",
-            {"metadata": "dashboard.c,dataset.name,dashboard.test"},
+            {"metadata": "global.dashboard.c,dataset.name,global.dashboard.test"},
             "drb",
             HTTPStatus.OK,
         )
         assert get.json == {
             "dataset.name": "drb",
-            "dashboard.test": None,
-            "dashboard.c": None,
+            "global.dashboard.test": None,
+            "global.dashboard.c": None,
         }
 
     def test_put_invalid_deletion(self, query_get_as, query_put_as):
@@ -375,7 +375,7 @@ class TestDatasetsMetadata:
                 "metadata": {
                     "user.one": 2,
                     "server.deletion": "1800-25-55",
-                    "user.test": "B",
+                    "user.dashboard.test": "B",
                 }
             },
             "drb",
@@ -389,13 +389,13 @@ class TestDatasetsMetadata:
         # verify that the values didn't change
         get = query_get_as(
             "drb",
-            {"metadata": "server.deletion,user.test,user.one"},
+            {"metadata": "server.deletion,user.dashboard.test,user.one"},
             "drb",
             HTTPStatus.OK,
         )
         assert get.json == {
             "server.deletion": "2022-12-26",
-            "user.test": None,
+            "user.dashboard.test": None,
             "user.one": None,
         }
 

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -402,7 +402,7 @@ class TestUpload:
         assert dataset.state == States.UPLOADED
         assert dataset.created.isoformat() == "2002-05-16T00:00:00+00:00"
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
-        assert Metadata.getvalue(dataset, "dashboard") is None
+        assert Metadata.getvalue(dataset, "global") is None
         assert Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-02"
         assert self.filetree_created
         assert dataset.name in self.filetree_created


### PR DESCRIPTION
PBENCH-814

Originally  we had the "dashboard" namespace for global dataset metadata controlled (albeit only by convention) by the dashboard, and the "user" namespace for general use by "other clients".  It's not entirely clear that this separation (as it was only a loose convention) made much sense, and the semantic of "user" was misleading.

After repurposing the "user" namespace for a new user-specific metadata concept, it makes sense to change "dashboard" to something more general.

The API documentation will recommend that each client assign a key under the namespace; e.g., I think the dashboard should be using something like "global.dashboard.seen" rather than just "global.seen".