### PR TITLE
Server Makefile housekeeping

### DIFF
--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -1,6 +1,23 @@
 # Makefile for generating a source RPM and, optionally, binary RPMs
 # for the Pbench server.
 
+# To limit the builds to certain chroots or exclude certain chroots
+# from building, add entries of the form
+#    "--chroot centos-stream-9-x86_64"
+# or
+#    "--exclude-chroot centos-stream-9-x86_64"
+# to the CHROOTS variable below.
+# Multiple such entries can be added to be passed as options to
+# `copr-cli build'.  By default, we build every chroot configured for
+# the project.
+# N.B. `copr-cli' flags an error if the value of a `--chroot' or
+# `--exclude-chroot' option is not configured in the project.
+# E.g. to build the RHEL9 chroots only:
+# CHROOTS = --chroot centos-stream-9-x86_64 \
+#           --chroot centos-stream-9-aarch64 \
+#           --chroot epel-9-x86_64 \
+#           --chroot epel-9-aarch64
+CHROOTS = --chroot rhel-9.dev-x86_64
 component = server
 subcomps = server web-server
 


### PR DESCRIPTION
This PR harmonizes the Pbench Server RPM `Makefile` with the Agent one.

The `Makefile`'s which drive the RPM builds for the Pbench Server and Agent, respectively, are basically a few definitions and an `include` directive for a common makefile.  The Pbench Server is missing the definition of `CHROOTS`, and this change supplies it (along with a copy of the block comment from the Agent `Makefile` which explains the definition).

The `CHROOTS` definition determines which distros are targeted when the RPMs are built using COPR.  Since we are now targeting the Pbench Server for RHEL-9, this change provides the appropriate value for the definition.

Note, however, that we don't actually intend to distribute a Pbench Server RPM from COPR, nor does the CI build procedure use COPR for building RPMs, so this change doesn't actually accomplish very much, other than to provide a little bit of documentation and a little bit of consistency with the Agent.