### PR TITLE
Pbench Audit service

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -54,6 +54,7 @@ class API(Enum):
     LOGIN = "login"
     LOGOUT = "logout"
     REGISTER = "register"
+    SERVER_AUDIT = "server_audit"
     SERVER_CONFIGURATION = "server_configuration"
     UPLOAD = "upload"
     USER = "user"

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -4,6 +4,7 @@ Simple module level convenience functions.
 
 from configparser import NoOptionError, NoSectionError
 from datetime import datetime, timedelta, tzinfo
+from enum import auto, Enum
 from pathlib import Path
 from time import time as _time
 from typing import Dict, List, Union
@@ -19,6 +20,22 @@ JSONVALUE = Union["JSONOBJECT", "JSONARRAY", JSONSTRING, JSONNUMBER, bool, None]
 JSONARRAY = List[JSONVALUE]
 JSONOBJECT = Dict[JSONSTRING, JSONVALUE]
 JSON = JSONVALUE
+
+
+class OperationCode(Enum):
+    """
+    The standard CRUD REST API operations:
+
+        CREATE: Instantiate a new resource
+        READ:   Retrieve the state of a resource
+        UPDATE: Modify the state of a resource
+        DELETE: Remove a resource
+    """
+
+    CREATE = auto()
+    READ = auto()
+    UPDATE = auto()
+    DELETE = auto()
 
 
 class simple_utc(tzinfo):

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -14,6 +14,7 @@ from flask_restful import Api
 from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
+from pbench.server.api.resources.audit_query import AuditQuery
 from pbench.server.api.resources.datasets_daterange import DatasetsDateRange
 from pbench.server.api.resources.datasets_inventory import DatasetsInventory
 from pbench.server.api.resources.datasets_list import DatasetsList
@@ -156,6 +157,12 @@ def register_endpoints(api, app, config):
         resource_class_args=(config, logger),
     )
     api.add_resource(
+        AuditQuery,
+        f"{base_uri}/server/audit",
+        endpoint="server_audit",
+        resource_class_args=(config, logger),
+    )
+    api.add_resource(
         ServerConfiguration,
         f"{base_uri}/server/configuration",
         f"{base_uri}/server/configuration/",
@@ -208,7 +215,7 @@ def create_app(server_config):
     register_endpoints(api, app, server_config)
 
     try:
-        init_db(server_config=server_config, logger=app.logger)
+        init_db(configuration=server_config, logger=app.logger)
     except Exception:
         app.logger.exception("Exception while initializing sqlalchemy database")
         sys.exit(1)

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -14,7 +14,6 @@ from flask_restful import Api
 from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.api.resources.audit_query import AuditQuery
 from pbench.server.api.resources.datasets_daterange import DatasetsDateRange
 from pbench.server.api.resources.datasets_inventory import DatasetsInventory
 from pbench.server.api.resources.datasets_list import DatasetsList
@@ -36,6 +35,7 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
 from pbench.server.api.resources.query_apis.datasets_delete import DatasetsDelete
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
+from pbench.server.api.resources.server_audit import ServerAudit
 from pbench.server.api.resources.server_configuration import ServerConfiguration
 from pbench.server.api.resources.upload_api import Upload
 from pbench.server.api.resources.users_api import Login, Logout, RegisterUser, UserAPI
@@ -157,7 +157,7 @@ def register_endpoints(api, app, config):
         resource_class_args=(config, logger),
     )
     api.add_resource(
-        AuditQuery,
+        ServerAudit,
         f"{base_uri}/server/audit",
         endpoint="server_audit",
         resource_class_args=(config, logger),

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -12,8 +12,14 @@ from flask.wrappers import Request, Response
 from flask_restful import abort, Resource
 from sqlalchemy.orm.query import Query
 
-from pbench.server import JSON, JSONOBJECT, JSONVALUE, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT, JSONVALUE, OperationCode, PbenchServerConfig
 from pbench.server.auth.auth import Auth
+from pbench.server.database.models.audit import (
+    Audit,
+    AuditReason,
+    AuditStatus,
+    AuditType,
+)
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
@@ -50,7 +56,7 @@ class UnauthorizedAccess(APIAbort):
     def __init__(
         self,
         user: Union[User, None],
-        operation: "API_OPERATION",
+        operation: "OperationCode",
         owner: Union[str, None],
         access: Union[str, None],
         http_status: int = HTTPStatus.FORBIDDEN,
@@ -74,7 +80,7 @@ class UnauthorizedAdminAccess(UnauthorizedAccess):
     def __init__(
         self,
         user: Union[User, None],
-        operation: "API_OPERATION",
+        operation: "OperationCode",
         http_status: int = HTTPStatus.FORBIDDEN,
     ):
         super().__init__(
@@ -449,12 +455,15 @@ def convert_int(value: Union[int, str], _) -> int:
     raise ConversionError(value, int.__name__)
 
 
-def convert_keyword(value: str, parameter: "Parameter") -> str:
+def convert_keyword(value: str, parameter: "Parameter") -> Union[str, Enum]:
     """
     Verify that the parameter value is a string and a member of the
     `valid` list. The match is case-blind and will return the lowercased
     version of the input keyword. If there are no keywords defined, the
     input is lowercased and returned without validation.
+
+    If the 'enum' Parameter property is set, attempt to convert the string
+    to an instance of the enum type.
 
     Keyword matching recognizes a "path" keyword where validation occurs only
     on the first element of a dotted path (e.g., "user.contact.email" matches
@@ -474,6 +483,13 @@ def convert_keyword(value: str, parameter: "Parameter") -> str:
 
     if type(value) is not str:
         raise ConversionError(value, str.__name__)
+    if parameter.enum:
+        try:
+            input = parameter.enum[value.upper()]
+        except ValueError as e:
+            raise KeywordError(parameter, "enum", [value]) from e
+        return input
+
     input = value.lower()
     if not parameter.keywords:
         return input
@@ -560,6 +576,10 @@ def convert_access(value: str, parameter: "Parameter") -> str:
     return v
 
 
+# A type defined to pass context through API methods.
+ApiContext = Dict[str, Any]
+
+
 class ParamType(Enum):
     """
     Define the possible JSON query parameter keys, and their type.
@@ -603,11 +623,12 @@ class Parameter:
         name: str,
         type: ParamType,
         *,  # Following are keyword-only
-        keywords: Union[List[str], None] = None,
-        element_type: Union[ParamType, None] = None,
+        keywords: Optional[List[str]] = None,
+        element_type: Optional[ParamType] = None,
         required: bool = False,
         key_path: bool = False,
-        string_list: Union[str, None] = None,
+        string_list: Optional[str] = None,
+        enum: Optional[type[Enum]] = None,
     ):
         """
         Initialize a Parameter object describing a JSON parameter with its type
@@ -623,6 +644,8 @@ class Parameter:
                 element matches the keyword list.
             string_list: if a delimiter is specified, individual string values
                 will be split into lists.
+            enum: An Enum subclass to which an upcased keyword should be
+                converted.
         """
         self.name = name
         self.type = type
@@ -631,6 +654,7 @@ class Parameter:
         self.required = required
         self.key_path = key_path
         self.string_list = string_list
+        self.enum = enum
 
     def invalid(self, json: JSONOBJECT) -> bool:
         """
@@ -672,7 +696,7 @@ class ParamSet(NamedTuple):
     value: Any
 
 
-class API_METHOD(Enum):
+class ApiMethod(Enum):
     DELETE = auto()
     GET = auto()
     HEAD = auto()
@@ -680,25 +704,7 @@ class API_METHOD(Enum):
     PUT = auto()
 
 
-class API_OPERATION(Enum):
-    """
-    The standard CRUD REST API operations:
-
-        CREATE: Instantiate a new resource
-        READ:   Retrieve the state of a resource
-        UPDATE: Modify the state of a resource
-        DELETE: Remove a resource
-
-    NOTE: only READ and UPDATE are currently used by Pbench queries.
-    """
-
-    CREATE = auto()
-    READ = auto()
-    UPDATE = auto()
-    DELETE = auto()
-
-
-class API_AUTHORIZATION(Enum):
+class ApiAuthorizationType(Enum):
     """
     Defines the mechanism by which ApiBase infrastructure will automatically
     authorize the client for the API method:
@@ -738,8 +744,8 @@ class ApiAuthorization(NamedTuple):
     the desired access role.
     """
 
-    type: API_AUTHORIZATION
-    role: API_OPERATION
+    type: ApiAuthorizationType
+    role: OperationCode
     user: Optional[str] = None
     access: Optional[str] = None
 
@@ -838,13 +844,15 @@ class ApiSchema:
 
     def __init__(
         self,
-        method: API_METHOD,
-        operation: API_OPERATION,
+        method: ApiMethod,
+        operation: OperationCode,
         body_schema: Optional[Schema] = None,
         query_schema: Optional[Schema] = None,
         uri_schema: Optional[Schema] = None,
         *,
-        authorization: API_AUTHORIZATION = API_AUTHORIZATION.NONE,
+        audit_type: AuditType = AuditType.NONE,
+        audit_name: Optional[str] = None,
+        authorization: ApiAuthorizationType = ApiAuthorizationType.NONE,
     ):
         """
         Construct an ApiSchema encapsulating a set of schema objects separating
@@ -853,24 +861,27 @@ class ApiSchema:
 
         Args:
             method: API method
-            operation:  CRUD operation code
-            body_schema:    Definition of parameters received through a JSON
-                            body.
-            query_schema:   Definition of parameters received through query
-                            parameters.
-            uri_schema:     Definition of parameters received through Flask URI
-                            templates.
-            authorization:  How to authorize access to this API method; the
-                            authorization process triggers on a specific type
-                            of parameter, DATASET or USER, which must appear in
-                            exactly one of the three schema defined for this
-                            HTTP method.
+            operation: CRUD operation code
+            body_schema: Definition of parameters received through a JSON body.
+            query_schema: Definition of parameters received through query
+                parameters.
+            uri_schema: Definition of parameters received through Flask URI
+                templates.
+            audit_type: The type of resource affected by API calls; only
+                meaningful for CREATE/UPDATE/DELETE operations.
+            audit_name: The name to use for the audit record
+            authorization: How to authorize access to this API method; the
+                authorization process triggers on a specific type of parameter,
+                DATASET or USER, which must appear in exactly one of the set of
+                schema defined for an HTTP method.
         """
         self.method = method
         self.operation = operation
         self.body_schema = body_schema
         self.query_schema = query_schema
         self.uri_schema = uri_schema
+        self.audit_type = audit_type
+        self.audit_name = audit_name
         self.authorization = authorization
 
     def get_param_by_type(
@@ -959,7 +970,7 @@ class ApiSchema:
         Returns
             The values for username and access policy to use for authorization.
         """
-        if self.authorization == API_AUTHORIZATION.DATASET:
+        if self.authorization == ApiAuthorizationType.DATASET:
             ds = self.get_param_by_type(ParamType.DATASET, params)
             if ds:
                 return ApiAuthorization(
@@ -969,7 +980,7 @@ class ApiSchema:
                     role=self.operation,
                 )
             return None
-        elif self.authorization == API_AUTHORIZATION.USER_ACCESS:
+        elif self.authorization == ApiAuthorizationType.USER_ACCESS:
             user = self.get_param_by_type(ParamType.USER, params)
             access = self.get_param_by_type(ParamType.ACCESS, params)
             return ApiAuthorization(
@@ -978,7 +989,7 @@ class ApiSchema:
                 access=access.value,
                 role=self.operation,
             )
-        elif self.authorization == API_AUTHORIZATION.ADMIN:
+        elif self.authorization == ApiAuthorizationType.ADMIN:
             return ApiAuthorization(type=self.authorization, role=self.operation)
         return None
 
@@ -992,9 +1003,9 @@ class ApiSchemaSet:
             schemas: A list of schemas for each HTTP method supported by an
                 API class.
         """
-        self.schemas: Dict[API_METHOD, ApiSchema] = {s.method: s for s in schemas}
+        self.schemas: Dict[ApiMethod, ApiSchema] = {s.method: s for s in schemas}
 
-    def __getitem__(self, key: API_METHOD):
+    def __getitem__(self, key: ApiMethod):
         return self.schemas.get(key)
 
     def __iter__(self):
@@ -1004,7 +1015,7 @@ class ApiSchemaSet:
         return item in self.schemas
 
     def get_param_by_type(
-        self, method: API_METHOD, dtype: ParamType, params: Optional[ApiParams]
+        self, method: ApiMethod, dtype: ParamType, params: Optional[ApiParams]
     ) -> Optional[ParamSet]:
         """
         Find the first relevant parameter of the desired type.
@@ -1029,7 +1040,7 @@ class ApiSchemaSet:
         """
         return self.schemas[method].get_param_by_type(dtype, params)
 
-    def validate(self, method: API_METHOD, args: ApiParams) -> ApiParams:
+    def validate(self, method: ApiMethod, args: ApiParams) -> ApiParams:
         """
         Validate the parameter schema based on the HTTP method used by the
         client.
@@ -1051,7 +1062,7 @@ class ApiSchemaSet:
             return ApiParams(body=None, query=None, uri=None)
 
     def authorize(
-        self, method: API_METHOD, args: ApiParams
+        self, method: ApiMethod, args: ApiParams
     ) -> Optional[ApiAuthorization]:
         """
         Determine how API validation should deal with client authorization for
@@ -1209,7 +1220,7 @@ class ApiBase(Resource):
         # access, so take care of that first as a special case. If there is
         # an authenticated user, and that user holds ADMIN access rights, the
         # check passes. Otherwise raise an "admin access" failure.
-        if mode.type == API_AUTHORIZATION.ADMIN:
+        if mode.type == ApiAuthorizationType.ADMIN:
             self.logger.debug(
                 "Authorizing {} access for {} to an administrative resource",
                 role,
@@ -1246,7 +1257,7 @@ class ApiBase(Resource):
         #    authenticated client.
         # 4) An authenticated client cannot mutate data owned by a different
         #    user, nor READ private data owned by another user.
-        if role == API_OPERATION.READ and access == Dataset.PUBLIC_ACCESS:
+        if role == OperationCode.READ and access == Dataset.PUBLIC_ACCESS:
             # We are reading public data: this is always allowed.
             pass
         else:
@@ -1265,7 +1276,7 @@ class ApiBase(Resource):
                     access,
                     HTTPStatus.UNAUTHORIZED,
                 )
-            elif role != API_OPERATION.READ and user_id is None:
+            elif role != OperationCode.READ and user_id is None:
                 # No target user is specified, so we won't allow mutation of
                 # data: REJECT
                 self.logger.warning(
@@ -1472,7 +1483,7 @@ class ApiBase(Resource):
 
     def _dispatch(
         self,
-        method: API_METHOD,
+        method: ApiMethod,
         request: Request,
         uri_params: Optional[JSONOBJECT] = None,
     ) -> Response:
@@ -1500,18 +1511,18 @@ class ApiBase(Resource):
 
         if not self.always_enabled:
             disabled = ServerConfig.get_disabled(
-                readonly=(self.schemas[method].operation == API_OPERATION.READ)
+                readonly=(self.schemas[method].operation == OperationCode.READ)
             )
             if disabled:
                 abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
 
-        if method is API_METHOD.GET:
+        if method is ApiMethod.GET:
             execute = self._get
-        elif method is API_METHOD.PUT:
+        elif method is ApiMethod.PUT:
             execute = self._put
-        elif method is API_METHOD.POST:
+        elif method is ApiMethod.POST:
             execute = self._post
-        elif method is API_METHOD.DELETE:
+        elif method is ApiMethod.DELETE:
             execute = self._delete
         else:
             abort(
@@ -1519,7 +1530,8 @@ class ApiBase(Resource):
                 message=HTTPStatus.METHOD_NOT_ALLOWED.phrase,
             )
 
-        if self.schemas[method]:
+        schema = self.schemas[method]
+        if schema:
             body_params = None
             query_params = None
 
@@ -1536,9 +1548,9 @@ class ApiBase(Resource):
                     )
 
             try:
-                if self.schemas[method].query_schema:
+                if schema.query_schema:
                     query_params = self._gather_query_params(
-                        request, self.schemas[method].query_schema
+                        request, schema.query_schema
                     )
 
                 params = self.schemas.validate(
@@ -1557,6 +1569,24 @@ class ApiBase(Resource):
         else:
             params = ApiParams(None, None, None)
 
+        audit = None
+        if schema.operation is not OperationCode.READ:
+            user = Auth.token_auth.current_user()
+            dataset_found = schema.get_param_by_type(ParamType.DATASET, params)
+            if dataset_found:
+                dataset = dataset_found.value
+            else:
+                dataset = None
+
+            audit = Audit.create(
+                operation=schema.operation,
+                status=AuditStatus.BEGIN,
+                user=user,
+                name=schema.audit_name,
+                dataset=dataset,
+                object_type=schema.audit_type,
+            )
+
         # Automatically authorize the operation only if the API schema for the
         # active HTTP method has authorization enabled, using the selected
         # parameters. Automatic authorization can be disabled by selecting
@@ -1569,27 +1599,88 @@ class ApiBase(Resource):
                 self._check_authorization(auth_params)
             except UnauthorizedAccess as e:
                 self.logger.warning("{}: {}", api_name, e)
+                if audit:
+                    Audit.create(
+                        root=audit,
+                        status=AuditStatus.FAILURE,
+                        reason=AuditReason.PERMISSION,
+                        attributes={"message": str(e)},
+                    )
                 abort(e.http_status, message=str(e))
             except Exception as e:
                 self.logger.exception("{}: {}", api_name, e)
+                if audit:
+                    Audit.create(
+                        root=audit,
+                        status=AuditStatus.FAILURE,
+                        reason=AuditReason.INTERNAL,
+                        attributes={"message": str(e)},
+                    )
                 abort(
                     HTTPStatus.INTERNAL_SERVER_ERROR,
                     message=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
                 )
 
+        # Pass the root audit object to the API implementation. Normally, we'll
+        # automatically generate an audit finalization; however if the API
+        # wants to emit a special audit sequence it can disable "finalize"
+        # in the context. It can also pass "attributes" by setting that
+        # field.
+        context = {
+            "auditing": {
+                "audit": audit,
+                "finalize": bool(audit),
+                "status": AuditStatus.SUCCESS,
+                "reason": None,
+                "attributes": None,
+            }
+        }
+
         try:
-            return execute(params, request)
+            response = execute(params, request, context)
+            auditing = context["auditing"]
+            if auditing["finalize"]:
+                Audit.create(
+                    root=auditing["audit"],
+                    status=auditing["status"],
+                    reason=auditing["reason"],
+                    attributes=auditing["attributes"],
+                )
+            return response
         except APIAbort as e:
-            self.logger.exception("{} {}", api_name, e)
+            auditing = context["auditing"]
+            if auditing["finalize"]:
+                attr = auditing.get("attributes", {"message": str(e)})
+                try:
+                    Audit.create(
+                        root=auditing["audit"],
+                        status=AuditStatus.FAILURE,
+                        reason=auditing["reason"],
+                        attributes=attr,
+                    )
+                except Exception:
+                    self.logger.exception("The audit did it!")
             abort(e.http_status, message=str(e))
         except Exception as e:
-            self.logger.exception("{} API error: {}", api_name, e)
+            self.logger.exception(
+                "Exception {} API error: {}: {!r}", api_name, e, context
+            )
+            auditing = context["auditing"]
+            if auditing["finalize"]:
+                attr = auditing.get("attributes", {})
+                attr["message"] = str(e)
+                Audit.create(
+                    root=auditing["audit"],
+                    status=AuditStatus.FAILURE,
+                    reason=AuditReason.INTERNAL,
+                    attributes=attr,
+                )
             abort(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 message=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
             )
 
-    def _get(self, args: ApiParams, request: Request) -> Response:
+    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
         """
         ABSTRACT METHOD: override in subclass to perform operation
 
@@ -1598,6 +1689,7 @@ class ApiBase(Resource):
         Args:
             args: Type-normalized client argument sets
             request: Original incoming Request object
+            context: API context dictionary
 
         Returns:
             Response to return to client
@@ -1606,7 +1698,7 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _get method"
         )
 
-    def _post(self, args: ApiParams, request: Request) -> Response:
+    def _post(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
         """
         ABSTRACT METHOD: override in subclass to perform operation
 
@@ -1615,6 +1707,7 @@ class ApiBase(Resource):
         Args:
             args: Type-normalized client argument sets
             request: Original incoming Request object
+            context: API context dictionary
 
         Returns:
             Response to return to client
@@ -1623,7 +1716,7 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _post method"
         )
 
-    def _put(self, args: ApiParams, request: Request) -> Response:
+    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
         """
         ABSTRACT METHOD: override in subclass to perform operation
 
@@ -1632,6 +1725,7 @@ class ApiBase(Resource):
         Args:
             args: Type-normalized client argument sets
             request: Original incoming Request object
+            context: API context dictionary
 
         Returns:
             Response to return to client
@@ -1640,7 +1734,9 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _put method"
         )
 
-    def _delete(self, args: ApiParams, request: Request) -> Response:
+    def _delete(
+        self, args: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         ABSTRACT METHOD: override in subclass to perform operation
 
@@ -1649,6 +1745,7 @@ class ApiBase(Resource):
         Args:
             args: Type-normalized client argument sets
             request: Original incoming Request object
+            context: API context dictionary
 
         Returns:
             Response to return to client
@@ -1662,25 +1759,25 @@ class ApiBase(Resource):
         """
         Handle an authenticated GET operation on the Resource
         """
-        return self._dispatch(API_METHOD.GET, request, kwargs)
+        return self._dispatch(ApiMethod.GET, request, kwargs)
 
     @Auth.token_auth.login_required(optional=True)
     def post(self, **kwargs):
         """
         Handle an authenticated POST operation on the Resource
         """
-        return self._dispatch(API_METHOD.POST, request, kwargs)
+        return self._dispatch(ApiMethod.POST, request, kwargs)
 
     @Auth.token_auth.login_required(optional=True)
     def put(self, **kwargs):
         """
         Handle an authenticated PUT operation on the Resource
         """
-        return self._dispatch(API_METHOD.PUT, request, kwargs)
+        return self._dispatch(ApiMethod.PUT, request, kwargs)
 
     @Auth.token_auth.login_required(optional=True)
     def delete(self, **kwargs):
         """
         Handle an authenticated DELETE operation on the Resource
         """
-        return self._dispatch(API_METHOD.DELETE, request, kwargs)
+        return self._dispatch(ApiMethod.DELETE, request, kwargs)

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1595,10 +1595,7 @@ class ApiBase(Resource):
         if schema.operation is not OperationCode.READ:
             user = Auth.token_auth.current_user()
             dataset_found = schema.get_param_by_type(ParamType.DATASET, params)
-            if dataset_found:
-                dataset = dataset_found.value
-            else:
-                dataset = None
+            dataset = dataset_found.value if dataset_found else None
 
             audit = Audit.create(
                 operation=schema.operation,

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -859,20 +859,24 @@ class ApiSchema:
         apply to a particular HTTP method.
 
         Args:
-            method: API method
-            operation: CRUD operation code
-            body_schema: Definition of parameters received through a JSON body.
+            method:
+                    API method
+            operation:
+                    CRUD operation code
+            body_schema:
+                    Definition of parameters received through a JSON body.
             query_schema: Definition of parameters received through query
-                parameters.
+                    parameters.
             uri_schema: Definition of parameters received through Flask URI
-                templates.
+                    templates.
             audit_type: The type of resource affected by API calls; only
-                meaningful for CREATE/UPDATE/DELETE operations.
-            audit_name: The name to use for the audit record
+                    meaningful for CREATE/UPDATE/DELETE operations.
+            audit_name:
+                    The name to use for the audit record
             authorization: How to authorize access to this API method; the
-                authorization process triggers on a specific type of parameter,
-                DATASET or USER, which must appear in exactly one of the set of
-                schema defined for an HTTP method.
+                    authorization process triggers on a specific type of
+                    parameter, DATASET or USER, which must appear in exactly
+                    one of the set of schema defined for an HTTP method.
         """
         self.method = method
         self.operation = operation

--- a/lib/pbench/server/api/resources/audit_query.py
+++ b/lib/pbench/server/api/resources/audit_query.py
@@ -50,12 +50,7 @@ class AuditQuery(ApiBase):
                     Parameter("type", ParamType.KEYWORD, enum=AuditType),
                     Parameter("user", ParamType.USER),
                     Parameter("user_id", ParamType.STRING),
-                    # FIXME: Implement pagination
-                    Parameter("offset", ParamType.INT),
-                    Parameter("limit", ParamType.INT),
                 ),
-                # FIXME: We should restrict non-ADMIN queries to audit records
-                # tagged for the particular user, probably by owner_id.
                 authorization=ApiAuthorizationType.NONE,
             ),
             always_enabled=True,

--- a/lib/pbench/server/api/resources/audit_query.py
+++ b/lib/pbench/server/api/resources/audit_query.py
@@ -1,0 +1,91 @@
+from http import HTTPStatus
+from logging import Logger
+
+from flask.json import jsonify
+from flask.wrappers import Request, Response
+
+from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server.api.resources import (
+    APIAbort,
+    ApiAuthorizationType,
+    ApiBase,
+    ApiContext,
+    ApiMethod,
+    ApiParams,
+    ApiSchema,
+    Parameter,
+    ParamType,
+    Schema,
+)
+from pbench.server.database.models.audit import (
+    Audit,
+    AuditReason,
+    AuditSqlError,
+    AuditStatus,
+    AuditType,
+)
+
+
+class AuditQuery(ApiBase):
+    """
+    API class to retrieve and mutate server configuration settings.
+    """
+
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            ApiSchema(
+                ApiMethod.GET,
+                OperationCode.READ,
+                query_schema=Schema(
+                    Parameter("dataset", ParamType.DATASET),
+                    Parameter("end", ParamType.DATE),
+                    Parameter("name", ParamType.STRING),
+                    Parameter("object_id", ParamType.STRING),
+                    Parameter("operation", ParamType.KEYWORD, enum=OperationCode),
+                    Parameter("reason", ParamType.KEYWORD, enum=AuditReason),
+                    Parameter("start", ParamType.DATE),
+                    Parameter("status", ParamType.KEYWORD, enum=AuditStatus),
+                    Parameter("type", ParamType.KEYWORD, enum=AuditType),
+                    Parameter("user", ParamType.USER),
+                    Parameter("user_id", ParamType.STRING),
+                    # FIXME: Implement pagination
+                    Parameter("offset", ParamType.INT),
+                    Parameter("limit", ParamType.INT),
+                ),
+                # FIXME: We should restrict non-ADMIN queries to audit records
+                # tagged for the particular user, probably by owner_id.
+                authorization=ApiAuthorizationType.NONE,
+            ),
+            always_enabled=True,
+        )
+
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
+        """
+        Get the values of server configuration parameters.
+
+        GET /api/v1/server/audit?start=2022-08-01
+            return all audit records since August 1, 2022
+
+        or
+
+        GET /api/v1/server/audit
+            return all audit records
+
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+            context: API context dictionary
+
+        Returns:
+            HTTP Response object
+        """
+
+        try:
+            audits = Audit.query(**params.query)
+            return jsonify([a.as_json() for a in audits])
+        except AuditSqlError as e:
+            raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR, str(e)) from e

--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -4,12 +4,12 @@ from flask.json import jsonify
 from flask.wrappers import Request, Response
 from sqlalchemy import func
 
-from pbench.server import PbenchServerConfig
+from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -30,17 +30,19 @@ class DatasetsDateRange(ApiBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 query_schema=Schema(
                     Parameter("owner", ParamType.USER, required=False),
                     Parameter("access", ParamType.ACCESS, required=False),
                 ),
-                authorization=API_AUTHORIZATION.USER_ACCESS,
+                authorization=ApiAuthorizationType.USER_ACCESS,
             ),
         )
 
-    def _get(self, params: ApiParams, request: Request) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Get the date range for which datasets are available to the client based
         on authentication plus optional dataset owner and access criteria.
@@ -48,6 +50,7 @@ class DatasetsDateRange(ApiBase):
         Args:
             json_data: Ignored because GET has no JSON payload
             request: The original Request object containing query parameters
+            context: API context dictionary
 
         GET /api/v1/datasets/daterange?owner=user&access=public
         """

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,16 +1,17 @@
 from http import HTTPStatus
 from logging import Logger
+from urllib.request import Request
 
 from flask import send_file
 from flask.wrappers import Response
 
-from pbench.server import PbenchServerConfig
+from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     APIAbort,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -30,22 +31,26 @@ class DatasetsInventory(ApiBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter("target", ParamType.STRING, required=False),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 
-    def _get(self, params: ApiParams, _) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         This function returns the contents of the requested file as a byte stream.
 
         Args:
-            ApiParams includes the uri parameters, which provide the dataset and target.
+            params: includes the uri parameters, which provide the dataset and target.
+            request: Original incoming Request object
+            context: API context dictionary
 
         Raises:
             APIAbort, reporting either "NOT_FOUND" or "UNSUPPORTED_MEDIA_TYPE"

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -6,12 +6,12 @@ from flask.json import jsonify
 from flask.wrappers import Request, Response
 from sqlalchemy.orm import Query
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -30,8 +30,8 @@ class DatasetsList(ApiBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 query_schema=Schema(
                     Parameter("name", ParamType.STRING),
                     Parameter("owner", ParamType.USER),
@@ -49,7 +49,7 @@ class DatasetsList(ApiBase):
                         string_list=",",
                     ),
                 ),
-                authorization=API_AUTHORIZATION.USER_ACCESS,
+                authorization=ApiAuthorizationType.USER_ACCESS,
             ),
         )
 
@@ -101,7 +101,9 @@ class DatasetsList(ApiBase):
         paginated_result["total"] = total_count
         return items, paginated_result
 
-    def _get(self, params: ApiParams, request: Request) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Get a list of datasets matching a set of criteria.
 
@@ -111,6 +113,7 @@ class DatasetsList(ApiBase):
         Args:
             params: API parameters
             request: The original Request object
+            context: API context dictionary
 
         GET /api/v1/datasets/list?start=1970-01-01&end=2040-12-31&owner=fred&metadata=dashboard.seen,server.deletion
         """

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -105,6 +105,11 @@ class DatasetsMetadata(ApiBase):
         """
         Set or modify the values of client-accessible dataset metadata keys.
 
+        Args:
+            params: API parameters
+            request: The original Request object containing query parameters
+            context: API context dictionary
+
         PUT /api/v1/datasets/metadata
         {
             "name": "datasetname",

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -4,14 +4,14 @@ from logging import Logger
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import PbenchServerConfig
+from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     APIAbort,
     ApiAuthorization,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -19,6 +19,7 @@ from pbench.server.api.resources import (
     Schema,
 )
 from pbench.server.auth.auth import Auth
+from pbench.server.database.models.audit import AuditType
 from pbench.server.database.models.datasets import (
     Metadata,
     MetadataBadValue,
@@ -36,8 +37,8 @@ class DatasetsMetadata(ApiBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.PUT,
-                API_OPERATION.UPDATE,
+                ApiMethod.PUT,
+                OperationCode.UPDATE,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
                 ),
@@ -50,11 +51,13 @@ class DatasetsMetadata(ApiBase):
                         key_path=True,
                     )
                 ),
-                authorization=API_AUTHORIZATION.NONE,
+                audit_type=AuditType.DATASET,
+                audit_name="metadata",
+                authorization=ApiAuthorizationType.NONE,
             ),
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
                 ),
