### PR TITLE
Framework for building RPMs in the CI

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -254,10 +254,17 @@ install-lib:
 # NOTE: we deliberately use `/usr/bin/python3` to make sure that when this is
 # invoked inside a python virtualenv the pip installation won't uninstall the
 # existing pbench module, breaking the environment.
+#
+# During the Python installation, it's going to test to see if the installation
+# directory is on the PYTHONPATH (which it is not...), so put it on the path,
+# just for the installation, based on our prefix and the version of Python.
+# For some reason, this only seems to be a problem on RHEL platforms prior to 9.
+pver = $(shell /usr/bin/python3 --version | sed -En -e 's/^Python (3\.[^.]+).*$$/python\1/p')
 install-python3-setup: install-util-scripts install-lib
 	${COPY} requirements.txt ${DESTDIR}
 	mkdir -p ${DESTDIR}/python3
-	(cd ..; /usr/bin/python3 -m pip install --prefix=${DESTDIR}/python3 -e .)
+	cd .. && PYTHONPATH=${DESTDIR}/python3/lib/${pver}/site-packages \
+	  /usr/bin/python3 -m pip install --prefix=${DESTDIR}/python3 -e .
 	${COPY} $(addprefix ${DESTDIR}/python3/bin/, ${click-scripts}) ${UTILDIR}/
 	rm -rf ${DESTDIR}/python3
 	${COPY} ../lib/pbench ${LIBDIR}/

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -259,7 +259,7 @@ install-lib:
 # directory is on the PYTHONPATH (which it is not...), so put it on the path,
 # just for the installation, based on our prefix and the version of Python.
 # For some reason, this only seems to be a problem on RHEL platforms prior to 9.
-pver = $(shell /usr/bin/python3 --version | sed -En -e 's/^Python (3\.[^.]+).*$$/python\1/p')
+pver = $(shell /usr/bin/python3 -c 'import sys; print(f"python{sys.version_info.major}.{sys.version_info.minor}")')
 install-python3-setup: install-util-scripts install-lib
 	${COPY} requirements.txt ${DESTDIR}
 	mkdir -p ${DESTDIR}/python3

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -1,26 +1,54 @@
-# Makefile for generating a source RPM and optional local RPM
+# Makefile for generating a source RPM and, optionally, binary RPMs
 # for the Pbench agent.
 
-# To limit the builds to certain chroots or exclude certain chroots
-# from building, add entries of the form
+# When building a binary RPM on COPR, to limit the builds to certain chroots
+# or to exclude certain chroots from building, add entries of the form
 #    "--chroot centos-stream-9-x86_64"
 # or
 #    "--exclude-chroot centos-stream-9-x86_64"
-# to the CHROOTS variable below.
+# to the definition of the CHROOTS variable.
+#
 # Multiple such entries can be added to be passed as options to
-# `copr-cli build'.  By default, we build every chroot configured for
-# the repo.
-# N.B. `copr-cli' flags an error if the value of a `--chroot' or
-# `--exclude-chroot' option is not configured in the repo.
+# `copr-cli build'.  N.B. `copr-cli' flags an error if the value of a
+# `--chroot' or `--exclude-chroot' option is not configured in the repo.
 # E.g. to build the RHEL9 chroots only:
 # CHROOTS = --chroot centos-stream-9-x86_64 \
 #           --chroot centos-stream-9-aarch64 \
 #           --chroot epel-9-x86_64 \
 #           --chroot epel-9-aarch64
-# By default, we build every chroot enabled in the repo.
+#
+# Unless overridden on the command line, build every chroot enabled in the repo.
 CHROOTS =
+
+# These targets build the binary RPM for the specified distro version; the "ci"
+# target builds them all.
+RHEL_RPMS = rhel-9-rpm rhel-8-rpm rhel-7-rpm
+CENTOS_RPMS = centos-9-rpm centos-8-rpm
+FEDORA_RPMS = fedora-34-rpm fedora-35-rpm fedora-36-rpm
+ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 
 component = agent
 subcomps = agent
 
