### PR TITLE
Refactor support for distro/version pattern rules in makefiles

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -28,6 +28,9 @@
 #     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile" files
 #
 
+# Include definition of _DISTROS
+include ../utils/utils.mk
+
 # By default we only build images for x86_64 architectures.
 _ARCH = x86_64
 
@@ -97,18 +100,6 @@ _WORKLOAD_RPMS = fio uperf
 
 # Not intended to be overridden with an environment variable.
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
-
-# Compose lists of potential distro-version strings with versions 0-99
-# (e.g., `_ALL_centos_VERSIONS` including "centos-7", "centos-8", "centos-9",
-# `_ALL_fedora_VERSIONS` including "fedora-32", "fedora-33", and "fedora-34",
-# and `_DISTROS` concatenating the contents of all the lists) which will be
-# used to drive pattern matching on distro-based target rules.
-_DIGITS := 0 1 2 3 4 5 6 7 8 9
-_NUMBERS := $(patsubst 0%,%,$(foreach tens,${_DIGITS},$(foreach ones,${_DIGITS},${tens}${ones})))
-_ALL_DISTRO_NAMES := centos fedora
-_ADV_TMPL = _ALL_${d}_VERSIONS := $(foreach v,${_NUMBERS},${d}-${v}) # template for setting version lists
-$(foreach d,${_ALL_DISTRO_NAMES},$(eval $(call _ADV_TMPL, ${d})))  # set _ALL_centos_VERSIONS, etc.
-_DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
 
 # By default we only build images for the following distributions.
 _DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -14,6 +14,9 @@
 #  push-rpmbuild-all:  pushes all the default RPM build containers to the registry
 #
 
+# Include definition of _DISTROS
+include ../utils/utils.mk
+
 # Default list of distributions for which to build containers in which to build RPMs
 RPMBUILD_BASEIMAGE_DEFAULTS = \
 	rhel-9 rhel-8 rhel-7 \
@@ -46,18 +49,6 @@ RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
 PKGMGR = dnf
 
 BRANCH := $(shell cat ./branch.name)
-
-# Compose lists of potential distro-version strings with versions 0-99
-# (e.g., `_ALL_centos_VERSIONS` including "centos-7", "centos-8", "centos-9",
-# `_ALL_fedora_VERSIONS` including "fedora-32", "fedora-33", and "fedora-34",
-# and `_DISTROS` concatenating the contents of all the lists) which will be
-# used to drive pattern matching on distro-based target rules.
-_DIGITS := 0 1 2 3 4 5 6 7 8 9
-_NUMBERS := $(patsubst 0%,%,$(foreach tens,${_DIGITS},$(foreach ones,${_DIGITS},${tens}${ones})))
-_ALL_DISTRO_NAMES := centos fedora rhel
-_ADV_TMPL = _ALL_${d}_VERSIONS := $(foreach v,${_NUMBERS},${d}-${v}) # template for setting version lists
-$(foreach d,${_ALL_DISTRO_NAMES},$(eval $(call _ADV_TMPL, ${d})))  # set _ALL_centos_VERSIONS, etc.
-_DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
 
 # For any given target, extract the distribution name and version from the last
 # two fields, e.g., image-rpmbuild-rhel-7 would yield values "rhel" and "7" for

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -1,0 +1,26 @@
+#
+# Utility widgets for makefiles
+#
+# This file is intended to be included into other makefiles.  It provides useful
+# devices of various sorts which are applicable to a variety of situations.
+#
+
+
+# Compose lists of potential distro-version strings with versions 0-99
+# (e.g., `_ALL_centos_VERSIONS` including "centos-7", "centos-8", "centos-9",
+# `_ALL_fedora_VERSIONS` including "fedora-32", "fedora-33", and "fedora-34",
+# `_ALL_rhel_VERSIONS` including "rhel-7", "rhel-8", and "rhel-9", and
+# `_DISTROS` concatenating the contents of all the lists) which can be used to
+# drive pattern matching on distro-based target rules.
+_DIGITS := 0 1 2 3 4 5 6 7 8 9
+_NUMBERS := $(patsubst 0%,%,$(foreach tens,${_DIGITS},$(foreach ones,${_DIGITS},${tens}${ones})))
+_ALL_DISTRO_NAMES := centos fedora rhel
+_ADV_TMPL = _ALL_${d}_VERSIONS := $(foreach v,${_NUMBERS},${d}-${v}) # template for setting version lists
+$(foreach d,${_ALL_DISTRO_NAMES},$(eval $(call _ADV_TMPL, ${d})))  # set _ALL_centos_VERSIONS, etc.
+_DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
+
+# In Make, it is hard to refer to a single blank or space character.  This pair
+# of definitions does that:  create a definition which is literally empty, and
+# then use that as a delimiter around a space character, and viola.
+_empty:=
+_space:= ${_empty} ${_empty}


### PR DESCRIPTION
As I implement support for building things on/for multiple distribution/version combinations, I find myself reusing the same (or similar) code idioms which drive Make pattern rules where the pattern consists of a tag with the distro name and the major version (like `rhel-9`, `centos-8`, or `fedora-35`).  There's a modest set of boilerplate definitions which support this usage, and, rather than continue to replicate it where it's needed, this PR moves it to a common, utility makefile which can be included by the makefiles which need the definition.

Also, in an upcoming PR, I will need some other standard Make magic, so I've added the definitions which support that (`_empty` and `_space`) to this file, as well.

PBENCH-720