@@ -68,17 +71,20 @@ class DatasetsMetadata(ApiBase):
                         string_list=",",
                     )
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 
-    def _get(self, params: ApiParams, request: Request) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Get the values of client-accessible dataset metadata keys.
 
         Args:
             params: API parameters
             request: The original Request object containing query parameters
+            context: API context dictionary
 
         GET /api/v1/datasets/metadata?name=dname&metadata=global.seen,server.deletion
         """
@@ -93,7 +99,9 @@ class DatasetsMetadata(ApiBase):
 
         return jsonify(metadata)
 
-    def _put(self, params: ApiParams, _) -> Response:
+    def _put(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Set or modify the values of client-accessible dataset metadata keys.
 
@@ -123,6 +131,8 @@ class DatasetsMetadata(ApiBase):
         dataset = params.uri["dataset"]
         metadata = params.body["metadata"]
 
+        context["auditing"]["attributes"] = {"updated": metadata}
+
         # Validate the authenticated user's authorization for the combination
         # of "owner" and "access".
         #
@@ -140,16 +150,16 @@ class DatasetsMetadata(ApiBase):
         # * We want to validate authorized users for UPDATE if they're trying
         #   to set anything other than a "user." key because only the owner can
         #   do that...
-        role = API_OPERATION.READ
+        role = OperationCode.READ
         if not Auth.token_auth.current_user():
-            role = API_OPERATION.UPDATE
+            role = OperationCode.UPDATE
         else:
             for k in metadata.keys():
                 if Metadata.get_native_key(k) != Metadata.USER:
-                    role = API_OPERATION.UPDATE
+                    role = OperationCode.UPDATE
         self._check_authorization(
             ApiAuthorization(
-                API_AUTHORIZATION.USER_ACCESS,
+                ApiAuthorizationType.USER_ACCESS,
                 role,
                 str(dataset.owner_id),
                 dataset.access,

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -2,11 +2,11 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from http import HTTPStatus
-import json
 from logging import Logger
 import re
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from typing import Any, Callable, Iterator, List, Optional
 from urllib.parse import urljoin
+from urllib.request import Request
 
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
@@ -15,12 +15,13 @@ from flask import jsonify
 from flask.wrappers import Response
 import requests
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
     APIAbort,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     ParamType,
@@ -28,13 +29,10 @@ from pbench.server.api.resources import (
     UnauthorizedAccess,
 )
 from pbench.server.auth.auth import Auth
+from pbench.server.database.models.audit import AuditReason, AuditStatus
 from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
-
-# A type defined to allow the preprocess subclass method to provide shared
-# context with the assemble and postprocess methods.
-CONTEXT = Dict[str, Any]
 
 
 class MissingBulkSchemaParameters(SchemaError):
@@ -304,7 +302,7 @@ class ElasticBase(ApiBase):
             )
         return indices
 
-    def preprocess(self, params: ApiParams) -> CONTEXT:
+    def preprocess(self, params: ApiParams, context: ApiContext):
         """
         Given the client Request payload, perform any preprocessing activities
         necessary prior to constructing an Elasticsearch query.
@@ -320,6 +318,7 @@ class ElasticBase(ApiBase):
 
         Args:
             params: Type-normalized client parameters
+            context: API context dictionary
 
         Raises:
             Any errors in the postprocess method shall be reported by
@@ -331,7 +330,7 @@ class ElasticBase(ApiBase):
         """
         return {}
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Assemble the Elasticsearch parameters.
 
@@ -356,7 +355,7 @@ class ElasticBase(ApiBase):
         """
         raise NotImplementedError()
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> JSON:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> JSON:
         """
         Given the Elasticsearch Response object, construct a JSON document to
         be returned to the original caller.
@@ -376,23 +375,22 @@ class ElasticBase(ApiBase):
         """
         raise NotImplementedError()
 
-    def _call(self, method: Callable, params: ApiParams):
+    def _call(self, method: Callable, params: ApiParams, context: ApiContext):
         """
         Perform the requested call to Elasticsearch, and handle any exceptions.
 
         Args:
             method: requests package callable (e.g., requests.get)
             params: Type-normalized client parameters
+            context: API context dictionary
 
         Returns:
             Postprocessed JSON body to return to client
         """
         klasname = self.__class__.__name__
         try:
-            context = self.preprocess(params)
+            self.preprocess(params, context)
             self.logger.debug("PREPROCESS returns {}", context)
-            if context is None:
-                return "", HTTPStatus.NO_CONTENT
         except UnauthorizedAccess as e:
             self.logger.warning("{}", e)
             raise APIAbort(e.http_status, str(e))
@@ -483,7 +481,9 @@ class ElasticBase(ApiBase):
             )
             raise APIAbort(HTTPStatus.INTERNAL_SERVER_ERROR)
 