-include ../../utils/rpm.mk
+export  # Export the definitions above in the invocation of the sub-make.
+
+# For historical compatibility, this is the default target.
+all: srpm
+
+# For the CI, we build all of our favorite RPMs, but we do that via the
+# dependency list rather than by any immediate action.  There are two things
+# happening here:  first, the dependencies can be built in parallel if the
+# invocation permits it, e.g., 'make -j 4 -O ci'; second, rpm.mk, when it is
+# invoked, determines which distro to build for based on the pattern of the
+# specified target, so having multiple targets in the same invocation for
+# different distributions won't work, so we need to invoke it separately for
+# each one, which this does.
+ci: ${ALL_RPMS} ;
+
+# This is a catch-all rule which forwards any target that we don't handle in
+# this makefile on to the common makefile.
+%: FORCE
+	@$(MAKE) --makefile ../../utils/rpm.mk $@
+
+# This recipe does nothing, other than to force the previous one to run.
+FORCE: ;

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -40,9 +40,9 @@ all: srpm
 # happening here:  first, the dependencies can be built in parallel if the
 # invocation permits it, e.g., 'make -j 4 -O ci'; second, rpm.mk, when it is
 # invoked, determines which distro to build for based on the pattern of the
-# specified target, so having multiple targets in the same invocation for
-# different distributions won't work, so we need to invoke it separately for
-# each one, which this does.
+# specified target, so we need to invoke it separately for each one, because
+# having multiple targets in the same invocation for different distributions
+# won't work.
 ci: ${ALL_RPMS} ;
 
 # This is a catch-all rule which forwards any target that we don't handle in

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -52,6 +52,8 @@ Requires: %{__python_name}-psutil
 
 %endif
 
+%define __python /usr/bin/python3
+
 # docutils is not available for RHEL7 - it is also *only* available as
 # `python3-docutil's on everything else, which is not good for
 # RHEL8/CentOS Stream 8 where we would want `python39-docutils', but

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -1,7 +1,9 @@
-# Makefile for generating a source RPM and optional local RPM
+# Makefile for generating a source RPM and, optionally, binary RPMs
 # for the Pbench server.
 
 component = server
 subcomps = server web-server
 
 include ../../utils/rpm.mk
+
+ci: rhel-9-rpm

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -121,7 +121,7 @@ ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
 # Determine the present working directory relative to ${PBENCHTOP} so that we
 # can find it inside the container, where the source tree might be in a
 # different location.
-pwdr = $(subst ${PBENCHTOP},,$(PWD))
+pwdr = $(subst ${PBENCHTOP},,${CURDIR})
 
 # NOTE:  we mount ${BLD_DIR}, which ends with 'rpmbuild<distro>-<version>',
 # inside the container as ${HOME}/rpmbuild (with no suffix), which is where

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -1,3 +1,4 @@
+#
 # Common definitions for making an RPM, used by both the Agent and the Server.
 #
 # Making a pbench component RPM requires a few steps:
@@ -6,22 +7,58 @@
 # 3. Update any GIT submodules.
 # 4. Do a "make install" to a temp directory.
 # 5. Generate a tar ball from the directory.
-# 6. Generate a local SRPM that will be uploaded to COPR for building.
+# 6. Generate a local SRPM that can be uploaded to COPR for building.
 # 7. Optionally generate a local RPM.
 # 8. Clean up the temp directory
+#
+# In addition, specifying a distro-specific target, like "rhel-9-rpm", will
+# cause Step 7 to be executed locally in a suitable container, to produce a
+# binary RPM for the indicated distribution.  In this case, the RPM will be
+# placed in ${HOME}/rpmbuild-<distro>-<version>/RPMS.
+#
+
+RPMBUILD_IMAGE_REPO = images.paas.redhat.com/pbench
+BUILD_CONTAINER = ${RPMBUILD_IMAGE_REPO}/pbench-rpmbuild:${*}
 
 PBENCHTOP := $(shell git rev-parse --show-toplevel)
