### PR TITLE
Correct UID template resolution

### DIFF
--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -1186,7 +1186,7 @@ class ResultData(PbenchData):
     @staticmethod
     def expand_uid_template(templ, d, run=None):
         """Given a UID template string using %<keyword>% pattern identifiers,
-        lookup those keywords in the given dictionary and replacing those
+        lookup those keywords in the given dictionary and replace those
         keywords which have values.
 
         There are two keywords which are treated specially:
@@ -1218,13 +1218,13 @@ class ResultData(PbenchData):
             except KeyError:
                 try:
                     if key == "benchmark_name":
-                        # Fix "benchmark_name" to try to find "name" in the
-                        # metadata if available (should be as we rename
-                        # benchmark_name to name).
+                        # Try the alternate key, "name", to see if it is
+                        # available in the metadata (should be as if we renamed
+                        # "benchmark_name" to "name").
                         val = d["name"]
                     elif run is not None and key == "controller_host":
-                        # Fix "controller_host" to try to find "controller" in the
-                        # run metadata if available.
+                        # Try the alternate key, "controller", in the run
+                        # metadata since the metadata was explicitly provided.
                         val = run["controller"]
                 except KeyError:
                     # Keyword not found, ignore

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -1203,7 +1203,6 @@ class ResultData(PbenchData):
         made.  For floats, 6 decimal places are used in the string conversion.
 
         Returns a new string with as many keywords replaced as possible.
-
         """
         # Even though this is just a second name bound to the same string
         # object, the `re.sub` method returns a new string object each time a
@@ -1212,23 +1211,17 @@ class ResultData(PbenchData):
         for m in re.findall(ResultData._uid_keyword_pat, templ):
             # Strips the initial and final % signs from the match.
             key = m[1:-1]
-            val = None
-            try:
-                val = d[key]
-            except KeyError:
-                try:
-                    if key == "benchmark_name":
-                        # Try the alternate key, "name", to see if it is
-                        # available in the metadata (should be as if we renamed
-                        # "benchmark_name" to "name").
-                        val = d["name"]
-                    elif run is not None and key == "controller_host":
-                        # Try the alternate key, "controller", in the run
-                        # metadata since the metadata was explicitly provided.
-                        val = run["controller"]
-                except KeyError:
-                    # Keyword not found, ignore
-                    pass
+            val = d.get(key)
+            if val is None:
+                if key == "benchmark_name":
+                    # Try the alternate key, "name", to see if it is available
+                    # in the metadata (should be as if we renamed
+                    # "benchmark_name" to "name").
+                    val = d.get("name")
+                elif key == "controller_host" and run is not None:
+                    # Try the alternate key, "controller", in the run metadata
+                    # since the metadata was explicitly provided.
+                    val = run.get("controller")
             if val is not None and isinstance(val, (str, int, float)):
                 val_s = f"{val:.6f}" if isinstance(val, float) else str(val)
                 result = re.sub(m, val_s, result)

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -1222,7 +1222,7 @@ class ResultData(PbenchData):
                     # Try the alternate key, "controller", in the run metadata
                     # since the metadata was explicitly provided.
                     val = run.get("controller")
-            if val is not None and isinstance(val, (str, int, float)):
+            if isinstance(val, (str, int, float)):
                 val_s = f"{val:.6f}" if isinstance(val, float) else str(val)
                 result = re.sub(m, val_s, result)
         return result

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -1194,7 +1194,7 @@ class ResultData(PbenchData):
           * If the "benchmark_name" is not found in the given dictionary, a
             second attempt to find a value using "name" will be attempted.
 
-          * If a additional `run` dictionary is provided, it'll be used on a
+          * If an additional `run` dictionary is provided, it'll be used on a
             second attempt to find a "controller_host" value by using
             "controller" in the `run` lookup.
 

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -1132,7 +1132,7 @@ class ResultData(PbenchData):
             # Now that we have a proper "template" field, generate the actual
             # UID from the template using the existing metadata we have
             # collected.
