### PR TITLE
Use latest `npm` in CI container image

### DIFF
--- a/jenkins/ci.fedora.Dockerfile
+++ b/jenkins/ci.fedora.Dockerfile
@@ -83,7 +83,8 @@ RUN \
     `#` \
     dnf -y clean all && rm -rf /var/cache/dnf && \
     `#` \
-    `# Configure npm.` \
+    `# Configure npm:  install the latest version and give us` \
+    `#                 extra time to install dependencies.` \
     `#` \
-    npm install -g npm@8.19.0 && \
+    npm install -g npm@8 && \
     npm config set fetch-retry-maxtimeout 120000


### PR DESCRIPTION
When we run `npm` in the CI container, it complains about being out of date.  At the end of the CI container image build, we attempted to update `npm` to the current release, but the current release has moved on from that point, and now we're getting complaints again.

This PR relaxes the requested `npm` update target, so now we should always get the latest published version.  And, while I was in there, I improved the descriptive comment.