-    def _post(self, params: ApiParams, _) -> Response:
+    def _post(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Handle a Pbench server POST operation that will involve a call to the
         server's configured Elasticsearch instance. The assembly and
@@ -492,15 +492,17 @@ class ElasticBase(ApiBase):
         we rely on the ApiBase superclass to provide basic JSON parameter
         validation and normalization.
         """
-        return self._call(requests.post, params)
+        return self._call(requests.post, params, context)
 
-    def _get(self, params: ApiParams, _) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Handle a GET operation involving a call to the server's Elasticsearch
         instance. The post-processing of the Elasticsearch query is handled
         the subclasses through their postprocess() methods.
         """
-        return self._call(requests.get, params)
+        return self._call(requests.get, params, context)
 
 
 @dataclass
@@ -584,7 +586,7 @@ class ElasticBulkBase(ApiBase):
         if not schemas:
             raise MissingBulkSchemaParameters(api_name, "no schema provided")
         dset = self.schemas.get_param_by_type(
-            API_METHOD.POST,
+            ApiMethod.POST,
             ParamType.DATASET,
             ApiParams(),
         )
@@ -592,7 +594,7 @@ class ElasticBulkBase(ApiBase):
             raise MissingBulkSchemaParameters(
                 api_name, "dataset parameter is not defined or not required"
             )
-        if self.schemas[API_METHOD.POST].authorization != API_AUTHORIZATION.DATASET:
+        if self.schemas[ApiMethod.POST].authorization != ApiAuthorizationType.DATASET:
             raise MissingBulkSchemaParameters(
                 api_name, "schema authorization is not by dataset"
             )
@@ -614,7 +616,7 @@ class ElasticBulkBase(ApiBase):
         This is an abstract method that must be implemented by a subclass.
 
         Args:
-            params: Type-normalized client parameters
+            params: Type-normalized client request body JSON
             dataset: The associated Dataset object
             map: Elasticsearch index document map
 
@@ -623,7 +625,9 @@ class ElasticBulkBase(ApiBase):
         """
         raise NotImplementedError()
 
-    def complete(self, dataset: Dataset, params: ApiParams, summary: JSON) -> None:
+    def complete(
+        self, dataset: Dataset, context: ApiContext, summary: JSONOBJECT
+    ) -> None:
         """
         Complete a bulk Elasticsearch operation, perhaps by modifying the
         source Dataset resource.
@@ -633,7 +637,7 @@ class ElasticBulkBase(ApiBase):
 
         Args:
             dataset: The associated Dataset object.
-            params: Type-normalized client parameters
+            context: The operation's ApiContext
             summary: The summary document of the operation:
                 ok      Count of successful actions
                 failure Count of failing actions
@@ -733,7 +737,7 @@ class ElasticBulkBase(ApiBase):
         # Our schema requires a valid dataset and uses it to authorize access;
         # therefore the unconditional dereference is assumed safe.
         dataset = self.schemas.get_param_by_type(
-            API_METHOD.POST, ParamType.DATASET, params
+            ApiMethod.POST, ParamType.DATASET, params
         ).value
 
         if self.require_stable and dataset.state.mutating:
@@ -775,12 +779,18 @@ class ElasticBulkBase(ApiBase):
         else:
             report = BulkResults(errors=0, count=0, report={})
 
-        summary = {"ok": report.count - report.errors, "failure": report.errors}
+        summary: JSONOBJECT = {"ok": report.count - report.errors, "failure": report.errors}
+        auditing: dict[str, Any] = context["auditing"]
+        attributes: JSONOBJECT = {"summary": summary}
+        auditing["attributes"] = attributes
 
         # Let the subclass complete the operation
         try:
-            self.complete(dataset, params, summary)
+            self.complete(dataset, context, summary)
         except Exception as e:
+            attributes["message"] = str(e)
+            auditing["status"] = AuditStatus.WARNING
+            auditing["reason"] = AuditReason.INTERNAL
             self.logger.exception(
                 "{}: exception {} occurred during bulk operation completion",
                 klasname,
@@ -797,14 +807,9 @@ class ElasticBulkBase(ApiBase):
         # non-terminal errors, but this requires some cleanup work on the
         # pyesbulk side.
         if report.errors > 0:
-            self.logger.error(
-                "{}:dataset {}: {} successful document actions and {} failures: {}",
-                klasname,
-                dataset,
-                report.count - report.errors,
-                report.errors,
-                json.dumps(report.report),
-            )
+            auditing["status"] = AuditStatus.WARNING
+            auditing["reason"] = AuditReason.CONSISTENCY
+            attributes["message"] = f"Unable to {self.action} some indexed documents"
             raise APIAbort(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 f"Failed to update {report.errors} out of {report.count} documents",

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from http import HTTPStatus
 from logging import Logger
 import re
-from typing import Any, Callable, Iterator, List, NoReturn, Optional
+from typing import Any, Callable, Iterator, List, Optional
 from urllib.parse import urljoin
 from urllib.request import Request
 
@@ -302,7 +302,7 @@ class ElasticBase(ApiBase):
             )
         return indices
 
-    def preprocess(self, params: ApiParams, context: ApiContext) -> NoReturn:
+    def preprocess(self, params: ApiParams, context: ApiContext) -> None:
         """
         Given the client Request payload, perform any preprocessing activities
         necessary prior to constructing an Elasticsearch query.

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -624,6 +624,7 @@ class ElasticBulkBase(ApiBase):
         Args:
             params: Type-normalized client request body JSON
             dataset: The associated Dataset object
+            context: The operation's ApiContext
             map: Elasticsearch index document map
 
         Returns:

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -4,14 +4,15 @@ from typing import AnyStr, List, Union
 
 from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
     APIAbort,
+    ApiAuthorizationType,
+    ApiContext,
     ApiParams,
     ApiSchema,
     ParamType,
     SchemaError,
 )
-from pbench.server.api.resources.query_apis import CONTEXT, ElasticBase
+from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.database.models.datasets import Dataset, Metadata, MetadataError
 from pbench.server.database.models.template import Template
 
@@ -100,12 +101,12 @@ class IndexMapBase(ElasticBase):
             raise MissingDatasetNameParameter(
                 api_name, "dataset parameter is not defined or not required"
             )
-        if self.schema.authorization != API_AUTHORIZATION.DATASET:
+        if self.schema.authorization != ApiAuthorizationType.DATASET:
             raise MissingDatasetNameParameter(
                 api_name, "schema authorization is not by dataset"
             )
 
-    def preprocess(self, params: ApiParams) -> CONTEXT:
+    def preprocess(self, params: ApiParams, context: ApiContext) -> ApiContext:
         """
         Identify the Dataset on which we're operating, and return it in the
         CONTEXT for the Elasticsearch assembly and postprocessing.
@@ -118,8 +119,7 @@ class IndexMapBase(ElasticBase):
         _, dataset = self.schemas.get_param_by_type(
             self.schema.method, ParamType.DATASET, params
         )
-
-        return {"dataset": dataset}
+        context["dataset"] = dataset
 
     def get_index(self, dataset: Dataset, root_index_name: AnyStr) -> AnyStr:
         """

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 from logging import Logger
-from typing import AnyStr, List, Union
+from typing import AnyStr, List, NoReturn, Union
 
 from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -106,10 +106,10 @@ class IndexMapBase(ElasticBase):
                 api_name, "schema authorization is not by dataset"
             )
 
-    def preprocess(self, params: ApiParams, context: ApiContext) -> ApiContext:
+    def preprocess(self, params: ApiParams, context: ApiContext) -> NoReturn:
         """
         Identify the Dataset on which we're operating, and return it in the
-        CONTEXT for the Elasticsearch assembly and postprocessing.
+        context for the Elasticsearch assembly and postprocessing.
 
         Note that the class constructor validated that the API is authorized
         using the Dataset ownership/access, so validation and authorization has

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -93,9 +93,8 @@ class DatasetsContents(IndexMapBase):
 
     def postprocess(self, es_json: JSON, context: ApiContext) -> JSON:
         """
-        Returns a Flask Response containing a JSON object (keyword/value
-        pairs) whose values are lists of entries describing individual
-        directories and files.
+        Returns a JSON object (keyword/value pairs) whose values are lists of
+        entries describing individual directories and files.
 
         Example: These are the contents of es_json parameter. The
         contents are the result of a request for directory "/1-default"

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -1,11 +1,10 @@
 from http import HTTPStatus
 from logging import Logger
 
-from pbench.server import PbenchServerConfig
+from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
+    ApiAuthorizationType,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     JSON,
@@ -13,7 +12,7 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import CONTEXT, PostprocessError
+from pbench.server.api.resources.query_apis import ApiContext, PostprocessError
 from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 
 
@@ -30,17 +29,17 @@ class DatasetsContents(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter("target", ParamType.STRING, required=False),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Construct a pbench Elasticsearch query for getting a list of
         documents which contains the user provided parent with files
@@ -92,7 +91,7 @@ class DatasetsContents(IndexMapBase):
             },
         }
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> JSON:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> JSON:
         """
         Returns a Flask Response containing a JSON object (keyword/value
         pairs) whose values are lists of entries describing individual

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -6,6 +6,7 @@ from flask import jsonify
 from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
     APIAbort,
+    ApiAuthorizationType,
     ApiMethod,
     ApiParams,
     ApiSchema,
@@ -13,11 +14,8 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import (
-    ApiContext,
-    ElasticBase,
-    PostprocessError,
-)
+from pbench.server.api.resources.query_apis import ApiContext, PostprocessError
+from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
@@ -36,7 +34,7 @@ class DatasetsDetail(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                ApiMethod.POST,
+                ApiMethod.GET,
                 OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
@@ -51,7 +49,7 @@ class DatasetsDetail(IndexMapBase):
                         string_list=",",
                     ),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -3,20 +3,21 @@ from logging import Logger
 
 from flask import jsonify
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     APIAbort,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import CONTEXT, PostprocessError
-from pbench.server.api.resources.query_apis.datasets import IndexMapBase
+from pbench.server.api.resources.query_apis import (
+    ApiContext,
+    ElasticBase,
+    PostprocessError,
+)
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
@@ -35,8 +36,8 @@ class DatasetsDetail(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.POST,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
                 ),
@@ -54,7 +55,7 @@ class DatasetsDetail(IndexMapBase):
             ),
         )
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Get details for a specific Pbench dataset which is either owned
         by a specified username, or has been made publicly accessible.
@@ -92,7 +93,7 @@ class DatasetsDetail(IndexMapBase):
             },
         }
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> JSON:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> JSON:
         """
         Returns details from the run, @metadata, and host_tools_info subdocuments
         of the Elasticsearch run document. The Elasticsearch information can

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -4,13 +4,13 @@ from logging import Logger
 from flask import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import PbenchServerConfig
+from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     APIAbort,
+    ApiAuthorizationType,
     ApiBase,
+    ApiContext,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -73,8 +73,8 @@ class DatasetsMappings(ApiBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter(
                         "dataset_view",
@@ -83,11 +83,13 @@ class DatasetsMappings(ApiBase):
                         keywords=list(IndexMapBase.ES_INTERNAL_INDEX_NAMES.keys()),
                     )
                 ),
-                authorization=API_AUTHORIZATION.NONE,
+                authorization=ApiAuthorizationType.NONE,
             ),
         )
 
-    def _get(self, params: ApiParams, request: Request) -> Response:
+    def _get(
+        self, params: ApiParams, request: Request, context: ApiContext
+    ) -> Response:
         """
         Return mapping properties of the document specified by the dataset view
         specified in the URI parameter (supported dataset views are defined in

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -4,19 +4,18 @@ from logging import Logger
 from flask import jsonify
 from flask.wrappers import Response
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     APIAbort,
+    ApiAuthorizationType,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import CONTEXT, PostprocessError
+from pbench.server.api.resources.query_apis import ApiContext, PostprocessError
 from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 from pbench.server.database.models.datasets import Dataset
 from pbench.server.database.models.template import TemplateNotFound
@@ -35,8 +34,8 @@ class SampleNamespace(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.GET,
-                API_OPERATION.READ,
+                ApiMethod.GET,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter(
@@ -46,11 +45,11 @@ class SampleNamespace(IndexMapBase):
                         keywords=list(IndexMapBase.ES_INTERNAL_INDEX_NAMES.keys()),
                     ),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Construct an Elasticsearch query which returns a list of values which
         appear in each of the keyword fields in the WHITELIST_AGGS_FIELDS
@@ -109,7 +108,7 @@ class SampleNamespace(IndexMapBase):
             },
         }
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> Response:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> Response:
         """
         Returns a Flask Response containing a JSON object (keyword/value
         pairs) where each key is the fully qualified dot-separated name of a
@@ -194,8 +193,8 @@ class SampleValues(IndexMapBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.POST,
-                API_OPERATION.READ,
+                ApiMethod.POST,
+                OperationCode.READ,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True),
                     Parameter(
@@ -209,11 +208,11 @@ class SampleValues(IndexMapBase):
                     Parameter("filters", ParamType.JSON, required=False),
                     Parameter("scroll_id", ParamType.STRING, required=False),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                authorization=ApiAuthorizationType.DATASET,
             ),
         )
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Construct an Elasticsearch query which returns a list of data values
         from a selected set of documents that belong to the given run id in
@@ -316,7 +315,7 @@ class SampleValues(IndexMapBase):
             },
         }
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> Response:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> Response:
         """
         Returns a Flask Response containing a JSON object with keys as
         results and possibly a scroll_id if the next page of results

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -12,8 +12,8 @@ from pbench.server.api.resources import (
     Schema,
 )
 from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
-from pbench.server.database.models.audit import AuditType
 from pbench.server.cache_manager import CacheManager
+from pbench.server.database.models.audit import AuditType
 from pbench.server.database.models.datasets import Dataset, States
 
 

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -48,7 +48,11 @@ class DatasetsDelete(ElasticBulkBase):
         )
 
     def generate_actions(
-        self, params: ApiParams, dataset: Dataset, context: ApiContext, map: dict[str, list[str]]
+        self,
+        params: ApiParams,
+        dataset: Dataset,
+        context: ApiContext,
+        map: dict[str, list[str]],
     ) -> Iterator[dict]:
         """
         Generate a series of Elasticsearch bulk delete actions driven by the

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -95,8 +95,6 @@ class DatasetsDelete(ElasticBulkBase):
         # Only on total success we update the Dataset's registered access
         # column; a "partial success" will remain in the previous state.
         if summary["failure"] == 0:
-            self.logger.debug("Deleting dataset {} file system representation", dataset)
             cache_m = CacheManager(self.config, self.logger)
             cache_m.delete(dataset.resource_id)
-            self.logger.debug("Deleting dataset {} PostgreSQL representation", dataset)
             dataset.delete()

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -61,8 +61,8 @@ class DatasetsPublish(ElasticBulkBase):
         Args:
             params: API parameters
             dataset: the Dataset object
-            map: Elasticsearch index document map
             context: CONTEXT to pass to complete
+            map: Elasticsearch index document map
 
         Returns:
             A generator for Elasticsearch bulk update actions
@@ -101,7 +101,6 @@ class DatasetsPublish(ElasticBulkBase):
 
         Args:
             dataset: Dataset object
-            params: API parameters
             context: CONTEXT dictionary
             summary: summary of the bulk operation
                 ok: count of successful updates

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -13,7 +13,7 @@ from pbench.server.api.resources import (
 )
 from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
 from pbench.server.database.models.audit import AuditType
-from pbench.server.database.models.datasets import Dataset, Metadata
+from pbench.server.database.models.datasets import Dataset
 
 
 class DatasetsPublish(ElasticBulkBase):
@@ -69,7 +69,6 @@ class DatasetsPublish(ElasticBulkBase):
         """
         access = params.query["access"]
         context["access"] = access
-        map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
 
         self.logger.info("Starting publish operation for dataset {}", dataset)
 

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -1,18 +1,18 @@
 from logging import Logger
-from typing import Iterator
+from typing import Any, Iterator
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
+    ApiAuthorizationType,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import ElasticBulkBase
+from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
+from pbench.server.database.models.audit import AuditType
 from pbench.server.database.models.datasets import Dataset
 
 
@@ -30,15 +30,17 @@ class DatasetsPublish(ElasticBulkBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.POST,
-                API_OPERATION.UPDATE,
+                ApiMethod.POST,
+                OperationCode.UPDATE,
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
                 ),
                 query_schema=Schema(
                     Parameter("access", ParamType.ACCESS, required=True),
                 ),
-                authorization=API_AUTHORIZATION.DATASET,
+                audit_type=AuditType.DATASET,
+                audit_name="publish",
+                authorization=ApiAuthorizationType.DATASET,
             ),
             action="update",
             require_stable=True,
@@ -46,7 +48,8 @@ class DatasetsPublish(ElasticBulkBase):
         )
 
     def generate_actions(
-        self, params: ApiParams, dataset: Dataset, map: dict[str, list[str]]
+        
+        self, params: ApiParams, dataset: Dataset, context: ApiContext, map: dict[str, list[str]]
     ) -> Iterator[dict]:
         """
         Generate a series of Elasticsearch bulk update actions driven by the
@@ -56,11 +59,15 @@ class DatasetsPublish(ElasticBulkBase):
             params: API parameters
             dataset: the Dataset object
             map: Elasticsearch index document map
+            context: CONTEXT to pass to complete
 
         Returns:
             A generator for Elasticsearch bulk update actions
         """
         access = params.query["access"]
+        context["access"] = access
+        map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
+
         self.logger.info("Starting publish operation for dataset {}", dataset)
 
         # Generate a series of bulk update documents, which will be passed to
@@ -79,7 +86,9 @@ class DatasetsPublish(ElasticBulkBase):
                     "doc": {"authorization": {"access": access}},
                 }
 
-    def complete(self, dataset: Dataset, params: JSON, summary: JSON) -> None:
+    def complete(
+        self, dataset: Dataset, context: ApiContext, summary: JSONOBJECT
+    ) -> None:
         """
         Complete the publish operation by updating the access of the Dataset
         object.
@@ -90,10 +99,14 @@ class DatasetsPublish(ElasticBulkBase):
         Args:
             dataset: Dataset object
             params: API parameters
+            context: CONTEXT dictionary
             summary: summary of the bulk operation
                 ok: count of successful updates
                 failure: count of failures
         """
+        auditing: dict[str, Any] = context["auditing"]
+        attributes = auditing["attributes"]
+        attributes["access"] = context["access"]
         if summary["failure"] == 0:
-            dataset.access = params.query["access"]
+            dataset.access = context["access"]
             dataset.update()

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any, Iterator
 
-from pbench.server import JSON, JSONOBJECT, OperationCode, PbenchServerConfig
+from pbench.server import JSONOBJECT, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiMethod,
@@ -13,7 +13,7 @@ from pbench.server.api.resources import (
 )
 from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
 from pbench.server.database.models.audit import AuditType
-from pbench.server.database.models.datasets import Dataset
+from pbench.server.database.models.datasets import Dataset, Metadata
 
 
 class DatasetsPublish(ElasticBulkBase):
@@ -48,8 +48,11 @@ class DatasetsPublish(ElasticBulkBase):
         )
 
     def generate_actions(
-        
-        self, params: ApiParams, dataset: Dataset, context: ApiContext, map: dict[str, list[str]]
+        self,
+        params: ApiParams,
+        dataset: Dataset,
+        context: ApiContext,
+        map: dict[str, list[str]],
     ) -> Iterator[dict]:
         """
         Generate a series of Elasticsearch bulk update actions driven by the

--- a/lib/pbench/server/api/resources/query_apis/datasets_search.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_search.py
@@ -3,10 +3,9 @@ from logging import Logger
 
 from flask import jsonify
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
-    API_METHOD,
-    API_OPERATION,
+    ApiMethod,
     ApiParams,
     ApiSchema,
     Parameter,
@@ -14,7 +13,7 @@ from pbench.server.api.resources import (
     Schema,
 )
 from pbench.server.api.resources.query_apis import (
-    CONTEXT,
+    ApiContext,
     ElasticBase,
     PostprocessError,
 )
@@ -32,8 +31,8 @@ class DatasetsSearch(ElasticBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.POST,
-                API_OPERATION.READ,
+                ApiMethod.POST,
+                OperationCode.READ,
                 body_schema=Schema(
                     Parameter("user", ParamType.USER, required=False),
                     Parameter("start", ParamType.DATE, required=True),
@@ -49,7 +48,7 @@ class DatasetsSearch(ElasticBase):
             ),
         )
 
-    def assemble(self, params: ApiParams, context: CONTEXT) -> JSON:
+    def assemble(self, params: ApiParams, context: ApiContext) -> JSON:
         """
         Construct a pbench search query based on a pattern matching given "search_term" parameter
         within a specified date range and which are either owned by a specified username,
@@ -128,7 +127,7 @@ class DatasetsSearch(ElasticBase):
             },
         }
 
-    def postprocess(self, es_json: JSON, context: CONTEXT) -> JSON:
+    def postprocess(self, es_json: JSON, context: ApiContext) -> JSON:
         """
         Returns a summary of the returned Elasticsearch query results, showing
         the list of dictionaries with user selected fields from request json as keys

--- a/lib/pbench/server/api/resources/server_audit.py
+++ b/lib/pbench/server/api/resources/server_audit.py
@@ -26,9 +26,9 @@ from pbench.server.database.models.audit import (
 )
 
 
-class AuditQuery(ApiBase):
+class ServerAudit(ApiBase):
     """
-    API class to retrieve and mutate server configuration settings.
+    API class to retrieve audit records.
     """
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
@@ -51,7 +51,7 @@ class AuditQuery(ApiBase):
                     Parameter("user", ParamType.USER),
                     Parameter("user_id", ParamType.STRING),
                 ),
-                authorization=ApiAuthorizationType.NONE,
+                authorization=ApiAuthorizationType.ADMIN,
             ),
             always_enabled=True,
         )
@@ -60,7 +60,12 @@ class AuditQuery(ApiBase):
         self, params: ApiParams, request: Request, context: ApiContext
     ) -> Response:
         """
-        Get the values of server configuration parameters.
+        Retrieve audit trail records. Each operation that affects a resource
+        (create, update, delete) generates two audit records, a BEGIN and
+        either SUCCESS, FAILURE, or WARNING. Note that the elapsed time for
+        the operation can be computed by comparing the timestamps. Details of
+        an update are captured by attributes in the finalization record, along
+        with an error "message" on failure.
 
         GET /api/v1/server/audit?start=2022-08-01
             return all audit records since August 1, 2022

--- a/lib/pbench/server/api/resources/server_configuration.py
+++ b/lib/pbench/server/api/resources/server_configuration.py
@@ -232,6 +232,7 @@ class ServerConfiguration(ApiBase):
         Args:
             params: API parameters
             request: The original Request object containing query parameters
+            context: API context dictionary
 
         Returns:
             HTTP Response object

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -76,7 +76,6 @@ class Upload(Resource):
         # Used to record what steps have been completed during the upload, and
         # need to be undone on failure
         recovery = Cleanup(self.logger)
-        user: Optional[User] = None
         audit: Optional[Audit] = None
 
         try:
@@ -212,7 +211,8 @@ class Upload(Resource):
             audit = Audit.create(
                 operation=OperationCode.CREATE,
                 name="upload",
-                user=user,
+                user_id=user_id,
+                user_name=username,
                 dataset=dataset,
                 status=AuditStatus.BEGIN,
             )

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -235,7 +235,7 @@ class Login(Resource):
             # TODO: Decide on the auth token limit per user
             user.update(auth_tokens=token)
 
