### PR TITLE
PBENCH-838 User auth configuration parameters for the client

### DIFF
--- a/lib/pbench/test/unit/server/auth/conftest.py
+++ b/lib/pbench/test/unit/server/auth/conftest.py
@@ -18,7 +18,7 @@ def keycloak_oidc(server_config, monkeypatch):
         OpenIDClient, "set_well_known_endpoints", mock_set_oidc_auth_endpoints
     )
     oidc = OpenIDClient(
-        server_url=server_config.get("keycloak", "server_url"),
+        server_url=server_config.get("authentication", "server_url"),
         realm_name="public_test_realm",
         client_id="test_client",
         logger=logger,

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -52,8 +52,10 @@ logging_level = DEBUG
 [Indexing]
 index_prefix = unit-test
 
-[keycloak]
-server_url = http://pbench.example.com/
+[authentication]
+server_url = keycloak.example.com:0000
+realm = pbench
+client = pbench-dashboard
 
 ###########################################################################
 # The rest will come from the default config file.

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -38,7 +38,18 @@ class TestEndpointConfig:
         uri_prefix = server_config.rest_uri
         host = "http://" + host
         uri = urljoin(host, uri_prefix)
+        auth_realm = server_config.get("authentication", "realm")
+        auth_issuer = (
+            server_config.get("authentication", "server_url") + f"/{auth_realm}"
+        )
+        auth_obj = {
+            "realm": auth_realm,
+            "client": server_config.get("authentication", "client"),
+            "issuer": auth_issuer,
+            "secret": "",
+        }
         expected_results = {
+            "authentication": auth_obj,
             "identification": f"Pbench server {server_config.COMMIT_ID}",
             "api": {
                 "datasets_contents": f"{uri}/datasets/contents",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -42,14 +42,13 @@ class TestEndpointConfig:
         auth_issuer = (
             server_config.get("authentication", "server_url") + f"/{auth_realm}"
         )
-        auth_obj = {
-            "realm": auth_realm,
-            "client": server_config.get("authentication", "client"),
-            "issuer": auth_issuer,
-            "secret": "",
-        }
         expected_results = {
-            "authentication": auth_obj,
+            "authentication": {
+                "realm": auth_realm,
+                "client": server_config.get("authentication", "client"),
+                "issuer": auth_issuer,
+                "secret": "",
+            },
             "identification": f"Pbench server {server_config.COMMIT_ID}",
             "api": {
                 "datasets_contents": f"{uri}/datasets/contents",

--- a/server/lib/config/pbench-server.cfg.example
+++ b/server/lib/config/pbench-server.cfg.example
@@ -38,16 +38,16 @@ port = 0000
 host = graphql.example.com
 port = 0000
 
-## User authentication section to use when authorizing the user with a Keycloak broker
+## User authentication section to use when authorizing the user with an OIDC identity provider
 [authentication]
 
-# URL of the Keycloak auth server with port
+# URL of the OIDC auth server with port
 server_url = keycloak.example.com:0000
 
-# Realm name that is used for the authentication with keycloak
+# Realm name that is used for the authentication with OIDC
 realm = Pbench
 
-# Client entity name requesting Keycloak to authenticate a user
+# Client entity name requesting OIDC to authenticate a user
 client = Pbench-dashboard
 
 # Client secret if the above client is not public

--- a/server/lib/config/pbench-server.cfg.example
+++ b/server/lib/config/pbench-server.cfg.example
@@ -38,6 +38,12 @@ port = 0000
 host = graphql.example.com
 port = 0000
 
+[authentication]
+server_url = keycloak.example.com:0000
+realm = pbench
+client = pbench-dashboard
+secret = client-secret
+
 ###########################################################################
 # crontab roles
 

--- a/server/lib/config/pbench-server.cfg.example
+++ b/server/lib/config/pbench-server.cfg.example
@@ -38,10 +38,19 @@ port = 0000
 host = graphql.example.com
 port = 0000
 
+## User authentication section to use when authorizing the user with a Keycloak broker
 [authentication]
+
+# URL of the Keycloak auth server with port
 server_url = keycloak.example.com:0000
-realm = pbench
-client = pbench-dashboard
+
+# Realm name that is used for the authentication with keycloak
+realm = Pbench
+
+# Client entity name requesting Keycloak to authenticate a user
+client = Pbench-dashboard
+
+# Client secret if the above client is not public
 secret = client-secret
 
 ###########################################################################


### PR DESCRIPTION
[PBENCH-838](https://issues.redhat.com/browse/PBENCH-838)

Endpoints API now returns the authentication schema for the client (Pbench-dashboard) to use for authenticating the end-user. 

The endpoints API would include the authentication object containing the realm, client, and authentication issuer information. 
```
GET pbench_server_rest_uri/endpoints"
Success: 200,
response = {
      authentication = {
      "realm": [realm-name],
      "client": [client-name],
      "issuer": [auth-issuer],
      "oidc_secret": [secret-string]
      }
     ...
}
```
Right now the easiest way to store this information on the server side is by adding them to the config file (which is not ideal and soon we need to think about how we want to store and fetch secrets on the server side).
