### PR TITLE
Correct UID template resolution

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -4,7 +4,7 @@ pipeline {
         stage('Linting & Unit Tests') {
             steps {
                 echo 'Linting and legacy unit tests'
-                sh 'jenkins/run jenkins/tox -r --current-env -e jenkins-unittests,py3-server'
+                sh 'jenkins/run jenkins/tox -r --current-env -e jenkins-unittests'
             }
         }
     }

--- a/jenkins/development.Dockerfile
+++ b/jenkins/development.Dockerfile
@@ -71,7 +71,6 @@ RUN \
         python3-click \
         python3-coverage \
         python3-daemon \
-        python3-elasticsearch \
         python3-entrypoints \
         python3-flake8 \
         python3-flask \

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -8,10 +8,8 @@ fi
 pip3 install --no-cache-dir --progress-bar off --no-color --prefix="${_prefix}" \
     -r ${progdir}/lint-requirements.txt \
     -r ${progdir}/server/requirements.txt \
+    -r ${progdir}/server/test-requirements.txt \
     -r ${progdir}/agent/test-requirements.txt
-    # -r ${progdir}/agent/requirements.txt \
-    # -r ${progdir}/server/test-requirements.txt \
-    # -r ${progdir}/docs/requirements.txt \
 
 _pdir=${_prefix}/bin
 if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
@@ -22,7 +20,9 @@ while read -r _pdir; do
     if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
         PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
     fi
-done <<< "$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null)
+done <<< "${progdir}/server/lib
+${progdir}/lib
+$(ls -1d ${_prefix}/lib*/python3.*/site-packages 2> /dev/null)
 $(head -n 1 ${_prefix}/lib*/python3.*/site-packages/pbench.egg-link 2> /dev/null)"
 
 export PYTHONPATH

--- a/jenkins/run-unittests
+++ b/jenkins/run-unittests
@@ -7,7 +7,9 @@ source $(dirname "${0}")/python-setup.sh
 
 typeset -i errors=0
 
-printf -- "black --check ...\n"
+printf -- "\n\n\nrun-unittests started ...\n"
+
+printf -- "\n\nblack --check ...\n"
 black --check .
 black_sts=${?}
 if [[ ${black_sts} -ne 0 ]]; then
@@ -15,14 +17,23 @@ if [[ ${black_sts} -ne 0 ]]; then
     (( errors++ ))
 fi
 
-printf -- "\nflake8 --verbose ...\n"
+printf -- "\n\nflake8 --verbose ...\n"
 flake8 --verbose .
 flake_sts=${?}
 if [[ ${flake_sts} -ne 0 ]]; then
     printf -- "FAILED: flake8 --verbose .\n" >&2
     (( errors++ ))
 fi
-printf -- "\n"
+
+printf -- "\n\npytests ...\n"
+pytest server/lib/pbench/test/unit
+pytest_sts=${?}
+if [[ ${pytest_sts} -ne 0 ]]; then
+    printf -- "FAILED: pytest server/lib/pbench/test/unit\n" >&2
+    (( errors++ ))
+fi
+
+printf -- "\n\n\n"
 
 export PBENCH_UNITTEST_SERVER_MODE=parallel
 
@@ -79,9 +90,9 @@ for env in ${envs}; do
 done
 
 if [[ ${errors} -gt 0 ]]; then
-    printf -- "\n\nTests failed! (%d errors)\n" ${errors}
+    printf -- "\n\nrun-unittests ... Tests failed! (%d errors)\n\n\n" ${errors}
     exit 1
 else
-    printf -- "\n\nTests succeeded.\n"
+    printf -- "\n\nrun-unittests ... Tests succeeded.\n"
     exit 0
 fi

--- a/server/lib/pbench/test/unit/test_indexer.py
+++ b/server/lib/pbench/test/unit/test_indexer.py
@@ -1,0 +1,54 @@
+from pbench.indexer import ResultData
+
+
+class TestResultData_expand_uid_template:
+    @staticmethod
+    def test_no_keywords():
+        templ = "no_keywords_in_this_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == templ
+
+    @staticmethod
+    def test_found():
+        templ = "%this%_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == "that_UID"
+
+    @staticmethod
+    def test_not_found():
+        templ = "%that%_UID"
+        res = ResultData.expand_uid_template(templ, {"this": "that"})
+        assert res == "%that%_UID"
+
+    @staticmethod
+    def test_fallbacks():
+        # This UID template is shared with multiple test cases.
+        templ = "%benchmark_name%_UID"
+        res = ResultData.expand_uid_template(templ, dict(foo=1, bar=2))
+        assert res == templ
+
+        # This dictionary is shared with all the other test cases.
+        keyvals = {"name": "myname"}
+
+        res = ResultData.expand_uid_template(templ, keyvals)
+        assert res == "myname_UID"
+
+        # This UID template is shared with multiple test cases.
+        templ = "%controller_host%_UID"
+        res = ResultData.expand_uid_template(templ, keyvals)
+        assert res == templ
+
+        res = ResultData.expand_uid_template(templ, keyvals, dict(abc=123))
+        assert res == templ
+
+        run_d = {"controller": "hostA"}
+        res = ResultData.expand_uid_template(templ, keyvals, run_d)
+        assert res == "hostA_UID"
+
+    @staticmethod
+    def test_value_types():
+        templ = "%str%_%int%_%float%_%other%_UID"
+        res = ResultData.expand_uid_template(
+            templ, {"str": "abc", "int": 123, "float": 45.6789012, "other": []}
+        )
+        assert res == "abc_123_45.678901_%other%_UID"


### PR DESCRIPTION
Backport of PRs #3029 (665132a89) and #3035 (4822f75af).

When a template key maps to a non-string value, an error is encountered like:

    "TypeError: decoding to str: need a bytes-like object, float found"

The code now converts all non-string values to strings, and ignores any keys which don't map to a value with one of the types: `string`, `int`, or `float`.

A set of unit tests for this operation is provided, and the function name was renamed to ensure its intended use is clear.

Unfortunately, as the bits have aged the backport of the unit tests is a bit more difficult.  To make this all work we had to:

 * Remove fallback `elasticsearch` import, it just confused things

 * Move `pytest` invocation under `jenkins-unittests` since we can't use `--current-env` with `py3-server`

 * Fix `PYTHONPATH` for unit tests to include the server code

 * Delineate the CI steps a bit more cleanly