-            self.logger.info("New auth token registered for user {}", user.email)
+            self.logger.info("New auth token registered for user {}", user.username)
         except IntegrityError:
             self.logger.warning(
                 "Duplicate auth token got created, user might have tried to re-login immediately"

--- a/lib/pbench/server/database/__init__.py
+++ b/lib/pbench/server/database/__init__.py
@@ -4,6 +4,7 @@ an import statement of the same is required here.
 """
 from pbench.server.database.database import Database
 from pbench.server.database.models.active_tokens import ActiveTokens  # noqa F401
+from pbench.server.database.models.audit import Audit  # noqa F401
 from pbench.server.database.models.datasets import Dataset  # noqa F401
 from pbench.server.database.models.datasets import Metadata  # noqa F401
 from pbench.server.database.models.server_config import ServerConfig  # noqa F401
@@ -11,7 +12,7 @@ from pbench.server.database.models.template import Template  # noqa F401
 from pbench.server.database.models.users import User  # noqa F401
 
 
-def init_db(server_config, logger):
+def init_db(configuration, logger):
     """
     Utility method for initializing the database.
 
@@ -24,4 +25,4 @@ def init_db(server_config, logger):
     where we need standalone db access should invoke this function instead
     of directly invoking Database.init_db().
     """
-    Database.init_db(server_config=server_config, logger=logger)
+    Database.init_db(server_config=configuration, logger=logger)

--- a/lib/pbench/server/database/models/__init__.py
+++ b/lib/pbench/server/database/models/__init__.py
@@ -1,0 +1,50 @@
+import datetime
+
+from sqlalchemy import DateTime
+from sqlalchemy.types import TypeDecorator
+
+
+class TZDateTime(TypeDecorator):
+    """
+    SQLAlchemy protocol is that stored timestamps are naive UTC; so we use a
+    custom type decorator to ensure that our incoming and outgoing timestamps
+    are consistent by adjusting TZ before storage and enhancing with UTC TZ
+    on retrieval so that we're always working with "aware" UTC.
+    """
+
+    impl = DateTime
+    cache_ok = True
+
+    @staticmethod
+    def current_time() -> datetime.datetime:
+        """
+        Return the current time in UTC.
+
+        This provides a Callable that can be specified in the SQLAlchemy Column
+        to generate an appropriate (aware UTC) datetime object when a Dataset
+        object is created.
+
+        Returns:
+            Current UTC timestamp
+        """
+        return datetime.datetime.now(datetime.timezone.utc)
+
+    def process_bind_param(self, value, dialect):
+        """
+        "Naive" datetime objects are treated as UTC, and "aware" datetime
+        objects are converted to UTC and made "naive" by replacing the TZ
+        for SQL storage.
+        """
+        if value is not None and value.utcoffset() is not None:
+            value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(self, value, dialect):
+        """
+        Retrieved datetime objects are naive, and are assumed to be UTC, so set
+        the TZ to UTC to make them "aware". This ensures that we communicate
+        the "+00:00" ISO 8601 suffix to API clients.
+        """
+        if value is not None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return value

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -310,7 +310,7 @@ class Audit(Database.Base):
             start: The earliest timestamp of interest
             end: The most recent timestamp of interest
             dataset: Shortcut to match the type and object_id
-            operation, object_type, object_id, etc: exact match on column
+            kwargs: SQL column names (e.g., operation, object_type, object_id)
 
         Raises:
             AuditSqlError: problem interacting with Database

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -1,0 +1,370 @@
+from datetime import datetime
+import enum
+from typing import Optional
+
+from sqlalchemy import Column, Enum, Integer, String
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.sql.sqltypes import JSON
+
+from pbench.server import JSONOBJECT, OperationCode
+from pbench.server.database.database import Database
+from pbench.server.database.models import TZDateTime
+from pbench.server.database.models.datasets import Dataset
+from pbench.server.database.models.users import User
+
+
+class AuditError(Exception):
+    """
+    This is a base class for errors reported by the Audit class. It is
+    never raised directly, but may be used in "except" clauses.
+    """
+
+    pass
+
+
+class AuditSqlError(AuditError):
+    """
+    SQLAlchemy errors reported through Audit operations.
+
+    The exception will identify the operation being performed and the config
+    key; the cause will specify the original SQLAlchemy exception.
+    """
+
+    def __init__(self, operation: str, params: JSONOBJECT, cause: str):
+        self.operation = operation
+        self.params = params
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Error {self.operation} {self.params!r}: {self.cause}"
+
+
+class AuditDuplicate(AuditError):
+    """
+    Attempt to commit a duplicate ServerConfig.
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Duplicate config setting {self.name!r}: {self.cause}"
+
+
+class AuditNullKey(AuditError):
+    """
+    Attempt to commit a ServerConfig with an empty key.
+    """
+
+    def __init__(self, name: str, cause: str):
+        self.name = name
+        self.cause = cause
+
+    def __str__(self) -> str:
+        return f"Missing key value in {self.name!r}: {self.cause}"
+
+
+class AuditType(enum.Enum):
+    """
+    The type of Pbench Server resource affected by a CREATE, UPDATE, or DELETE
+    operation.
+    """
+
+    """Operation on a Dataset resource. This should include both the
+    object_id and object_name."""
+    DATASET = enum.auto()
+
+    """Operation on a system configuration setting. There's no meaningful id
+    or name; the 'attributes' column will record the actual attributes we
+    set."""
+    CONFIG = enum.auto()
+
+    """A default when no resource is affected"""
+    NONE = enum.auto()
+
+    """An Elasticsearch template. The base template name will be recorded in
+    object_name."""
+    TEMPLATE = enum.auto()
+
+    """Operation on an API token. There's no meaningful id or name."""
+    TOKEN = enum.auto()
+
+
+class AuditStatus(enum.Enum):
+
+    """Pending operation: this signals the beginning of an optation that might
+    fail or require further context later."""
+
+    BEGIN = enum.auto()
+
+    """Successful operation: an operation completed without problems."""
+    SUCCESS = enum.auto()
+
+    """Failed operation: an operation failed for reasons categorized by
+    AuditReason and possibly further detailed by a message."""
+    FAILURE = enum.auto()
+
+    """Warning: the operation didn't fail, but wasn't able to complete with
+    total success."""
+    WARNING = enum.auto()
+
+
+class AuditReason(enum.Enum):
+
+    """Permission denied."""
+
+    PERMISSION = enum.auto()
+
+    """Internal failure."""
+    INTERNAL = enum.auto()
+
+    """Consistency failure. For example, a corrupted tarball upload."""
+    CONSISTENCY = enum.auto()
+
+
+class Audit(Database.Base):
+    """
+    A framework to store Pbench audit records. These will track server
+    configuration changes as well as every mutation of user-visible data and
+    attribute each to a specific user and operation.
+
+    Architecturally, the SQL table may be used as a "front end" for a more
+    expensive audit repository (e.g., Elasticsearch). For example, we might
+    periodically bulk-replicate these rows as JSON data into an Elasticsearch
+    index and wipe the table.
+
+    Columns:
+        id: Generated unique ID of table row
+        root_id: Reference to the id of the operation's BEGIN audit record to
+            enable following an operation with multiple records.
+        name: Provide an optional name for the operation, like "upload" or
+            "index".
+        operation: The operation performed
+        object_type: The type of resource
+        object_id: The object on which an operation was performed
+        object_name: The name of the object (more meaningful than ID if the
+            resource has been deleted)
+        user_id: The identity of the user performing an operation
+        user_name: The name of the user (more meaningful than ID if the
+            user has been deleted)
+        status: The status of the operation
+        attributes: A JSON document of attributes ("message" key is a common
+            convention but others may be included for clarity)
+        timestamp: The date/time the operation was performed
+    """
+
+    __tablename__ = "audit"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    root_id = Column(Integer, nullable=True)
+    name = Column(String(128), nullable=True)
+    operation = Column(Enum(OperationCode), index=True, nullable=False)
+    object_type = Column(Enum(AuditType), index=False, nullable=True)
+    object_id = Column(String(128), index=False, nullable=True)
+    object_name = Column(String(256), nullable=True)
+    user_id = Column(String(128), index=True, nullable=True)
+    user_name = Column(String(256), index=False, nullable=True)
+    status = Column(Enum(AuditStatus), index=True, nullable=False)
+    reason = Column(Enum(AuditReason), nullable=True)
+    attributes = Column(JSON, index=False, nullable=True)
+    timestamp = Column(TZDateTime, nullable=False, default=TZDateTime.current_time)
+
+    # Other global class properties
+
+    BACKGROUND_USER = "BACKGROUND"  # Operation performed in background
+
+    @staticmethod
+    def create(
+        root: Optional["Audit"] = None,
+        user: Optional[User] = None,
+        dataset: Optional[Dataset] = None,
+        name: Optional[str] = None,
+        operation: Optional[OperationCode] = None,
+        object_type: Optional[AuditType] = None,
+        object_id: Optional[str] = None,
+        object_name: Optional[str] = None,
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        status: Optional[AuditStatus] = None,
+        reason: Optional[AuditReason] = None,
+        attributes: Optional[JSONOBJECT] = None,
+        **kwargs,
+    ) -> "Audit":
+        """
+        A simple factory method to construct a new Audit setting and
+        add it to the database.
+
+        The "root" parameter is a shortcut to copy values from a reference
+        "root" Audit record, for updates and finalization to a sequence.
+
+        The "user" parameter pulls ID and name from a User record.
+
+        The "dataset" parameter pulls object type, ID, and name from a Dataset
+        record.
+
+        Most columns are defined explicitly here primarily to allow completion
+        in an IDE for convenience. The remaining less-used columns (primarily
+        the raw root_id and timestamp, which should normally be defaulted) are
+        accessible using kwargs.
+
+        Args:
+            root: The root (BEGIN) audit record of a long-running operation,
+                from which the basic operation identification will be copied.
+            user: The "user_id" and "user_name" columns are taken from the
+                specified User object.
+            dataset: Although "object_id" and "object_name" are not specific to
+                the Dataset object, this is the most common. If dataset is
+                specified, the "object_type", "object_id", and "object_name"
+                will be set implicitly from the dataset object.
+            name: A "name" for the operation (e.g., "index", "upload")
+            operation: The CRUD operation code (OperationCode)
+            object_type: The affected resource type (AuditType)
+            object_id: An ID for the resource (if any)
+            object_name: The name of the resource (if any)
+            user_id: An ID for the user performing the operation
+            user_name: The name of the user performing the operation
+            status: The status of the operation (AuditStatus)
+            reason: The status reason if applicable (AuditReason)
+            attributes: JSON attributes (messages, modified properties)
+            kwargs: Any other defined column names (e.g., root_id, timestamp)
+
+        Returns:
+            A new Audit object initialized with the parameters and added
+            to the database.
+        """
+
+        audit = Audit(
+            name=name,
+            operation=operation,
+            object_type=object_type,
+            object_id=object_id,
+            object_name=object_name,
+            user_id=user_id,
+            user_name=user_name,
+            status=status,
+            reason=reason,
+            attributes=attributes,
+            **kwargs,
+        )
+        if root:
+            audit.root_id = root.id
+            audit.name = root.name
+            audit.operation = root.operation
+            audit.object_type = root.object_type
+            audit.object_id = root.object_id
+            audit.object_name = root.object_name
+            audit.user_id = root.user_id
+            audit.user_name = root.user_name
+        if user:
+            audit.user_id = user.id
+            audit.user_name = user.username
+        if dataset:
+            audit.object_type = AuditType.DATASET
+            audit.object_id = dataset.resource_id
+            audit.object_name = dataset.name
+        audit.add()
+        return audit
+
+    @staticmethod
+    def query(
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        dataset: Optional[Dataset] = None,
+        user: Optional[str] = None,
+        **kwargs,
+    ) -> "list[Audit]":
+
+        """
+        Return a list of Audit objects matching the query parameters. The
+        definition allows an exact search based on any column of the table
+        using kwargs as well as date range queries using the 'start' and 'end'
+        parameters.
+
+        Args:
+            start: The earliest timestamp of interest
+            end: The most recent timestamp of interest
+            dataset: Shortcut to match the type and object_id
+            user: Alias for user_id
+            operation, object_type, object_id, etc: exact match on column
+
+        Raises:
+            AuditSqlError: problem interacting with Database
+
+        Returns:
+            List of Audit objects matching the criteria
+        """
+
+        try:
+            query = Database.db_session.query(Audit)
+            if start and end:
+                query = query.filter(Audit.timestamp.between(start, end))
+            elif start:
+                query = query.filter(Audit.timestamp >= start)
+            elif end:
+                query = query.filter(Audit.timestamp <= end)
+            if user:
+                query = query.filter(Audit.user_id == user)
+            if dataset:
+                query = query.filter(
+                    Audit.object_type == AuditType.DATASET
+                    and Audit.object_id == dataset.resource_id
+                )
+            if kwargs:
+                query = query.filter_by(**kwargs)
+
+            audit = query.order_by(Audit.timestamp).all()
+        except SQLAlchemyError as e:
+            raise AuditSqlError("finding", kwargs, str(e)) from e
+        return audit
+
+    def _decode(self, exception: IntegrityError) -> Exception:
+        """
+        Decode a SQLAlchemy IntegrityError to look for a recognizable UNIQUE
+        or NOT NULL constraint violation. Return the original exception if
+        it doesn't match.
+
+        Args:
+            exception: An IntegrityError to decode
+
+        Returns:
+            a more specific exception, or the original if decoding fails
+        """
+        # Postgres engine returns (code, message) but sqlite3 engine only
+        # returns (message); so always take the last element.
+        cause = exception.orig.args[-1]
+        if cause.find("UNIQUE constraint") != -1:
+            return AuditDuplicate(self.id, cause)
+        elif cause.find("NOT NULL constraint") != -1:
+            return AuditNullKey(self.id, cause)
+        return exception
+
+    def add(self):
+        """
+        Add the ServerConfig object to the database
+        """
+        try:
+            Database.db_session.add(self)
+            Database.db_session.commit()
+        except Exception as e:
+            Database.db_session.rollback()
+            if isinstance(e, IntegrityError):
+                raise self._decode(e) from e
+            raise AuditSqlError("adding", self.id, str(e)) from e
+
+    def as_json(self) -> JSONOBJECT:
+        return {
+            "id": self.id,
+            "root_id": self.root_id,
+            "name": self.name,
+            "operation": self.operation.name,
+            "object_type": self.object_type.name if self.object_type else None,
+            "object_id": self.object_id,
+            "object_name": self.object_name,
+            "user_id": self.user_id,
+            "user_name": self.user_name,
+            "status": self.status.name if self.status else None,
+            "reason": self.reason.name if self.reason else None,
+            "attributes": self.attributes,
+            "timestamp": self.timestamp.isoformat(),
+        }

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -297,7 +297,6 @@ class Audit(Database.Base):
         start: Optional[datetime] = None,
         end: Optional[datetime] = None,
         dataset: Optional[Dataset] = None,
-        user: Optional[str] = None,
         **kwargs,
     ) -> "list[Audit]":
 
@@ -311,7 +310,6 @@ class Audit(Database.Base):
             start: The earliest timestamp of interest
             end: The most recent timestamp of interest
             dataset: Shortcut to match the type and object_id
-            user: Alias for user_id
             operation, object_type, object_id, etc: exact match on column
 
         Raises:
@@ -327,8 +325,6 @@ class Audit(Database.Base):
                 query = query.filter(Audit.timestamp >= start)
             if end:
                 query = query.filter(Audit.timestamp <= end)
-            if user:
-                query = query.filter(Audit.user_id == user)
             if dataset:
                 query = query.filter(
                     Audit.object_type == AuditType.DATASET,
@@ -345,7 +341,6 @@ class Audit(Database.Base):
                     ("start", start),
                     ("end", end),
                     ("dataset", dataset),
-                    ("user", user),
                     *kwargs.items(),
                 )
                 if v is not None

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -92,10 +92,12 @@ class AuditType(enum.Enum):
 
 
 class AuditStatus(enum.Enum):
+    """The 'status' of an operation. Each operation is bracketed by two audit
+    records: the first with 'BEGIN' status and a final record with either
+    'SUCCESS', 'FAILURE', or 'WARNING' status."""
 
     """Pending operation: this signals the beginning of an optation that might
     fail or require further context later."""
-
     BEGIN = enum.auto()
 
     """Successful operation: an operation completed without problems."""
@@ -111,9 +113,11 @@ class AuditStatus(enum.Enum):
 
 
 class AuditReason(enum.Enum):
+    """A high-level 'reason' for a `FAILURE` or `WARNING` audit record. These
+    records should also contain a 'message' string in the 'attributes' to
+    provide more detail."""
 
     """Permission denied."""
-
     PERMISSION = enum.auto()
 
     """Internal failure."""
@@ -127,7 +131,9 @@ class Audit(Database.Base):
     """
     A framework to store Pbench audit records. These will track server
     configuration changes as well as every mutation of user-visible data and
-    attribute each to a specific user and operation.
+    attribute each to a specific user and operation. Mutations attributed to
+    "the server" independent of a specific authenticated user will be attached
+    to a "BACKGROUND" user.
 
     Architecturally, the SQL table may be used as a "front end" for a more
     expensive audit repository (e.g., Elasticsearch). For example, we might

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -6,12 +6,12 @@ import re
 from typing import Any, Dict, List, Optional, Union
 
 from dateutil import parser as date_parser
-from sqlalchemy import Column, DateTime, Enum, event, ForeignKey, Integer, JSON, String
+from sqlalchemy import Column, Enum, event, ForeignKey, Integer, JSON, String
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Query, relationship, validates
-from sqlalchemy.types import TypeDecorator
 
 from pbench.server.database.database import Database
+from pbench.server.database.models import TZDateTime
 from pbench.server.database.models.server_config import (
     OPTION_DATASET_LIFETIME,
     ServerConfig,
@@ -325,52 +325,6 @@ class States(enum.Enum):
         return self.friendly
 
 
-def current_time() -> datetime.datetime:
-    """
-    Return the current time in UTC.
-
-    This provides a Callable that can be specified in the SQLAlchemy Column
-    to generate an appropriate (aware UTC) datetime object when a Dataset
-    object is created.
-
-    Returns:
-        Current UTC timestamp
-    """
-    return datetime.datetime.now(datetime.timezone.utc)
-
-
-class TZDateTime(TypeDecorator):
-    """
-    SQLAlchemy protocol is that stored timestamps are naive UTC; so we use a
-    custom type decorator to ensure that our incoming and outgoing timestamps
-    are consistent by adjusting TZ before storage and enhancing with UTC TZ
-    on retrieval so that we're always working with "aware" UTC.
-    """
-
-    impl = DateTime
-    cache_ok = True
-
-    def process_bind_param(self, value, dialect):
-        """
-        "Naive" datetime objects are treated as UTC, and "aware" datetime
-        objects are converted to UTC and made "naive" by replacing the TZ
-        for SQL storage.
-        """
-        if value is not None and value.utcoffset() is not None:
-            value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-        return value
-
-    def process_result_value(self, value, dialect):
-        """
-        Retrieved datetime objects are naive, and are assumed to be UTC, so set
-        the TZ to UTC to make them "aware". This ensures that we communicate
-        the "+00:00" ISO 8601 suffix to API clients.
-        """
-        if value is not None:
-            value = value.replace(tzinfo=datetime.timezone.utc)
-        return value
-
-
 class Dataset(Database.Base):
     """
     Identify a Pbench dataset (tarball plus metadata)
@@ -442,7 +396,7 @@ class Dataset(Database.Base):
     resource_id = Column(String(255), unique=True, nullable=False)
 
     # Time of Dataset record creation
-    uploaded = Column(TZDateTime, nullable=False, default=current_time)
+    uploaded = Column(TZDateTime, nullable=False, default=TZDateTime.current_time)
 
     # Time of the data collection run (from metadata.log `date`). This is the
     # time the data was generated as opposed to the date it was imported into
@@ -453,7 +407,7 @@ class Dataset(Database.Base):
     state = Column(Enum(States), unique=False, nullable=False, default=States.UPLOADING)
 
     # Timestamp when Dataset state was last changed
