### PR TITLE
Get the current Agent container build working again

### DIFF
--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -19,7 +19,6 @@ RUN {{ pkgmgr }} install -y --setopt=tsflags=nodocs \
         {% if distro == 'centos-9' %}--enablerepo crb \
         {% else %}
         {% if distro == 'centos-8' %}--enablerepo powertools {% endif %} \
-        {% if kind in ('tools', 'all') %}--enablerepo pcp-rpm-release {% endif %} \
         {% endif %}
         {{ rpms }} && \
     {{ pkgmgr }} -y clean all && \

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -7,25 +7,53 @@
 #     all (default):  make all images for all default platforms
 #     tds:  make Tool Data Sink images for all default platforms
 #     tm:  make Tool Meister images for all default platforms
-#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to all images for all default platforms
-#     push:  push images for all default platforms with "<git commit hash>" and "v<full RPM version>" tags
-#     push-<TYPE> (e.g., "push-latest"):  push images for all default platforms with specified tag
+#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to all images for
+#                                       all default platforms
+#     push:  push images for all default platforms with "<git commit hash>"
+#            and "v<full RPM version>" tags
+#     push-<TYPE> (e.g., "push-latest"):  push images for all default
+#                                         platforms with specified tag
 #
 #   These act on the indicated distribution's containers:
 #
-#     <DISTRO> (e.g., "fedora-34"):  make all images for the requested platform
-#     <DISTRO>-tds (e.g., "fedora-34-tds"):  make the TDS image for the requested platform
-#     <DISTRO>-tm (e.g., "fedora-34-tm"):  make the TM image for the requested platform
-#     <DISTRO>-tag-<TYPE> (e.g., "fedora-34-tag-alpha"):  apply the specified tag to the distro containers
+#     <DISTRO> (e.g., "fedora-34"):  make all images for the distribution
+#     <DISTRO>-tds (e.g., "fedora-34-tds"):  make the TDS image for the distro
+#     <DISTRO>-tm (e.g., "fedora-34-tm"):  make the TM image for the distro
+#     <DISTRO>-tag-<TYPE> (e.g., "fedora-34-tag-alpha"):  apply the specified
+#                                                         tag to the distro
+#                                                         containers
 #     <DISTRO>-push (e.g., "fedora-34-push"):  push the specified containers
-#     <DISTRO>-push-<TYPE> (e.g., "fedora-34-push-alpha"):  push the specified containers
+#     <DISTRO>-push-<TYPE> (e.g., "fedora-34-push-alpha"):  push the specified
+#                                                           containers
+#
+#     NOTE: the supported distributions are centos-# and fedora-#, where the
+#           the minimum CentOS version is 7, and the minimum Fedora version is
+#           the latest non-end-of-life releases.
+#
+#     Further, each container has its own build target per distribution:
+#
+#     <DISTRO>-all[-tagged]            - depends on others below
+#         NOTE: the "all" here is the kind of container, which is composed of 
+#               the combined contents of the other containers for a <DISTRO>
+#     <DISTRO>-tool-data-sink[-tagged] - depends on <DISTRO>-tools-tagged
+#     <DISTRO>-tool-meister[-tagged]   - depends on <DISTRO>-tools-tagged
+#     <DISTRO>-tools[-tagged]          - depends on <DISTRO>-base-tagged
+#     <DISTRO>-workloads[-tagged]      - depends on <DISTRO>-base-tagged
+#     <DISTRO>-base[-tagged]
 #
 #   Utility targets:
 #
 #     clean:  remove build artifacts
 #     pkgmgr-clean:  clear the local package manager cache
-#     all-tags:  build all default distro "-tags.lis" files and verify that they are consistent.
-#     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile" files
+#     all-tags:  build all default distro "-tags.lis" files and verify that
+#                they are consistent
+#     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile"
+#                       files
+#
+# NOTE: for debugging purposes, you can set the environment variable,
+#       `BUILDAH_ECHO` to the value of `echo` to prevent container build
+#       operations from taking place so that you can see all the other build
+#       steps and their output.
 #
 
 _PBENCH_TOP := $(shell git rev-parse --show-toplevel)
@@ -127,11 +155,11 @@ tm: all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 #-
 
 # We also offer targets per distribution target
-${_DISTROS}: %: all-tags %-all-tagged
+${_DISTROS}: %: %-all-tagged
 
