### PR TITLE
RPM build fixes related to Python 3

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -260,7 +260,7 @@ install-lib:
 install-python3-setup: install-util-scripts install-lib
 	${COPY} requirements.txt ${DESTDIR}
 	mkdir -p ${DESTDIR}/python3
-	(cd ..; SKIP_GENERATE_AUTHORS=1 SKIP_WRITE_GIT_CHANGELOG=1 python3 setup.py install --prefix=${DESTDIR}/python3)
+	(cd ..; /usr/bin/python3 -m pip install --prefix=${DESTDIR}/python3 -e .)
 	${COPY} $(addprefix ${DESTDIR}/python3/bin/, ${click-scripts}) ${UTILDIR}/
 	rm -rf ${DESTDIR}/python3
 	${COPY} ../lib/pbench ${LIBDIR}/

--- a/utils/rpmlint
+++ b/utils/rpmlint
@@ -1,3 +1,2 @@
 addFilter("setup-not-quiet")
 addFilter("invalid-url Source0")
-addFilter("macro-in-comment")


### PR DESCRIPTION
Backport from PR #2882 (a957705ee).

* Remove unused `rpmlint` filter

* Stop using deprecated setuptools method of install

The new way to install our Python3 interfaces is:

    /usr/bin/python3 -m pip install --prefix=${dir} -e .

See https://docs.python.org/3.6/installing/index.html#installing-index.

The new interface allows for the `agent/Makefile` to create the python CLI interfaces on environments running Python 3.10 and later.

Why do we use `/usr/bin/python3`?  If you invoke pip inside a virtualenv to install a package, it automatically uninstalls the previous one from where it was installed, and installs it again in the `--prefix` path. That is wrong on so many levels. So, to work around this terrible behavior we have to invoke the non-virtualenv `/usr/bin/python3` so that the installation works without touching the virtualenv.