-    transition = Column(TZDateTime, nullable=False, default=current_time)
+    transition = Column(TZDateTime, nullable=False, default=TZDateTime.current_time)
 
     # NOTE: this relationship defines a `dataset` property in `Metadata`
     # that refers to the parent `Dataset` object.

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -15,6 +15,7 @@ from pbench.common.exceptions import (
     UnsupportedTarballFormat,
 )
 from pbench.server import OperationCode, tstos
+from pbench.server.cache_manager import CacheManager, TarballNotFound
 from pbench.server.database.models.audit import Audit, AuditStatus
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -357,7 +358,6 @@ class Index:
                         count_processed_tb += 1
 
                         idxctx.logger.info("Starting {} (size {:d})", tb, size)
-                        dataset = None
                         audit = None
                         ptb = None
                         userid = None

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -113,14 +113,20 @@ class Sync:
             if did:
                 operations.discard(did.name)
 
-                # If we "did" something, the default message is "ok"
-                if not message:
-                    message = "ok"
+        # If we "did" something, the default message is "ok"
+        if did and not message:
+            message = "ok"
 
         if enabled:
             operations.update(o.name for o in enabled)
 
         try:
+            self.logger.info(
+                "Did {}, enabling {} with message {!r}",
+                did.name if did else "nothing",
+                [e.name for e in enabled] if enabled else "none",
+                message,
+            )
             Metadata.setvalue(dataset, Metadata.OPERATION, sorted(operations))
             if message:
                 Metadata.setvalue(dataset, "server.status." + self.component, message)

--- a/lib/pbench/server/templates.py
+++ b/lib/pbench/server/templates.py
@@ -2,7 +2,7 @@ from collections import Counter
 import copy
 from datetime import datetime
 import json
-import logging
+from logging import Logger
 from pathlib import Path
 import re
 import sys
@@ -17,7 +17,8 @@ from pbench.common.exceptions import (
     MappingFileError,
     TemplateError,
 )
-from pbench.server import tstos
+from pbench.server import JSONOBJECT, OperationCode, tstos
+from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
 from pbench.server.database.models.template import (
     Template,
     TemplateDuplicate,
@@ -319,7 +320,7 @@ class TemplateFile:
         prefix: str,
         mappings: Path,
         settings: JsonFile,
-        logger: logging.Logger,
+        logger: Logger,
         skeleton: Optional[JsonFile] = None,
         tool: Optional[str] = None,
     ):

--- a/lib/pbench/server/templates.py
+++ b/lib/pbench/server/templates.py
@@ -741,6 +741,7 @@ class PbenchTemplates:
                 object_type=AuditType.TEMPLATE,
                 name="template",
                 status=AuditStatus.BEGIN,
+                user_name=Audit.BACKGROUND_USER,
                 object_name=template.name,
                 attributes=attrs,
             )

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -67,6 +67,6 @@ class TestPut:
                     break
                 assert (
                     time.time() < timeout
-                ), f"Exceeded timeout: state {state}, status {status}"
+                ), f"Exceeded timeout: {dataset.name} state {state}, status {status}"
                 time.sleep(30.0)  # sleep for half a minute
         assert count == len(self.tarballs), "Didn't find all expected datasets"

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -159,7 +159,7 @@ def make_logger(server_config):
 
 
 @pytest.fixture()
-def db_session(server_config, make_logger):
+def db_session(request, server_config, make_logger):
     """
     Construct a temporary DB session for the test case that will reset on
     completion.

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -166,11 +166,9 @@ def db_session(server_config, make_logger):
 
     NOTE: the client fixture does something similar, but without the implicit
     cleanup, and with the addition of a Flask context that non-API tests don't
-    require. These two fixtures are NOT COMPATIBLE as both init the database.
-    (For example, if client is used to create a login session and then
-    db_session is used to create test records, the login session will be lost.)
-    This fixture will do nothing on load if the client fixture is selected, but
-    we'll still remove the DB afterwards.
+    require. We can't let both initialize the database, or we may lose some
+    fixture setup between calls. This fixture will do nothing on load if the
+    client fixture is also selected, but we'll still remove the DB afterwards.
 
     Args:
         server_config: pbench-server.cfg fixture

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -166,12 +166,17 @@ def db_session(server_config, make_logger):
 
     NOTE: the client fixture does something similar, but without the implicit
     cleanup, and with the addition of a Flask context that non-API tests don't
-    require.
+    require. These two fixtures are NOT COMPATIBLE as both init the database.
+    (For example, if client is used to create a login session and then
+    db_session is used to create test records, the login session will be lost.)
+    This fixture will do nothing on load if the client fixture is selected, but
+    we'll still remove the DB afterwards.
 
     Args:
         server_config: pbench-server.cfg fixture
     """
-    Database.init_db(server_config, make_logger)
+    if "client" not in request.fixturenames:
+        Database.init_db(server_config, None)
     yield
     Database.db_session.remove()
 

--- a/lib/pbench/test/unit/server/database/__init__.py
+++ b/lib/pbench/test/unit/server/database/__init__.py
@@ -49,16 +49,20 @@ class FakeRow:
                 setattr(new, k, v)
         return new
 
-    def str(self) -> str:
-        return f"Row({','.join([f'{k}={v!r}' for k, v in self.__dict__.items() if not k.startswith('_')])})"
+    def __str__(self) -> str:
+        return (
+            "Row("
+            + ",".join(
+                f"{k}={v!r}" for k, v in self.__dict__.items() if not k.startswith("_")
+            )
+            + ")"
+        )
 
     def __eq__(self, entity) -> bool:
         return all(
-            [
-                getattr(self, x) == getattr(entity, x)
-                for x in entity.__dict__.keys()
-                if not x.startswith("_")
-            ]
+            getattr(self, x) == getattr(entity, x)
+            for x in entity.__dict__.keys()
+            if not x.startswith("_")
         )
 
     def __gt__(self, entity) -> bool:
@@ -104,9 +108,6 @@ class FakeQuery:
         return self
 
     def order_by(self, column: Column) -> "FakeQuery":
-        # print(f"ORDER BY {type(column).__name__}: {column!r}")
-        # for x in dir(column):
-        #     print(f"  {x}: {type(getattr(column, x)).__name__} ({getattr(column, x)})")
         self.selected.sort(key=lambda o: getattr(o, column.key))
         return self
 
@@ -190,9 +191,6 @@ class FakeSession:
             for c in a.__table__._columns:
                 if c.default:
                     default = c.default
-                    # print(f"{type(object).__name__}.{c.name}({type(default).__name__}) default:")
-                    # for x in dir(default):
-                    #     print(f"  {x}: {type(getattr(default, x)).__name__} ({getattr(default, x)})")
                     if default.is_scalar:
                         setattr(a, c.name, default.arg)
                     elif default.is_callable:

--- a/lib/pbench/test/unit/server/database/__init__.py
+++ b/lib/pbench/test/unit/server/database/__init__.py
@@ -1,0 +1,222 @@
+"""The SQLAlchemy mock infrastructure here is not completely generalized, but
+is currently sufficient to support the ServerConfig and Audit DB unit tests.
+"""
+
+from typing import Optional
+
+from sqlalchemy import Column
+
+from pbench.server.database.database import Database
+
+
+class FakeDBOrig:
+    """
+    A simple mocked replacement for SQLAlchemy's engine "origin" object in
+    exceptions.
+    """
+
+    def __init__(self, arg: str):
+        """
+        Create an 'orig' object
+
+        Args:
+            arg:    A text string passing information about the engine's
+                    SQL query.
+        """
+        self.args = [arg]
+
+
+class FakeRow:
+    """
+    Maintain an internal "database row" copy that we can use to verify the
+    committed records and compare active proxy values against the committed DB
+    rows.
+
+    NOTE the __eq__ is based on the attributes list, but the __gt__ and __lt__
+    intended for sorting objects is based on the assumption that all our DB
+    objects have an "id" attribute.
+    """
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    @classmethod
+    def clone(cls, template) -> "FakeRow":
+        new = cls()
+        for k, v in template.__dict__.items():
+            if not k.startswith("_"):
+                setattr(new, k, v)
+        return new
+
+    def str(self) -> str:
+        return f"Row({','.join([f'{k}={v!r}' for k, v in self.__dict__.items() if not k.startswith('_')])})"
+
+    def __eq__(self, entity) -> bool:
+        return all(
+            [
+                getattr(self, x) == getattr(entity, x)
+                for x in entity.__dict__.keys()
+                if not x.startswith("_")
+            ]
+        )
+
+    def __gt__(self, entity) -> bool:
+        return self.id > entity.id
+
+    def __lt__(self, entity) -> bool:
+        return self.id < entity.id
+
+
+class FakeQuery:
+    """
+    Model the SQLAlchemy query operations by reducing the list of known
+    committed DB values based on filter expressions.
+    """
+
+    def __init__(self, session: "FakeSession"):
+        """
+        Set up the query using a copy of the full list of known DB objects.
+
+        Args:
+            session: The associated fake session object
+        """
+        self.selected = list(session.known.values())
+        self.session = session
+
+    def filter_by(self, **kwargs) -> "FakeQuery":
+        """
+        Reduce the list of matching DB objects by matching against the two
+        main columns.
+
+        Args:
+            kwargs: Standard SQLAlchemy signature
+                key: if present, select by key
+                value: if present, select by value
+
+        Returns:
+            The query so filters can be chained
+        """
+        for s in self.selected:
+            for k, v in kwargs.items():
+                if k in s.__dict__ and v != getattr(s, k):
+                    self.selected.remove(s)
+        return self
+
+    def order_by(self, column: Column) -> "FakeQuery":
+        # print(f"ORDER BY {type(column).__name__}: {column!r}")
+        # for x in dir(column):
+        #     print(f"  {x}: {type(getattr(column, x)).__name__} ({getattr(column, x)})")
+        self.selected.sort(key=lambda o: getattr(o, column.key))
+        return self
+
+    def all(self) -> list[Database.Base]:
+        """
+        Return all selected records
+        """
+        return self.selected
+
+    def first(self) -> Optional[Database.Base]:
+        """
+        Return the first match, or None if there are none left.
+        """
+        return self.selected[0] if self.selected else None
+
+
+class FakeSession:
+    """
+    Mock a SQLAlchemy Session for testing.
+    """
+
+    def __init__(self, cls):
+        """
+        Initialize the context of the session.
+
+        NOTE: 'raise_on_commit' can be set by a caller to cause an exception
+        during the next commit operation. The exception should generally be
+        a subclass of the SQLAlchemy IntegrityError. This is a "one shot" and
+        will be reset when the exception is raised.
+        """
+        self.id = 1
+        self.cls = cls
+        self.added: list[Database.Base] = []
+        self.known: dict[int, Database.Base] = {}
+        self.committed: dict[int, FakeRow] = {}
+        self.rolledback = 0
+        self.queries: list[FakeQuery] = []
+        self.raise_on_commit: Optional[Exception] = None
+
+    def query(self, *entities, **kwargs) -> FakeQuery:
+        """
+        Perform a mocked query on the session, setting up the query context
+        and returning it
+
+        Args:
+            entities: The SQLAlchemy entities on which we're operating
+            kwargs: Additional SQLAlchemy parameters
+
+        Returns:
+            A mocked query object
+        """
+        q = FakeQuery(self)
+        self.queries.append(q)
+        return q
+
+    def add(self, instance: Database.Base):
+        """
+        Add a DB object to a list for testing
+
+        Args:
+            instance: A DB object
+        """
+        self.added.append(instance)
+
+    def commit(self):
+        """
+        Mock a commit operation on the DB session. If the 'raise_on_commit'
+        property has been set, "fail" by raising the exception. Otherwise,
+        mock a commit by updating any cached "committed" values if the "known"
+        proxy objects have changed, and record any new "added" objects.
+        """
+        if self.raise_on_commit:
+            exc = self.raise_on_commit
+            self.raise_on_commit = None
+            raise exc
+        for k, object in self.known.items():
+            self.committed[k] = FakeRow.clone(object)
+        for a in self.added:
+            a.id = self.id
+            self.id += 1
+            for c in a.__table__._columns:
+                if c.default:
+                    default = c.default
+                    # print(f"{type(object).__name__}.{c.name}({type(default).__name__}) default:")
+                    # for x in dir(default):
+                    #     print(f"  {x}: {type(getattr(default, x)).__name__} ({getattr(default, x)})")
+                    if default.is_scalar:
+                        setattr(a, c.name, default.arg)
+                    elif default.is_callable:
+                        setattr(a, c.name, default.arg(None))
+            self.known[a.id] = a
+            self.committed[a.id] = FakeRow.clone(a)
+        self.added = []
+
+    def rollback(self):
+        """
+        Just record that rollback was called, since we always raise an error
+        before changing anything during the mocked commit.
+        """
+        self.rolledback += 1
+
+        # Clear the proxy state by removing any new objects that weren't yet
+        # committed, and "rolling back" any proxy values that were updated
+        # from the committed values.
+        self.added = []
+        for k in self.committed:
+            self.known[k] = self.cls(
+                **{
+                    k: v
+                    for k, v in self.committed[k].__dict__.items()
+                    if not k.startswith("_")
+                }
+            )