-$(_DISTROS:%=%-tds): %-tds: all-tags %-tool-data-sink-tagged
+$(_DISTROS:%=%-tds): %-tds: %-tool-data-sink-tagged
 
-$(_DISTROS:%=%-tm): %-tm: all-tags %-tool-meister-tagged
+$(_DISTROS:%=%-tm): %-tm: %-tool-meister-tagged
 
 # For any given target, extract the distribution name and version from the
 # first two fields, e.g., fedora-35-tds would yield values "fedora" and "35"

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -85,6 +85,10 @@ _DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35 fedora-36
 # By default we build the Tool Data Sink and Tool Meister images as well.
 everything: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
 
+# Do not use `all` as a target!
+all:
+	@printf -- "Do not use 'all' as a Make target, please use 'everything' instead\n" >&2
+
 # Convenience target to only build the Tool Data Sink images.
 tds: all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)
 
@@ -102,11 +106,11 @@ tm: all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 #-
 
 # We also offer targets per distribution target
-${_DISTROS}: %: %-all-tagged
+${_DISTROS}: %: pkgmgr-clean %-all-tagged
 
-$(_DISTROS:%=%-tds): %-tds: %-tool-data-sink-tagged
+$(_DISTROS:%=%-tds): %-tds: pkgmgr-clean %-tool-data-sink-tagged
 
-$(_DISTROS:%=%-tm): %-tm: %-tool-meister-tagged
+$(_DISTROS:%=%-tm): %-tm: pkgmgr-clean %-tool-meister-tagged
 
 # For any given target, extract the distribution name and version from the
 # first two fields, e.g., fedora-35-tds would yield values "fedora" and "35"

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -7,12 +7,12 @@
 #     everything (default):  make every image for the default platforms
 #     tds:  make Tool Data Sink images for the default platforms
 #     tm:  make Tool Meister images for the default platforms
-#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to every images for
-#                                       the default platforms
+#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to every image for
+#         the default platforms
 #     push:  push images for the default platforms with "<git commit hash>"
-#            and "v<full RPM version>" tags
+#         and "v<full RPM version>" tags
 #     push-<TYPE> (e.g., "push-latest"):  push images for the default
-#                                         platforms with specified tag
+#         platforms with specified tag
 #
 #   These act on the indicated distribution's containers:
 #
@@ -20,21 +20,20 @@
 #     <DISTRO>-tds (e.g., "fedora-34-tds"):  make the TDS image for the distro
 #     <DISTRO>-tm (e.g., "fedora-34-tm"):  make the TM image for the distro
 #     <DISTRO>-tag-<TYPE> (e.g., "fedora-34-tag-alpha"):  apply the specified
-#                                                         tag to the distro
-#                                                         containers
+#         tag to the distro containers
 #     <DISTRO>-push (e.g., "fedora-34-push"):  push the specified containers
 #     <DISTRO>-push-<TYPE> (e.g., "fedora-34-push-alpha"):  push the specified
-#                                                           containers
+#         containers
 #
 #     NOTE: the supported distributions are centos-# and fedora-#, where the
-#           the minimum CentOS version is 7, and the minimum Fedora version is
-#           the latest non-end-of-life releases.
+#         minimum CentOS version is 7, and the minimum Fedora version is the
+#         latest non-end-of-life releases.
 #
 #     Further, each container has its own build target per distribution:
 #
 #     <DISTRO>-all[-tagged]            - depends on others below
 #         NOTE: the "all" here is the kind of container, which is composed of 
-#               the combined contents of the other containers for a <DISTRO>
+#             the combined contents of the other containers for a <DISTRO>
 #     <DISTRO>-tool-data-sink[-tagged] - depends on <DISTRO>-tools-tagged
 #     <DISTRO>-tool-meister[-tagged]   - depends on <DISTRO>-tools-tagged
 #     <DISTRO>-tools[-tagged]          - depends on <DISTRO>-base-tagged
@@ -46,14 +45,14 @@
 #     clean:  remove build artifacts
 #     pkgmgr-clean:  clear the local package manager cache
 #     all-tags:  build all default distro "-tags.lis" files and verify that
-#                they are consistent
+#         they are consistent
 #     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile"
-#                       files
+#         files
 #
 # NOTE: for debugging purposes, you can set the environment variable,