-            bm_md["uid"] = ResultData.expand_template(
+            bm_md["uid"] = ResultData.expand_uid_template(
                 bm_md["uid_tmpl"], bm_md, run=self.run_metadata
             )
 
@@ -1152,7 +1152,7 @@ class ResultData(PbenchData):
             # Now that we have a proper "template" field, generate the actual
             # UID from the template using the existing metadata we have
             # collected.
-            bm_md["trafficgen_uid"] = ResultData.expand_template(
+            bm_md["trafficgen_uid"] = ResultData.expand_uid_template(
                 bm_md["trafficgen_uid_tmpl"], bm_md, run=self.run_metadata
             )
 
@@ -1180,42 +1180,59 @@ class ResultData(PbenchData):
         ):
             yield source, PbenchData.make_source_id(source), _parent, _type
 
-    # UID keyword pattern
+    # UID keyword pattern, non-greedy
     _uid_keyword_pat = re.compile(r"%\w*?%")
 
     @staticmethod
-    def expand_template(templ, d, run=None):
-        # match %...% patterns non-greedily.
-        s = templ
-        for m in re.findall(ResultData._uid_keyword_pat, s):
-            # m[1:-1] strips the initial and final % signs from the match.
+    def expand_uid_template(templ, d, run=None):
+        """Given a UID template string using %<keyword>% pattern identifiers,
+        lookup those keywords in the given dictionary and replacing those
+        keywords which have values.
+
+        There are two keywords which are treated specially:
+
+          * If the "benchmark_name" is not found in the given dictionary, a
+            second attempt to find a value using "name" will be attempted.
+
+          * If a additional `run` dictionary is provided, it'll be used on a
+            second attempt to find a "controller_host" value by using
+            "controller" in the `run` lookup.
+
+        The supported keyword values are one of: `str`, `int`, or `float`.  If
+        a keyword's value is not a supported type, the replacement is not
+        made.  For floats, 6 decimal places are used in the string conversion.
+
+        Returns a new string with as many keywords replaced as possible.
+
+        """
+        # Even though this is just a second name bound to the same string
+        # object, the `re.sub` method returns a new string object each time a
+        # change is made.
+        result = templ
+        for m in re.findall(ResultData._uid_keyword_pat, templ):
+            # Strips the initial and final % signs from the match.
             key = m[1:-1]
+            val = None
             try:
                 val = d[key]
             except KeyError:
-                if key == "benchmark_name":
-                    # Fix "benchmark_name" to try to find "name" in the
-                    # metadata if available (should be as we rename
-                    # benchmark_name to name).
-                    try:
+                try:
+                    if key == "benchmark_name":
+                        # Fix "benchmark_name" to try to find "name" in the
+                        # metadata if available (should be as we rename
+                        # benchmark_name to name).
                         val = d["name"]
-                    except KeyError:
-                        pass
-                    else:
-                        s = re.sub(m, val, s)
-                elif key == "controller_host" and run is not None:
-                    # Fix "controller_host" to try to find "controller" in the
-                    # run metadata if available.
-                    try:
+                    elif run is not None and key == "controller_host":
+                        # Fix "controller_host" to try to find "controller" in the
+                        # run metadata if available.
                         val = run["controller"]
-                    except KeyError:
-                        pass
-                    else:
-                        s = re.sub(m, val, s)
-                # Keyword not found, ignore
-            else:
-                s = re.sub(m, val, s)
-        return s
+                except KeyError:
+                    # Keyword not found, ignore
+                    pass
+            if val is not None and isinstance(val, (str, int, float)):
+                val_s = f"{val:.6f}" if isinstance(val, float) else str(val)
+                result = re.sub(m, val_s, result)
+        return result
 
     @staticmethod
     def make_sample_wrapper(result_type, title, result_el_idx, result_el):
@@ -1249,7 +1266,9 @@ class ResultData(PbenchData):
         # Construct the uid from the template and the values in result_el
         # and replace the template with the result.
         result_el["uid_tmpl"] = result_el["uid"]
-        result_el["uid"] = ResultData.expand_template(result_el["uid_tmpl"], result_el)
+        result_el["uid"] = ResultData.expand_uid_template(
+            result_el["uid_tmpl"], result_el
+        )
         try:
             mean_val = float(result_el["mean"])
         except KeyError:

--- a/lib/pbench/test/unit/server/test_indexer.py
+++ b/lib/pbench/test/unit/server/test_indexer.py
@@ -1,0 +1,39 @@
+from pbench.server.indexer import ResultData
+
+
+class TestResultData_expand_uid_template:
+    @staticmethod
+    def test_no_keywords():
+        templ = "no_keywords_in_this_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == templ
+
+    @staticmethod
+    def test_found():
+        templ = "%this%_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == "that_UID"
+
+    @staticmethod
+    def test_not_found():
+        templ = "%that%_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == "%that%_UID"
+
+    @staticmethod
+    def test_fallbacks():
+        keyvals = {"name": "mybm"}
+        templ = "%benchmark_name%_UID"
+        res = ResultData.expand_uid_template(templ, keyvals)
+        assert res == "mybm_UID"
+        templ = "%controller_host%_UID"
+        res = ResultData.expand_uid_template(templ, keyvals, {"controller": "hostA"})
+        assert res == "hostA_UID"
+
+    @staticmethod
+    def test_value_types():
+        templ = "%str%_%int%_%float%_%other%_UID"
+        res = ResultData.expand_uid_template(
+            templ, {"str": "abc", "int": 123, "float": 45.6789012, "other": []}
+        )
+        assert res == "abc_123_45.678901_%other%_UID"


### PR DESCRIPTION
When a template key maps to a non-string value, a error is encountered like:

    "TypeError: decoding to str: need a bytes-like object, float found"

The code now converts all non-string values to strings, and ignores any keys which don't map to a value with one of the types: `string`, `int`, or `float`.

A set of unit tests for this operation is provided, and the function was renamed to ensure its intended use is clear.