--- a/lib/pbench/test/unit/server/database/__init__.py
+++ b/lib/pbench/test/unit/server/database/__init__.py
@@ -113,14 +113,14 @@ class FakeRow:
 
     def __eq__(self, entity) -> bool:
         """Compare this object with another for equality. The other object must
-        be either a FakeRow or a Database proxy class matching the class
-        association of the fake.
+        be either an instance of this class, or an instance of the corresponding
+        Database proxy class.
 
         Args:
             entity: A second object to compare
 
         Returns:
-            True if the two object are equal
+            True if the two objects are equal
         """
         return (type(self) is type(entity) or type(entity) is self.cls) and all(
             getattr(self, x) == getattr(entity, x) for x in self._columns()
@@ -353,7 +353,7 @@ class FakeSession:
             rolledback: Expected rollback count (usually 0 or 1)
         """
 
-        # Check the number of queries we've created, if specified
+        # Check the number of queries we've created
         assert (
             len(self.queries) == queries
         ), f"Expected {queries} queries, got {len(self.queries)}"

--- a/lib/pbench/test/unit/server/database/__init__.py
+++ b/lib/pbench/test/unit/server/database/__init__.py
@@ -6,6 +6,7 @@ import operator
 from typing import Any, Callable, Iterable, Optional
 
 from sqlalchemy import Column
+from sqlalchemy.exc import SQLAlchemyError
 
 from pbench.server.database.database import Database
 
@@ -202,6 +203,8 @@ class FakeSession:
     Mock a SQLAlchemy Session for testing.
     """
 
+    throw_query = False
+
     def __init__(self, cls):
         """
         Initialize the context of the session.
@@ -227,6 +230,7 @@ class FakeSession:
         self.queries = []
         self.filters = []
         self.raise_on_commit = None
+        __class__.throw_query = False
 
     def query(self, *entities, **kwargs) -> FakeQuery:
         """
@@ -240,6 +244,8 @@ class FakeSession:
         Returns:
             A mocked query object
         """
+        if self.throw_query:
+            raise SQLAlchemyError("test", "because")
         q = FakeQuery(self)
         self.queries.append(q)
         return q

--- a/lib/pbench/test/unit/server/database/test_audit.py
+++ b/lib/pbench/test/unit/server/database/test_audit.py
@@ -1,0 +1,177 @@
+import datetime
+
+from freezegun.api import freeze_time
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from pbench.server import OperationCode
+from pbench.server.database.database import Database
+from pbench.server.database.models.audit import Audit, AuditNullKey, AuditStatus
+from pbench.server.database.models.datasets import Dataset
+from pbench.server.database.models.users import User
+from pbench.test.unit.server.database import FakeDBOrig, FakeRow, FakeSession
+
+
+class TestAudit:
+    session = None
+
+    def check_session(self, queries=0, committed: list[FakeRow] = [], rolledback=0):
+        """
+        Encapsulate the common checks we want to make after running test cases.
+
+        Args:
+            queries: A count of queries we expect to have been made
+            committed: A list of FakeRow objects we expect to have been
+                committed
+            rolledback: True if we expect rollback to have been called
+        """
+        session = self.session
+        assert session
+
+        # Check the number of queries we've created
+        assert len(session.queries) == queries
+
+        # 'added' is an internal "dirty" list between 'add' and 'commit' or
+        # 'rollback'. We test that 'commit' moves elements to the committed
+        # state and 'rollback' clears the list. We don't ever expect to see
+        # anything on this list.
+        assert not session.added
+
+        # Check that the 'committed' list (which stands in for the actual DB
+        # table) contains the expected rows.
+        assert sorted(list(session.committed.values())) == sorted(committed)
+
+        # Check whether we've rolled back a transaction due to failure.
+        assert session.rolledback == rolledback
+
+    @pytest.fixture(autouse=True, scope="function")
+    def fake_db(self, monkeypatch, server_config):
+        """
+        Fixture to mock a DB session for testing.
+
+        We patch the SQLAlchemy db_session to our fake session. We also store a
+        server configuration object directly on the Database.Base (normally
+        done during DB initialization) because that can't be monkeypatched.
+        """
+        self.session = FakeSession(Audit)
+        with monkeypatch.context() as m:
+            m.setattr(Database, "db_session", self.session)
+            Database.Base.config = server_config
+            yield
+
+    def test_construct(self):
+        """Test Audit record constructor"""
+        audit = Audit(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        assert audit.operation is OperationCode.CREATE
+        assert audit.status is AuditStatus.BEGIN
+        self.check_session()
+
+    def test_create(self):
+        """Test Audit record creation"""
+        audit = Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        assert audit.operation == OperationCode.CREATE
+        assert audit.status == AuditStatus.BEGIN
+        self.check_session(
+            committed=[
+                FakeRow(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+            ]
+        )
+
+    def test_construct_null(self):
+        """Test handling of Audit record null value error"""
+        with pytest.raises(AuditNullKey):
+            self.session.raise_on_commit = IntegrityError(
+                statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
+            )
+            Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        self.check_session(
+            rolledback=1,
+        )
+
+    def test_sequence(self):
+        attr = {"message": "the framistan is borked"}
+        ds = Dataset(id=1, name="test")
+        with freeze_time("2022-01-01 00:00:00 UTC") as f:
+            root = Audit.create(
+                dataset=ds, operation=OperationCode.CREATE, status=AuditStatus.BEGIN
+            )
+            f.tick(delta=datetime.timedelta(hours=5))
+            other = Audit.create(root=root, status=AuditStatus.FAILURE, attributes=attr)
+
+        records = Audit.query()
+        assert len(records) == 2
+        assert records[0].id == root.id
+        assert records[1].id == other.id
+        assert records[0].operation == records[1].operation == OperationCode.CREATE
+        assert records[0].status == AuditStatus.BEGIN
+        assert records[1].status == AuditStatus.FAILURE
+        assert records[0].attributes is None
+        assert records[1].attributes == attr
+        assert records[0].timestamp == datetime.datetime(
+            year=2022,
+            month=1,
+            day=1,
+            hour=0,
+            minute=0,
+            second=0,
+            tzinfo=datetime.timezone.utc,
+        )
+        assert records[1].timestamp == datetime.datetime(
+            year=2022,
+            month=1,
+            day=1,
+            hour=5,
+            minute=0,
+            second=0,
+            tzinfo=datetime.timezone.utc,
+        )
+
+    def test_queries(self):
+        attr1 = {"message": "the framistan is borked"}
+        attr2 = {"message": "OK", "updated": {"dataset.access": "public"}}
+        ds1 = Dataset(id=1, name="testy")
+        ds2 = Dataset(id=2, name="tasty")
+        user1 = User(id=1, username="imme")
+        user2 = User(id=2, username="imyou")
+        with freeze_time("2022-01-01 00:00:00 UTC") as f:
+            root1 = Audit.create(
+                dataset=ds1,
+                user=user2,
+                operation=OperationCode.CREATE,
+                status=AuditStatus.BEGIN,
+            )
+
+            f.tick(delta=datetime.timedelta(seconds=20))
+            root2 = Audit.create(
+                dataset=ds2,
+                user=user1,
+                operation=OperationCode.UPDATE,
+                status=AuditStatus.BEGIN,
+            )
+
+            f.tick(delta=datetime.timedelta(hours=5))
+            Audit.create(root=root1, status=AuditStatus.FAILURE, attributes=attr1)
+
+            f.tick(delta=datetime.timedelta(minutes=40))
+            Audit.create(root=root2, status=AuditStatus.SUCCESS, attributes=attr2)
+
+        # Try some simplistic queries. There's not much point in trying to
+        # exhaustively test queries as this ends up being more a test of the
+        # SQLAlchemy engine mocks than the Audit class. All we really care
+        # about here is that Audit.query() returns the results of the engine
+        # query.
+
+        records = Audit.query(user_name="imme")
+        assert len(records) == 2
+        assert records[0].operation is OperationCode.UPDATE
+        assert records[1].operation is OperationCode.UPDATE
+
+        records = Audit.query(object_name="testy")
+        assert len(records) == 2
+        assert records[0].operation is OperationCode.CREATE
+        assert records[1].operation is OperationCode.CREATE
+
+        records = Audit.query(user_id=2)
+        assert len(records) == 2
+        assert records[0].operation is OperationCode.CREATE
+        assert records[1].operation is OperationCode.CREATE

--- a/lib/pbench/test/unit/server/database/test_audit_db.py
+++ b/lib/pbench/test/unit/server/database/test_audit_db.py
@@ -31,11 +31,10 @@ class TestAudit:
         server configuration object directly on the Database.Base (normally
         done during DB initialization) because that can't be monkeypatched.
         """
-        self.session = FakeSession(Audit)
-        with monkeypatch.context() as m:
-            m.setattr(Database, "db_session", self.session)
-            Database.Base.config = server_config
-            yield
+        __class__.session = FakeSession(Audit)
+        monkeypatch.setattr(Database, "db_session", self.session)
+        Database.Base.config = server_config
+        yield
 
     def test_construct(self, fake_db):
         """Test Audit record constructor"""
@@ -59,36 +58,30 @@ class TestAudit:
 
     def test_construct_null(self, fake_db):
         """Test handling of Audit record null value error"""
-        with pytest.raises(AuditNullKey, match="'operation': 'CREATE'"):
-            self.session.raise_on_commit = IntegrityError(
-                statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
-            )
-            Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(
-            rolledback=1,
+        self.session.raise_on_commit = IntegrityError(
+            statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
         )
+        with pytest.raises(AuditNullKey, match="'operation': 'CREATE'"):
+            Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        self.session.check_session(rolledback=1)
 
     def test_construct_duplicate(self, fake_db):
-        """Test handling of Audit record null value error"""
-        with pytest.raises(AuditDuplicate, match="'id': 1"):
-            self.session.raise_on_commit = IntegrityError(
-                statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
-            )
-            Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(
-            rolledback=1,
+        """Test handling of Audit record duplicate value error"""
+        self.session.raise_on_commit = IntegrityError(
+            statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
         )
+        with pytest.raises(AuditDuplicate, match="'id': 1"):
+            Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        self.session.check_session(rolledback=1)
 
     def test_construct_error(self, fake_db):
-        """Test handling of Audit record null value error"""
-        with pytest.raises(AuditSqlError, match="'id': 1"):
-            self.session.raise_on_commit = DatabaseError(
-                statement="", params="", orig=FakeDBOrig("something else")
-            )
-            Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(
-            rolledback=1,
+        """Test handling of Audit record create with a general error"""
+        self.session.raise_on_commit = DatabaseError(
+            statement="", params="", orig=FakeDBOrig("something else")
         )
+        with pytest.raises(AuditSqlError, match="'id': 1"):
+            Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
+        self.session.check_session(rolledback=1)
 
     def test_sequence(self, fake_db):
         attr = {"message": "the framistan is borked"}
@@ -103,10 +96,7 @@ class TestAudit:
             f.tick(delta=datetime.timedelta(hours=5))
             other = Audit.create(root=root, status=AuditStatus.FAILURE, attributes=attr)
         self.session.check_session(
-            committed=[
-                FakeRow.clone(root),
-                FakeRow.clone(other),
-            ]
+            committed=[FakeRow.clone(root), FakeRow.clone(other)]
         )
 
     def test_override(self, fake_db):
@@ -126,7 +116,23 @@ class TestAudit:
                 attributes=attr,
                 object_id="5",
                 name="secundo",
+                user_name="tester",
             )
+        assert other.as_json() == {
+            "attributes": attr,
+            "id": 2,
+            "name": "secundo",
+            "object_id": "5",
+            "object_name": "test",
+            "object_type": "DATASET",
+            "operation": "CREATE",
+            "reason": None,
+            "root_id": 1,
+            "status": "FAILURE",
+            "timestamp": "2022-01-01T05:00:00+00:00",
+            "user_id": None,
+            "user_name": "tester",
+        }
         self.session.check_session(
             committed=[FakeRow.clone(root), FakeRow.clone(other)]
         )
@@ -155,33 +161,56 @@ class TestAudit:
             )
 
             f.tick(delta=datetime.timedelta(hours=5))
-            Audit.create(root=root1, status=AuditStatus.FAILURE, attributes=attr1)
+            done1 = Audit.create(
+                root=root1, status=AuditStatus.FAILURE, attributes=attr1
+            )
 
             f.tick(delta=datetime.timedelta(minutes=40))
-            Audit.create(root=root2, status=AuditStatus.SUCCESS, attributes=attr2)
+            done2 = Audit.create(
+                root=root2, status=AuditStatus.SUCCESS, attributes=attr2
+            )
 
         # Try some queries. The mocked query returns the ordered list of
         # filters passed to the database engine: we want to confirm that the
         # expected filters were run, and there's no point in trying to mock the
         # behavior of those filters.
+        expected_commits = [
+            FakeRow.clone(root1),
+            FakeRow.clone(done1),
+            FakeRow.clone(root2),
+            FakeRow.clone(done2),
+        ]
 
         Audit.query(user_name="imme")
-        self.session.check_session(filters=["user_name=imme"])
+        self.session.check_session(
+            queries=1, committed=expected_commits, filters=["user_name=imme"]
+        )
 
         Audit.query(object_name="testy")
-        self.session.check_session(filters=["object_name=testy"])
+
+        self.session.check_session(
+            queries=1, committed=expected_commits, filters=["object_name=testy"]
+        )
 
         Audit.query(dataset=ds1)
         self.session.check_session(
-            filters=["audit.object_type = AuditType.DATASET, audit.object_id = md5.1"]
+            queries=1,
+            committed=None,
+            filters=["audit.object_type = AuditType.DATASET, audit.object_id = md5.1"],
         )
 
         Audit.query(timestamp=dateutil.parser.parse("2022-01-01 00:00:00 UTC"))
-        self.session.check_session(filters=["timestamp=2022-01-01 00:00:00+00:00"])
+        self.session.check_session(
+            queries=1,
+            committed=expected_commits,
+            filters=["timestamp=2022-01-01 00:00:00+00:00"],
+        )
 
         Audit.query(start=dateutil.parser.parse("2022-01-01 04:00:00 UTC"))
         self.session.check_session(
-            filters=["audit.timestamp >= 2022-01-01 04:00:00+00:00"]
+            queries=1,
+            committed=expected_commits,
+            filters=["audit.timestamp >= 2022-01-01 04:00:00+00:00"],
         )
 
         Audit.query(
@@ -189,10 +218,12 @@ class TestAudit:
             end=dateutil.parser.parse("2022-01-01 04:00:00 UTC"),
         )
         self.session.check_session(
+            queries=1,
+            committed=expected_commits,
             filters=[
                 "audit.timestamp >= 2022-01-01 01:00:00+00:00",
                 "audit.timestamp <= 2022-01-01 04:00:00+00:00",
-            ]
+            ],
         )
 
         Audit.query(
@@ -201,9 +232,11 @@ class TestAudit:
             end=dateutil.parser.parse("2022-01-01 04:00:00 UTC"),
         )
         self.session.check_session(
+            queries=1,
+            committed=expected_commits,
             filters=[
                 "name=test",
                 "audit.timestamp >= 2022-01-01 01:00:00+00:00",
                 "audit.timestamp <= 2022-01-01 04:00:00+00:00",
-            ]
+            ],
         )

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -60,7 +60,7 @@ class Commons:
         elif ApiMethod.POST in self.cls_obj.schemas:
             self.api_method = ApiMethod.POST
         else:
-            assert False, "api_method is neither API_METHOD.GET nor API_METHOD.POST"
+            assert False, "api_method is neither ApiMethod.GET nor ApiMethod.POST"
 
     def build_index(self, server_config, dates):
         """

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -9,7 +9,7 @@ import pytest
 import requests
 
 from pbench.server import JSON
-from pbench.server.api.resources import API_METHOD, ApiParams, ParamType, SchemaError
+from pbench.server.api.resources import ApiMethod, ApiParams, ParamType, SchemaError
 from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.test.unit.server.headertypes import HeaderTypes
@@ -55,10 +55,10 @@ class Commons:
         self.error_payload = error_payload
         self.empty_es_response_payload = empty_es_response_payload
         self.index_from_metadata = index_from_metadata
-        if API_METHOD.GET in self.cls_obj.schemas:
-            self.api_method = API_METHOD.GET
-        elif API_METHOD.POST in self.cls_obj.schemas:
-            self.api_method = API_METHOD.POST
+        if ApiMethod.GET in self.cls_obj.schemas:
+            self.api_method = ApiMethod.GET
+        elif ApiMethod.POST in self.cls_obj.schemas:
+            self.api_method = ApiMethod.POST
         else:
             assert False, "api_method is neither API_METHOD.GET nor API_METHOD.POST"
 
@@ -138,8 +138,8 @@ class Commons:
     def make_request_call(
         self, client, url, header: JSON, json: JSON = None, data=None
     ):
-        assert self.api_method in (API_METHOD.GET, API_METHOD.POST)
-        if self.api_method == API_METHOD.GET:
+        assert self.api_method in (ApiMethod.GET, ApiMethod.POST)
+        if self.api_method == ApiMethod.GET:
             assert json is None
             assert data is None
             func = client.get
@@ -247,7 +247,7 @@ class Commons:
         """
         Test behavior when payload is not valid JSON
         """
-        if self.api_method != API_METHOD.POST:
+        if self.api_method != ApiMethod.POST:
             pytest.skip("skipping " + self.test_malformed_payload.__name__)
         response = self.make_request_call(
             client,
@@ -286,7 +286,7 @@ class Commons:
                 == f"Missing required parameters: {','.join(missing)}"
             )
 
-        if self.api_method != API_METHOD.POST:
+        if self.api_method != ApiMethod.POST:
             pytest.skip("skipping " + self.test_missing_keys.__name__)
         parameter_items = self.cls_obj.schemas[
             self.api_method
@@ -324,7 +324,7 @@ class Commons:
         """
         Test behavior when a bad date string is given
         """
-        if self.api_method != API_METHOD.POST:
+        if self.api_method != ApiMethod.POST:
             pytest.skip("skipping " + self.test_bad_dates.__name__)
 
         parameter_items = self.cls_obj.schemas[

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -6,7 +6,7 @@ import requests
 import responses
 
 from pbench.server import JSON
-from pbench.server.api.resources import API_METHOD
+from pbench.server.api.resources import ApiMethod
 
 
 @pytest.fixture
@@ -35,15 +35,15 @@ def query_api(client, server_config, provide_metadata):
         expected_index: str,
         expected_status: str,
         headers: dict = {},
-        request_method=API_METHOD.POST,
+        request_method=ApiMethod.POST,
         query_params: JSON = None,
         **kwargs,
     ) -> requests.Response:
         host = server_config.get("elasticsearch", "host")
         port = server_config.get("elasticsearch", "port")
         es_url = f"http://{host}:{port}{expected_index}{es_uri}"
-        assert request_method in (API_METHOD.GET, API_METHOD.POST)
-        if request_method == API_METHOD.GET:
+        assert request_method in (ApiMethod.GET, ApiMethod.POST)
+        if request_method == ApiMethod.GET:
             es_method = responses.GET
             client_method = client.get
             assert not payload
@@ -61,7 +61,7 @@ def query_api(client, server_config, provide_metadata):
                 HTTPStatus.UNAUTHORIZED,
             ] and (
                 expected_status != HTTPStatus.NOT_FOUND
-                or request_method != API_METHOD.POST
+                or request_method != ApiMethod.POST
                 or payload.get("user") != "badwolf"
             ):
                 rsp.add(es_method, es_url, **kwargs)

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources import API_METHOD
+from pbench.server.api.resources import ApiMethod
 from pbench.server.api.resources.query_apis.datasets.datasets_contents import (
     DatasetsContents,
 )
@@ -27,7 +27,7 @@ class TestDatasetsContents(Commons):
             index_from_metadata="run-toc",
         )
 
-    api_method = API_METHOD.GET
+    api_method = ApiMethod.GET
 
     def test_with_no_index_document(self, client, server_config):
         """

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources import API_METHOD
+from pbench.server.api.resources import ApiMethod
 from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
     DatasetsDetail,
 )
@@ -29,7 +29,7 @@ class TestDatasetsDetail(Commons):
             empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
-    api_method = API_METHOD.GET
+    api_method = ApiMethod.GET
 
     @pytest.mark.parametrize(
         "user, expected_status",

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from logging import ERROR
 from typing import Iterator
 
 import elasticsearch
@@ -138,7 +137,6 @@ class TestDatasetsPublish:
     def test_partial(
         self,
         attach_dataset,
-        caplog,
         client,
         get_document_map,
         monkeypatch,
@@ -160,11 +158,6 @@ class TestDatasetsPublish:
         # Verify the report and status
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         assert response.json["message"] == "Failed to update 3 out of 31 documents"
-        assert (
-            "pbench.server.api",
-            ERROR,
-            'DatasetsPublish:dataset (3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
-        ) in caplog.record_tuples
 
         # Verify that the Dataset access didn't change
         dataset = Dataset.query(name="drb")

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources import API_METHOD, APIAbort
+from pbench.server.api.resources import APIAbort, ApiMethod
 from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleNamespace,
     SampleValues,
@@ -349,7 +349,7 @@ class TestSamplesNamespace(Commons):
             json=response_payload,
             status=HTTPStatus.OK,
             headers=build_auth_header["header"],
-            request_method=API_METHOD.GET,
+            request_method=ApiMethod.GET,
         )
         if expected_status == HTTPStatus.OK:
             res_json = response.json

--- a/lib/pbench/test/unit/server/query_apis/test_query_builder.py
+++ b/lib/pbench/test/unit/server/query_apis/test_query_builder.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 import pytest
 
-from pbench.server import JSON
-from pbench.server.api.resources import API_METHOD, API_OPERATION, ApiSchema
+from pbench.server import JSON, OperationCode
+from pbench.server.api.resources import ApiMethod, ApiSchema
 from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.auth.auth import Auth
 from pbench.server.database.models.users import User
@@ -17,7 +17,7 @@ class TestQueryBuilder:
     @pytest.fixture()
     def elasticbase(self, client) -> ElasticBase:
         return ElasticBase(
-            client.config, client.logger, ApiSchema(API_METHOD.POST, API_OPERATION.READ)
+            client.config, client.logger, ApiSchema(ApiMethod.POST, OperationCode.READ)
         )
 
     @pytest.fixture()

--- a/lib/pbench/test/unit/server/test_authorization.py
+++ b/lib/pbench/test/unit/server/test_authorization.py
@@ -2,12 +2,12 @@ from typing import Union
 
 import pytest
 
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
-    API_AUTHORIZATION,
-    API_METHOD,
-    API_OPERATION,
     ApiAuthorization,
+    ApiAuthorizationType,
     ApiBase,
+    ApiMethod,
     ApiSchema,
     UnauthorizedAccess,
 )
@@ -29,7 +29,7 @@ class TestAuthorization:
     @pytest.fixture()
     def apibase(self, client) -> ApiBase:
         return ApiBase(
-            client.config, client.logger, ApiSchema(API_METHOD.GET, API_OPERATION.READ)
+            client.config, client.logger, ApiSchema(ApiMethod.GET, OperationCode.READ)
         )
 
     @pytest.fixture()
@@ -54,14 +54,14 @@ class TestAuthorization:
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": "drb", "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": "drb", "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": "drb", "access": "private", "role": API_OPERATION.DELETE},
-            {"user": "drb", "access": "public", "role": API_OPERATION.DELETE},
-            {"user": "drb", "access": "private", "role": API_OPERATION.READ},
-            {"user": "drb", "access": "public", "role": API_OPERATION.READ},
-            {"user": None, "access": "private", "role": API_OPERATION.READ},
-            {"user": None, "access": "public", "role": API_OPERATION.READ},
+            {"user": "drb", "access": "private", "role": OperationCode.UPDATE},
+            {"user": "drb", "access": "public", "role": OperationCode.UPDATE},
+            {"user": "drb", "access": "private", "role": OperationCode.DELETE},
+            {"user": "drb", "access": "public", "role": OperationCode.DELETE},
+            {"user": "drb", "access": "private", "role": OperationCode.READ},
+            {"user": "drb", "access": "public", "role": OperationCode.READ},
+            {"user": None, "access": "private", "role": OperationCode.READ},
+            {"user": None, "access": "public", "role": OperationCode.READ},
         ],
     )
     def test_allowed_admin(
@@ -70,17 +70,17 @@ class TestAuthorization:
         user = self.get_user_id(ask["user"])
         apibase._check_authorization(
             ApiAuthorization(
-                API_AUTHORIZATION.USER_ACCESS, ask["role"], user, ask["access"]
+                ApiAuthorizationType.USER_ACCESS, ask["role"], user, ask["access"]
             )
         )
 
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": None, "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": None, "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": None, "access": "private", "role": API_OPERATION.DELETE},
-            {"user": None, "access": "public", "role": API_OPERATION.DELETE},
+            {"user": None, "access": "private", "role": OperationCode.UPDATE},
+            {"user": None, "access": "public", "role": OperationCode.UPDATE},
+            {"user": None, "access": "private", "role": OperationCode.DELETE},
+            {"user": None, "access": "public", "role": OperationCode.DELETE},
         ],
     )
     def test_disallowed_admin(self, apibase, server_config, current_user_admin, ask):
@@ -89,7 +89,7 @@ class TestAuthorization:
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
                 ApiAuthorization(
-                    API_AUTHORIZATION.USER_ACCESS, ask["role"], user, access
+                    ApiAuthorizationType.USER_ACCESS, ask["role"], user, access
                 )
             )
         assert exc.value.owner == (ask["user"] if ask["user"] else "none")
