### PR TITLE
Fixed API to pass resource_id rather than dataset's name

### DIFF
--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -59,7 +59,7 @@ class DatasetsInventory(ApiBase):
 
         file_tree = FileTree(self.config, self.logger)
         try:
-            tarball = file_tree.find_dataset(dataset.name)
+            tarball = file_tree.find_dataset(dataset.resource_id)
         except TarballNotFound as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
         dataset_location = tarball.unpacked

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -55,7 +55,7 @@ class TestDatasetsAccess:
     def test_dataset_not_present(self, query_get_as):
         response = query_get_as("fio_2", "metadata.log", HTTPStatus.NOT_FOUND)
         assert response.json == {
-            "message": "The dataset tarball named 'fio_2' is not present in the file tree"
+            "message": "The dataset tarball named 'random_md5_string4' is not present in the file tree"
         }
 
     def test_unauthorized_access(self, query_get_as):

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -41,13 +41,11 @@ class TestDatasetsAccess:
         return query_api
 
     def mock_find_dataset(self, dataset):
-        ds = Dataset.query(resource_id=dataset)
-        if ds is None:
-            raise DatasetNotFound(resource_id=ds)
-
         class Tarball(object):
             unpacked = Path("/dataset1/")
 
+        # Validate the resource_id
+        Dataset.query(resource_id=dataset)
         return Tarball
 
     def test_get_no_dataset(self, query_get_as):
@@ -70,13 +68,11 @@ class TestDatasetsAccess:
 
     def test_dataset_is_not_unpacked(self, query_get_as, monkeypatch):
         def mock_find_not_unpacked(self, dataset):
-            ds = Dataset.query(resource_id=dataset)
-            if ds is None:
-                raise DatasetNotFound(resource_id=ds)
-
             class Tarball(object):
                 unpacked = None
 
+            # Validate the resource_id
+            Dataset.query(resource_id=dataset)
             return Tarball
 
         monkeypatch.setattr(FileTree, "find_dataset", mock_find_not_unpacked)

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -41,6 +41,10 @@ class TestDatasetsAccess:
         return query_api
 
     def mock_find_dataset(self, dataset):
+        ds = Dataset.query(resource_id=dataset)
+        if ds is None:
+            raise DatasetNotFound(resource_id=ds)
+
         class Tarball(object):
             unpacked = Path("/dataset1/")
 
@@ -66,6 +70,10 @@ class TestDatasetsAccess:
 
     def test_dataset_is_not_unpacked(self, query_get_as, monkeypatch):
         def mock_find_not_unpacked(self, dataset):
+            ds = Dataset.query(resource_id=dataset)
+            if ds is None:
+                raise DatasetNotFound(resource_id=ds)
+
             class Tarball(object):
                 unpacked = None
 


### PR DESCRIPTION
PBENCH-848

Fixed the bug in Inventory API - Passing `resource_id` instead of dataset `name` 