-#       `BUILDAH_ECHO` to the value of `echo` to prevent container build
-#       operations from taking place so that you can see all the other build
-#       steps and their output.
+#     `BUILDAH_ECHO`, to the value of `echo` to prevent container build
+#     operations from taking place. This behavior allows a person to quickly see
+#     all the build steps and their output.
 #
 
 _PBENCH_TOP := $(shell git rev-parse --show-toplevel)

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -108,13 +108,13 @@ _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 _DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35
 
 # By default we build the Tool Data Sink and Tool Meister images as well.
-all: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
+all: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
 
 # Convenience target to only build the Tool Data Sink images.
-tds: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)
+tds: all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)
 
 # Convenience target to only build the Tool Meister images.
-tm: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
+tm: all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 
 #+
 # For the following rule patterns, the "%" represents the "distribution" name,
@@ -127,11 +127,11 @@ tm: pkgmgr-clean all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 #-
 
 # We also offer targets per distribution target
-${_DISTROS}: %: pkgmgr-clean %-all-tagged
+${_DISTROS}: %: all-tags %-all-tagged
 
-$(_DISTROS:%=%-tds): %-tds: pkgmgr-clean %-tool-data-sink-tagged
+$(_DISTROS:%=%-tds): %-tds: all-tags %-tool-data-sink-tagged
 
-$(_DISTROS:%=%-tm): %-tm: pkgmgr-clean %-tool-meister-tagged
+$(_DISTROS:%=%-tm): %-tm: all-tags %-tool-meister-tagged
 
 # For any given target, extract the distribution name and version from the
 # first two fields, e.g., fedora-35-tds would yield values "fedora" and "35"

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -1,22 +1,22 @@
-# Base Makefile for building all images and tagging them
+# Base Makefile for building images and tagging them
 
 # List of external Make targets:
 #
-#   These act on all default platforms' containers:
+#   These act on the default platforms' containers:
 #
-#     all (default):  make all images for all default platforms
-#     tds:  make Tool Data Sink images for all default platforms
-#     tm:  make Tool Meister images for all default platforms
-#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to all images for
-#                                       all default platforms
-#     push:  push images for all default platforms with "<git commit hash>"
+#     everything (default):  make every image for the default platforms
+#     tds:  make Tool Data Sink images for the default platforms
+#     tm:  make Tool Meister images for the default platforms
+#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to every images for
+#                                       the default platforms
+#     push:  push images for the default platforms with "<git commit hash>"
 #            and "v<full RPM version>" tags
-#     push-<TYPE> (e.g., "push-latest"):  push images for all default
+#     push-<TYPE> (e.g., "push-latest"):  push images for the default
 #                                         platforms with specified tag
 #
 #   These act on the indicated distribution's containers:
 #
-#     <DISTRO> (e.g., "fedora-34"):  make all images for the distribution
+#     <DISTRO> (e.g., "fedora-34"):  make every image kind for the distribution
 #     <DISTRO>-tds (e.g., "fedora-34-tds"):  make the TDS image for the distro
 #     <DISTRO>-tm (e.g., "fedora-34-tm"):  make the TM image for the distro
 #     <DISTRO>-tag-<TYPE> (e.g., "fedora-34-tag-alpha"):  apply the specified
@@ -136,7 +136,7 @@ _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 _DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35 fedora-36
 
 # By default we build the Tool Data Sink and Tool Meister images as well.
-all: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
+everything: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
 
 # Convenience target to only build the Tool Data Sink images.
 tds: all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -105,8 +105,10 @@ tm: all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
 # See https://www.gnu.org/software/make/manual/make.html#Automatic-Variables
 #-
 
-# We also offer targets per distribution target
-${_DISTROS}: %: pkgmgr-clean %-all-tagged
+# We also offer targets per distribution.
+${_DISTROS}: %: %-everything
+
+$(_DISTROS:%=%-everything): %-everything: pkgmgr-clean %-all-tagged
 
 $(_DISTROS:%=%-tds): %-tds: pkgmgr-clean %-tool-data-sink-tagged
 

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -49,7 +49,7 @@ URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 # test COPR repos to have a suffix added, typically "test", so that
 # the final repo name would be "pbench-test".
 TEST =