-TMPDIR = /tmp/opt
+
+# Include definition of _DISTROS, _space, etc.
+include ${PBENCHTOP}/utils/utils.mk
 
 prog = pbench-${component}
-VERSION := $(file < ${PBENCHTOP}/${component}/VERSION)
+VERSION := $(shell cat ${PBENCHTOP}/${component}/VERSION)
 TBDIR = ${TMPDIR}/${prog}-${VERSION}
+
+# If we are building for a distro, use a distro-specific suffix on the build and
+# temporary directories, so that builds can be done in parallel and so that the
+# build products don't overwrite each other.
+ifneq ($(findstring $(word 1,$(subst -,${_space},${MAKECMDGOALS})),${_ALL_DISTRO_NAMES}),)
+  # Extract the distribution name and version from the first two fields, e.g.,
+  # fedora-35-rpm would yield values "fedora" and "35" for DIST_NAME and
+  # DIST_VERSION, respectively.
+  DIST_NAME := $(word 1,$(subst -,${_space},${MAKECMDGOALS}))
+  DIST_VERSION := $(word 2,$(subst -,${_space},${MAKECMDGOALS}))
+  BLD_SUFFIX := -${DIST_NAME}-${DIST_VERSION}
+else
+  BLD_SUFFIX :=
+endif
+
+# Set BLD_DIR to "${HOME}/rpmbuild" when the target has no specific distro and
+# to "${HOME}/rpmbuild-<DISTRO>-<VERSION>" when there is a specific distro.
+# (Keep BLD_SUBDIR separate from BLD_DIR for mapping the location into the
+# container.)  Set TMPDIR, analogously.  This prevents builds for one distro
+# from interfering with builds for another.
+BLD_SUBDIR := rpmbuild${BLD_SUFFIX}
+BLD_DIR := ${HOME}/${BLD_SUBDIR}
+TMPDIR := /tmp/rpmbuild${BLD_SUFFIX}/opt
+
+$(info Building ${MAKECMDGOALS} for ${prog}-${VERSION} from ${TBDIR} to ${BLD_DIR})
 
 RPMDIRS = BUILD BUILDROOT SPECS SOURCES SRPMS RPMS
 
-RPMSRC = ${HOME}/rpmbuild/SOURCES
-RPMSRPM = ${HOME}/rpmbuild/SRPMS
-RPMSPEC = ${HOME}/rpmbuild/SPECS
+RPMSRC = ${BLD_DIR}/SOURCES
+RPMSRPM = ${BLD_DIR}/SRPMS
+RPMSPEC = ${BLD_DIR}/SPECS
 
 sha1 := $(shell git rev-parse --short HEAD)
 seqno := $(shell if [ -e ./seqno ] ;then cat ./seqno ;else echo "1" ;fi)
@@ -31,12 +68,12 @@ all: srpm
 
 .PHONY: rpm
 rpm: spec srpm
-	rpmbuild -bb ${RPMSPEC}/${prog}.spec
+	rpmbuild --define "_topdir ${BLD_DIR}" -bb ${RPMSPEC}/${prog}.spec
 
 .PHONY: srpm
 srpm: spec patches tarball
 	rm -f ${RPMSRPM}/$(prog)-*.src.rpm
-	rpmbuild -bs ${RPMSPEC}/${prog}.spec
+	rpmbuild --define "_topdir ${BLD_DIR}" -bs ${RPMSPEC}/${prog}.spec
 
 .PHONY: spec
 spec: rpm-dirs ${prog}.spec.j2
@@ -58,11 +95,11 @@ tarball: rpm-dirs submodules ${subcomps}
 
 .PHONY: rpm-dirs
 rpm-dirs:
-	mkdir -p $(addprefix ${HOME}/rpmbuild/,${RPMDIRS})
+	mkdir -p $(addprefix ${BLD_DIR}/,${RPMDIRS})
 
 .PHONY: submodules
 submodules:
