### PR TITLE
Small server rpm spec cleanup

### DIFF
--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -15,7 +15,7 @@ Requires: python3 python3-devel cronie
 Requires:       policycoreutils
 %if 0%{?rhel} != 7
 Requires: policycoreutils-python-utils
-Requires: libselinux-python3 python3-psycopg2
+Requires: libselinux-python3
 %else
 Requires: policycoreutils-python
 Requires: python3-libselinux

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -59,8 +59,8 @@ Requires: python3-certifi python3-bcrypt python3-greenlet
 # because we don't know where the config file is. Note that we omit
 # the initial / - it is added in every use below.  IMO, that's more
 # readable since it appears in the middle of the path in all cases,
-# *except* in the %files section (and one instance in the %post
-# and %postun sections).
+# *except* in the files section (and one instance in the post
+# and postun sections).
 
 %define installdir opt/pbench-server
 %define static html/static
@@ -92,7 +92,7 @@ cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 # for the npm install below
 mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
-# The %dir directive creates this directory on install, but needs a source
+# The %%dir directive creates this directory on install, but needs a source
 mkdir -p %{buildroot}/var/log/pbench-server/
 
 %post
@@ -129,7 +129,7 @@ su pbench -c "python3 -m pip --no-cache-dir install --user --no-warn-script-loca
 # site-library paths, and /opt/pbench-server/lib.
 su pbench -c "echo /%{installdir}/lib > \$(python3 -m site --user-site)/pbench.pth"
 
-# install node.js modules under /%{installdir}
+# install node.js modules under /{installdir}
 cd /%{installdir}
 rm -rf node_modules
 echo 'package-lock=false' >> .npmrc


### PR DESCRIPTION
This PR contains some small clean-ups for the Server RPM spec file (template):
- Remove a redundant dependency on `python3-psycopg2` (we already have an unconditional `Requires` for it, so we remove the reference from the conditional one).
- Remove or escape references to `rpmbuild` macros in code-comments.  `rpmbuild` expands macros, even inside comments; normally, this goes unnoticed and isn't a problem, but if the macro expands to multiple lines, the expansion can escape the comment and break the build; therefore, `rpmlint` checks for macros in comments and warns about them.  So, in cases where the context is clear, I simply removed the leading `%` so that the references cease to be macros; in the other case, I added a second `%` which escapes the macro-introducer, which produces the same effect.  And, now there are no more complaints from `rpmlint`.