-_TEST_SUFFIX = $(if $(TEST),-$(TEST),"")
+_TEST_SUFFIX = $(if $(TEST),-$(TEST),)
 _PBENCH_REPO_NAME = pbench-$(shell grep -oE '[0-9]+\.[0-9]+' ${_PBENCH_TOP}/agent/VERSION)${_TEST_SUFFIX}
 
 # By default we use the pbench Quay.io organization for the image

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -1,58 +1,6 @@
-# Base Makefile for building images and tagging them
-
-# List of external Make targets:
+# Base Makefile for building images and tagging them.
 #
-#   These act on the default platforms' containers:
-#
-#     everything (default):  make every image for the default platforms
-#     tds:  make Tool Data Sink images for the default platforms
-#     tm:  make Tool Meister images for the default platforms
-#     tag-<TYPE> (e.g., "tag-latest"):  apply specified tag to every image for
-#         the default platforms
-#     push:  push images for the default platforms with "<git commit hash>"
-#         and "v<full RPM version>" tags
-#     push-<TYPE> (e.g., "push-latest"):  push images for the default
-#         platforms with specified tag
-#
-#   These act on the indicated distribution's containers:
-#
-#     <DISTRO> (e.g., "fedora-34"):  make every image kind for the distribution
-#     <DISTRO>-tds (e.g., "fedora-34-tds"):  make the TDS image for the distro
-#     <DISTRO>-tm (e.g., "fedora-34-tm"):  make the TM image for the distro
-#     <DISTRO>-tag-<TYPE> (e.g., "fedora-34-tag-alpha"):  apply the specified
-#         tag to the distro containers
-#     <DISTRO>-push (e.g., "fedora-34-push"):  push the specified containers
-#     <DISTRO>-push-<TYPE> (e.g., "fedora-34-push-alpha"):  push the specified
-#         containers
-#
-#     NOTE: the supported distributions are centos-# and fedora-#, where the
-#         minimum CentOS version is 7, and the minimum Fedora version is the
-#         latest non-end-of-life releases.
-#
-#     Further, each container has its own build target per distribution:
-#
-#     <DISTRO>-all[-tagged]            - depends on others below
-#         NOTE: the "all" here is the kind of container, which is composed of 
-#             the combined contents of the other containers for a <DISTRO>
-#     <DISTRO>-tool-data-sink[-tagged] - depends on <DISTRO>-tools-tagged
-#     <DISTRO>-tool-meister[-tagged]   - depends on <DISTRO>-tools-tagged
-#     <DISTRO>-tools[-tagged]          - depends on <DISTRO>-base-tagged
-#     <DISTRO>-workloads[-tagged]      - depends on <DISTRO>-base-tagged
-#     <DISTRO>-base[-tagged]
-#
-#   Utility targets:
-#
-#     clean:  remove build artifacts
-#     pkgmgr-clean:  clear the local package manager cache
-#     all-tags:  build all default distro "-tags.lis" files and verify that
-#         they are consistent
-#     all-dockerfiles:  build all default distro ".repo" and ".Dockerfile"
-#         files
-#
-# NOTE: for debugging purposes, you can set the environment variable,
-#     `BUILDAH_ECHO`, to the value of `echo` to prevent container build
-#     operations from taking place. This behavior allows a person to quickly see
-#     all the build steps and their output.
+# See the README.md file for a description of the interface.
 #
 
 _PBENCH_TOP := $(shell git rev-parse --show-toplevel)

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -59,7 +59,7 @@ IMAGE_REPO = docker://quay.io/pbench
 
 # Convenience reference to the repo template in the pbench tree.
 # Not intended to be overridden with an environment variable.
-_PBENCH_REPO_TEMPLATE = ../../ansible/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
+_PBENCH_REPO_TEMPLATE = ../../ansible/collection/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
 
 # This is for use on CentOS; on Fedora, the package is available without a
 # custom .repo file.
@@ -105,7 +105,7 @@ _WORKLOAD_RPMS = fio uperf
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 
 # By default we only build images for the following distributions.
-_DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35
+_DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35 fedora-36
 
 # By default we build the Tool Data Sink and Tool Meister images as well.
 all: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -293,8 +293,8 @@ pkgmgr-clean:
 # between the distribution name and the repo name, which for CentOS images
 # is "epel".  And for both CentOS and Fedora, the distribution image
 # reference, the package manager (dnf vs yum), and image name, also require
