### PR TITLE
Accessing results tarballs over http

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -101,6 +101,7 @@ def register_endpoints(api, app, config):
     api.add_resource(
         DatasetsInventory,
         f"{base_uri}/datasets/inventory/<string:dataset>",
+        f"{base_uri}/datasets/inventory/<string:dataset>/",
         f"{base_uri}/datasets/inventory/<string:dataset>/<path:target>",
         endpoint="datasets_inventory",
         resource_class_args=(config, logger),

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -101,7 +101,7 @@ def register_endpoints(api, app, config):
     api.add_resource(
         DatasetsInventory,
         f"{base_uri}/datasets/inventory/<string:dataset>",
-        f"{base_uri}/datasets/inventory/<string:dataset>/<path:path>",
+        f"{base_uri}/datasets/inventory/<string:dataset>/<path:target>",
         endpoint="datasets_inventory",
         resource_class_args=(config, logger),
     )

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -100,6 +100,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         DatasetsInventory,
+        f"{base_uri}/datasets/inventory/<string:dataset>/",
         f"{base_uri}/datasets/inventory/<string:dataset>/<path:path>",
         endpoint="datasets_inventory",
         resource_class_args=(config, logger),

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -100,7 +100,7 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         DatasetsInventory,
-        f"{base_uri}/datasets/inventory/<string:dataset>/",
+        f"{base_uri}/datasets/inventory/<string:dataset>",
         f"{base_uri}/datasets/inventory/<string:dataset>/<path:path>",
         endpoint="datasets_inventory",
         resource_class_args=(config, logger),

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -34,7 +34,7 @@ class DatasetsInventory(ApiBase):
                 API_OPERATION.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
-                    Parameter("path", ParamType.STRING, required=False),
+                    Parameter("target", ParamType.STRING, required=False),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,
             ),
@@ -45,17 +45,17 @@ class DatasetsInventory(ApiBase):
         This function returns the contents of the requested file as a byte stream.
 
         Args:
-            ApiParams includes the uri parameters, which provide the dataset and path.
+            ApiParams includes the uri parameters, which provide the dataset and target.
 
         Raises:
             APIAbort, reporting either "NOT_FOUND" or "UNSUPPORTED_MEDIA_TYPE"
 
 
-        GET /api/v1/datasets/inventory/{dataset}/{path}
+        GET /api/v1/datasets/inventory/{dataset}/{target}
         """
 
         dataset = params.uri["dataset"]
-        path = params.uri.get("path")
+        target = params.uri.get("target")
 
         file_tree = FileTree(self.config, self.logger)
         try:
@@ -63,13 +63,13 @@ class DatasetsInventory(ApiBase):
         except TarballNotFound as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
 
-        if path is None:
+        if target is None:
             file_path = tarball.tarball_path
         else:
             dataset_location = tarball.unpacked
             if dataset_location is None:
                 raise APIAbort(HTTPStatus.NOT_FOUND, "The dataset is not unpacked")
-            file_path = dataset_location / path
+            file_path = dataset_location / target
 
         if file_path.is_file():
             return send_file(file_path)

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -34,7 +34,7 @@ class DatasetsInventory(ApiBase):
                 API_OPERATION.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
-                    Parameter("path", ParamType.STRING, required=True),
+                    Parameter("path", ParamType.STRING, required=False),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,
             ),
@@ -53,27 +53,35 @@ class DatasetsInventory(ApiBase):
 
         GET /api/v1/datasets/inventory/{dataset}/{path}
         """
+        try:
+            path = params.uri["path"]
+        except KeyError:
+            path = None
 
         dataset = params.uri["dataset"]
-        path = params.uri["path"]
-
         file_tree = FileTree(self.config, self.logger)
         try:
             tarball = file_tree.find_dataset(dataset.resource_id)
         except TarballNotFound as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
-        dataset_location = tarball.unpacked
-        if dataset_location is None:
-            raise APIAbort(HTTPStatus.NOT_FOUND, "The dataset is not unpacked")
-        file_path = dataset_location / path
-        if file_path.is_file():
-            return send_file(file_path)
-        elif file_path.exists():
-            raise APIAbort(
-                HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
-                "The specified path does not refer to a regular file",
-            )
+
+        if path is None:
+            tarball_path = tarball.tarball_path
+            return send_file(tarball_path)
+
         else:
-            raise APIAbort(
-                HTTPStatus.NOT_FOUND, "The specified path does not refer to a file"
-            )
+            dataset_location = tarball.unpacked
+            if dataset_location is None:
+                raise APIAbort(HTTPStatus.NOT_FOUND, "The dataset is not unpacked")
+            file_path = dataset_location / path
+            if file_path.is_file():
+                return send_file(file_path)
+            elif file_path.exists():
+                raise APIAbort(
+                    HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
+                    "The specified path does not refer to a regular file",
+                )
+            else:
+                raise APIAbort(
+                    HTTPStatus.NOT_FOUND, "The specified path does not refer to a file"
+                )

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -38,8 +38,9 @@ class TestDatasetsAccess:
                     headers=headers,
                 )
             else:
+                k = "" if target is None else f"/{target}"
                 response = client.get(
-                    f"{server_config.rest_uri}/datasets/inventory/{dataset_id}",
+                    f"{server_config.rest_uri}/datasets/inventory/{dataset_id}{k}",
                     headers=headers,
                 )
             assert response.status_code == expected_status
@@ -119,10 +120,11 @@ class TestDatasetsAccess:
         response = query_get_as("fio_2", "1-default/default.csv", HTTPStatus.OK)
         assert response.status_code == HTTPStatus.OK
 
-    def test_get_result_tarball(self, query_get_as, monkeypatch):
+    @pytest.mark.parametrize("key", (None, ""))
+    def test_get_result_tarball(self, query_get_as, monkeypatch, key):
         monkeypatch.setattr(FileTree, "find_dataset", self.mock_find_dataset)
         monkeypatch.setattr(Path, "is_file", lambda self: True)
         monkeypatch.setattr(werkzeug.utils, "send_file", self.mock_send_file)
 
-        response = query_get_as("fio_2", "", HTTPStatus.OK)
+        response = query_get_as("fio_2", key, HTTPStatus.OK)
         assert response.status_code == HTTPStatus.OK

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -25,16 +25,16 @@ class TestDatasetsAccess:
         """
 
         def query_api(
-            dataset: str, path: str, expected_status: HTTPStatus
+            dataset: str, target: str, expected_status: HTTPStatus
         ) -> requests.Response:
             try:
                 dataset_id = Dataset.query(name=dataset).resource_id
             except DatasetNotFound:
                 dataset_id = dataset  # Allow passing deliberately bad value
             headers = {"authorization": f"bearer {pbench_token}"}
-            if path:
+            if target:
                 response = client.get(
-                    f"{server_config.rest_uri}/datasets/inventory/{dataset_id}/{path}",
+                    f"{server_config.rest_uri}/datasets/inventory/{dataset_id}/{target}",
                     headers=headers,
                 )
             else:

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -43,6 +43,7 @@ class TestDatasetsAccess:
     def mock_find_dataset(self, dataset):
         class Tarball(object):
             unpacked = Path("/dataset1/")
+            tarball_path = Path("/dataset1/")
 
         # Validate the resource_id
         Dataset.query(resource_id=dataset)
@@ -107,4 +108,12 @@ class TestDatasetsAccess:
             werkzeug.utils, "send_file", lambda *args, **kwargs: {"status": "OK"}
         )
         response = query_get_as("fio_2", "1-default/default.csv", HTTPStatus.OK)
+        assert response.status_code == HTTPStatus.OK
+
+    def test_get_result_tarball(self, query_get_as, monkeypatch):
+        monkeypatch.setattr(FileTree, "find_dataset", self.mock_find_dataset)
+        monkeypatch.setattr(
+            werkzeug.utils, "send_file", lambda *args, **kwargs: {"status": "OK"}
+        )
+        response = query_get_as("fio_2", "", HTTPStatus.OK)
         assert response.status_code == HTTPStatus.OK

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -81,8 +81,11 @@ class TestEndpointConfig:
                     "params": {"dataset": {"type": "string"}},
                 },
                 "datasets_inventory": {
-                    "template": f"{uri}/datasets/inventory/{{dataset}}/{{path}}",
-                    "params": {"dataset": {"type": "string"}, "path": {"type": "path"}},
+                    "template": f"{uri}/datasets/inventory/{{dataset}}/{{target}}",
+                    "params": {
+                        "dataset": {"type": "string"},
+                        "target": {"type": "path"},
+                    },
                 },
                 "datasets_list": {"template": f"{uri}/datasets/list", "params": {}},
                 "datasets_mappings": {


### PR DESCRIPTION
PBENCH-602


This API URL `http://host/api/v1/datasets/inventory/<dataset>/`  retrieves the raw ARCHIVE tree tarball file of the requested dataset as a byte stream.