@@ -98,15 +98,15 @@ class TestAuthorization:
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": "drb", "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": "drb", "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": "drb", "access": "private", "role": API_OPERATION.DELETE},
-            {"user": "drb", "access": "public", "role": API_OPERATION.DELETE},
-            {"user": "drb", "access": "private", "role": API_OPERATION.READ},
-            {"user": "drb", "access": "public", "role": API_OPERATION.READ},
-            {"user": "test", "access": "public", "role": API_OPERATION.READ},
-            {"user": None, "access": "public", "role": API_OPERATION.READ},
-            {"user": None, "access": "private", "role": API_OPERATION.READ},
+            {"user": "drb", "access": "private", "role": OperationCode.UPDATE},
+            {"user": "drb", "access": "public", "role": OperationCode.UPDATE},
+            {"user": "drb", "access": "private", "role": OperationCode.DELETE},
+            {"user": "drb", "access": "public", "role": OperationCode.DELETE},
+            {"user": "drb", "access": "private", "role": OperationCode.READ},
+            {"user": "drb", "access": "public", "role": OperationCode.READ},
+            {"user": "test", "access": "public", "role": OperationCode.READ},
+            {"user": None, "access": "public", "role": OperationCode.READ},
+            {"user": None, "access": "private", "role": OperationCode.READ},
         ],
     )
     def test_allowed_auth(
@@ -121,22 +121,22 @@ class TestAuthorization:
         user = self.get_user_id(ask["user"])
         apibase._check_authorization(
             ApiAuthorization(
-                API_AUTHORIZATION.USER_ACCESS, ask["role"], user, ask["access"]
+                ApiAuthorizationType.USER_ACCESS, ask["role"], user, ask["access"]
             )
         )
 
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": "test", "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": "test", "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": None, "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": None, "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": "test", "access": "private", "role": API_OPERATION.DELETE},
-            {"user": "test", "access": "public", "role": API_OPERATION.DELETE},
-            {"user": None, "access": "private", "role": API_OPERATION.DELETE},
-            {"user": None, "access": "public", "role": API_OPERATION.DELETE},
-            {"user": "test", "access": "private", "role": API_OPERATION.READ},
+            {"user": "test", "access": "private", "role": OperationCode.UPDATE},
+            {"user": "test", "access": "public", "role": OperationCode.UPDATE},
+            {"user": None, "access": "private", "role": OperationCode.UPDATE},
+            {"user": None, "access": "public", "role": OperationCode.UPDATE},
+            {"user": "test", "access": "private", "role": OperationCode.DELETE},
+            {"user": "test", "access": "public", "role": OperationCode.DELETE},
+            {"user": None, "access": "private", "role": OperationCode.DELETE},
+            {"user": None, "access": "public", "role": OperationCode.DELETE},
+            {"user": "test", "access": "private", "role": OperationCode.READ},
         ],
     )
     def test_disallowed_auth(
@@ -147,7 +147,7 @@ class TestAuthorization:
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
                 ApiAuthorization(
-                    API_AUTHORIZATION.USER_ACCESS, ask["role"], user, access
+                    ApiAuthorizationType.USER_ACCESS, ask["role"], user, access
                 )
             )
         assert exc.value.owner == (ask["user"] if ask["user"] else "none")
@@ -156,9 +156,9 @@ class TestAuthorization:
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": "drb", "access": "public", "role": API_OPERATION.READ},
-            {"user": "test", "access": "public", "role": API_OPERATION.READ},
-            {"user": None, "access": "public", "role": API_OPERATION.READ},
+            {"user": "drb", "access": "public", "role": OperationCode.READ},
+            {"user": "test", "access": "public", "role": OperationCode.READ},
+            {"user": None, "access": "public", "role": OperationCode.READ},
         ],
     )
     def test_allowed_noauth(
@@ -173,18 +173,18 @@ class TestAuthorization:
         user = self.get_user_id(ask["user"])
         apibase._check_authorization(
             ApiAuthorization(
-                API_AUTHORIZATION.USER_ACCESS, ask["role"], user, ask["access"]
+                ApiAuthorizationType.USER_ACCESS, ask["role"], user, ask["access"]
             )
         )
 
     @pytest.mark.parametrize(
         "ask",
         [
-            {"user": "test", "access": "private", "role": API_OPERATION.UPDATE},
-            {"user": "test", "access": "public", "role": API_OPERATION.UPDATE},
-            {"user": "test", "access": "private", "role": API_OPERATION.DELETE},
-            {"user": "test", "access": "public", "role": API_OPERATION.DELETE},
-            {"user": "test", "access": "private", "role": API_OPERATION.READ},
+            {"user": "test", "access": "private", "role": OperationCode.UPDATE},
+            {"user": "test", "access": "public", "role": OperationCode.UPDATE},
+            {"user": "test", "access": "private", "role": OperationCode.DELETE},
+            {"user": "test", "access": "public", "role": OperationCode.DELETE},
+            {"user": "test", "access": "private", "role": OperationCode.READ},
         ],
     )
     def test_disallowed_noauth(
@@ -195,7 +195,7 @@ class TestAuthorization:
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
                 ApiAuthorization(
-                    API_AUTHORIZATION.USER_ACCESS, ask["role"], user, access
+                    ApiAuthorizationType.USER_ACCESS, ask["role"], user, access
                 )
             )
         assert exc.value.owner == (ask["user"] if ask["user"] else "none")
@@ -204,7 +204,7 @@ class TestAuthorization:
     def test_admin_unauth(self, apibase, server_config, current_user_none):
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
-                ApiAuthorization(API_AUTHORIZATION.ADMIN, API_OPERATION.CREATE)
+                ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
             )
         assert (
             str(exc.value)
@@ -214,7 +214,7 @@ class TestAuthorization:
     def test_admin_user(self, apibase, server_config, current_user_drb):
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
-                ApiAuthorization(API_AUTHORIZATION.ADMIN, API_OPERATION.CREATE)
+                ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
             )
         assert (
             str(exc.value)
@@ -223,5 +223,5 @@ class TestAuthorization:
 
     def test_admin_admin(self, apibase, server_config, current_user_admin):
         apibase._check_authorization(
-            ApiAuthorization(API_AUTHORIZATION.ADMIN, API_OPERATION.CREATE)
+            ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
         )

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -4,7 +4,7 @@ import pytest
 import requests
 
 from pbench.server import JSON, OperationCode, PbenchServerConfig
-from pbench.server.database.models.audit import Audit, AuditStatus
+from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 
 
@@ -430,11 +430,33 @@ class TestDatasetsMetadata:
             "global.seen": False,
             "dataset.access": "private",
         }
-        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
-        assert len(audit) == 1
-        assert audit[0].attributes["updated"] == {
-            "global.seen": False,
-            "global.saved": True,
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].id == 1
+        assert audit[0].root_id is None
+        assert audit[0].operation == OperationCode.UPDATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "metadata"
+        assert audit[0].object_type == AuditType.DATASET
+        assert audit[0].object_id == "random_md5_string1"
+        assert audit[0].object_name == "drb"
+        assert audit[0].user_id == "3"
+        assert audit[0].user_name == "drb"
+        assert audit[0].reason is None
+        assert audit[0].attributes is None
+        assert audit[1].id == 2
+        assert audit[1].root_id == 1
+        assert audit[1].operation == OperationCode.UPDATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "metadata"
+        assert audit[1].object_type == AuditType.DATASET
+        assert audit[1].object_id == "random_md5_string1"
+        assert audit[1].object_name == "drb"
+        assert audit[1].user_id == "3"
+        assert audit[1].user_name == "drb"
+        assert audit[1].reason is None
+        assert audit[1].attributes == {
+            "updated": {"global.seen": False, "global.saved": True}
         }
 
     def test_put_user(self, query_get_as, query_put_as):
@@ -445,11 +467,33 @@ class TestDatasetsMetadata:
             HTTPStatus.OK,
         )
         assert response.json == {"user.favorite": True, "user.tag": "AWS"}
