### PR TITLE
Restore agent RPM builds

### DIFF
--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -105,7 +105,6 @@ The Pbench Agent - wraps benchmark workloads to collect specified tool and confi
 %prep
 
 %setup
-%patch0 -p1
 
 %build
 


### PR DESCRIPTION
PR #2971 removed the stockpile patch file, but the RPM spec file was still referencing it.