### PR TITLE
Remove the UNPACKING/UNPACKED states

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -13,7 +13,7 @@ from pbench.server.api.resources import (
     ParamType,
 )
 from pbench.server.api.resources.query_apis import ElasticBulkBase
-from pbench.server.database.models.datasets import Dataset, Metadata
+from pbench.server.database.models.datasets import Dataset, Metadata, States
 from pbench.server.filetree import FileTree
 
 
@@ -56,6 +56,7 @@ class DatasetsDelete(ElasticBulkBase):
         Returns:
             A generator for Elasticsearch bulk delete actions
         """
+        dataset.advance(States.DELETING)
         map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
 
         self.logger.info("Starting delete operation for dataset {}", dataset)

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -314,12 +314,10 @@ class States(enum.Enum):
 
     UPLOADING = ("Uploading", True)
     UPLOADED = ("Uploaded", False)
-    UNPACKING = ("Unpacking", True)
-    UNPACKED = ("Unpacked", False)
     INDEXING = ("Indexing", True)
     INDEXED = ("Indexed", False)
-    EXPIRING = ("Expiring", True)
-    EXPIRED = ("Expired", False)
+    DELETING = ("Deleting", True)
+    DELETED = ("Deleted", False)
     QUARANTINED = ("Quarantined", False)
 
     def __init__(self, friendly: str, mutating: bool):
@@ -411,13 +409,11 @@ class Dataset(Database.Base):
 
     transitions = {
         States.UPLOADING: [States.UPLOADED, States.QUARANTINED],
-        States.UPLOADED: [States.UNPACKING, States.QUARANTINED],
-        States.UNPACKING: [States.UNPACKED, States.QUARANTINED],
-        States.UNPACKED: [States.INDEXING, States.QUARANTINED],
+        States.UPLOADED: [States.INDEXING, States.QUARANTINED],
         States.INDEXING: [States.INDEXED, States.QUARANTINED],
-        States.INDEXED: [States.INDEXING, States.EXPIRING, States.QUARANTINED],
-        States.EXPIRING: [States.EXPIRED, States.INDEXED, States.QUARANTINED],
-        # NOTE: EXPIRED and QUARANTINED do not appear as keys in the table
+        States.INDEXED: [States.INDEXING, States.DELETING, States.QUARANTINED],
+        States.DELETING: [States.DELETED, States.INDEXED, States.QUARANTINED],
+        # NOTE: DELETED and QUARANTINED do not appear as keys in the table
         # because they're terminal states that cannot be exited.
     }
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -19,7 +19,7 @@ from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
 from pbench.server.api.auth import Auth
 from pbench.server.database.database import Database
-from pbench.server.database.models.datasets import Dataset, Metadata
+from pbench.server.database.models.datasets import Dataset, Metadata, States
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
 from pbench.test import on_disk_config
@@ -314,6 +314,7 @@ def attach_dataset(create_drb_user, create_user):
             owner="drb",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
+            state=States.INDEXED,
             name="drb",
             access="private",
             resource_id="random_md5_string1",
@@ -321,6 +322,7 @@ def attach_dataset(create_drb_user, create_user):
         Dataset(
             owner="test",
             created=datetime.datetime(2002, 5, 16),
+            state=States.INDEXED,
             name="test",
             access="private",
             resource_id="random_md5_string2",
@@ -355,6 +357,7 @@ def more_datasets(
             owner="drb",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
+            state=States.INDEXED,
             name="fio_1",
             access="public",
             resource_id="random_md5_string3",
@@ -362,6 +365,7 @@ def more_datasets(
         Dataset(
             owner="test",
             created=datetime.datetime(2002, 5, 16),
+            state=States.INDEXED,
             name="fio_2",
             access="public",
             resource_id="random_md5_string4",

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -16,7 +16,7 @@ from pbench.server.database.models.users import User
 class TestDatasets:
     def test_state_enum(self):
         """Test the States ENUM properties"""
-        assert len(States.__members__) == 9
+        assert len(States.__members__) == 7
         for n, s in States.__members__.items():
             assert str(s) == s.friendly
             assert s.mutating == (
@@ -76,7 +76,7 @@ class TestDatasets:
             "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
             "owner": "drb",
-            "state": "Uploading",
+            "state": "Indexed",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
             "metalog": {
@@ -182,7 +182,7 @@ class TestDatasets:
         ds = Dataset(owner=create_user.username, name="fio", resource_id="debead")
         ds.add()
         with pytest.raises(DatasetBadStateTransition):
-            ds.advance(States.EXPIRED)
+            ds.advance(States.DELETED)
 
     def test_advanced_terminal(self, db_session, create_user):
         """Test that we can't advance from a terminal state"""
