### PR TITLE
Initial support for building replacements for COPR chroots

### DIFF
--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -1,12 +1,76 @@
+#
 # A simple Makefile for building and pushing the various pbench-devel-*
-# container images.
+# and pbench-rpmbuild container images.
 #
-# WARNING: Do not publish images layered on top of UBI images.
+# This makefile defines the following targets:
 #
+#  all (the default):  builds the CI image and a Fedora-based development image
+#  image-ci:           builds the CI image
+#  image-fedora:       builds the Fedora-based development image
+#  image-rpmbuild-all: builds all the default containers for building RPMs
+#  image-rpmbuild-rhel-7:  builds a single RPM build container (e.g., for RHEL-7)
+#  push-ci:            pushes the CI image to the registry
+#  push-fedora:        pushes the Fedora-based development image to the registry
+#  push-rpmbuild-all:  pushes all the default RPM build containers to the registry
+#
+
+# Default list of distributions for which to build containers in which to build RPMs
+RPMBUILD_BASEIMAGE_DEFAULTS = \
+	rhel-9 rhel-8 rhel-7 \
+	fedora-36 fedora-35 fedora-34 \
+	centos-9 centos-8
+
+# Registry where the resulting RPM build container images are to be stored
+RPMBUILD_IMAGE_REPO = images.paas.redhat.com/pbench
+
+# Templates for the various distributions' base images.  For the moment, for a
+# given distribution, all of the versions can be found by tweaking the image
+# tag; so, to generate the appropriate repository for the base image, we just
+# have to pick the appropriate template and insert the requested version, which
+# is exactly what happens when RPMBUILD_BASEIMAGE_REPO is expanded.
+#
+# Note that registry.access.redhat.com is moving to registry.redhat.io where it
+# will no longer permit anonymous access, but it works for the moment.
+VER := __version__
+RPMBUILD_BASEIMAGE_rhel = registry.access.redhat.com/ubi${VER}:latest
+RPMBUILD_BASEIMAGE_fedora = quay.io/fedora/fedora:${VER}
+RPMBUILD_BASEIMAGE_centos = quay.io/centos/centos:stream${VER}
+RPMBUILD_BASEIMAGE_REPO = $(subst ${VER},${DIST_VERSION},${RPMBUILD_BASEIMAGE_${DIST_NAME}})
+
+# List of packages required to build RPMs, to be installed in the build
+# containers.  (The jinja2 CLI is not available as an RPM on RHEL, so we
+# install it via pip for all platforms, to keep things simple.)
+RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
+
+# Default package manager tool (may be overridden for some distros)
+PKGMGR = dnf
 
 BRANCH := $(shell cat ./branch.name)
 
+# Compose lists of potential distro-version strings with versions 0-99
+# (e.g., `_ALL_centos_VERSIONS` including "centos-7", "centos-8", "centos-9",
+# `_ALL_fedora_VERSIONS` including "fedora-32", "fedora-33", and "fedora-34",
+# and `_DISTROS` concatenating the contents of all the lists) which will be
+# used to drive pattern matching on distro-based target rules.
+_DIGITS := 0 1 2 3 4 5 6 7 8 9
+_NUMBERS := $(patsubst 0%,%,$(foreach tens,${_DIGITS},$(foreach ones,${_DIGITS},${tens}${ones})))
+_ALL_DISTRO_NAMES := centos fedora rhel
+_ADV_TMPL = _ALL_${d}_VERSIONS := $(foreach v,${_NUMBERS},${d}-${v}) # template for setting version lists
+$(foreach d,${_ALL_DISTRO_NAMES},$(eval $(call _ADV_TMPL, ${d})))  # set _ALL_centos_VERSIONS, etc.
+_DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
+
+# For any given target, extract the distribution name and version from the last
+# two fields, e.g., image-rpmbuild-rhel-7 would yield values "rhel" and "7" for
+# DIST_NAME and DIST_VERSION, respectively.
+%: DIST_VERSION = $(lastword $(subst -, ,$*))
+%: DIST_NAME = $(lastword $(subst ${DIST_VERSION},,$(subst -, ,$*)))
+
+
 all: image-ci image-fedora
