### PR TITLE
Collapse overlapping Flask URI Rule patterns

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -58,104 +58,123 @@ def register_endpoints(api, app, config):
     api.add_resource(
         DatasetsContents,
         f"{base_uri}/datasets/contents/<string:dataset>",
+        endpoint="datasets_contents",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsDateRange,
         f"{base_uri}/datasets/daterange",
+        endpoint="datasets_daterange",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsDelete,
         f"{base_uri}/datasets/delete/<string:dataset>",
+        endpoint="datasets_delete",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsDetail,
         f"{base_uri}/datasets/detail/<string:dataset>",
+        endpoint="datasets_detail",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsList,
         f"{base_uri}/datasets/list",
+        endpoint="datasets_list",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsMappings,
         f"{base_uri}/datasets/mappings/<string:dataset_view>",
+        endpoint="datasets_mappings",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsMetadata,
         f"{base_uri}/datasets/metadata/<string:dataset>",
+        endpoint="datasets_metadata",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsInventory,
         f"{base_uri}/datasets/inventory/<string:dataset>/<path:path>",
+        endpoint="datasets_inventory",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         SampleNamespace,
         f"{base_uri}/datasets/namespace/<string:dataset_view>",
+        endpoint="datasets_namespace",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         SampleValues,
         f"{base_uri}/datasets/values/<string:dataset_view>",
+        endpoint="datasets_values",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsPublish,
         f"{base_uri}/datasets/publish/<string:dataset>",
+        endpoint="datasets_publish",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         DatasetsSearch,
         f"{base_uri}/datasets/search",
+        endpoint="datasets_search",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         Elasticsearch,
         f"{base_uri}/elasticsearch",
+        endpoint="elasticsearch",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         EndpointConfig,
         f"{base_uri}/endpoints",
+        endpoint="endpoints",
         resource_class_args=(config, logger),
     )
 
     api.add_resource(
         GraphQL,
         f"{base_uri}/graphql",
+        endpoint="graphql",
         resource_class_args=(config, logger),
     )
 
     api.add_resource(
         Login,
         f"{base_uri}/login",
+        endpoint="login",
         resource_class_args=(config, logger, token_auth),
     )
     api.add_resource(
         Logout,
         f"{base_uri}/logout",
+        endpoint="logout",
         resource_class_args=(config, logger, token_auth),
     )
     api.add_resource(
         RegisterUser,
         f"{base_uri}/register",
+        endpoint="register",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         UserAPI,
         f"{base_uri}/user/<string:target_username>",
+        endpoint="user",
         resource_class_args=(logger, token_auth),
     )
-
     api.add_resource(
         Upload,
         f"{base_uri}/upload/<string:filename>",
+        endpoint="upload",
         resource_class_args=(config, logger),
     )
 

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -158,10 +158,19 @@ class EndpointConfig(Resource):
                     },
                 }
                 url = self.param_template.sub("", url)
-                path = url[len(self.uri_prefix) + 1 :]
-                path = path.replace("/", "_")
-                apis[path] = urljoin(host, url)
-                templates[path] = template
+                path = rule.endpoint
+
+                # We have some URI endpoints that repeat a basic URI pattern.
+                # The "primary" may have several URI parameters; the others
+                # have fewer parameters (e.g., "/x/{p}" and "/x" or
+                # "/x/{p}/{n}" and "/x/{p}" and "/x") and won't capture all
+                # the information we want. So we only keep the variant with the
+                # highest parameter count.
+                if path not in templates or (
+                    len(template["params"]) > len(templates[path]["params"])
+                ):
+                    apis[path] = urljoin(host, url)
+                    templates[path] = template
 
         try:
             endpoints = {


### PR DESCRIPTION
PBENCH-844

The `/api/v1/endpoints` generator reads Flask `Rule` objects and uses them to create the API descriptions dynamically. This has gotten complicated as we now have several APIs with multiple rule patterns in order to support defaulting parameters: e.g., `/server/configuration/key`, `/server/configuration/` and `/server/configuration`. The `/datasets/contents` API will support two parameters and allow dropping the second.

The solution is to explicitly collapse these separate `Rule` objects, saving the one with the most parameters defined.