@@ -190,7 +190,7 @@ class TestDatasets:
             owner=create_user.username,
             name="fio",
             resource_id="beadde",
-            state=States.EXPIRED,
+            state=States.DELETED,
         )
         ds.add()
         with pytest.raises(DatasetTerminalStateViolation):
@@ -216,10 +216,7 @@ class TestDatasets:
             ds.advance(next)
             assert ds.state == next
         lifecycle = ",".join([s.name for s in beenthere])
-        assert (
-            lifecycle
-            == "UPLOADING,UPLOADED,UNPACKING,UNPACKED,INDEXING,INDEXED,EXPIRING,EXPIRED"
-        )
+        assert lifecycle == "UPLOADING,UPLOADED,INDEXING,INDEXED,DELETING,DELETED"
 
     def test_delete(self, db_session, create_user):
         """Test that we can delete a dataset"""

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -122,7 +122,7 @@ class TestInternalMetadata:
             "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
             "owner": "drb",
-            "state": "Uploading",
+            "state": "Indexed",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
             "metalog": {
@@ -139,7 +139,7 @@ class TestInternalMetadata:
     def test_dataset_keys(self, provide_metadata):
         ds = Dataset.query(name="drb")
         metadata = Metadata.getvalue(ds, "dataset.state")
-        assert metadata == "Uploading"
+        assert metadata == "Indexed"
         metadata = Metadata.getvalue(ds, "dataset.transition")
         assert metadata == "1970-01-01T00:42:00+00:00"
         metadata = Metadata.getvalue(ds, "dataset.metalog.run")

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -161,7 +161,7 @@ class TestDatasetsMetadata:
                 "created": "2020-02-15T00:00:00+00:00",
                 "name": "drb",
                 "owner": "drb",
-                "state": "Uploading",
+                "state": "Indexed",
                 "transition": "1970-01-01T00:42:00+00:00",
                 "uploaded": "2022-01-01T00:00:00+00:00",
                 "metalog": {

--- a/server/bin/gold/test-16.txt
+++ b/server/bin/gold/test-16.txt
@@ -290,7 +290,7 @@ run-1970-01-01T00:00:42-UTC: Processed 3 tarballs
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-fake|benchmark-result-medium_1970-01-01T00:00:00|UNPACKED|
-test|benchmark-result-large_1970-01-01T00:00:00|UNPACKED|
-test|benchmark-result-small_1970-01-01T00:00:00|UNPACKED|
+fake|benchmark-result-medium_1970-01-01T00:00:00|UPLOADED|
+test|benchmark-result-large_1970-01-01T00:00:00|UPLOADED|
+test|benchmark-result-small_1970-01-01T00:00:00|UPLOADED|
 --- SqliteDB Datasets

--- a/server/bin/gold/test-17.txt
+++ b/server/bin/gold/test-17.txt
@@ -290,7 +290,7 @@ run-1970-01-01T00:00:42-UTC: Processed 3 tarballs
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-fake|benchmark-result-medium_1970-01-01T00:00:00|UNPACKED|
-test|benchmark-result-large_1970-01-01T00:00:00|UNPACKED|
-test|benchmark-result-small_1970-01-01T00:00:00|UNPACKED|
+fake|benchmark-result-medium_1970-01-01T00:00:00|UPLOADED|
+test|benchmark-result-large_1970-01-01T00:00:00|UPLOADED|
+test|benchmark-result-small_1970-01-01T00:00:00|UPLOADED|
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.13.txt
+++ b/server/bin/gold/test-6.13.txt
@@ -195,6 +195,6 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-fake|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
-test|pbench-user-benchmark__2016-08-24_21:32:01|UNPACKED| server = {"archived": true}
+fake|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
+test|pbench-user-benchmark__2016-08-24_21:32:01|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.14.txt
+++ b/server/bin/gold/test-6.14.txt
@@ -195,6 +195,6 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
-test|pbench-user-benchmark__2016-08-24_21:32:01|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
+test|pbench-user-benchmark__2016-08-24_21:32:01|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.15.txt
+++ b/server/bin/gold/test-6.15.txt
@@ -189,5 +189,5 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-fake|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
+fake|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.16.txt
+++ b/server/bin/gold/test-6.16.txt
@@ -202,5 +202,5 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.17.txt
+++ b/server/bin/gold/test-6.17.txt
@@ -202,5 +202,5 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.5.txt
+++ b/server/bin/gold/test-6.5.txt
@@ -207,6 +207,6 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
-test|pbench-user-benchmark__2016-08-24_21:32:01|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
+test|pbench-user-benchmark__2016-08-24_21:32:01|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.6.txt
+++ b/server/bin/gold/test-6.6.txt
@@ -193,6 +193,6 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
 test|pbench-user-benchmark__2016-08-24_21:32:01|QUARANTINED|
 --- SqliteDB Datasets

--- a/server/bin/gold/test-6.9.txt
+++ b/server/bin/gold/test-6.9.txt
@@ -187,5 +187,5 @@ drwxrwxr-x          - tmp
 ---- pbench-satellite-local/logs
 --- pbench log file contents
 +++ SqliteDB Datasets
-test|fio__2016-08-18_15:47:09|UNPACKED| server = {"archived": true}
+test|fio__2016-08-18_15:47:09|UPLOADED| server = {"archived": true}
 --- SqliteDB Datasets

--- a/server/bin/pbench-unpack-tarballs.sh
+++ b/server/bin/pbench-unpack-tarballs.sh
@@ -207,17 +207,6 @@ function do_work() {
             continue
         fi
 
-        # Record that we're currently unpacking this dataset
-        pbench-state-manager --path="${result}" --state=unpacking
-        status=${?}
-        if [[ ${status} -ne 0 ]]; then
-            log_error "${TS}: code ${status}: pbench-state-manager ${hostname} ${resultname} unpacking" "${mail_content}"
-            nerrs=${nerrs}+1
-            move_symlink ${hostname} ${resultname} ${linksrc} ${linkerr} || doexit "Error handling failed for state update"
-            if [[ ${SECONDS} -ge ${max_seconds} ]]; then break; fi
-            continue
-        fi
-
         let start_time=$(timestamp-seconds-since-epoch)
         tar --extract --no-same-owner --touch --delay-directory-restore --file="${result}" --force-local --directory="${incoming}.unpack"
         status=${?}
@@ -343,19 +332,6 @@ function do_work() {
                 if [[ ${SECONDS} -ge ${max_seconds} ]]; then break; fi
                 continue
             fi
-        fi
-
-        # Finalize the state transition to UNPACKED
-        pbench-state-manager --path="${result}" --state=unpacked
-        status=${?}
-        if [[ ${status} -ne 0 ]]; then
-            log_error "${TS}: code ${status}: pbench-state-manager ${hostname} ${resultname} unpacked" "${mail_content}"
-            nerrs=${nerrs}+1
-            rm -rf ${incoming}
-            rm -f ${RESULTS}/${hostname}/${prefix}${resultname}
-            move_symlink ${hostname} ${resultname} ${linksrc} ${linkerr} || doexit "Error handling failed for state finalization"
-            if [[ ${SECONDS} -ge ${max_seconds} ]]; then break; fi
-            continue
         fi
 
         move_symlink ${hostname} ${resultname} ${linksrc} ${linkdest}

--- a/server/bin/state/test-6.13.db
+++ b/server/bin/state/test-6.13.db
@@ -1,2 +1,2 @@
-foo fio__2016-08-18_15:47:09 unpacked fake
-foo pbench-user-benchmark__2016-08-24_21:32:01 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded fake
+foo pbench-user-benchmark__2016-08-24_21:32:01 uploaded test

--- a/server/bin/state/test-6.14.db
+++ b/server/bin/state/test-6.14.db
@@ -1,2 +1,2 @@
-foo fio__2016-08-18_15:47:09 unpacked test
-foo pbench-user-benchmark__2016-08-24_21:32:01 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded test
+foo pbench-user-benchmark__2016-08-24_21:32:01 uploaded test

--- a/server/bin/state/test-6.15.db
+++ b/server/bin/state/test-6.15.db
@@ -1,1 +1,1 @@
-foo fio__2016-08-18_15:47:09 unpacked fake
+foo fio__2016-08-18_15:47:09 uploaded fake

--- a/server/bin/state/test-6.16.db
+++ b/server/bin/state/test-6.16.db
@@ -1,1 +1,1 @@
-foo fio__2016-08-18_15:47:09 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded test

--- a/server/bin/state/test-6.17.db
+++ b/server/bin/state/test-6.17.db
@@ -1,1 +1,1 @@
-foo fio__2016-08-18_15:47:09 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded test

--- a/server/bin/state/test-6.5.db
+++ b/server/bin/state/test-6.5.db
@@ -1,2 +1,2 @@
-foo pbench-user-benchmark__2016-08-24_21:32:01 unpacked test
-foo fio__2016-08-18_15:47:09 unpacked test
+foo pbench-user-benchmark__2016-08-24_21:32:01 uploaded test
+foo fio__2016-08-18_15:47:09 uploaded test

--- a/server/bin/state/test-6.6.db
+++ b/server/bin/state/test-6.6.db
@@ -1,2 +1,2 @@
-foo pbench-user-benchmark__2016-08-24_21:32:01 unpacked test
-foo fio__2016-08-18_15:47:09 unpacked test
+foo pbench-user-benchmark__2016-08-24_21:32:01 uploaded test
+foo fio__2016-08-18_15:47:09 uploaded test

--- a/server/bin/state/test-6.7.db
+++ b/server/bin/state/test-6.7.db
@@ -1,2 +1,2 @@
-foo fio__2016-08-18_15:47:09 unpacked test
-foo pbench-user-benchmark__2016-08-24_21:32:01 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded test
+foo pbench-user-benchmark__2016-08-24_21:32:01 uploaded test

--- a/server/bin/state/test-6.9.db
+++ b/server/bin/state/test-6.9.db
@@ -1,1 +1,1 @@
-foo fio__2016-08-18_15:47:09 unpacked test
+foo fio__2016-08-18_15:47:09 uploaded test

--- a/server/bin/state/test-7.26.db
+++ b/server/bin/state/test-7.26.db
@@ -1,1 +1,1 @@
-ctlrA linpack_mock_2020.02.28T19.10.55 unpacked fake
+ctlrA linpack_mock_2020.02.28T19.10.55 uploaded fake


### PR DESCRIPTION
PBENCH-842

With the impending arrival of the cache manager, we're moving away from a static "unpack" phase. This is a bit of prep work towards that day, removing the dataset SQL table "UNPACKING" and "UNPACKED" states.

This also allows "re-unpacking" after unpacked data has been aged out (another problem we'll no longer have after the cache manager) because the unpack tool is no longer constrained by the state transition rules.