+
+push-rpmbuild-all: $(RPMBUILD_BASEIMAGE_DEFAULTS:%=push-rpmbuild-%)
+
+image-rpmbuild-all: $(RPMBUILD_BASEIMAGE_DEFAULTS:%=image-rpmbuild-%)
 
 push-ci:
 	buildah push localhost/pbench-ci-fedora:${BRANCH} quay.io/pbench/pbench-ci-fedora:${BRANCH}
@@ -19,6 +83,17 @@ push-fedora:
 
 image-fedora: development.fedora.Dockerfile
 	buildah bud -f development.fedora.Dockerfile -t localhost/pbench-devel-fedora:${BRANCH}
+
+${_DISTROS:%=push-rpmbuild-%}: push-rpmbuild-%:
+	buildah push localhost/pbench-rpmbuild:${*} ${RPMBUILD_IMAGE_REPO}/pbench-rpmbuild:${*}
+
+image-rpmbuild-rhel-7 : PKGMGR = yum
+${_DISTROS:%=image-rpmbuild-%}: image-rpmbuild-%:
+	container=$$(buildah from ${RPMBUILD_BASEIMAGE_REPO}) && \
+		buildah run $$container ${PKGMGR} install -y ${RPMBUILD_PACKAGES} && \
+		buildah run $$container ${PKGMGR} clean all && \
+		buildah run $$container python3 -m pip install jinja2-cli && \
+		buildah commit $$container localhost/pbench-rpmbuild:${*}
 
 image-ubi: development.ubi.Dockerfile
 	buildah bud -f development.ubi.Dockerfile -t localhost/pbench-devel-ubi:${BRANCH}


### PR DESCRIPTION
This PR extends the `jenkins/Makefile` to allow it to build containers in which we can build RPMs for the Server and Agent for all platforms on which we intend to deploy them.  This will allow us to build RPMs locally as part of the CI pipeline, instead of using COPR.

This change adds the targets `image-rpmbuild-all` and `push-rpmbuild-all` which build and push, respectively, containers for each of our favorite versions of our favorite distributions (specifically, RHEL, Fedora, and CentOS) to the a repository in the `pbench` organization in the internal Quay registry.  These are implemented via pattern rules which also allow a container for any particular distribution version to be built and/or pushed individually (as long as the distribution is one of those three, and as long as the base image is available in the expected way from the expected repository).

The resulting containers can be used to build source or binary RPMs via the `jenkins/run` command by specifying a command line like `make -C server/rpm rpm`.  However, at the moment, there is no provision for extracting the RPM from the container once the build completes, and this PR does not include adding the RPM build to the CI pipeline (those are the next steps to be implemented).

A couple of notes on the approach, here.
- Apparently, the EULA for the RHEL UBI container images _does_ allow them to be freely distributed.  (I don't know when this changed, but it's handy.)
- Nevertheless, I'm sticking with storing the container images on the internal Quay, since they are intended to be used by our CI and our release process, and they don't have general uses that we want to support.
- However, I've left the CI image build untouched for the moment, so it is still stored on the external Quay, as is our Fedora development image.  We should probably consider moving these.
- The fact that the Jinja2 CLI is not available as an RPM on RHEL means that we have to use Pip to install it; to avoid conditional code, I've taken that approach on all of the platforms.
- Currently, _pulling_ all of the base images can be done anonymously; _pushing_ requires that the user has logged into the the registry via the `buildah login` command.  (It would seem that `buildah` and `podman` maintain separate credentials, so if you're using this stuff, you'll probably end up needing to log into `buildah` for building and `podman` for running.)  For my testing, I'm using the Mr. Jenkins "robot" credentials associated with the `pbench` organization.
- I opted not to use a Dockerfile for the RPM build containers.  This freed me from having to have a jinja2 template for it and having to have an extra step/target in the Makefile.  Instead, the build is done via a pipeline of five `buildah` commands directly in the Makefile "recipe" which allowed me to use Make to do the substitutions.  I think the result is much simpler (or, at least, it's nice having it all in one place!).

PBENCH-720