### PR TITLE
Pbench refactor namespace values

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -109,13 +109,13 @@ def register_endpoints(api, app, config):
     )
     api.add_resource(
         SampleNamespace,
-        f"{base_uri}/datasets/namespace/<string:dataset_view>",
+        f"{base_uri}/datasets/namespace/<string:dataset>/<string:dataset_view>",
         endpoint="datasets_namespace",
         resource_class_args=(config, logger),
     )
     api.add_resource(
         SampleValues,
-        f"{base_uri}/datasets/values/<string:dataset_view>",
+        f"{base_uri}/datasets/values/<string:dataset>/<string:dataset_view>",
         endpoint="datasets_values",
         resource_class_args=(config, logger),
     )

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -67,7 +67,7 @@ class SampleNamespace(IndexMapBase):
         }
         """
         dataset: Dataset = context["dataset"]
-        document = self.ES_INTERNAL_INDEX_NAMES[params.uri.get("dataset_view")]
+        document = self.ES_INTERNAL_INDEX_NAMES[params.uri["dataset_view"]]
 
         document_index = document["index"]
 

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -35,17 +35,17 @@ class SampleNamespace(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.POST,
+                API_METHOD.GET,
                 API_OPERATION.READ,
                 uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter(
                         "dataset_view",
                         ParamType.KEYWORD,
                         required=True,
                         keywords=list(IndexMapBase.ES_INTERNAL_INDEX_NAMES.keys()),
-                    )
+                    ),
                 ),
-                body_schema=Schema(Parameter("name", ParamType.DATASET, required=True)),
                 authorization=API_AUTHORIZATION.DATASET,
             ),
         )
@@ -67,7 +67,7 @@ class SampleNamespace(IndexMapBase):
         }
         """
         dataset: Dataset = context["dataset"]
-        document = self.ES_INTERNAL_INDEX_NAMES[params.uri["dataset_view"]]
+        document = self.ES_INTERNAL_INDEX_NAMES[params.uri.get("dataset_view")]
 
         document_index = document["index"]
 
@@ -197,16 +197,16 @@ class SampleValues(IndexMapBase):
                 API_METHOD.POST,
                 API_OPERATION.READ,
                 uri_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter(
                         "dataset_view",
                         ParamType.KEYWORD,
                         required=True,
                         keywords=list(IndexMapBase.ES_INTERNAL_INDEX_NAMES.keys()),
-                    )
+                    ),
                 ),
                 body_schema=Schema(
                     Parameter("filters", ParamType.JSON, required=False),
-                    Parameter("name", ParamType.DATASET, required=True),
                     Parameter("scroll_id", ParamType.STRING, required=False),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -28,8 +28,6 @@ class TestSamplesNamespace(Commons):
             index_from_metadata="result-data-sample",
         )
 
-    api_method = API_METHOD.GET
-
     def test_with_no_index_document(
         self, client, server_config, pbench_token, attach_dataset
     ):
@@ -351,7 +349,7 @@ class TestSamplesNamespace(Commons):
             json=response_payload,
             status=HTTPStatus.OK,
             headers=build_auth_header["header"],
-            request_method=self.api_method,
+            request_method=API_METHOD.GET,
         )
         if expected_status == HTTPStatus.OK:
             res_json = response.json

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources import APIAbort
+from pbench.server.api.resources import API_METHOD, APIAbort
 from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleNamespace,
     SampleValues,
@@ -16,18 +16,19 @@ class TestSamplesNamespace(Commons):
     Unit testing for SamplesNamespace class.
     In a web service context, we access class functions mostly via the
     Flask test client rather than trying to directly invoke the class
-    constructor and `post` service.
+    constructor and `get` service.
     """
 
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
             cls_obj=SampleNamespace(client.config, client.logger),
-            pbench_endpoint="/datasets/namespace/iterations",
+            pbench_endpoint="/datasets/namespace/random_md5_string1/iterations",
             elastic_endpoint="/_search",
-            payload={"name": "random_md5_string1"},
             index_from_metadata="result-data-sample",
         )
+
+    api_method = API_METHOD.GET
 
     def test_with_no_index_document(
         self, client, server_config, pbench_token, attach_dataset
@@ -49,10 +50,9 @@ class TestSamplesNamespace(Commons):
         timeseries (result-data) documents
         """
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-1]) + "/test"
-        response = client.post(
+        response = client.get(
             f"{server_config.rest_uri}{incorrect_endpoint}",
             headers={"Authorization": "Bearer " + pbench_token},
-            json=self.payload,
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
 
@@ -351,6 +351,7 @@ class TestSamplesNamespace(Commons):
             json=response_payload,
             status=HTTPStatus.OK,
             headers=build_auth_header["header"],
+            request_method=self.api_method,
         )
         if expected_status == HTTPStatus.OK:
             res_json = response.json
@@ -406,9 +407,9 @@ class TestSampleValues(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=SampleValues(client.config, client.logger),
-            pbench_endpoint="/datasets/values/iterations",
+            pbench_endpoint="/datasets/values/random_md5_string1/iterations",
             elastic_endpoint="/_search",
-            payload={"name": "random_md5_string1"},
+            payload={},
             index_from_metadata="result-data-sample",
         )
 

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -100,8 +100,11 @@ class TestEndpointConfig:
                     "params": {"dataset": {"type": "string"}},
                 },
                 "datasets_namespace": {
-                    "template": f"{uri}/datasets/namespace/{{dataset_view}}",
-                    "params": {"dataset_view": {"type": "string"}},
+                    "template": f"{uri}/datasets/namespace/{{dataset}}/{{dataset_view}}",
+                    "params": {
+                        "dataset": {"type": "string"},
+                        "dataset_view": {"type": "string"},
+                    },
                 },
                 "datasets_publish": {
                     "template": f"{uri}/datasets/publish/{{dataset}}",
@@ -109,8 +112,11 @@ class TestEndpointConfig:
                 },
                 "datasets_search": {"template": f"{uri}/datasets/search", "params": {}},
                 "datasets_values": {
-                    "template": f"{uri}/datasets/values/{{dataset_view}}",
-                    "params": {"dataset_view": {"type": "string"}},
+                    "template": f"{uri}/datasets/values/{{dataset}}/{{dataset_view}}",
+                    "params": {
+                        "dataset": {"type": "string"},
+                        "dataset_view": {"type": "string"},
+                    },
                 },
                 "elasticsearch": {"template": f"{uri}/elasticsearch", "params": {}},
                 "endpoints": {"template": f"{uri}/endpoints", "params": {}},


### PR DESCRIPTION
PBENCH-748

Refactored `SampleNamespace` to GET API and moved the `<dataset>` attribute to the URI from JSON payload. And it'll be like
`GET /datasets/namespace/<dataset>/<dataset_view>`

And also did the same for the `SampleValues` API, since this API has multiple JSON attributes in the payload, it remains as a `POST` request and it'll be like
`POST /datasets/values/<dataset>/<dataset_view>`