### PR TITLE
PBENCH-672 Refactor `/datasets/detail` to GET API

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -23,6 +23,9 @@ from pbench.server.api.resources.graphql_api import GraphQL
 from pbench.server.api.resources.query_apis.datasets.datasets_contents import (
     DatasetsContents,
 )
+from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
+    DatasetsDetail,
+)
 from pbench.server.api.resources.query_apis.datasets.datasets_mappings import (
     DatasetsMappings,
 )
@@ -31,9 +34,6 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleValues,
 )
 from pbench.server.api.resources.query_apis.datasets_delete import DatasetsDelete
-from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
-    DatasetsDetail,
-)
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -31,7 +31,9 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleValues,
 )
 from pbench.server.api.resources.query_apis.datasets_delete import DatasetsDelete
-from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetail
+from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
+    DatasetsDetail,
+)
 from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
 from pbench.server.api.resources.query_apis.elasticsearch_api import Elasticsearch

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -59,13 +59,7 @@ class DatasetsDetail(IndexMapBase):
         Get details for a specific Pbench dataset which is either owned
         by a specified username, or has been made publicly accessible.
 
-        POST /datasets/detail/<dataset>
-        {
-            "user": "username",
-            "start": "start-time",
-            "end": "end-time",
-            "metadata": ["seen", "saved"]
-        }
+        GET /datasets/detail/<dataset>?name=dname&metadata=global.seen,server.deletion
 
         params: API parameter set
 

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -5,6 +5,7 @@ from flask import jsonify
 
 from pbench.server import JSON, PbenchServerConfig
 from pbench.server.api.resources import (
+    API_AUTHORIZATION,
     API_METHOD,
     API_OPERATION,
     APIAbort,
@@ -14,11 +15,8 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.api.resources.query_apis import (
-    CONTEXT,
-    ElasticBase,
-    PostprocessError,
-)
+from pbench.server.api.resources.query_apis import CONTEXT, PostprocessError
+from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 from pbench.server.database.models.datasets import (
     Dataset,
     DatasetNotFound,
@@ -27,7 +25,7 @@ from pbench.server.database.models.datasets import (
 )
 
 
-class DatasetsDetail(ElasticBase):
+class DatasetsDetail(IndexMapBase):
     """
     Get detailed data from the run document for a dataset by name.
     """
@@ -37,16 +35,12 @@ class DatasetsDetail(ElasticBase):
             config,
             logger,
             ApiSchema(
-                API_METHOD.POST,
+                API_METHOD.GET,
                 API_OPERATION.READ,
                 uri_schema=Schema(
-                    Parameter("dataset", ParamType.STRING, required=True)
+                    Parameter("dataset", ParamType.DATASET, required=True)
                 ),
-                body_schema=Schema(
-                    Parameter("user", ParamType.USER, required=False),
-                    Parameter("access", ParamType.ACCESS, required=False),
-                    Parameter("start", ParamType.DATE, required=True),
-                    Parameter("end", ParamType.DATE, required=True),
+                query_schema=Schema(
                     Parameter(
                         "metadata",
                         ParamType.LIST,
@@ -56,6 +50,7 @@ class DatasetsDetail(ElasticBase):
                         string_list=",",
                     ),
                 ),
+                authorization=API_AUTHORIZATION.DATASET,
             ),
         )
 
@@ -77,16 +72,7 @@ class DatasetsDetail(ElasticBase):
             URI parameters:
                 "dataset" is the name of a Pbench agent dataset (tarball).
 
-            JSON body parameters:
-                user: specifies the owner of the data to be searched; it need not
-                    necessarily be the user represented by the session token
-                    header, assuming the session user is authorized to view "user"s
-                    data. If "user": None is specified, then only public datasets
-                    will be returned.
-
-                "start" and "end" are time strings representing a set of Elasticsearch
-                    run document indices in which the dataset will be found.
-
+            Query parameters:
                 "metadata" specifies the set of Dataset metadata properties the
                     caller needs to see. (If not specified, no metadata will be
                     returned.)
@@ -94,32 +80,22 @@ class DatasetsDetail(ElasticBase):
         context: Context passed from preprocess method: used to propagate the
             requested set of metadata to the postprocess method.
         """
-        dataset = params.uri.get("dataset")
-        user = params.body.get("user")
-        access = params.body.get("access")
-        start = params.body.get("start")
-        end = params.body.get("end")
+        dataset = context["dataset"]
 
         # Copy client's metadata request to CONTEXT for postprocessor
-        context["metadata"] = params.body.get("metadata")
-        self.logger.info(
-            "Return dataset {} for user {}, prefix {}: ({} - {})",
-            dataset,
-            user,
-            self.prefix,
-            start,
-            end,
-        )
+        context["metadata"] = params.query.get("metadata")
 
-        uri_fragment = self._gen_month_range("run", start, end)
+        self.logger.info("Return dataset {}, prefix {}", dataset, self.prefix)
+        indices = self.get_index(dataset, "run-data")
+
         return {
-            "path": f"/{uri_fragment}/_search",
+            "path": f"/{indices}/_search",
             "kwargs": {
                 "params": {"ignore_unavailable": "true"},
                 "json": {
-                    "query": self._build_elasticsearch_query(
-                        user, access, [{"term": {"run.name": dataset}}]
-                    ),
+                    "query": {
+                        "bool": {"filter": {"match": {"run.id": dataset.resource_id}}}
+                    },
                     "sort": "_index",
                 },
             },

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -59,7 +59,7 @@ class DatasetsDetail(IndexMapBase):
         Get details for a specific Pbench dataset which is either owned
         by a specified username, or has been made publicly accessible.
 
-        GET /datasets/detail/<dataset>?name=dname&metadata=global.seen,server.deletion
+        GET /datasets/detail/<dataset>?metadata=global.seen,server.deletion
 
         params: API parameter set
 
@@ -79,7 +79,6 @@ class DatasetsDetail(IndexMapBase):
         # Copy client's metadata request to CONTEXT for postprocessor
         context["metadata"] = params.query.get("metadata")
 
-        self.logger.info("Return dataset {}, prefix {}", dataset, self.prefix)
         indices = self.get_index(dataset, "run-data")
 
         return {
@@ -87,9 +86,7 @@ class DatasetsDetail(IndexMapBase):
             "kwargs": {
                 "params": {"ignore_unavailable": "true"},
                 "json": {
-                    "query": {
-                        "bool": {"filter": {"match": {"run.id": dataset.resource_id}}}
-                    },
+                    "query": {"term": {"run.id": dataset.resource_id}},
                     "sort": "_index",
                 },
             },

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import requests
 import responses
 
+from pbench.server import JSON
 from pbench.server.api.resources import API_METHOD
 
 
@@ -35,6 +36,7 @@ def query_api(client, server_config, provide_metadata):
         expected_status: str,
         headers: dict = {},
         request_method=API_METHOD.POST,
+        query_params: JSON = None,
         **kwargs,
     ) -> requests.Response:
         host = server_config.get("elasticsearch", "host")
@@ -67,6 +69,7 @@ def query_api(client, server_config, provide_metadata):
                 f"{server_config.rest_uri}{pbench_uri}",
                 headers=headers,
                 json=payload,
+                query_string=query_params,
             )
         assert response.status_code == expected_status
         return response

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -2,7 +2,6 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server import PbenchServerConfig
 from pbench.server.api.resources import API_METHOD
 from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
     DatasetsDetail,

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -2,7 +2,10 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources.query_apis.datasets.datasets_detail import DatasetsDetail
+from pbench.server.api.resources import API_METHOD
+from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
+    DatasetsDetail,
+)
 from pbench.test.unit.server.query_apis.commons import Commons
 
 
@@ -19,20 +22,17 @@ class TestDatasetsDetail(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=DatasetsDetail(client.config, client.logger),
-            pbench_endpoint="/datasets/detail/fio",
+            pbench_endpoint="/datasets/detail/random_md5_string1",
             elastic_endpoint="/_search?ignore_unavailable=true",
-            payload={
-                "user": "drb",
-                "access": "private",
-                "start": "2020-08",
-                "end": "2020-10",
-            },
+            index_from_metadata="run-data",
             empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
+    api_method = API_METHOD.GET
+
     @pytest.mark.parametrize(
         "user",
-        ("drb", "badwolf", "no_user"),
+        ("drb", "no_user"),
     )
     def test_query(
         self, client, server_config, query_api, find_template, build_auth_header, user
@@ -42,20 +42,13 @@ class TestDatasetsDetail(Commons):
         The test will run once with each parameter supplied from the local parameterization,
         and, for each of those, three times with different values of the build_auth_header fixture.
         """
-        dataset_name = "fio_rhel8_kvm_perf43_preallocfull_nvme_run4_iothread_isolcpus_2020.04.29T12.49.13"
-        payload = {
-            "user": user,
-            "access": "private",
-            "start": "2020-08",
-            "end": "2020-10",
-        }
-
-        # We expect "no_user" to succeed, looking for only public data. We
-        # normally remove the user parameter; for this case, we'll look for
-        # public data owned by a known user; which should succeed.
+        auth_json = {"user": user, "access": "private"}
+        """
+        We expect "no_user" to succeed, looking for public data. In this case, we'll look for
+        public data owned by a known user; which should succeed.
+        """
         if user == "no_user":
-            del payload["user"]
-            payload["access"] = "public"
+            auth_json["access"] = "public"
 
         response_payload = {
             "took": 112,
@@ -119,23 +112,21 @@ class TestDatasetsDetail(Commons):
             },
         }
 
-        index = self.build_index(
-            server_config, self.date_range(self.payload["start"], self.payload["end"])
-        )
-
-        expected_status = HTTPStatus.OK
+        index = self.build_index_from_metadata()
 
         expected_status = self.get_expected_status(
-            payload, build_auth_header["header_param"]
+            auth_json, build_auth_header["header_param"]
         )
+
         response = query_api(
-            f"/datasets/detail/{dataset_name}",
+            self.pbench_endpoint,
             self.elastic_endpoint,
-            payload,
-            index,
-            expected_status,
-            headers=build_auth_header["header"],
+            payload=None,
+            expected_index=index,
+            expected_status=expected_status,
             json=response_payload,
+            headers=build_auth_header["header"],
+            request_method=self.api_method,
         )
         assert response.status_code == expected_status
         if response.status_code == HTTPStatus.OK:
@@ -196,13 +187,7 @@ class TestDatasetsDetail(Commons):
         focus on the PostgreSQL dataset metadata... but necessarily has to
         borrow much of the setup.
         """
-        dataset_name = "drb"
-        payload = {
-            "user": "drb",
-            "start": "2020-08",
-            "end": "2020-10",
-            "metadata": ["global.seen", "server.deletion"],
-        }
+        query_params = {"metadata": ["global.seen", "server.deletion"]}
 
         response_payload = {
             "took": 112,
@@ -266,18 +251,18 @@ class TestDatasetsDetail(Commons):
             },
         }
 
-        index = self.build_index(
-            server_config, self.date_range(self.payload["start"], self.payload["end"])
-        )
+        index = self.build_index_from_metadata()
 
         response = query_api(
-            f"/datasets/detail/{dataset_name}",
+            self.pbench_endpoint,
             self.elastic_endpoint,
-            payload,
+            self.payload,
             index,
             HTTPStatus.OK,
             headers={"authorization": f"Bearer {pbench_token}"},
             json=response_payload,
+            request_method=self.api_method,
+            query_params=query_params,
         )
         assert response.status_code == HTTPStatus.OK
         res_json = response.json
@@ -341,17 +326,18 @@ class TestDatasetsDetail(Commons):
         The test will run thrice with different values of the build_auth_header
         fixture.
         """
+        auth_json = {"user": "drb", "access": "private"}
+
         expected_status = self.get_expected_status(
-            self.payload, build_auth_header["header_param"]
+            auth_json, build_auth_header["header_param"]
         )
 
         # In this case, if we don't get a validation/permission error, expect
         # to fail because of the unexpectedly empty Elasticsearch result.
         if expected_status == HTTPStatus.OK:
             expected_status = HTTPStatus.BAD_REQUEST
-        index = self.build_index(
-            server_config, self.date_range(self.payload["start"], self.payload["end"])
-        )
+        index = self.build_index_from_metadata()
+
         response = query_api(
             f"{self.pbench_endpoint}",
             self.elastic_endpoint,
@@ -360,18 +346,19 @@ class TestDatasetsDetail(Commons):
             expected_status,
             headers=build_auth_header["header"],
             json=self.empty_es_response_payload,
+            request_method=self.api_method,
         )
         assert response.status_code == expected_status
         if response.status_code == HTTPStatus.BAD_REQUEST:
             assert response.json["message"].find("dataset has gone missing") != -1
 
-    def test_nonunique_query(self, client, server_config, query_api, find_template):
+    def test_nonunique_query(
+        self, client, server_config, query_api, find_template, pbench_token
+    ):
         """
         Check the handling of a query that returns too much data.
         """
-        # We look for public data so we can make an unauthorized query
-        del self.payload["user"]
-        self.payload["access"] = "public"
+
         response_payload = {
             "hits": {
                 "total": {"value": 0, "relation": "eq"},
@@ -380,7 +367,7 @@ class TestDatasetsDetail(Commons):
             },
         }
 
-        index = self.build_index(server_config, ("2020-08", "2020-09", "2020-10"))
+        index = self.build_index_from_metadata()
         response = query_api(
             f"{self.pbench_endpoint}",
             self.elastic_endpoint,
@@ -388,5 +375,7 @@ class TestDatasetsDetail(Commons):
             index,
             HTTPStatus.BAD_REQUEST,
             json=response_payload,
+            headers={"authorization": f"Bearer {pbench_token}"},
+            request_method=self.api_method,
         )
         assert response.json["message"].find("Too many hits for a unique query") != -1

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources.query_apis.datasets_detail import DatasetsDetail
+from pbench.server.api.resources.query_apis.datasets.datasets_detail import DatasetsDetail
 from pbench.test.unit.server.query_apis.commons import Commons
 
 


### PR DESCRIPTION
PBENCH-672

Refactored  `POST /datasets/detail/<dataset>`  to `GET` API with metadata will be provided in `query_schema`.

And modified this `DatasetsDetail` to be an IndexMap subclass that identifies the document IDs and indices using the map rather than a full Elasticsearch query.