-# mappings (e.g. centos-7 -> yum, centos:7, CentOS 7, fedora-32 -> dnf,
-# fedora:32, Fedora 32).
+# mappings (e.g. centos-7 -> yum, centos:7, CentOS 7; or fedora-## -> dnf,
+# fedora:##, Fedora ##).
 #-
 _PKGMGR = dnf
 centos-7-base.Dockerfile: _PKGMGR = yum

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -52,8 +52,8 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 ```
 
 There are make targets for each of the five supported distributions, CentOS 9
-(`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 33
-(`fedora-33`), and Fedora 35 (`fedora-35`).  There are also make targets for
+(`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 36
+(`fedora-36`), and Fedora 35 (`fedora-35`).  There are also make targets for
 each subset of the container image kinds (`all`, `tool-data-sink`,
 `tool-meister`, `tools`, `workloads`, `base`) built for each distribution, e.g.
 `centos-8-tools-tagged`, `fedora-35-base-tagged`, etc.
@@ -128,9 +128,7 @@ These act on the indicated distribution's containers:
  * `<DISTRO>-push-<TYPE>` (e.g., "fedora-34-push-alpha"):  push the specified
    containers
 
-_NOTE_: the supported distributions are centos-# and fedora-#, where the
-minimum CentOS version is 7, and the minimum Fedora version is the latest
-non-end-of-life releases.
+_NOTE_: the supported distributions are listed above.
 
 Further, each container has its own build target per distribution:
 

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -30,12 +30,12 @@ environment variables, and use `pbench-test` repos by setting the `TEST`
 environment variable to `test`).
 
 Once the proper RPMs are available in the target repo, the default
-`Makefile` target, `all`, will build all the default images, and tag
+`Makefile` target, `everything`, will build each default image, and tag
 them with the pbench-agent RPM version and git commit hash ID.  E.g.,
 when done, one might see output from `buildah images` that looks like:
 
 ```
-$ make all
+$ make everything
 .
 . (lots of build output here ...)
 .
@@ -89,20 +89,18 @@ allow the administrator of the container image repository to label the
 images based on what they have built in relation to what has been
 published already.  The push targets are:
 
- * `push` - pushes all the images by their `<git commit ID>` tag,
+ * `push` - pushes each image by their `<git commit ID>` tag,
    and their RPM version tag
 
- * `push-latest` - pushes all the images by their `latest` tag
+ * `push-latest` - pushes each image by their `latest` tag
 
- * `push-major` - pushes all the images by their `v<Major>-latest`
-   tag
+ * `push-major` - pushes each image by their `v<Major>-latest` tag
 
- * `push-major-minor` - pushes all the images by their
-   `v<Major>.<Minor>-latest` tag
+ * `push-major-minor` - pushes each image by their `v<Major>.<Minor>-latest` tag
 
- * `push-alpha` - pushes all the images by their `alpha` tag
+ * `push-alpha` - pushes each image by their `alpha` tag
 
- * `push-beta` - pushes all the images by their `beta` tag
+ * `push-beta` - pushes each image by their `beta` tag
 
 NOTE WELL: Each separate tag for each image needs to be pushed to
 the non-local container image repository.  This does NOT result in

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -98,7 +98,60 @@ relation to what has been published already.  The push targets are:
 
  * `push-beta` - pushes each image by its `beta` tag
 
-NOTE WELL: Each separate tag for each image needs to be pushed to the non-local
-container image repository.  This does NOT result in multiple image copies over
-the wire using up network bandwidth, as `buildah push` is smart enough to push
-the actual image only once.
+**_NOTE WELL_**: Each separate tag for each image needs to be pushed to the
+non-local container image repository.  This does NOT result in multiple image
+copies over the wire using up network bandwidth, as `buildah push` is smart
+enough to push the actual image only once.
+
+# Detailed list of external Make targets
+
+These act on the default platforms' containers:
+
+ * `everything` (default):  make every image for the default platforms
+ * `tds`:  make Tool Data Sink images for the default platforms
+ * `tm`:  make Tool Meister images for the default platforms
+ * `tag-<TYPE>` (e.g., "tag-latest"):  apply specified tag to every image for
+   the default platforms
+ * `push`:  push images for the default platforms with `<git commit hash>`
+   and `v<full RPM version>` tags
+ * `push-<TYPE>` (e.g., "push-latest"):  push images for the default
+   platforms with specified tag
+
+These act on the indicated distribution's containers:
+
+ * `<DISTRO>` (e.g., "fedora-34"):  make every image kind for the distribution
+ * `<DISTRO>-tds` (e.g., "fedora-34-tds"):  make the TDS image for the distro
+ * `<DISTRO>-tm` (e.g., "fedora-34-tm"):  make the TM image for the distro
+ * `<DISTRO>-tag-<TYPE>` (e.g., "fedora-34-tag-alpha"):  apply the specified
+   tag to the distro containers
+ * `<DISTRO>-push` (e.g., "fedora-34-push"):  push the specified containers
+ * `<DISTRO>-push-<TYPE>` (e.g., "fedora-34-push-alpha"):  push the specified
+   containers
+
+_NOTE_: the supported distributions are centos-# and fedora-#, where the
+minimum CentOS version is 7, and the minimum Fedora version is the latest
+non-end-of-life releases.
+
+Further, each container has its own build target per distribution:
+
+ * `<DISTRO>-all[-tagged]`:  depends on others below
+   _NOTE_: the "all" here is the kind of container, which is composed of 
+   the combined contents of the other containers for a <DISTRO>
+ * `<DISTRO>-tool-data-sink[-tagged]`:  depends on <DISTRO>-tools-tagged
+ * `<DISTRO>-tool-meister[-tagged]`:  depends on <DISTRO>-tools-tagged
+ * `<DISTRO>-tools[-tagged]`:  depends on <DISTRO>-base-tagged
+ *  `<DISTRO>-workloads[-tagged]`:  depends on <DISTRO>-base-tagged
+ * `<DISTRO>-base[-tagged]`
+
+Utility targets:
+
+ * `clean`:  remove build artifacts
+ * `pkgmgr-clean`:  clear the local package manager cache
+ * `all-tags`:  build all default distro "-tags.lis" files and verify that they
+   are consistent
+ * `all-dockerfiles`:  build all default distro ".repo" and ".Dockerfile" files
+
+_NOTE_: for debugging purposes, you can set the environment variable,
+`BUILDAH_ECHO`, to the value of `echo` to prevent container build operations
+from taking place. This behavior allows a person to quickly see all the build
+steps and their output.

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -89,18 +89,18 @@ allow the administrator of the container image repository to label the
 images based on what they have built in relation to what has been
 published already.  The push targets are:
 
- * `push` - pushes each image by their `<git commit ID>` tag,
-   and their RPM version tag
+ * `push` - pushes each image by its `<git commit ID>` tag,
+   and its RPM version tag
 
- * `push-latest` - pushes each image by their `latest` tag
+ * `push-latest` - pushes each image by its `latest` tag
 
- * `push-major` - pushes each image by their `v<Major>-latest` tag
+ * `push-major` - pushes each image by its `v<Major>-latest` tag
 
- * `push-major-minor` - pushes each image by their `v<Major>.<Minor>-latest` tag
+ * `push-major-minor` - pushes each image by its `v<Major>.<Minor>-latest` tag
 
- * `push-alpha` - pushes each image by their `alpha` tag
+ * `push-alpha` - pushes each image by its `alpha` tag
 
- * `push-beta` - pushes each image by their `beta` tag
+ * `push-beta` - pushes each image by its `beta` tag
 
 NOTE WELL: Each separate tag for each image needs to be pushed to
 the non-local container image repository.  This does NOT result in

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -1,7 +1,7 @@
 # Build Requirements
 
-Container image building requires both the `buildah` and `jinja2` CLI
-commands to be present.
+Container image building requires both the `buildah` and `jinja2` CLI commands
+to be present.
 
 On Fedora 35 and later systems, use the following command to install the
 required CLI interface RPMs:
@@ -10,29 +10,28 @@ required CLI interface RPMs:
 
 # Notes
 
-  * We currently only support building container images from previously
-    built RPMs in an accessible yum/dnf set of repos
+  * We currently only support building container images from previously built
+    RPMs in an accessible yum/dnf set of repos
 
-  * We currently only support container images built from `x86_64`
-    architecture RPMs
+  * We currently only support container images built from `x86_64` architecture
+    RPMs
 
-  * Visualizers have been moved to a new repo, source code can be found
-    at: [distributed-system-analysis/visualizers](https://github.com/distributed-system-analysis/visualizers)
+  * Visualizers have been moved to a new repo, source code can be found at:
+    [distributed-system-analysis/visualizers](https://github.com/distributed-system-analysis/visualizers)
 
 # How to Use
 
-The first step is taken elsewhere, where one would build `pbench-agent`,
-and `pbench-sysstat` RPMs, build or find proper RPMs for `fio` & `uperf`,
-and place them in a single yum/dnf repository accessible via HTTPS.  By
-default, we use Fedora COPR repos under the `ndokos` user (one can
-override the yum/dnf repos and user via the `URL_PREFIX` and `USER`
-environment variables, and use `pbench-test` repos by setting the `TEST`
-environment variable to `test`).
+The first step is taken elsewhere, where one would build `pbench-agent`, and
+`pbench-sysstat` RPMs, build or find proper RPMs for `fio` & `uperf`, and place
+them in a single yum/dnf repository accessible via HTTPS.  By default, we use
+Fedora COPR repos under the `ndokos` user (one can override the yum/dnf repos
+and user via the `URL_PREFIX` and `USER` environment variables, and use
+`pbench-test` repos by setting the `TEST` environment variable to `test`).
 
-Once the proper RPMs are available in the target repo, the default
-`Makefile` target, `everything`, will build each default image, and tag
-them with the pbench-agent RPM version and git commit hash ID.  E.g.,
-when done, one might see output from `buildah images` that looks like:
+Once the proper RPMs are available in the target repo, the default `Makefile`
+target, `everything`, will build each default image, and tag them with the
+pbench-agent RPM version and git commit hash ID.  E.g., when done, one might
+see output from `buildah images` that looks like:
 
 ```
 $ make everything
@@ -52,45 +51,42 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 .
 ```
 
-There are make targets for each of the five supported distributions,
-CentOS 9 (`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`),
-Fedora 33 (`fedora-33`), and Fedora 35 (`fedora-35`).  There are also
-make targets for each subset of the container image kinds (`all`,
-`tool-data-sink`, `tool-meister`, `tools`, `workloads`, `base`) built
-for each distribution, e.g. `centos-8-tools-tagged`,
-`fedora-35-base-tagged`, etc.
+There are make targets for each of the five supported distributions, CentOS 9
+(`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 33
+(`fedora-33`), and Fedora 35 (`fedora-35`).  There are also make targets for
+each subset of the container image kinds (`all`, `tool-data-sink`,
+`tool-meister`, `tools`, `workloads`, `base`) built for each distribution, e.g.
+`centos-8-tools-tagged`, `fedora-35-base-tagged`, etc.
 
-Two tags are always applied to an image that is built, the `<git
-commit ID>` derived from the RPM version, and the version string of
-the RPM itself (without the trailing commit ID).
+Two tags are always applied to an image that is built, the `<git commit ID>`
+derived from the RPM version, and the version string of the RPM itself (without
+the trailing commit ID).
 
-One can add additional local tags using the following targets when
-appropriate (these tags are not automatically applied at build time):
+One can add additional local tags using the following targets when appropriate
+(these tags are not automatically applied at build time):
 
  * `tag-latest` - adds the `latest` label to the images with the
-   `<git commit ID>` as derived from the RPM version string of the
-   pbench-agent RPM
+   `<git commit ID>` as derived from the RPM version string of the pbench-agent
+   RPM
 
- * `tag-major` - adds the `v<Major>-latest` label to the images
-   as derived from the RPM version string ...
+ * `tag-major` - adds the `v<Major>-latest` label to the images as derived from
+   the RPM version string ...
 
- * `tag-major-minor` -adds the `v<Major>.<Minor>-latest` label to
-   the images ...
+ * `tag-major-minor` -adds the `v<Major>.<Minor>-latest` label to the images ...
 
  * `tag-alpha` - adds the `alpha` label to the images ...
 
  * `tag-beta` - adds the `beta` label to the images ...
 
-Finally, there are "push" targets to copy the locally built and
-tagged images to a non-local container image repository.  By default
-we use `docker://quay.io/pbench` (you can override that via the
-environment variable `IMAGE_REPO`).  We have separate push targets to
-allow the administrator of the container image repository to label the
-images based on what they have built in relation to what has been
-published already.  The push targets are:
+Finally, there are "push" targets to copy the locally built and tagged images
+to a non-local container image repository.  By default we use
+`docker://quay.io/pbench` (you can override that via the environment variable
+`IMAGE_REPO`).  We have separate push targets to allow the administrator of the
+container image repository to label the images based on what they have built in
+relation to what has been published already.  The push targets are:
 
- * `push` - pushes each image by its `<git commit ID>` tag,
-   and its RPM version tag
+ * `push` - pushes each image by its `<git commit ID>` tag, and its RPM version
+   tag
 
  * `push-latest` - pushes each image by its `latest` tag
 
@@ -102,7 +98,7 @@ published already.  The push targets are:
 
  * `push-beta` - pushes each image by its `beta` tag
 
-NOTE WELL: Each separate tag for each image needs to be pushed to
-the non-local container image repository.  This does NOT result in
-multiple image copies over the wire using up network bandwidth, as
-`buildah push` is smart enough to push the actual image only once.
+NOTE WELL: Each separate tag for each image needs to be pushed to the non-local
+container image repository.  This does NOT result in multiple image copies over
+the wire using up network bandwidth, as `buildah push` is smart enough to push
+the actual image only once.

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -3,7 +3,7 @@
 Container image building requires both the `buildah` and `jinja2` CLI
 commands to be present.
 
-On Fedora 32 and later systems, use the following command to install the
+On Fedora 35 and later systems, use the following command to install the
 required CLI interface RPMs:
 
     sudo dnf install buildah python3-jinja2-cli
@@ -52,11 +52,13 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 .
 ```
 
-There are make targets for each of the four supported distributions,
-CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 33 (`fedora-33`),
-and Fedora 32 (`fedora-32`).  There are also make targets for each
-subset of the four images (all, base, tools, workloads) built for
-each distribution, e.g. `centos-8-tools`, `fedora-32-base`, etc.
+There are make targets for each of the five supported distributions,
+CentOS 9 (`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`),
+Fedora 33 (`fedora-33`), and Fedora 35 (`fedora-35`).  There are also
+make targets for each subset of the container image kinds (`all`,
+`tool-data-sink`, `tool-meister`, `tools`, `workloads`, `base`) built
+for each distribution, e.g. `centos-8-tools-tagged`,
+`fedora-35-base-tagged`, etc.
 
 Two tags are always applied to an image that is built, the `<git
 commit ID>` derived from the RPM version, and the version string of

--- a/agent/containers/images/apply-tags
+++ b/agent/containers/images/apply-tags
@@ -13,7 +13,7 @@ fi
 githash="$(grep -v -E "^v" ${tags_file})"
 
 function apply_tag {
-    buildah tag ${1}:${githash} ${1}:${2}
+    ${BUILDAH_ECHO} buildah tag ${1}:${githash} ${1}:${2}
 }
 
 for tag in $(grep -E "^v" ${tags_file} | grep ${latest} latest); do

--- a/agent/containers/images/build-image
+++ b/agent/containers/images/build-image
@@ -6,4 +6,4 @@ tags_file="${3}"
 
 githash="$(grep -v -E "^v" ${tags_file})"
 
-buildah bud -f ${distro}-${image}.Dockerfile -t pbench-agent-${image}-${distro}:${githash} .
+${BUILDAH_ECHO} buildah bud -f ${distro}-${image}.Dockerfile -t pbench-agent-${image}-${distro}:${githash} .

--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -6,3 +6,9 @@ repos:
     gpgkey: "{{ url_prefix }}/{{ name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1
+  - name: pbench
+    user: {{ user }}
+    baseurl: "{{ url_prefix }}/pbench/{{ distro }}-$basearch"
+    gpgkey: "{{ url_prefix }}/pbench/pubkey.gpg"
+    gpgcheck: 1
+    enabled: 1


### PR DESCRIPTION
Replaces PR #3013.

Apparently, the Agent container builds aren't working any more.  This PR restores them to working order.

The principal changes:

- The container build depends on the `pbench.repo.j2` template from the Ansible collection...which, apparently, moved recently (#2991)
- Added a second repository to the `agent/containers/images/repo.yml.j2` template for the "auxillary" RPMs

We also made some smaller changes:
- Added Fedora-36 to the list of default targets
- The `-TEST` suffix will now _really_ disappear when it's not needed
- Removed some redundant dependencies on the `pkgmgr-clean` target
- Tweaked a code comment
- Removed an unnecessary PCP repo enablement
- Enabled a method of quickly executing all `make` targets for container build