-	git submodule update --init --recursive
+	cd ${PBENCHTOP} && git submodule update --init --recursive
 
 .PHONY: ${subcomps}
 ${subcomps}:
@@ -81,13 +118,28 @@ COPR_TARGETS = copr copr-test
 ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(version)-$(seqno)$(sha1).src.rpm
 	copr-cli build ${CHROOTS} $(_copr_user)/$(subst copr,pbench,$@) $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 
+# Determine the present working directory relative to ${PBENCHTOP} so that we
+# can find it inside the container, where the source tree might be in a
+# different location.
+pwdr = $(subst ${PBENCHTOP},,$(PWD))
+
+# NOTE:  we mount ${BLD_DIR}, which ends with 'rpmbuild<distro>-<version>',
+# inside the container as ${HOME}/rpmbuild (with no suffix), which is where
+# the build will put the RPM when invoked without a distro target.
+.PHONY: %-rpm
+%-rpm: spec srpm
+	cd ${PBENCHTOP} && \
+	  IMAGE=${BUILD_CONTAINER} \
+	    EXTRA_PODMAN_SWITCHES="-v ${BLD_DIR}:$${HOME}/rpmbuild:z" \
+	    jenkins/run make -C $${HOME}/pbench/${pwdr} rpm
+
 .PHONY: distclean
 distclean:
-	rm -rf $(addprefix ${HOME}/rpmbuild/,${RPMDIRS})
+	rm -rf $(addprefix ${HOME}/rpmbuild*/,${RPMDIRS}) /tmp/rpmbuild*/opt
 
 .PHONY: clean
 clean:: rpm-clean
 
 .PHONY: rpm-clean
 rpm-clean:
-	rm -rf $(foreach dir,${RPMDIRS},${HOME}/rpmbuild/${dir}/*)
+	rm -rf $(foreach dir,${RPMDIRS},${HOME}/rpmbuild*/${dir}/*)


### PR DESCRIPTION
This PR contains the various bits of mechanism and tweaks required to build RPMs in containers.  (The _next_ step will be to enhance the CI to use the facilities added here -- this doesn't actually hook them up.)

There are several pieces to these changes, but most are small enough and localized enough that it wasn't worth splitting them into separate commits or PRs.

Here are the highlights of the changes:
- `agent/Makefile`:  For no reason which is obvious to me, while the RHEL-9 builds worked fine, the RHEL-8 and RHEL-7 Agent builds failed with a complaint during the SRPM build where we "install" the Python components, because the target location was not a site path nor was it in `PYTHONPATH`.  (Apparently, this doesn't happen when building on or for COPR, but perhaps that's because no one is doing that on RHEL-7/8?)  Given that in this context we don't intend to execute the stuff we're installing, this wouldn't be a problem, but the tools object nonetheless.  I tried several things to address the problem and ended up simply adding the installation target to the `PYTHONPATH` (which is empty, otherwise) for the duration of the installation, and that seemed to mollify the tools.  Unfortunately, I kind of had to guess where the installation would land, but it's an educated guess, and it seems to work.  (Also, I removed the unneeded parentheses --  Make executes each line of a recipe in its own subshell anyway -- and I replaced the `;` there with a `&&` which I think better represents our requirements.)
- `agent/rpm/pbench-agent.spec.j2`:  Again, for no reason which is obvious to me, while the RHEL-9 builds worked fine, the RHEL-8 and RHEL-7 Agent builds failed during the RPM build where it byte-compiles all the Python code, because it decided to run Python 2.6 instead of the Python3, because it had to guess.  (Again, apparently, this doesn't happen when building on COPR; I don't know why.)  The fix is to add a definition to the spec file for `__python` (we already have one for `__python3`...) to specify that, when we use Python, we want Python **_3_**.
- `server/rpm/Makefile` and `agent/rpm/Makefile`:
  - Add a `ci` target, for building binary RPM(s) for our favorite distro versions.
    - For the Server, this is just RHEL-9.
    - For the Agent, the list is:
      - RHEL: 7, 8, 9
      - CentOS: 8, 9
      - Fedora: 34, 35, 36
  - Some minor comment copyediting
  - For the Agent, I added some Make magic.  Instead of including the common makefile and using the targets directly, it now uses a recursive `make` invocation.  If you're building a single target, there is virtually no difference (I hope!) from the old behavior.  However, because the CI wants to build eight logically-independent targets, with this approach it can specify the `--jobs` flag on the outer `make` command and all of the RPMs will be built in parallel automagically.
- `utils/rpm.mk`:  This is the real meat of this PR.
  - The principal change is the addition of the `%-rpm` target, which invokes the `make` command recursively inside the appropriate specific container to build the generic `rpm` target.  This means that any distribution/version whose tag matches an image label in the container repository can be built, and adding new distro/version can be done without having to modify the makefile simply by pushing new container images.
  - There are a few "details" to note, however.  `rpmbuild` is fairly opinionated about where it gets build inputs from and where it sends its outputs to.  This can be controlled by setting the `_topdir` macro, but it turned out to be awkward to get too fancy with that.  So, instead, I set up the container invocation to mount the output directory where `rpmbuild` expects it.  Nevertheless, because I wanted to be able to run multiple RPM builds (sequentially at least, and concurrently at best) without them interfering with each other or overwriting each other, it was necessary to make the input/output directory tree distro/version-specific, so I ended up explicitly specifying `_topdir` anyway.  The net result is that `rpmbuild` uses `${HOME}/rpmbuild${DIST_SUFFIX}`, where the suffix is empty for normal builds and it's set to something like `-rhel-9` for distro/version builds; thus, the makefile still behaves as it used to if you're doing a "local" build, and otherwise all of the products are maintained separately for each distro/version.
  - Accordingly, I tweaked the references (and definitions) of the temporary directory and the build directories.  For the most part, they are referenced symbolically, and they refer to a distro/version-specific directory as appropriate.  I say "for the most part", because the "clean-up" make targets are a little bit "raw-er" in order to be thorough and to make the wildcarding work.
  - Unfortunately, because everything is built separately from the same source, we end up with sequential version numbers on the RPMs, e.g. here are a set of RPMs all built from the same Git checkout (so they all have the same hash), but they have different numbers preceding the `g` (if we think this is a problem, and I craft a fix for it in another PR):
    - `~/rpmbuild/RPMS/noarch/pbench-agent-0.72.0-77ge34d2b480.noarch.rpm`
    - `~/rpmbuild-centos-8/RPMS/noarch/pbench-agent-0.72.0-70ge34d2b480.noarch.rpm`
    - `~/rpmbuild-centos-9/RPMS/noarch/pbench-agent-0.72.0-69ge34d2b480.noarch.rpm`
    - `~/rpmbuild-fedora-34/RPMS/noarch/pbench-agent-0.72.0-74ge34d2b480.noarch.rpm`
    - `~/rpmbuild-fedora-35/RPMS/noarch/pbench-agent-0.72.0-69ge34d2b480.noarch.rpm`
    - `~/rpmbuild-fedora-36/RPMS/noarch/pbench-agent-0.72.0-75ge34d2b480.noarch.rpm`
    - `~/rpmbuild-rhel-7/RPMS/noarch/pbench-agent-0.72.0-72ge34d2b4.noarch.rpm`
    - `~/rpmbuild-rhel-8/RPMS/noarch/pbench-agent-0.72.0-71ge34d2b480.noarch.rpm`
    - `~/rpmbuild-rhel-9/RPMS/noarch/pbench-agent-0.72.0-73ge34d2b480.noarch.rpm`
  - I had to "dumb down" the definition of `VERSION` because it unaccountably (and silently) failed on the older versions of RHEL (perhaps because they have an older version of Git?).  Likewise, the `git submodule` command got pissy on the older versions, but that was straightforward to work around, as well.

PBENCH-720