### PR TITLE
Add a new NPM packaging workaround; remove the previous one

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -87,7 +87,8 @@
     "jsdoc": "^3.6.10",
     "less": "^4.1.2",
     "less-loader": "^11.0.0",
-    "prettier": "^2.6.2",
-    "tough-cookie": "^4.1.2"
+    "prettier": "^2.6.2"
+  },
+  "overrides": {
   }
 }


### PR DESCRIPTION
Once again our build was [broken by an external update to an NPM package](https://github.com/jashkenas/underscore/issues/2967).  Happily, they were quick to fix it, so it's no longer necessary for us to work around the problem.

However, this PR commits the residue from that effort:
- First, we remove the workaround from the last time we had this firedrill, since it's no longer necessary.
- Second, we add a stub structure to hold the override for the next time (so we don't have to re-remember how to do it).  (The form is different from the last time, because we're now running a current version of `npm` which supports it.)