### PR TITLE
Fix CI Dashboard unit testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,8 +19,9 @@ if [[ ${GITTOP} =~ "fatal: unsafe repository ('/home/root/pbench'" ]] ; then
 fi
 
 # Install the Dashboard dependencies, including the linter's dependencies and
-# the unit test dependencies.
-( cd dashboard && npm install )
+# the unit test dependencies.  First, remove any existing Node modules and
+# package-lock.json to ensure that we install the latest.
+( cd dashboard && rm -rf node_modules package-lock.json && npm install )
 
 # Test for code style and lint
 black --check .

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,6 @@
     "jest": "^27.5.1",
     "js-cookie": "^3.0.1",
     "less-watch-compiler": "^1.16.3",
-    "nvm": "0.0.4",
     "patternfly": "^3.9.0",
     "react": "^17.0.2",
     "react-app-rewired": "^2.2.1",
@@ -88,6 +87,7 @@
     "jsdoc": "^3.6.10",
     "less": "^4.1.2",
     "less-loader": "^11.0.0",
-    "prettier": "^2.6.2"
+    "prettier": "^2.6.2",
+    "tough-cookie": "^4.1.2"
   }
 }


### PR DESCRIPTION
This PR addresses some of the issues that we've seen recently with the Dashboard unit testing in the CI.

In particular, the unit tests were failing with
```
    Cookie has domain set to the public suffix "localhost" which is a special use domain. To allow this, configure your CookieJar with {allowSpecialUseDomain:true, rejectPublicSuffixes: false}.

      at Object.getPublicSuffix (node_modules/tough-cookie/lib/pubsuffix-psl.js:62:11)
      at permuteDomain (node_modules/tough-cookie/lib/permuteDomain.js:38:28)
      at MemoryCookieStore.findCookies (node_modules/tough-cookie/lib/memstore.js:99:21)
      at MemoryCookieStore.findCookies (node_modules/universalify/index.js:5:67)
      at CookieJar.getCookies (node_modules/tough-cookie/lib/cookie.js:1407:11)
      at CookieJar.getCookies (node_modules/universalify/index.js:5:67)
      at CookieJar.getCookieString (node_modules/tough-cookie/lib/cookie.js:1452:21)
      at CookieJar.getCookieString (node_modules/universalify/index.js:5:67)
      at CookieJar.getCookieStringSync (node_modules/tough-cookie/lib/cookie.js:1723:21)
      at DocumentImpl.get cookie [as cookie] (node_modules/jsdom/lib/jsdom/living/nodes/Document-impl.js:860:28)
```
which was the result of [a breaking change to the `tough-cookie` component](https://github.com/salesforce/tough-cookie/issues/246).  `tough-cookie` is not used by the Dashboard; rather, it's a dependency of a dependency of Jest which we use for Dashboard unit testing.

This PR makes three changes:
- Add an explicit (development) dependency on `tough-cookie` v4.1.2 (the breakage was introduced in v4.1.0, and v4.1.1 was a failed attempt to fix it); without the explicit dependency, we seem to still pick up v4.1.0.
- Add a command to the build script to remove the `node_modules` directory, to ensure that we pick up a fresh installation of our dependencies.  (There are other ways to accomplish this (such as the `npm` commands, `clean-install` and `ci`), but without a version-controlled `package-lock.json` file, they all present problems, so we'll just brute-force it for now.)  Also, since it's not currently version-controlled, remove the `package-lock.json` file, so that we generate a fresh set of dependencies on each build.
- Remove the dependency on `nvm`.  It pulls a very old version of the manager, and we don't seem to actually need it (at least, as a production dependency...).
