### PR TITLE
Enhance the Pbench CI to build Server and Agent containers

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,6 +35,7 @@ tox                                     # Agent and Server unit tests and legacy
 ( cd dashboard && CI=true npm test )    # Dashboard unit tests
 
 # Build RPMS for the Server and Agent
+make -C server/rpm distclean  # Cleans all RPMs, both Server and Agent.
 make -C server/rpm ci
 make -C agent/rpm ci
 

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -1,17 +1,32 @@
 pipeline {
     agent { label 'pbench' }
     environment {
-        IMAGE_ROLE="ci"
+        EXTRA_PODMAN_SWITCHES="--pull=always -e=COV_REPORT_XML=yes"
         IMAGE_KIND="fedora"
         IMAGE_REPO="quay.io/pbench"
-        EXTRA_PODMAN_SWITCHES="--pull=always -e COV_REPORT_XML=yes"
+        IMAGE_ROLE="ci"
         NO_COLORS=0
+        PB_AGENT_CONTAINER_REG="quay.io"
+        PB_SERVER_CONTAINER_REG="images.paas.redhat.com"
+        PODMAN_AGENT=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
+        PODMAN_SERVER=credentials('12b404ca-3036-4960-9929-979148b9e49a')
         PY_COLORS=0
         TERM='dumb'
     }
     stages {
-        stage('Linting & Unit Tests') {
+        stage('Agent Python3.6 Check') {
             steps {
+                echo 'Verify agent side works with Python 3.6'
+                sh 'jenkins/run tox -e py36 -- agent'
+            }
+        }
+        stage('Linting, Unit Tests, RPM builds') {
+            steps {
+                // If we don't have a sequence number file left over from a
+                // previous run, then create one.
+                sh 'if [[ ! -e agent/rpm/seqno ]] ; then echo "1" > agent/rpm/seqno ; fi'
+                sh 'if [[ ! -e server/rpm/seqno ]] ; then echo "1" > server/rpm/seqno ; fi'
+
                 // If there is somehow a symlink left over from a previous run's
                 // Cobertura processing, remove it, because it seems to confuse
                 // the coverage data collection.
@@ -21,10 +36,11 @@ pipeline {
                 sh 'jenkins/run ./build.sh'
             }
         }
-        stage('Agent Python3.6 Check') {
+        stage('Pbench Server Container build') {
             steps {
-                echo 'Verify agent side works with Python 3.6'
-                sh 'jenkins/run tox -e py36 -- agent'
+                sh 'buildah login -u="${PODMAN_SERVER_USR}" -p="${PODMAN_SERVER_PSW}" ${PB_SERVER_CONTAINER_REG}'
+                sh 'RPM_PATH=${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm OUTPUT_IMAGE_TAG=${CHANGE_ID:-${BRANCH_NAME}} bash -ex ./server/pbenchinacan/container-build.sh'
+                sh 'buildah push localhost/pbench-server:${CHANGE_ID:-${BRANCH_NAME}} ${PB_SERVER_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver:${CHANGE_ID:-${BRANCH_NAME}}'
             }
         }
     }

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -22,29 +22,21 @@ Requires: python3-libselinux
 %endif
 
 Requires: npm
-Requires: python3-alembic python3-aniso8601 python3-boto3 python3-click
-Requires: python3-dateutil python3-elasticsearch python3-email-validator
-Requires: python3-flask python3-flask-cors
+Requires: python3-click python3-dateutil python3-elasticsearch python3-flask
 
-# The following is available on recent Fedora versions, but not in RHEL8,
-# so we exclude it on RHEL8: we'll pick it up through `pip3 install'
-# as a Pypi package.
-%if 0%{?rhel} != 8
-Requires:  python3-flask-httpauth
-%endif
+# The following are not available as RPMs in RHEL9, so we'll pick them up
+# through `pip3 install'.
+#
+# Requires: python3-alembic python3-aniso8601 python3-boto3
+# Requires: python3-email-validator python3-flask-cors
+# Requires: python3-flask-httpauth
+# Requires: python3-flask-migrate python3-flask-restful python3-flask-sqlalchemy
+# Requires: python3-Bcrypt-Flask flask-jwt-extended
+# Requires: python3-sqlalchemy-utils
 
-Requires: python3-flask-migrate python3-flask-restful python3-flask-sqlalchemy
-# Requires: python3-Bcrypt-Flask flask-jwt-extended  # Not available
 Requires: python3-gunicorn python3-humanize python3-psycopg2 python3-requests
 # Requires: pyesbulk>=2.0.1 PyJwt  # Not available
 Requires: python3-sqlalchemy
-
-# The following is available on recent Fedora versions, but not in RHEL8,
-# so we exclude it on RHEL8: we'll pick it up through `pip3 install'
-# as a Pypi package.
-%if 0%{?rhel} != 8
-Requires: python3-sqlalchemy-utils
-%endif
 
 # The following are indirect dependencies -- dependencies of dependencies that
 # we currently install via pip -- we require them here so that they will


### PR DESCRIPTION
This PR enhances the Pbench CI, adding a stage which builds a Pbench Server container image and pushes it to the internal Quay registry.  Access to the repository is granted via "robot" credentials which are managed as a Jenkins "secret".  The container image is tagged with the PR number for PR builds and with the branch name for other builds.

Note, at the moment, there is no mechanism for removing old container images.  However, the registry offers the ability to set an expiration on images; we just need to find out how to set that automatically.  (In the meantime, we can remove them manually -- each time a PR is rebuilt it will replace the previous image, so we won't build them up too fast.)  Ideally, we would only build new images when changes are made to _Server_ code, but that's also a challenge for another day.

Details:
- Jenkins Pipeline:
  - Reorder Jenkins pipeline stages to put the Py3.6 stage first
  - Add a stage for building the Server container image
  - Add configuration for container registries and credentials
- Update the Pbench Server RPM spec file for RHEL-9.
- Update the canned Server build script:
  - The base image is configurable but uses a RHEL-9 UBI image by default
  - The Server RPM is accessed directly instead of via a .repo
  - Both the RPM and the requirements.txt are installed in the image
- `build.sh` now does a "clean" before building the RPMs.

PBENCH-721