### PR TITLE
Use `psycopg2-binary` to avoid build dependencies

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -14,7 +14,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-psycopg2
+psycopg2-binary
 pyesbulk>=2.0.1
 PyJwt
 python-dateutil


### PR DESCRIPTION
The `psycopg2` Python 3 module dependency requires the environment have the correct source build infrastructure to make the module.  While the CI environment has that, developers for some reason don't have that setup all the time.  This will ease their pain.

Pulled from PR #3008.