### PR TITLE
Add RPM builds to the CI pipeline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,7 @@ fi
 # Install the Dashboard dependencies, including the linter's dependencies and
 # the unit test dependencies.  First, remove any existing Node modules and
 # package-lock.json to ensure that we install the latest.
+mkdir -p ${HOME}/.config
 ( cd dashboard && rm -rf node_modules package-lock.json && npm install )
 
 # Test for code style and lint
@@ -36,3 +37,6 @@ tox                                     # Agent and Server unit tests and legacy
 # Build RPMS for the Server and Agent
 make -C server/rpm ci
 make -C agent/rpm ci
+
+# Display our victory
+ls -l ${HOME}/rpmbuild*/RPMS/noarch/*

--- a/build.sh
+++ b/build.sh
@@ -33,4 +33,6 @@ isort --check .
 tox                                     # Agent and Server unit tests and legacy tests
 ( cd dashboard && CI=true npm test )    # Dashboard unit tests
 
-exit 0
+# Build RPMS for the Server and Agent
+make -C server/rpm ci
+make -C agent/rpm ci

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -41,8 +41,11 @@ RPMBUILD_BASEIMAGE_centos = quay.io/centos/centos:stream${VER}
 RPMBUILD_BASEIMAGE_REPO = $(subst ${VER},${DIST_VERSION},${RPMBUILD_BASEIMAGE_${DIST_NAME}})
 
 # List of packages required to build RPMs, to be installed in the build
-# containers.  (The jinja2 CLI is not available as an RPM on RHEL, so we
-# install it via pip for all platforms, to keep things simple.)
+# containers.
+#
+# TODO:  The Jinja2 CLI is not currently available as an RPM on RHEL, so we
+#        install it via pip for all platforms, to keep things simple; we should
+#        reevaluate this (and the other) dependencies in the future.
 RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
 
 # Default package manager tool (may be overridden for some distros)

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -45,7 +45,7 @@ RPMBUILD_BASEIMAGE_REPO = $(subst ${VER},${DIST_VERSION},${RPMBUILD_BASEIMAGE_${
 #
 # TODO:  The Jinja2 CLI is not currently available as an RPM on RHEL, so we
 #        install it via pip for all platforms, to keep things simple; we should
-#        reevaluate this (and the other) dependencies in the future.
+#        reevaluate this dependency (and the other dependencies) in the future.
 RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
 
 # Default package manager tool (may be overridden for some distros)

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -45,7 +45,7 @@ RPMBUILD_BASEIMAGE_REPO = $(subst ${VER},${DIST_VERSION},${RPMBUILD_BASEIMAGE_${
 #
 # TODO:  The Jinja2 CLI is not currently available as an RPM on RHEL, so we
 #        install it via pip for all platforms, to keep things simple; we should
-#        reevaluate this dependency (and the other dependencies) in the future.
+#        reevaluate this dependency in the future.
 RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
 
 # Default package manager tool (may be overridden for some distros)

--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -83,7 +83,7 @@ RUN \
     `#` \
     dnf -y clean all && rm -rf /var/cache/dnf && \
     `#` \
-    `# Tweak npm.` \
+    `# Configure npm.` \
     `#` \
     npm install -g npm@8.19.0 && \
     npm config set fetch-retry-maxtimeout 120000

--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -30,7 +30,8 @@
 FROM quay.io/fedora/fedora:34
 
 RUN \
-    dnf install -y \
+    dnf -y update && \
+    dnf install -y --exclude container-selinux \
         `#` \
         `# Required for agent python unit tests` \
         `#` \
@@ -72,6 +73,10 @@ RUN \
         `#` \
         npm \
         tox \
+        `#` \
+        `# Required for creating peer-containers on the host` \
+        `#` \
+        podman-remote \
         && \
     `#` \
     `# Save space in the container image.` \

--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -27,7 +27,7 @@
 #
 # [1] See https://www.redhat.com/sysadmin/user-flag-rootless-containers
 
-FROM quay.io/fedora/fedora:34
+FROM quay.io/fedora/fedora:35
 
 RUN \
     dnf -y update && \
@@ -81,4 +81,9 @@ RUN \
     `#` \
     `# Save space in the container image.` \
     `#` \
-    dnf -y clean all && rm -rf /var/cache/dnf
+    dnf -y clean all && rm -rf /var/cache/dnf && \
+    `#` \
+    `# Tweak npm.` \
+    `#` \
+    npm install -g npm@8.19.0 && \
+    npm config set fetch-retry-maxtimeout 120000

--- a/jenkins/run
+++ b/jenkins/run
@@ -53,15 +53,36 @@ fi
 
 _image=${IMAGE:-${_image_repo}/pbench-${_image_role}-${_image_kind}:${_branch_name}}
 
-podman run \
+if [ -n "${CONTAINER_HOST}" ]; then
+    # Since CONTAINER_HOST is defined, when we want to run another container, do
+    # it with `podman-remote` (which will run it where CONTAINER_HOST points).
+    # This works nicely, e.g., if we are already inside a properly configured
+    # container.
+    PODMAN="podman-remote"
+else
+    # Since CONTAINER_HOST is not defined, don't invoke the container remotely.
+    # However, we might want to run a container "remotely" on this host;
+    # therefore, enable the service which makes it available to receive
+    # `podman-remote` invocations.  This creates a listener on
+    # /run/user/$(id -u)/podman/podman.sock, which will be mapped into the
+    # container in the invocation below so that we can create peer-containers
+    # on this host from inside the container.
+    PODMAN="podman"
+    systemctl --user enable --quiet --now podman.socket
+fi
+
+${PODMAN} run \
     --userns=keep-id \
+    --security-opt label=disable \
     --volume ${HOME_DIR} \
     --volume ${HOME_DIR}/.config \
-    --volume $(pwd):${HOME_DIR}/pbench:z \
+    --volume $(pwd):${HOME_DIR}/pbench \
+    --volume /run/user/${UID}/podman/podman.sock:/run/user/${UID}/podman/podman.sock \
     ${GIT_BASE_VOLUME} \
     -w ${HOME_DIR}/pbench \
     --env HOME=${HOME_DIR} \
     --env USER=${USER_NAME} \
+    --env CONTAINER_HOST=unix://run/user/${UID}/podman/podman.sock \
     --ulimit nofile=65536:65536 \
     --rm \
     ${EXTRA_PODMAN_SWITCHES} \

--- a/jenkins/run
+++ b/jenkins/run
@@ -38,8 +38,19 @@ _image_repo=${IMAGE_REPO:-quay.io/pbench}
 _image_role=${IMAGE_ROLE:-devel}
 _image_kind=${IMAGE_KIND:-fedora}
 
+# USER_NAME:  the name of the user (and the home directory) inside the container
+# HOME_DIR:   the path to the user's home directory inside the container
+# PODMAN_SOCK: the path to the Podman remote socket both in-/outside the container
+# WORKSPACE:  the directory containing the Git checkout -- in the Jenkins
+#             environment this is set and setup for us; otherwise, it defaults to
+#             the current working directory, which is required by this script to
+#             be a Git checkout.
+#             NOTE:  this is the path on the HOST, if we're already in a container;
+#             inside the container, it will be mapped to /home/${USER}/pbench.
 USER_NAME=${USER}
 HOME_DIR=/home/${USER_NAME}
+PODMAN_SOCK=/run/user/${UID}/podman/podman.sock
+WORKSPACE=${WORKSPACE:-$(pwd)}
 
 # The PBR in our setup.py Pbench installer relies on `git` knowledge and can't
 # handle a git worktree. This handy sequence solves the problem by importing
@@ -76,14 +87,16 @@ ${PODMAN} run \
     --security-opt label=disable \
     --volume ${HOME_DIR} \
     --volume ${HOME_DIR}/.config \
-    --volume $(pwd):${HOME_DIR}/pbench \
-    --volume /run/user/${UID}/podman/podman.sock:/run/user/${UID}/podman/podman.sock \
+    --volume ${WORKSPACE}:${HOME_DIR}/pbench \
+    --volume ${PODMAN_SOCK}:${PODMAN_SOCK} \
     ${GIT_BASE_VOLUME} \
     -w ${HOME_DIR}/pbench \
     --env HOME=${HOME_DIR} \
     --env USER=${USER_NAME} \
-    --env CONTAINER_HOST=unix://run/user/${UID}/podman/podman.sock \
+    --env CONTAINER_HOST=unix:/${PODMAN_SOCK} \
+    --env WORKSPACE=${WORKSPACE} \
     --ulimit nofile=65536:65536 \
     --rm \
     ${EXTRA_PODMAN_SWITCHES} \
-    ${_image} jenkins/runner "${@}"
+    ${_image} \
+    jenkins/runner "${@}"

--- a/jenkins/run
+++ b/jenkins/run
@@ -77,6 +77,16 @@ GIT_BASE_VOLUME=""
 git_dir="$(git rev-parse --absolute-git-dir)"
 if [ "${git_dir}" != "$(pwd)/.git" ]; then
     git_common_dir="$(git rev-parse --git-common-dir)"
+    if [ "${git_common_dir}" == "${HOME_DIR}/pbench/.git" ]; then
+            # When the Git checkout is in a Git "worktree", the path to the
+            # "main worktree" must NOT be `~/pbench`:  this is the path used to
+            # mount the checkout inside the containers, and, once the worktree
+            # is mounted there, the common Git directory cannot be mounted at
+            # `~/pbench/.git` because the worktree contains a back-link file
+            # there.
+        echo "When the checkout is a Git worktree, the path to the main worktree cannot be ~/pbench." >&2
+        exit 2
+    fi
     GIT_BASE_VOLUME="--volume ${git_common_dir}:${git_common_dir}:z"
 fi
 
@@ -126,7 +136,10 @@ if [ -z "${WORKSPACE_TMP}" ]; then
     echo Using new WORKSPACE_TMP=${WORKSPACE_TMP}
 fi
 
-echo Starting container:  WORKSPACE_TMP=${WORKSPACE_TMP}, WORKSPACE=${WORKSPACE}
+echo "Starting container with ${PODMAN}:
+        WORKSPACE_TMP=${WORKSPACE_TMP}
+        WORKSPACE=${WORKSPACE}
+        ${GIT_BASE_VOLUME:+GIT_BASE_VOLUME=${GIT_BASE_VOLUME}}"
 ${PODMAN} run \
     --userns=keep-id \
     --security-opt label=disable \

--- a/jenkins/run
+++ b/jenkins/run
@@ -101,7 +101,7 @@ else
     systemctl --user enable --quiet --now podman.socket
 fi
 
-# We have two directory trees which we are concerned with inside the container:
+# We have two volumes which we are concerned with inside the container:
 # $HOME_DIR and $HOME_DIR/pbench.  The first is provided for anything which
 # happens to reference it (such as RPM builds and npm), and the second contains
 # the Git checkout.
@@ -111,9 +111,10 @@ fi
 # this script is run locally by an individual developer, $HOME_DIR is mapped
 # from a Podman volume, to maintain isolation from the surrounding environment;
 # this volume is created automatically by Podman if it does not already exist
-# (it is deleted after the container exits, if it is no longer in use), and
-# $WORKSPACE_TMP inside the container is set to it so that any containers
-# created inside this container will use the same volume for their $HOME_DIR.
+# (it is deleted by this script after the container exits, if it is no longer
+# in use), and $WORKSPACE_TMP inside the container is set to it so that any
+# containers created inside this container will use the same volume for their
+# $HOME_DIR.
 #
 # When run under the CI (or in any other environment which defines $WORKSPACE),
 # the $HOME_DIR/pbench is mapped from $WORKSPACE, which is where the Jenkins

--- a/jenkins/run
+++ b/jenkins/run
@@ -110,11 +110,10 @@ fi
 # defines $WORKSPACE_TMP), the $HOME_DIR is mapped from $WORKSPACE_TMP.  When
 # this script is run locally by an individual developer, $HOME_DIR is mapped
 # from a Podman volume, to maintain isolation from the surrounding environment;
-# this volume is created automatically by Podman if it does not already exist
-# (it is deleted by this script after the container exits, if it is no longer
-# in use), and $WORKSPACE_TMP inside the container is set to it so that any
-# containers created inside this container will use the same volume for their
-# $HOME_DIR.
+# this is a temporary but named volume which will be deleted by this script
+# after the container exits (if it is not in use by another container), and
+# $WORKSPACE_TMP inside the container is set to it so that any containers
+# created inside this container will use the same volume for their $HOME_DIR.
 #
 # When run under the CI (or in any other environment which defines $WORKSPACE),
 # the $HOME_DIR/pbench is mapped from $WORKSPACE, which is where the Jenkins

--- a/jenkins/run
+++ b/jenkins/run
@@ -6,9 +6,32 @@
 #
 # EXTRA_PODMAN_SWITCHES []
 # IMAGE_REPO [quay.io/pbench]
-# IMAGE_ROLE [devel] (see Makefile for options)
-# IMAGE_KIND [fedora] (see Makefile for options)
-# IMAGE [image spec you want, overrides all of the above]
+# IMAGE_ROLE [devel] (See Makefile for options)
+# IMAGE_KIND [fedora] (See Makefile for options)
+# IMAGE      [${IMAGE_REPO}-${IMAGE_ROLE}-${IMAGE_KIND}:<branch_name>]
+#            If defined, will override the $IMAGE_* values above.
+# CONTAINER_HOST [] (see podman-remote man page)
+#            May be defined to control remote container execution; will already
+#            be defined, if running inside a container invoked by this script,
+#            to point to the current host.
+# WORKSPACE: [$(pwd)]
+#            The directory containing the Git checkout -- in the Jenkins
+#            environment this is set and setup for us; otherwise, it defaults to
+#            the current working directory, which is required by this script to
+#            be a Git checkout.
+#            NOTE:  if we're already running inside a container this is the path
+#            to the checkout on the HOST file system; inside the container, it
+#            will be mapped to /home/${USER}/pbench.
+# WORKSPACE_TMP: []
+#            If defined, used as the mapping for /home/${USER} in the container
+#            (inside the container, the Git checkout will be mounted over the
+#            pbench subdirectory).  In the Jenkins environment, this points to a
+#            place where we can create a temporary directory tree. In a local
+#            environment, defining this value (e.g., to /home/${USER} _outside_
+#            the container) will allow the user to receive files created inside
+#            the container.
+#            NOTE:  if we're already running inside a container this is either
+#            the path to the directory on the HOST file system or a Podman volume.
 #
 # For example, run an interactive bash shell:
 #
@@ -41,12 +64,7 @@ _image_kind=${IMAGE_KIND:-fedora}
 # USER_NAME:  the name of the user (and the home directory) inside the container
 # HOME_DIR:   the path to the user's home directory inside the container
 # PODMAN_SOCK: the path to the Podman remote socket both in-/outside the container
-# WORKSPACE:  the directory containing the Git checkout -- in the Jenkins
-#             environment this is set and setup for us; otherwise, it defaults to
-#             the current working directory, which is required by this script to
-#             be a Git checkout.
-#             NOTE:  this is the path on the HOST, if we're already in a container;
-#             inside the container, it will be mapped to /home/${USER}/pbench.
+# WORKSPACE:  the directory containing the Git checkout
 USER_NAME=${USER}
 HOME_DIR=/home/${USER_NAME}
 PODMAN_SOCK=/run/user/${UID}/podman/podman.sock
@@ -67,26 +85,52 @@ _image=${IMAGE:-${_image_repo}/pbench-${_image_role}-${_image_kind}:${_branch_na
 if [ -n "${CONTAINER_HOST}" ]; then
     # Since CONTAINER_HOST is defined, when we want to run another container, do
     # it with `podman-remote` (which will run it where CONTAINER_HOST points).
-    # This works nicely, e.g., if we are already inside a properly configured
-    # container.
+    # This is the core mechanism that allows CI jobs, which are run inside one
+    # container, to run sub-sets of the build inside separate containers on the
+    # same host.
     PODMAN="podman-remote"
 else
-    # Since CONTAINER_HOST is not defined, don't invoke the container remotely.
-    # However, we might want to run a container "remotely" on this host;
-    # therefore, enable the service which makes it available to receive
-    # `podman-remote` invocations.  This creates a listener on
-    # /run/user/$(id -u)/podman/podman.sock, which will be mapped into the
-    # container in the invocation below so that we can create peer-containers
-    # on this host from inside the container.
+    # Since CONTAINER_HOST is not defined, arrange to invoke the container
+    # directly.  Since the code running in the container might want to run an
+    # additional container "remotely" on this host, enable the service which
+    # makes it available to receive `podman-remote` invocations.  This creates a
+    # listener on /run/user/$(id -u)/podman/podman.sock, which will be mapped
+    # into the container in the invocation below so that we can create
+    # peer-containers on this host from inside the container.
     PODMAN="podman"
     systemctl --user enable --quiet --now podman.socket
 fi
 
+# We have two directory trees which we are concerned with inside the container:
+# $HOME_DIR and $HOME_DIR/pbench.  The first is provided for anything which
+# happens to reference it (such as RPM builds and npm), and the second contains
+# the Git checkout.
+#
+# When this script is run under the CI (or in any other environment which
+# defines $WORKSPACE_TMP), the $HOME_DIR is mapped from $WORKSPACE_TMP.  When
+# this script is run locally by an individual developer, $HOME_DIR is mapped
+# from a Podman volume, to maintain isolation from the surrounding environment;
+# this volume is created automatically by Podman if it does not already exist
+# (it is deleted after the container exits, if it is no longer in use), and
+# $WORKSPACE_TMP inside the container is set to it so that any containers
+# created inside this container will use the same volume for their $HOME_DIR.
+#
+# When run under the CI (or in any other environment which defines $WORKSPACE),
+# the $HOME_DIR/pbench is mapped from $WORKSPACE, which is where the Jenkins
+# setup checks out the Git sources.  Otherwise, the current working directory
+# (which is required to be the root of the Git checkout) is mapped as the second
+# directory inside the container.
+if [ -z "${WORKSPACE_TMP}" ]; then
+    WORKSPACE_TMP=$(uuidgen)  # Generate a volume name
+    _volume="True"
+    echo Using new WORKSPACE_TMP=${WORKSPACE_TMP}
+fi
+
+echo Starting container:  WORKSPACE_TMP=${WORKSPACE_TMP}, WORKSPACE=${WORKSPACE}
 ${PODMAN} run \
     --userns=keep-id \
     --security-opt label=disable \
-    --volume ${HOME_DIR} \
-    --volume ${HOME_DIR}/.config \
+    --volume ${WORKSPACE_TMP}:${HOME_DIR} \
     --volume ${WORKSPACE}:${HOME_DIR}/pbench \
     --volume ${PODMAN_SOCK}:${PODMAN_SOCK} \
     ${GIT_BASE_VOLUME} \
@@ -95,8 +139,15 @@ ${PODMAN} run \
     --env USER=${USER_NAME} \
     --env CONTAINER_HOST=unix:/${PODMAN_SOCK} \
     --env WORKSPACE=${WORKSPACE} \
+    --env WORKSPACE_TMP=${WORKSPACE_TMP} \
     --ulimit nofile=65536:65536 \
     --rm \
     ${EXTRA_PODMAN_SWITCHES} \
     ${_image} \
     jenkins/runner "${@}"
+
+rc=$?
+
+[ "${_volume}" == "True" ] && podman volume rm $WORKSPACE_TMP
+
+exit $rc

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -128,7 +128,7 @@ pwdr = $(subst ${PBENCHTOP},,${CURDIR})
 # inside the container as ${HOME}/rpmbuild (with no suffix), which is where
 # the build will put the RPM when invoked without a distro target.
 .PHONY: %-rpm
-%-rpm: spec srpm
+%-rpm: rpm-dirs
 	cd ${PBENCHTOP} && \
 	  IMAGE=${BUILD_CONTAINER} \
 	    EXTRA_PODMAN_SWITCHES="-v ${BLD_DIR}:$${HOME}/rpmbuild:z" \

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -124,9 +124,20 @@ ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 # different location.
 pwdr = $(subst ${PBENCHTOP},,${CURDIR})
 
-# NOTE:  we mount ${BLD_DIR}, which ends with 'rpmbuild<distro>-<version>',
-# inside the container as ${HOME}/rpmbuild (with no suffix), which is where
-# the build will put the RPM when invoked without a distro target.
+# This is a pattern target used to build RPMs for specific distros.  It launches
+# a "normal" `rpm` target in a sub-make that is run inside a container built
+# from the distro for which the RPM is targeted.  We mount ${BLD_DIR}, which
+# ends with `rpmbuild<distro>-<version>`, inside the container as
+# `${HOME}/rpmbuild` (with no suffix), which is where the build will put the RPM
+# when invoked without a distro target.  Each sub-make is self contained -- it
+# builds its own SRPM and binary RPM -- putting the output in the file system
+# mapped in from the host.  So, the pattern target here only needs to create the
+# output directories which will be mapped into the containers.
+#
+# TODO:  When building more than one container, we should probably build the
+#        SRPM exactly once (on the host) and then map it into the container(s).
+#        And, we should presumably share the values of $(version)/$(VERSION),
+#        $(seqno), and $(sha1), as well.
 .PHONY: %-rpm
 %-rpm: rpm-dirs
 	cd ${PBENCHTOP} && \

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -14,7 +14,7 @@
 # In addition, specifying a distro-specific target, like "rhel-9-rpm", will
 # cause Step 7 to be executed locally in a suitable container, to produce a
 # binary RPM for the indicated distribution.  In this case, the RPM will be
-# placed in ${HOME}/pbench/rpmbuild-<distro>-<version>/RPMS.
+# placed in ${HOME}/rpmbuild-<distro>-<version>/RPMS.
 #
 
 RPMBUILD_IMAGE_REPO = images.paas.redhat.com/pbench
@@ -28,7 +28,7 @@ include ${PBENCHTOP}/utils/utils.mk
 prog = pbench-${component}
 VERSION := $(shell cat ${PBENCHTOP}/${component}/VERSION)
 MAJORMINOR := $(shell grep -oE '[0-9]+\.[0-9]+' ${PBENCHTOP}/${component}/VERSION)
-TBDIR = ${TMPDIR}/${prog}-${VERSION}
+TBDIR = ${RPMTMP}/${prog}-${VERSION}
 
 # If we are building for a distro, use a distro-specific suffix on the build and
 # temporary directories, so that builds can be done in parallel and so that the
@@ -47,24 +47,23 @@ endif
 # Set BLD_DIR to `${BLD_ROOT}/rpmbuild-<DISTRO>-<VERSION>` when the target has
 # a specific distro and to `${BLD_ROOT}/rpmbuild` when the target has no
 # specific distro.  (Define BLD_SUBDIR separately from BLD_DIR to allow us to
-# mix and match them for mapping the location into the container.)  Set TMPDIR,
-# analogously.  This prevents builds for one distro from interfering with
-# builds for another.
-BLD_ROOT := ${HOME}/pbench
-BLD_SUBDIR := rpmbuild${BLD_SUFFIX}
+# mix and match them for mapping the location into the container.)  This
+# prevents builds for one distro from interfering with builds for another.
+BLD_ROOT ?= ${HOME}
+BLD_SUBDIR ?= rpmbuild${BLD_SUFFIX}
 BLD_DIR := ${BLD_ROOT}/${BLD_SUBDIR}
-TMPDIR := /tmp/rpmbuild${BLD_SUFFIX}/opt
 
-$(info Building ${MAKECMDGOALS} for ${prog}-${VERSION} from ${TBDIR} to ${BLD_DIR})
-
-RPMDIRS = BUILD BUILDROOT SPECS SOURCES SRPMS RPMS
+RPMDIRS = BUILD BUILDROOT SPECS SOURCES SRPMS RPMS TMP
 
 RPMSRC = ${BLD_DIR}/SOURCES
 RPMSRPM = ${BLD_DIR}/SRPMS
 RPMSPEC = ${BLD_DIR}/SPECS
+RPMTMP = ${BLD_DIR}/TMP
 
 sha1 := $(shell git rev-parse --short HEAD)
 seqno := $(shell if [ -e ./seqno ] ;then cat ./seqno ;else echo "1" ;fi)
+
+$(info Building ${MAKECMDGOALS} for ${prog}-${VERSION} from ${TBDIR} to ${BLD_DIR})
 
 # By default we only build a source RPM
 all: srpm
@@ -93,8 +92,8 @@ patches: rpm-dirs
 tarball: rpm-dirs submodules ${subcomps}
 	echo "${sha1}" > ${TBDIR}/${component}/SHA1
 	echo "${seqno}" > ${TBDIR}/${component}/SEQNO
-	tar zcf ${RPMSRC}/${prog}-${VERSION}.tar.gz -C ${TMPDIR} ${prog}-${VERSION}
-	rm -rf ${TMPDIR}/*
+	tar zcf ${RPMSRC}/${prog}-${VERSION}.tar.gz -C ${RPMTMP} ${prog}-${VERSION}
+	rm -rf ${RPMTMP}/*
 
 .PHONY: rpm-dirs
 rpm-dirs:
@@ -126,26 +125,27 @@ ${COPR_TARGETS}: $(RPMSRPM)/$(prog)-$(VERSION)-$(seqno)g$(sha1).src.rpm
 # different location.
 pwdr = $(subst ${PBENCHTOP}/,,${CURDIR})
 
-# This is a pattern target used to build RPMs for specific distros.  It launches
-# a "normal" `rpm` target in a sub-make that is run inside a container built
-# from the distro for which the RPM is targeted.  We mount the output path,
-# which ends with `rpmbuild<distro>-<version>`, inside the container as
-# `${BLD_ROOT}/rpmbuild` (with no suffix), which is where the build will put the
-# RPM when invoked without a distro target.  Each sub-make is self contained --
-# it builds its own SRPM and binary RPM -- putting the output in the file system
-# mapped in from the host.  So, the pattern target here only needs to create the
-# output directories which will be mapped into the containers.
+# This target is used to build RPMs for specific distros.  It launches a
+# "normal" `rpm` target in a sub-make that is run inside a container built from
+# the distro for which the RPM is targeted.  We override the definitions for
+# `${BLD_ROOT}` and `${BLD_SUBDIR}` so that they point to the distro-specific
+# directory inside the container.
+#
+# Each sub-make is self contained -- it builds its own SRPM and binary RPM --
+# putting the output in the file system mapped in from the host.  So, the
+# pattern target here only needs to create the output directories which will be
+# mapped into the containers.
 #
 # TODO:  When building more than one container, we should probably build the
 #        SRPM exactly once (on the host) and then map it into the container(s).
-#        And, we should presumably share the values of $(version)/$(VERSION),
-#        $(seqno), and $(sha1), as well.
+#        And, we should presumably share the values of $(VERSION), $(seqno),
+#        and $(sha1), as well.
 .PHONY: %-rpm
 %-rpm: rpm-dirs
 	cd ${PBENCHTOP} && \
 	  IMAGE=${BUILD_CONTAINER} \
-	    EXTRA_PODMAN_SWITCHES="--volume $${WORKSPACE:-${BLD_ROOT}}/${BLD_SUBDIR}:${BLD_ROOT}/rpmbuild" \
-	    jenkins/run make -C ${pwdr} rpm
+	    jenkins/run \
+	      make BLD_ROOT=${BLD_ROOT} BLD_SUBDIR=${BLD_SUBDIR} -C ${pwdr} rpm
 
 .PHONY: distclean
 distclean:


### PR DESCRIPTION
This PR enhances `build.sh` to extend the CI pipeline to include building binary RPMs for the Agent and the Server.

There are a few related changes which include:
- `build.sh`:
  - We create the `${HOME}/.config` directory if it doesn't exist.  Previously, in the container scenarios, we mapped this to a temporary file system; now it just resides on the same file system as ${HOME}, but we cannot be guaranteed that it will exist unless we create it.
  - We list the RPMs at the end of the build.  This is a "victory lap" which will be removed in the next PR when the RPMs are actually consumed.
- `jenkins/Makefile`:  A change requested in another PR for a code comment 
- `jenkins/ci.fedora.Dockerfile`:
  - Updated to Fedora 35!
  - The addition of the `podman-remote` package to allow us to invoke containers on the host from within the container running the build
  - A couple of `dnf` tweaks that I ran across in my investigations which seemed like a good idea
  - A couple of `npm` tweaks (one which `npm` itself suggested, and the other avoids a timeout problem)
- `jenkins/run`:  changes to support running a container from inside the container
  - Documentation of the environment/shell variables which govern the script's operation
  - If the `CONTAINER_HOST` environment variable is defined, then we set up the new-container invocation to be made with `podman-remote` which will run the container at the location specified by `CONTAINER_HOST`.
  - If the `CONTAINER_HOST` environment variable is not defined, then we set up the new-container invocation to be made with `podman`, and we start a `systemd` service which will listen for a request from `podman-remote`.
  - We use the environment variable `WORKSPACE` to determine where the Git checkout is.  When running in the CI, this is defined by the Jenkins environment; if it is undefined, we set it to the current working directory, which `jenkins/run` requires to be the Git checkout.  We define this environment variable inside the container, so that it knows where _on the host_ the Git checkout is, so that invocations of `podman-remote` can set up the mapping properly, even though they are made from inside a container.
  - We use the environment variable `WORKSPACE_TMP` to determine where the home directory inside the container should be mapped.  When running in the CI, this is defined by the Jenkins environment (although, we have to create the directory tree, which is done in `build.sh`).  If it is undefined, we set up a temporary Podman volume for the mapping (using a UUID for the volume name; the volume is deleted at the end of the script if it is no longer in use).  `WORKSPACE_TMP` can also be defined to point to a real file system on the host, which a developer can use to capture the build products locally.  We define this environment variable inside the container, so that it knows what _on the host_ to map to the home directory inside the container, so that invocations of `podman-remote` can set up the mapping properly, even though they are made from inside a container.
  - Some other tweaks to the container invocation:
    - We define the `CONTAINER_HOST` environment variable in the container, to trigger the use of `podman-remote` inside the container, and we point it at the service which we've defined if it was not already defined.
    - We map into the container the unix socket where the Podman listener is configured, so that the `podman-remote` command can use it to communicate to the service on the host.
    - We disable SELinux labeling inside the container (because it just seems to get in the way without producing any value in our use cases), and we remove the re-labeling directives from the volume mappings.
- `utils/rpm.mk`:
  - Set the build area (`${BLD_ROOT}`) to `${HOME}` by default, but allow the distro-specific build invocations to override it.  Likewise, set the build subdirectory to `rpmbuild` but allow it to be overridden, as well.
  - Add a new `TMP` directory to the `RPMDIRS` list and use it instead of `/tmp`, so that we don't have collisions between concurrent distros' builds.  Define a variable, `${RPMTMP}` for use instead of `${TMPDIR}`.
  - Correct the dependency of the `<distro>-rpm` target so that it requires only the build output directories and not the spec file and source RPM.  (The `rpm` target of the sub-make already has those dependencies.)
  - The output location for the RPMs is, by default, still `~/rpmbuild`, but, if the build is run inside a container, this location will be remapped appropriately by `jenkins/run`.
  - Removed a spurious slash from the sub-make current directory and changed it to be a relative path.
  - Modified the nested container invocation so that it passes in the appropriate definitions of `${BLD_ROOT}` and `${BLD_SUBDIR}`.

PBENCH-720