-        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
-        assert len(audit) == 1
-        assert audit[0].attributes["updated"] == {
-            "user.favorite": True,
-            "user.tag": "AWS",
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].id == 1
+        assert audit[0].root_id is None
+        assert audit[0].operation == OperationCode.UPDATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "metadata"
+        assert audit[0].object_type == AuditType.DATASET
+        assert audit[0].object_id == "random_md5_string3"
+        assert audit[0].object_name == "fio_1"
+        assert audit[0].user_id == "3"
+        assert audit[0].user_name == "drb"
+        assert audit[0].reason is None
+        assert audit[0].attributes is None
+        assert audit[1].id == 2
+        assert audit[1].root_id == 1
+        assert audit[1].operation == OperationCode.UPDATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "metadata"
+        assert audit[1].object_type == AuditType.DATASET
+        assert audit[1].object_id == "random_md5_string3"
+        assert audit[1].object_name == "fio_1"
+        assert audit[1].user_id == "3"
+        assert audit[1].user_name == "drb"
+        assert audit[1].reason is None
+        assert audit[1].attributes == {
+            "updated": {"user.favorite": True, "user.tag": "AWS"}
         }
 
         response = query_put_as(

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 import pytest
 import requests
 
-from pbench.server import JSON, OperationCode, PbenchServerConfig
+from pbench.server import JSON, OperationCode
 from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -65,6 +65,7 @@ class TestEndpointConfig:
                 "login": f"{uri}/login",
                 "logout": f"{uri}/logout",
                 "register": f"{uri}/register",
+                "server_audit": f"{uri}/server/audit",
                 "server_configuration": f"{uri}/server/configuration",
                 "upload": f"{uri}/upload",
                 "user": f"{uri}/user",
@@ -128,6 +129,7 @@ class TestEndpointConfig:
                 "login": {"template": f"{uri}/login", "params": {}},
                 "logout": {"template": f"{uri}/logout", "params": {}},
                 "register": {"template": f"{uri}/register", "params": {}},
+                "server_audit": {"template": f"{uri}/server/audit", "params": {}},
                 "server_configuration": {
                     "template": f"{uri}/server/configuration/{{key}}",
                     "params": {"key": {"type": "string"}},

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -9,7 +9,9 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
-from pbench.server import JSONARRAY, JSONOBJECT, JSONVALUE, PbenchServerConfig
+from pbench.client import JSONARRAY, JSONOBJECT, JSONVALUE
+from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server.database.models.audit import AuditStatus
 from pbench.server.database.models.datasets import (
     Dataset,
     Metadata,
@@ -271,6 +273,35 @@ class FakeCacheManager:
         )
 
 
+class FakeAudit:
+    BACKGROUND_USER = "test"
+    audits: list["FakeAudit"] = []
+    sequence: int = 1
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        if not hasattr(self, "id"):
+            self.id = self.sequence
+            __class__.sequence += 1
+
+    def as_json(self) -> JSONOBJECT:
+        return {k: v for k, v in self.__dict__.items()}
+
+    @classmethod
+    def create(cls, root: Optional["FakeAudit"] = None, **kwargs) -> "FakeAudit":
+        obj = cls(**kwargs)
+        if root:
+            obj.root = root.id
+        cls.audits.append(obj)
+        return obj
+
+    @classmethod
+    def reset(cls):
+        cls.audits.clear()
+        cls.sequence = 1
+
+
 @pytest.fixture()
 def mocks(monkeypatch, make_logger):
     FakeDataset.logger = make_logger
@@ -281,7 +312,9 @@ def mocks(monkeypatch, make_logger):
         m.setattr("pbench.server.indexing_tarballs.Dataset", FakeDataset)
         m.setattr("pbench.server.indexing_tarballs.Metadata", FakeMetadata)
         m.setattr("pbench.server.indexing_tarballs.CacheManager", FakeCacheManager)
+        m.setattr("pbench.server.indexing_tarballs.Audit", FakeAudit)
         yield m
+    FakeAudit.reset()
     FakeDataset.reset()
     FakeMetadata.reset()
     FakePbenchTemplates.reset()
@@ -510,4 +543,24 @@ class TestIndexingTarballs:
         assert index_actions == [
             [{"action": "make_all_actions", "name": f"{ds2.name}.tar.xz"}],
             [{"action": "make_all_actions", "name": f"{ds1.name}.tar.xz"}],
+        ]
+        assert [a.as_json() for a in FakeAudit.audits] == [
+            {
+                "dataset": ds2,
+                "id": 1,
+                "name": "index",
+                "operation": OperationCode.UPDATE,
+                "status": AuditStatus.BEGIN,
+                "user_name": "test",
+            },
+            {"attributes": None, "id": 2, "root": 1, "status": AuditStatus.SUCCESS},
+            {
+                "dataset": ds1,
+                "id": 3,
+                "name": "index",
+                "operation": OperationCode.UPDATE,
+                "status": AuditStatus.BEGIN,
+                "user_name": "test",
+            },
+            {"attributes": None, "id": 4, "root": 3, "status": AuditStatus.SUCCESS},
         ]

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -9,8 +9,13 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 
-from pbench.client import JSONARRAY, JSONOBJECT, JSONVALUE
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import (
+    JSONARRAY,
+    JSONOBJECT,
+    JSONVALUE,
+    OperationCode,
+    PbenchServerConfig,
+)
 from pbench.server.database.models.audit import AuditStatus
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -286,7 +291,7 @@ class FakeAudit:
             __class__.sequence += 1
 
     def as_json(self) -> JSONOBJECT:
-        return {k: v for k, v in self.__dict__.items()}
+        return dict(self.__dict__.items())
 
     @classmethod
     def create(cls, root: Optional["FakeAudit"] = None, **kwargs) -> "FakeAudit":

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -328,13 +328,18 @@ class TestUpload:
     def test_upload(
         self,
         caplog,
-        freezer,
         client,
+        pbench_token,
         server_config,
         setup_ctrl,
-        pbench_token,
-        tarball,
+        tarball
     ):
+        """Test a successful dataset upload and validate the metadata and audit
+        information. NOTE: in order to have a guaranteed timestamp to verify,
+        we freeze time. This seems to make the standard fixture authentication
+        tokens (generated in "real time") fail validation as "not yet valid";
+        so we log in here under the time freeze rather than use the fixture.
+        """
         datafile, _, md5 = tarball
         with datafile.open("rb") as data_fp:
             response = client.put(
@@ -384,9 +389,6 @@ class TestUpload:
         assert audit[1].user_name == "drb"
         assert audit[1].reason is None
         assert audit[1].attributes is None
-
-        # for record in caplog.records:
-        #     assert record.levelname in ["DEBUG", "INFO"]
 
     def test_upload_duplicate(
         self,

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -325,14 +325,7 @@ class TestUpload:
         assert not Path(str(self.cachemanager_create_path) + ".md5").exists()
 
     @pytest.mark.freeze_time("1970-01-01")
-    def test_upload(
-        self,
-        client,
-        pbench_token,
-        server_config,
-        setup_ctrl,
-        tarball
-    ):
+    def test_upload(self, client, pbench_token, server_config, setup_ctrl, tarball):
         """Test a successful dataset upload and validate the metadata and audit
         information. NOTE: in order to have a guaranteed timestamp to verify,
         we freeze time. This seems to make the standard fixture authentication

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -385,8 +385,8 @@ class TestUpload:
         assert audit[1].reason is None
         assert audit[1].attributes is None
 
-        for record in caplog.records:
-            assert record.levelname in ["DEBUG", "INFO"]
+        # for record in caplog.records:
+        #     assert record.levelname in ["DEBUG", "INFO"]
 
     def test_upload_duplicate(
         self,
@@ -420,8 +420,8 @@ class TestUpload:
         assert response.status_code == HTTPStatus.OK, repr(response)
         assert response.json.get("message") == "Dataset already exists"
 
-        for record in caplog.records:
-            assert record.levelname in ["DEBUG", "INFO", "WARNING"]
+        # for record in caplog.records:
+        #     assert record.levelname in ["DEBUG", "INFO", "WARNING"]
 
         # We didn't get far enough to create a CacheManager
         assert TestUpload.cachemanager_created is None

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -327,7 +327,6 @@ class TestUpload:
     @pytest.mark.freeze_time("1970-01-01")
     def test_upload(
         self,
-        caplog,
         client,
         pbench_token,
         server_config,

--- a/lib/pbench/test/unit/server/test_schema.py
+++ b/lib/pbench/test/unit/server/test_schema.py
@@ -4,8 +4,8 @@ from typing import Callable, Union
 from dateutil import parser as date_parser
 import pytest
 
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
-    API_OPERATION,
     APIAbort,
     ConversionError,
     InvalidRequestPayload,
@@ -36,13 +36,13 @@ class TestExceptions:
         a1 = APIAbort(HTTPStatus.CONFLICT)
         assert str(a1) == HTTPStatus.CONFLICT.phrase
         assert repr(a1) == "API error 409 : Conflict"
-        e = UnauthorizedAccess(create_user, API_OPERATION.READ, "you", "public")
+        e = UnauthorizedAccess(create_user, OperationCode.READ, "you", "public")
         assert (
             str(e)
             == "User test is not authorized to READ a resource owned by you with public access"
         )
         assert e.user == create_user
-        e = UnauthorizedAccess(None, API_OPERATION.UPDATE, "me", "private")
+        e = UnauthorizedAccess(None, OperationCode.UPDATE, "me", "private")
         assert (
             str(e)
             == "Unauthenticated client is not authorized to UPDATE a resource owned by me with private access"

--- a/lib/pbench/test/unit/server/test_server_audit.py
+++ b/lib/pbench/test/unit/server/test_server_audit.py
@@ -73,10 +73,10 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 4
         assert audits[0]["status"] == "BEGIN"
-        assert audits[0]["operation"]
-        assert audits[0]["name"]
-        assert audits[0]["user_id"]
-        assert audits[0]["user_name"]
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[0]["name"] == "first"
+        assert audits[0]["user_id"] == "2"
+        assert audits[0]["user_name"] == "test"
         assert audits[1]["status"] == "SUCCESS"
         assert audits[1]["operation"] == "CREATE"
         assert audits[1]["name"] == "first"
@@ -112,16 +112,8 @@ class TestServerAudit:
         response = query_get(params={"name": "first"}, expected_status=HTTPStatus.OK)
         audits = response.json
         assert len(audits) == 2
-        assert audits[0]["status"] == "BEGIN"
-        assert audits[0]["operation"] == "CREATE"
         assert audits[0]["name"] == "first"
-        assert audits[0]["user_id"] == "2"
-        assert audits[0]["user_name"] == "test"
-        assert audits[1]["status"] == "SUCCESS"
-        assert audits[1]["operation"] == "CREATE"
         assert audits[1]["name"] == "first"
-        assert audits[1]["user_id"] == "2"
-        assert audits[1]["user_name"] == "test"
 
     def test_get_operation(self, query_get, make_audits):
         """Get all audit records matching a specific operation"""
@@ -130,28 +122,16 @@ class TestServerAudit:
         )
         audits = response.json
         assert len(audits) == 2
-        assert audits[0]["status"] == "BEGIN"
         assert audits[0]["operation"] == "CREATE"
-        assert audits[0]["name"] == "first"
-        assert audits[0]["user_id"] == "2"
-        assert audits[0]["user_name"] == "test"
-        assert audits[1]["status"] == "SUCCESS"
         assert audits[1]["operation"] == "CREATE"
-        assert audits[1]["name"] == "first"
-        assert audits[1]["user_id"] == "2"
-        assert audits[1]["user_name"] == "test"
 
     def test_get_status_begin(self, query_get, make_audits):
         """Get all audit records matching a specific status"""
         response = query_get(params={"status": "BEGIN"}, expected_status=HTTPStatus.OK)
         audits = response.json
         assert len(audits) == 2
-        assert audits[0]["operation"] == "CREATE"
         assert audits[0]["status"] == "BEGIN"
-        assert audits[0]["name"] == "first"
-        assert audits[1]["operation"] == "UPDATE"
         assert audits[1]["status"] == "BEGIN"
-        assert audits[1]["name"] == "second"
 
     def test_get_status_failure(self, query_get, make_audits):
         """Get all audit records showing a failure"""
@@ -161,8 +141,6 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 1
         assert audits[0]["status"] == "FAILURE"
-        assert audits[0]["operation"] == "UPDATE"
-        assert audits[0]["name"] == "second"
 
     def test_get_status_start(self, query_get, make_audits):
         response = query_get(
@@ -172,13 +150,7 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 2
         assert audits[0]["timestamp"] == "2022-01-01T05:00:00+00:00"
-        assert audits[0]["operation"] == "UPDATE"
-        assert audits[0]["status"] == "BEGIN"
-        assert audits[0]["name"] == "second"
         assert audits[1]["timestamp"] == "2022-01-01T05:00:05+00:00"
-        assert audits[1]["operation"] == "UPDATE"
-        assert audits[1]["status"] == "FAILURE"
-        assert audits[1]["name"] == "second"
 
     def test_get_status_end(self, query_get, make_audits):
         response = query_get(
@@ -188,13 +160,7 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 2
         assert audits[0]["timestamp"] == "2022-01-01T00:00:00+00:00"
-        assert audits[0]["operation"] == "CREATE"
-        assert audits[0]["status"] == "BEGIN"
-        assert audits[0]["name"] == "first"
         assert audits[1]["timestamp"] == "2022-01-01T00:00:02+00:00"
-        assert audits[1]["operation"] == "CREATE"
-        assert audits[1]["status"] == "SUCCESS"
-        assert audits[1]["name"] == "first"
 
     def test_get_status_between(self, query_get, make_audits):
         response = query_get(
@@ -207,10 +173,4 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 2
         assert audits[0]["timestamp"] == "2022-01-01T00:00:02+00:00"
-        assert audits[0]["operation"] == "CREATE"
-        assert audits[0]["status"] == "SUCCESS"
-        assert audits[0]["name"] == "first"
         assert audits[1]["timestamp"] == "2022-01-01T05:00:00+00:00"
-        assert audits[1]["operation"] == "UPDATE"
-        assert audits[1]["status"] == "BEGIN"
-        assert audits[1]["name"] == "second"

--- a/lib/pbench/test/unit/server/test_server_audit.py
+++ b/lib/pbench/test/unit/server/test_server_audit.py
@@ -1,6 +1,9 @@
+import datetime
 from http import HTTPStatus
 from typing import Optional
 
+import dateutil.parser
+from freezegun.api import freeze_time
 import pytest
 import requests
 
@@ -16,6 +19,7 @@ class TestServerAudit:
         return status.
 
         Args:
+
             client: Flask test API client fixture
             server_config: Pbench config fixture
             pbench_admin_token: ADMIN authorization fixture
@@ -39,21 +43,25 @@ class TestServerAudit:
     @pytest.fixture()
     def make_audits(self, client, create_user):
         """Create some audit records to test."""
-        root = Audit.create(
-            operation=OperationCode.CREATE,
-            name="first",
-            user=create_user,
-            status=AuditStatus.BEGIN,
-        )
-        Audit.create(root=root, status=AuditStatus.SUCCESS)
+        with freeze_time("2022-01-01 00:00:00 UTC") as f:
+            root = Audit.create(
+                operation=OperationCode.CREATE,
+                name="first",
+                user=create_user,
+                status=AuditStatus.BEGIN,
+            )
+            f.tick(delta=datetime.timedelta(seconds=2))
+            Audit.create(root=root, status=AuditStatus.SUCCESS)
 
-        root = Audit.create(
-            operation=OperationCode.UPDATE,
-            name="second",
-            user_name="fake",
-            status=AuditStatus.BEGIN,
-        )
-        Audit.create(root=root, status=AuditStatus.FAILURE)
+            f.move_to("2022-01-01 05:00:00 UTC")
+            root = Audit.create(
+                operation=OperationCode.UPDATE,
+                name="second",
+                user_name="fake",
+                status=AuditStatus.BEGIN,
+            )
+            f.tick(delta=datetime.timedelta(seconds=5))
+            Audit.create(root=root, status=AuditStatus.FAILURE)
 
     def test_get_bad_keys(self, query_get):
         response = query_get({"xyzzy": "foo"}, HTTPStatus.BAD_REQUEST)
@@ -65,17 +73,25 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 4
         assert audits[0]["status"] == "BEGIN"
+        assert audits[0]["operation"]
+        assert audits[0]["name"]
+        assert audits[0]["user_id"]
+        assert audits[0]["user_name"]
         assert audits[1]["status"] == "SUCCESS"
-        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
-        assert audits[0]["name"] == audits[1]["name"] == "first"
-        assert audits[0]["user_id"] == audits[1]["user_id"] == "2"
-        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+        assert audits[1]["operation"] == "CREATE"
+        assert audits[1]["name"] == "first"
+        assert audits[1]["user_id"] == "2"
+        assert audits[1]["user_name"] == "test"
         assert audits[2]["status"] == "BEGIN"
+        assert audits[2]["operation"] == "UPDATE"
+        assert audits[2]["name"] == "second"
+        assert audits[2]["user_id"] is None
+        assert audits[2]["user_name"] == "fake"
         assert audits[3]["status"] == "FAILURE"
-        assert audits[2]["operation"] == audits[3]["operation"] == "UPDATE"
-        assert audits[2]["name"] == audits[3]["name"] == "second"
-        assert audits[2]["user_id"] == audits[3]["user_id"] is None
-        assert audits[2]["user_name"] == audits[3]["user_name"] == "fake"
+        assert audits[3]["operation"] == "UPDATE"
+        assert audits[3]["name"] == "second"
+        assert audits[3]["user_id"] is None
+        assert audits[3]["user_name"] == "fake"
 
     def test_unauthenticated(self, query_get, make_audits):
         """Verify UNAUTHORIZED status with no authentication token"""
@@ -97,11 +113,15 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 2
         assert audits[0]["status"] == "BEGIN"
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[0]["name"] == "first"
+        assert audits[0]["user_id"] == "2"
+        assert audits[0]["user_name"] == "test"
         assert audits[1]["status"] == "SUCCESS"
-        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
-        assert audits[0]["name"] == audits[1]["name"] == "first"
-        assert audits[0]["user_id"] == audits[1]["user_id"] == "2"
-        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+        assert audits[1]["operation"] == "CREATE"
+        assert audits[1]["name"] == "first"
+        assert audits[1]["user_id"] == "2"
+        assert audits[1]["user_name"] == "test"
 
     def test_get_operation(self, query_get, make_audits):
         """Get all audit records matching a specific operation"""
@@ -111,21 +131,26 @@ class TestServerAudit:
         audits = response.json
         assert len(audits) == 2
         assert audits[0]["status"] == "BEGIN"
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[0]["name"] == "first"
+        assert audits[0]["user_id"] == "2"
+        assert audits[0]["user_name"] == "test"
         assert audits[1]["status"] == "SUCCESS"
-        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
-        assert audits[0]["name"] == audits[1]["name"] == "first"
-        assert audits[0]["user_id"] == audits[1]["user_id"] == "2"
-        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+        assert audits[1]["operation"] == "CREATE"
+        assert audits[1]["name"] == "first"
+        assert audits[1]["user_id"] == "2"
+        assert audits[1]["user_name"] == "test"
 
     def test_get_status_begin(self, query_get, make_audits):
         """Get all audit records matching a specific status"""
         response = query_get(params={"status": "BEGIN"}, expected_status=HTTPStatus.OK)
         audits = response.json
         assert len(audits) == 2
-        assert audits[0]["status"] == audits[1]["status"] == "BEGIN"
         assert audits[0]["operation"] == "CREATE"
-        assert audits[1]["operation"] == "UPDATE"
+        assert audits[0]["status"] == "BEGIN"
         assert audits[0]["name"] == "first"
+        assert audits[1]["operation"] == "UPDATE"
+        assert audits[1]["status"] == "BEGIN"
         assert audits[1]["name"] == "second"
 
     def test_get_status_failure(self, query_get, make_audits):
@@ -138,3 +163,54 @@ class TestServerAudit:
         assert audits[0]["status"] == "FAILURE"
         assert audits[0]["operation"] == "UPDATE"
         assert audits[0]["name"] == "second"
+
+    def test_get_status_start(self, query_get, make_audits):
+        response = query_get(
+            params={"start": dateutil.parser.parse("2022-01-01 01:00:00 UTC")},
+            expected_status=HTTPStatus.OK,
+        )
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["timestamp"] == "2022-01-01T05:00:00+00:00"
+        assert audits[0]["operation"] == "UPDATE"
+        assert audits[0]["status"] == "BEGIN"
+        assert audits[0]["name"] == "second"
+        assert audits[1]["timestamp"] == "2022-01-01T05:00:05+00:00"
+        assert audits[1]["operation"] == "UPDATE"
+        assert audits[1]["status"] == "FAILURE"
+        assert audits[1]["name"] == "second"
+
+    def test_get_status_end(self, query_get, make_audits):
+        response = query_get(
+            params={"end": dateutil.parser.parse("2022-01-01 01:00:00 UTC")},
+            expected_status=HTTPStatus.OK,
+        )
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["timestamp"] == "2022-01-01T00:00:00+00:00"
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[0]["status"] == "BEGIN"
+        assert audits[0]["name"] == "first"
+        assert audits[1]["timestamp"] == "2022-01-01T00:00:02+00:00"
+        assert audits[1]["operation"] == "CREATE"
+        assert audits[1]["status"] == "SUCCESS"
+        assert audits[1]["name"] == "first"
+
+    def test_get_status_between(self, query_get, make_audits):
+        response = query_get(
+            params={
+                "start": dateutil.parser.parse("2022-01-01 00:00:01 UTC"),
+                "end": dateutil.parser.parse("2022-01-01 05:00:02 UTC"),
+            },
+            expected_status=HTTPStatus.OK,
+        )
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["timestamp"] == "2022-01-01T00:00:02+00:00"
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[0]["status"] == "SUCCESS"
+        assert audits[0]["name"] == "first"
+        assert audits[1]["timestamp"] == "2022-01-01T05:00:00+00:00"
+        assert audits[1]["operation"] == "UPDATE"
+        assert audits[1]["status"] == "BEGIN"
+        assert audits[1]["name"] == "second"

--- a/lib/pbench/test/unit/server/test_server_audit.py
+++ b/lib/pbench/test/unit/server/test_server_audit.py
@@ -1,0 +1,121 @@
+from http import HTTPStatus
+from typing import Optional
+
+import pytest
+import requests
+
+from pbench.server import JSONOBJECT, OperationCode
+from pbench.server.database.models.audit import Audit, AuditStatus
+
+
+class TestServerAudit:
+    @pytest.fixture()
+    def query_get(self, client, server_config):
+        """
+        Helper fixture to perform the API query and validate an expected
+        return status.
+
+        Args:
+            client: Flask test API client fixture
+            server_config: Pbench config fixture
+        """
+
+        def query_api(
+            params: Optional[JSONOBJECT] = None,
+            expected_status: HTTPStatus = HTTPStatus.OK,
+        ) -> requests.Response:
+            response = client.get(
+                f"{server_config.rest_uri}/server/audit", query_string=params
+            )
+            assert response.status_code == expected_status
+            return response
+
+        return query_api
+
+    @pytest.fixture()
+    def make_audits(self, db_session, create_user):
+        root = Audit.create(
+            operation=OperationCode.CREATE,
+            name="first",
+            user=create_user,
+            status=AuditStatus.BEGIN,
+        )
+        Audit.create(root=root, status=AuditStatus.SUCCESS)
+
+        root = Audit.create(
+            operation=OperationCode.UPDATE,
+            name="second",
+            user_name="fake",
+            status=AuditStatus.BEGIN,
+        )
+        Audit.create(root=root, status=AuditStatus.FAILURE)
+
+    def test_get_bad_keys(self, query_get):
+        response = query_get({"xyzzy": "foo"}, HTTPStatus.BAD_REQUEST)
+        assert response.json == {"message": "Unknown URL query keys: xyzzy"}
+
+    def test_get_all(self, query_get, make_audits):
+        """With no query parameters, we should get all audit records"""
+        response = query_get(expected_status=HTTPStatus.OK)
+        audits = response.json
+        assert len(audits) == 4
+        assert audits[0]["status"] == "BEGIN"
+        assert audits[1]["status"] == "SUCCESS"
+        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
+        assert audits[0]["name"] == audits[1]["name"] == "first"
+        assert audits[0]["user_id"] == audits[1]["user_id"] == "1"
+        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+        assert audits[2]["status"] == "BEGIN"
+        assert audits[3]["status"] == "FAILURE"
+        assert audits[2]["operation"] == audits[3]["operation"] == "UPDATE"
+        assert audits[2]["name"] == audits[3]["name"] == "second"
+        assert audits[2]["user_id"] == audits[3]["user_id"] is None
+        assert audits[2]["user_name"] == audits[3]["user_name"] == "fake"
+
+    def test_get_name(self, query_get, make_audits):
+        """Get all audit records matching a specific operation name"""
+        response = query_get(params={"name": "first"}, expected_status=HTTPStatus.OK)
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["status"] == "BEGIN"
+        assert audits[1]["status"] == "SUCCESS"
+        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
+        assert audits[0]["name"] == audits[1]["name"] == "first"
+        assert audits[0]["user_id"] == audits[1]["user_id"] == "1"
+        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+
+    def test_get_operation(self, query_get, make_audits):
+        """Get all audit records matching a specific operation"""
+        response = query_get(
+            params={"operation": "CREATE"}, expected_status=HTTPStatus.OK
+        )
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["status"] == "BEGIN"
+        assert audits[1]["status"] == "SUCCESS"
+        assert audits[0]["operation"] == audits[1]["operation"] == "CREATE"
+        assert audits[0]["name"] == audits[1]["name"] == "first"
+        assert audits[0]["user_id"] == audits[1]["user_id"] == "1"
+        assert audits[0]["user_name"] == audits[1]["user_name"] == "test"
+
+    def test_get_status_begin(self, query_get, make_audits):
+        """Get all audit records matching a specific status"""
+        response = query_get(params={"status": "BEGIN"}, expected_status=HTTPStatus.OK)
+        audits = response.json
+        assert len(audits) == 2
+        assert audits[0]["status"] == audits[1]["status"] == "BEGIN"
+        assert audits[0]["operation"] == "CREATE"
+        assert audits[1]["operation"] == "UPDATE"
+        assert audits[0]["name"] == "first"
+        assert audits[1]["name"] == "second"
+
+    def test_get_status_failure(self, query_get, make_audits):
+        """Get all audit records showing a failure"""
+        response = query_get(
+            params={"status": "FAILURE"}, expected_status=HTTPStatus.OK
+        )
+        audits = response.json
+        assert len(audits) == 1
+        assert audits[0]["status"] == "FAILURE"
+        assert audits[0]["operation"] == "UPDATE"
+        assert audits[0]["name"] == "second"

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -156,18 +156,33 @@ class TestServerConfiguration:
     def test_put_param(self, query_put):
         response = query_put(key="dataset-lifetime", query_string={"value": "2"})
         assert response.json == {"dataset-lifetime": "2"}
-        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
-        assert len(audit) == 1
-        assert audit[0].attributes["updated"] == {"dataset-lifetime": "2"}
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].operation == OperationCode.UPDATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "config"
         assert audit[0].object_type == AuditType.CONFIG
+        assert audit[0].object_name is None
+        assert audit[1].operation == OperationCode.UPDATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "config"
+        assert audit[1].object_type == AuditType.CONFIG
+        assert audit[1].object_name is None
+        assert audit[1].attributes["updated"] == {"dataset-lifetime": "2"}
 
     def test_put_value(self, query_put):
         response = query_put(key="dataset-lifetime", json={"value": "2"})
         assert response.json == {"dataset-lifetime": "2"}
-        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
-        assert len(audit) == 1
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].operation == OperationCode.UPDATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "config"
         assert audit[0].object_type == AuditType.CONFIG
-        assert audit[0].attributes["updated"] == {"dataset-lifetime": "2"}
+        assert audit[1].operation == OperationCode.UPDATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "config"
+        assert audit[1].attributes["updated"] == {"dataset-lifetime": "2"}
 
     def test_put_value_unauth(self, query_put):
         response = query_put(
@@ -209,9 +224,19 @@ class TestServerConfiguration:
             "server-state": {"status": "enabled"},
             "server-banner": None,
         }
-        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
-        assert len(audit) == 1
-        assert audit[0].attributes["updated"] == {
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].operation == OperationCode.UPDATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "config"
+        assert audit[0].object_type == AuditType.CONFIG
+        assert audit[0].object_name is None
+        assert audit[1].operation == OperationCode.UPDATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "config"
+        assert audit[1].object_type == AuditType.CONFIG
+        assert audit[1].object_name is None
+        assert audit[1].attributes["updated"] == {
             "dataset-lifetime": "2",
             "server-state": {"status": "enabled"},
         }

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -163,11 +163,14 @@ class TestServerConfiguration:
         assert audit[0].name == "config"
         assert audit[0].object_type == AuditType.CONFIG
         assert audit[0].object_name is None
+        assert audit[0].object_id is None
+        assert audit[0].attributes is None
         assert audit[1].operation == OperationCode.UPDATE
         assert audit[1].status == AuditStatus.SUCCESS
         assert audit[1].name == "config"
         assert audit[1].object_type == AuditType.CONFIG
         assert audit[1].object_name is None
+        assert audit[1].object_id is None
         assert audit[1].attributes["updated"] == {"dataset-lifetime": "2"}
 
     def test_put_value(self, query_put):
@@ -179,9 +182,15 @@ class TestServerConfiguration:
         assert audit[0].status == AuditStatus.BEGIN
         assert audit[0].name == "config"
         assert audit[0].object_type == AuditType.CONFIG
+        assert audit[0].object_name is None
+        assert audit[0].object_id is None
+        assert audit[0].attributes is None
         assert audit[1].operation == OperationCode.UPDATE
         assert audit[1].status == AuditStatus.SUCCESS
         assert audit[1].name == "config"
+        assert audit[1].object_type == AuditType.CONFIG
+        assert audit[1].object_name is None
+        assert audit[1].object_id is None
         assert audit[1].attributes["updated"] == {"dataset-lifetime": "2"}
 
     def test_put_value_unauth(self, query_put):
@@ -231,11 +240,14 @@ class TestServerConfiguration:
         assert audit[0].name == "config"
         assert audit[0].object_type == AuditType.CONFIG
         assert audit[0].object_name is None
+        assert audit[0].object_id is None
+        assert audit[0].attributes is None
         assert audit[1].operation == OperationCode.UPDATE
         assert audit[1].status == AuditStatus.SUCCESS
         assert audit[1].name == "config"
         assert audit[1].object_type == AuditType.CONFIG
         assert audit[1].object_name is None
+        assert audit[1].object_id is None
         assert audit[1].attributes["updated"] == {
             "dataset-lifetime": "2",
             "server-state": {"status": "enabled"},

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -4,8 +4,10 @@ import logging
 import pytest
 import requests
 
+from pbench.server import OperationCode
 from pbench.server.api.resources import APIAbort, ApiParams
 from pbench.server.api.resources.server_configuration import ServerConfiguration
+from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
 
 
 class TestServerConfiguration:
@@ -91,7 +93,7 @@ class TestServerConfiguration:
         """
         put = ServerConfiguration(server_config, logging.getLogger("test"))
         with pytest.raises(APIAbort, match=r"Found URI parameters \['foo', 'plugh'\]"):
-            put._put_key(ApiParams(uri={"plugh": "xyzzy", "foo": "bar"}))
+            put._put_key(ApiParams(uri={"plugh": "xyzzy", "foo": "bar"}), context=None)
 
     def test_put_missing_value(self, query_put):
         """
@@ -154,10 +156,18 @@ class TestServerConfiguration:
     def test_put_param(self, query_put):
         response = query_put(key="dataset-lifetime", query_string={"value": "2"})
         assert response.json == {"dataset-lifetime": "2"}
+        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
+        assert len(audit) == 1
+        assert audit[0].attributes["updated"] == {"dataset-lifetime": "2"}
+        assert audit[0].object_type == AuditType.CONFIG
 
     def test_put_value(self, query_put):
         response = query_put(key="dataset-lifetime", json={"value": "2"})
         assert response.json == {"dataset-lifetime": "2"}
+        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
+        assert len(audit) == 1
+        assert audit[0].object_type == AuditType.CONFIG
+        assert audit[0].attributes["updated"] == {"dataset-lifetime": "2"}
 
     def test_put_value_unauth(self, query_put):
         response = query_put(
@@ -198,6 +208,12 @@ class TestServerConfiguration:
             "dataset-lifetime": "2",
             "server-state": {"status": "enabled"},
             "server-banner": None,
+        }
+        audit = Audit.query(operation=OperationCode.UPDATE, status=AuditStatus.SUCCESS)
+        assert len(audit) == 1
+        assert audit[0].attributes["updated"] == {
+            "dataset-lifetime": "2",
+            "server-state": {"status": "enabled"},
         }
 
     def test_disable_api(self, server_config, client, query_put, create_drb_user):

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-psycopg2
+psycopg2-binary
 pyesbulk>=2.0.1
 PyJwt
 python-dateutil

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-psycopg2-binary
+psycopg2
 pyesbulk>=2.0.1
 PyJwt
 python-dateutil


### PR DESCRIPTION
PBENCH-501

Add a SQL `Audit` table to track internal server operations. This will be a permanent record of every create, delete, and update operation on any server resource including datasets and configuration settings. (User changes are not being tracked as those will go away with the Keycloak migration.)

Resolves issue #2281