### PR TITLE
Remove default repo name

### DIFF
--- a/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
@@ -1,10 +1,11 @@
 ---
+# We have agreed as a community that by default the official builds are
+# provided by the `ndokos` COPR user.
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
-pbench_repo_name: pbench
 
 repos:
-  - tag: "{{ pbench_repo_name }}"
+  - name: "{{ pbench_repo_name }}"
     user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"

--- a/agent/ansible/collection/roles/pbench_repo_install/tasks/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 # Install pbench.repo
+- name: Assert pbench_repo_name is defined
+  assert:
+    that:
+      - pbench_repo_name is defined
+    fail_msg: "Please specify the COPR repository name to use in the `pbench_repo_name` variable"
+
 - name: Ensure we have the pbench.repo file properly in place
   ansible.builtin.template:
     src: etc/yum.repos.d/pbench.repo.j2

--- a/agent/ansible/collection/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
+++ b/agent/ansible/collection/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
@@ -1,9 +1,8 @@
 {% for repo in repos %}
 
-[copr-{{ repo.tag }}-{{ repo.user }}]
-name=COPR {{ repo.tag }} ({{ repo.user }}) repo
+[copr-{{ repo.name }}-{{ repo.user }}]
+name=COPR {{ repo.name }} ({{ repo.user }}) repo
 baseurl={{ repo.baseurl }}
-skip_if_unavailable=True
 gpgcheck={{ repo.gpgcheck }}
 gpgkey={{ repo.gpgkey }}
 enabled={{ repo.enabled }}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -48,6 +48,7 @@ URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 # the final repo name would be "pbench-test".
 TEST =
 _TEST_SUFFIX = $(if $(TEST),-$(TEST),"")
+_PBENCH_REPO_NAME = pbench${_TEST_SUFFIX}
 
 # By default we use the pbench Quay.io organization for the image
 # repository.  You can override this default using an environment
@@ -275,7 +276,7 @@ $(foreach tagtype,${_TAG_TYPES},$(eval $(call _TAG_RULE,${tagtype})))  # Define 
 
 # Build the tags file for the given distribution. (We rename "centos" to "epel".)
 %-tags.lis:
-	./gen-tags-from-rpm "${URL_PREFIX}" "$(subst centos,epel,$*)" "${_ARCH}" "${_TEST_SUFFIX}" > ${@}
+	./gen-tags-from-rpm "${URL_PREFIX}" "$(subst centos,epel,$*)" "${_ARCH}" "${_PBENCH_REPO_NAME}" > ${@}
 
 # This file takes a long time to generate, so preserve it between builds (it can
 # be removed explicitly via the `clean` target).
@@ -320,7 +321,7 @@ all-tags: pkgmgr-clean $(_DEFAULT_DISTROS:%=%-tags.lis)
 	jinja2 ${_PBENCH_REPO_TEMPLATE} $*-pbench.yml -o $@
 
 %-pbench.yml: repo.yml.j2
-	jinja2 repo.yml.j2 -D test_suffix=${_TEST_SUFFIX} -D user=${COPR_USER} \
+	jinja2 repo.yml.j2 -D name=${_PBENCH_REPO_NAME} -D user=${COPR_USER} \
         -D distro=$(if $(filter centos,${DIST_NAME}),$(subst centos,epel,$*),$*) \
         -D url_prefix=${URL_PREFIX} -o $@
 

--- a/agent/containers/images/gen-tags-from-rpm
+++ b/agent/containers/images/gen-tags-from-rpm
@@ -24,11 +24,11 @@
 url_prefix="${1}"
 dist="${2}"
 arch="${3}"
-test="${4}"
+name="${4}"
 
 # Ensure we only consider the pbench-agent RPM's version string from the
 # target repo.
-url="${url_prefix}/pbench${test}/${dist}-${arch}"
+url="${url_prefix}/${name}/${dist}-${arch}"
 version_string="$(yum list -q --repofrompath pbench,"${url}" pbench-agent.noarch 2>/dev/null | awk 'FNR==2{print $2}')"
 if [[ -z "${version_string}" ]]; then
     printf -- "Failed to fetch pbench-agent.noarch version string from '%s'\n" "${url}" >&2

--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -1,8 +1,8 @@
 ---
 repos:
-  - tag: pbench{{ test_suffix }}
+  - name: {{ name }}
     user: {{ user }}
-    baseurl: "{{ url_prefix }}/pbench{{ test_suffix }}/{{ distro }}-$basearch"
-    gpgkey: "{{ url_prefix }}/pbench{{ test_suffix }}/pubkey.gpg"
+    baseurl: "{{ url_prefix }}/{{ name }}/{{ distro }}-$basearch"
+    gpgkey: "{{ url_prefix }}/{{ name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1


### PR DESCRIPTION
PBENCH-902

In preparation for PR #2937, we remove the use of a default COPR repo name from the `pbench_repo_install` role.  This necessitates a change to the container image build mechanism since it relies on the repo template file from the ansible role.