### PR TITLE
PBENCH-934 Remove user table relationship with dataset and metadata table

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1457,11 +1457,14 @@ class ApiBase(Resource):
             if Metadata.is_key_path(i, Metadata.METADATA_KEYS):
                 native_key = Metadata.get_native_key(i)
                 user: Optional[User] = None
+                user_id = None
                 if native_key == Metadata.USER:
                     user = Auth.token_auth.current_user()
+                    if user:
+                        user_id = user.id
                 try:
                     metadata[i] = Metadata.getvalue(
-                        dataset=dataset, key=i, user_id=user.id if user else None
+                        dataset=dataset, key=i, user_id=user_id
                     )
                 except MetadataNotFound:
                     metadata[i] = None

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1460,7 +1460,9 @@ class ApiBase(Resource):
                 if native_key == Metadata.USER:
                     user = Auth.token_auth.current_user()
                 try:
-                    metadata[i] = Metadata.getvalue(dataset=dataset, key=i, user=user)
+                    metadata[i] = Metadata.getvalue(
+                        dataset=dataset, key=i, user=user.username if user else None
+                    )
                 except MetadataNotFound:
                     metadata[i] = None
             else:

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1458,9 +1458,7 @@ class ApiBase(Resource):
                 native_key = Metadata.get_native_key(i)
                 user_id = None
                 if native_key == Metadata.USER:
-                    user = Auth.token_auth.current_user()
-                    if user:
-                        user_id = user.id
+                    user_id = Auth.get_user_id()
                 try:
                     metadata[i] = Metadata.getvalue(
                         dataset=dataset, key=i, user_id=user_id

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1456,7 +1456,6 @@ class ApiBase(Resource):
         for i in requested_items:
             if Metadata.is_key_path(i, Metadata.METADATA_KEYS):
                 native_key = Metadata.get_native_key(i)
-                user: Optional[User] = None
                 user_id = None
                 if native_key == Metadata.USER:
                     user = Auth.token_auth.current_user()

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1461,7 +1461,7 @@ class ApiBase(Resource):
                     user = Auth.token_auth.current_user()
                 try:
                     metadata[i] = Metadata.getvalue(
-                        dataset=dataset, key=i, user=user.username if user else None
+                        dataset=dataset, key=i, user_id=user.id if user else None
                     )
                 except MetadataNotFound:
                     metadata[i] = None

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -180,7 +180,12 @@ class DatasetsMetadata(ApiBase):
             if native_key == Metadata.USER:
                 user = Auth.token_auth.current_user()
             try:
-                Metadata.setvalue(key=k, value=v, dataset=dataset, user=user)
+                Metadata.setvalue(
+                    key=k,
+                    value=v,
+                    dataset=dataset,
+                    user=user.username if user else None,
+                )
             except MetadataError as e:
                 self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))
                 fail = True

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -1,6 +1,5 @@
 from http import HTTPStatus
 from logging import Logger
-from typing import Optional
 
 from flask.json import jsonify
 from flask.wrappers import Request, Response
@@ -25,7 +24,6 @@ from pbench.server.database.models.datasets import (
     MetadataBadValue,
     MetadataError,
 )
-from pbench.server.database.models.users import User
 
 
 class DatasetsMetadata(ApiBase):
@@ -176,7 +174,6 @@ class DatasetsMetadata(ApiBase):
         fail = False
         for k, v in metadata.items():
             native_key = Metadata.get_native_key(k)
-            user: Optional[User] = None
             user_id = None
             if native_key == Metadata.USER:
                 user = Auth.token_auth.current_user()

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -176,9 +176,7 @@ class DatasetsMetadata(ApiBase):
             native_key = Metadata.get_native_key(k)
             user_id = None
             if native_key == Metadata.USER:
-                user = Auth.token_auth.current_user()
-                if user:
-                    user_id = user.id
+                user_id = Auth.get_user_id()
             try:
                 Metadata.setvalue(key=k, value=v, dataset=dataset, user_id=user_id)
             except MetadataError as e:

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -177,15 +177,13 @@ class DatasetsMetadata(ApiBase):
         for k, v in metadata.items():
             native_key = Metadata.get_native_key(k)
             user: Optional[User] = None
+            user_id = None
             if native_key == Metadata.USER:
                 user = Auth.token_auth.current_user()
+                if user:
+                    user_id = user.id
             try:
-                Metadata.setvalue(
-                    key=k,
-                    value=v,
-                    dataset=dataset,
-                    user_id=user.id if user else None,
-                )
+                Metadata.setvalue(key=k, value=v, dataset=dataset, user_id=user_id)
             except MetadataError as e:
                 self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))
                 fail = True

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -184,7 +184,7 @@ class DatasetsMetadata(ApiBase):
                     key=k,
                     value=v,
                     dataset=dataset,
-                    user=user.username if user else None,
+                    user_id=user.id if user else None,
                 )
             except MetadataError as e:
                 self.logger.warning("Unable to update key {} = {!r}: {}", k, v, str(e))

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -74,9 +74,7 @@ class Upload(Resource):
                 username = Auth.token_auth.current_user().username
             except Exception:
                 username = None
-                raise CleanupTime(
-                    HTTPStatus.INTERNAL_SERVER_ERROR, "Error verifying user_id"
-                )
+                raise CleanupTime(HTTPStatus.UNAUTHORIZED, "Verifying user_id failed")
 
             controller = request.headers.get("controller")
             if not controller:
@@ -144,7 +142,7 @@ class Upload(Resource):
             bytes_received = 0
 
             self.logger.info(
-                "PUT uploading {}:{} for user {}|{} to {}",
+                "PUT uploading {}:{} for user = (user_id: {}, username: {}) to {}",
                 controller,
                 filename,
                 user_id,
@@ -163,7 +161,7 @@ class Upload(Resource):
             except DatasetDuplicate:
                 dataset_name = Dataset.stem(tar_full_path)
                 self.logger.info(
-                    "Dataset already exists, user = {}|{}, file = {!a}",
+                    "Dataset already exists, user = (user_id: {}, username: {}), file = {!a}",
                     user_id,
                     username,
                     dataset_name,
@@ -172,10 +170,10 @@ class Upload(Resource):
                     Dataset.query(resource_id=md5sum)
                 except DatasetNotFound:
                     self.logger.error(
-                        "Duplicate dataset {}|{}:{} not found",
+                        "Duplicate dataset {} for user = (user_id: {}, username: {}) not found",
+                        dataset_name,
                         user_id,
                         username,
-                        dataset_name,
                     )
                     raise CleanupTime(
                         HTTPStatus.INTERNAL_SERVER_ERROR, "INTERNAL ERROR"
@@ -195,7 +193,7 @@ class Upload(Resource):
             recovery.add(dataset.delete)
 
             self.logger.info(
-                "Uploading file {!a} (user = {}|{}, ctrl = {!a}) to {}",
+                "Uploading file {!a} (user = (user_id: {}, username: {}), ctrl = {!a}) to {}",
                 filename,
                 user_id,
                 username,

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -70,11 +70,12 @@ class Upload(Resource):
 
         try:
             try:
+                user_id = Auth.token_auth.current_user().id
                 username = Auth.token_auth.current_user().username
             except Exception:
                 username = None
                 raise CleanupTime(
-                    HTTPStatus.INTERNAL_SERVER_ERROR, "Error verifying username"
+                    HTTPStatus.INTERNAL_SERVER_ERROR, "Error verifying user_id"
                 )
 
             controller = request.headers.get("controller")
@@ -143,9 +144,10 @@ class Upload(Resource):
             bytes_received = 0
 
             self.logger.info(
-                "PUT uploading {}:{} for user {} to {}",
+                "PUT uploading {}:{} for user {}|{} to {}",
                 controller,
                 filename,
+                user_id,
                 username,
                 tar_full_path,
             )
@@ -153,7 +155,7 @@ class Upload(Resource):
             # Create a tracking dataset object; it'll begin in UPLOADING state
             try:
                 dataset = Dataset(
-                    owner=username,
+                    owner_id=user_id,
                     name=Dataset.stem(tar_full_path),
                     resource_id=md5sum,
                 )
@@ -161,7 +163,8 @@ class Upload(Resource):
             except DatasetDuplicate:
                 dataset_name = Dataset.stem(tar_full_path)
                 self.logger.info(
-                    "Dataset already exists, user = {}, file = {!a}",
+                    "Dataset already exists, user = {}|{}, file = {!a}",
+                    user_id,
                     username,
                     dataset_name,
                 )
@@ -169,7 +172,8 @@ class Upload(Resource):
                     Dataset.query(resource_id=md5sum)
                 except DatasetNotFound:
                     self.logger.error(
-                        "Duplicate dataset {}:{} not found",
+                        "Duplicate dataset {}|{}:{} not found",
+                        user_id,
                         username,
                         dataset_name,
                     )
@@ -191,8 +195,9 @@ class Upload(Resource):
             recovery.add(dataset.delete)
 
             self.logger.info(
-                "Uploading file {!a} (user = {}, ctrl = {!a}) to {}",
+                "Uploading file {!a} (user = {}|{}, ctrl = {!a}) to {}",
                 filename,
+                user_id,
                 username,
                 controller,
                 dataset,

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -1,6 +1,7 @@
 import datetime
 from http import HTTPStatus
 import os
+from typing import Optional
 
 from flask import abort, request
 from flask_httpauth import HTTPTokenAuth
@@ -18,6 +19,18 @@ class Auth:
     def set_logger(logger):
         # Logger gets set at the time of auth module initialization
         Auth.logger = logger
+
+    @staticmethod
+    def get_user_id() -> Optional[str]:
+        """
+        Returns the user id of the current authenticated user.
+        If the user not authenticated this would return None
+        """
+        user_id = None
+        user = Auth.token_auth.current_user()
+        if user:
+            user_id = user.id
+        return user_id
 
     def encode_auth_token(self, time_delta: datetime.timedelta, user_id: int) -> str:
         """

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -394,7 +394,7 @@ class Dataset(Database.Base):
 
     Columns:
         id          Generated unique ID of table row
-        owner_id    Owning uuid of the owner of the dataset
+        owner_id    Owning UUID of the owner of the dataset
         access      Dataset is "private" to owner, or "public"
         name        Base name of dataset (tarball)
         md5         The dataset MD5 hash (Elasticsearch ID)

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -29,12 +29,6 @@ class User(Database.Base):
     role = Column(Enum(Roles), unique=False, nullable=True)
     auth_tokens = relationship("ActiveTokens", backref="users")
 
-    # NOTE: this relationship defines a `user` property in `Metadata`
-    # that refers to the parent `User` object.
-    dataset_metadata = relationship(
-        "Metadata", back_populates="user", cascade="all, delete-orphan"
-    )
-
     def __str__(self):
         return f"User, id: {self.id}, username: {self.username}"
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -316,6 +316,7 @@ def attach_dataset(create_drb_user, create_user):
     with freeze_time("1970-01-01 00:42:00"):
         Dataset(
             owner="drb",
+            owner_id="3",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
             state=States.INDEXED,
@@ -325,6 +326,7 @@ def attach_dataset(create_drb_user, create_user):
         ).add()
         Dataset(
             owner="test",
+            owner_id="5",
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,
             name="test",
@@ -359,6 +361,7 @@ def more_datasets(
     with freeze_time("1978-06-26 08:00:00"):
         Dataset(
             owner="drb",
+            owner_id="3",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
             state=States.INDEXED,
@@ -368,6 +371,7 @@ def more_datasets(
         ).add()
         Dataset(
             owner="test",
+            owner_id="5",
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,
             name="fio_2",

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -315,7 +315,6 @@ def attach_dataset(create_drb_user, create_user):
     # for one Dataset and letting it default for the other.
     with freeze_time("1970-01-01 00:42:00"):
         Dataset(
-            owner="drb",
             owner_id="3",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
@@ -325,7 +324,6 @@ def attach_dataset(create_drb_user, create_user):
             resource_id="random_md5_string1",
         ).add()
         Dataset(
-            owner="test",
             owner_id="5",
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,
@@ -360,7 +358,6 @@ def more_datasets(
     """
     with freeze_time("1978-06-26 08:00:00"):
         Dataset(
-            owner="drb",
             owner_id="3",
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
@@ -370,7 +367,6 @@ def more_datasets(
             resource_id="random_md5_string3",
         ).add()
         Dataset(
-            owner="test",
             owner_id="5",
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -335,7 +335,12 @@ def attach_dataset(create_drb_user, create_user):
 
 @pytest.fixture()
 def more_datasets(
-    client, server_config, create_drb_user, create_admin_user, attach_dataset
+    client,
+    server_config,
+    create_drb_user,
+    create_admin_user,
+    attach_dataset,
+    create_user,
 ):
     """
     Supplement the conftest.py "attach_dataset" fixture with a few more
@@ -358,7 +363,7 @@ def more_datasets(
     """
     with freeze_time("1978-06-26 08:00:00"):
         Dataset(
-            owner_id="3",
+            owner_id=str(create_drb_user.id),
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
             state=States.INDEXED,
@@ -367,7 +372,7 @@ def more_datasets(
             resource_id="random_md5_string3",
         ).add()
         Dataset(
-            owner_id="5",
+            owner_id=str(create_user.id),
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,
             name="fio_2",

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -337,9 +337,9 @@ def attach_dataset(create_drb_user, create_user):
 def more_datasets(
     client,
     server_config,
+    attach_dataset,
     create_drb_user,
     create_admin_user,
-    attach_dataset,
     create_user,
 ):
     """

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -315,7 +315,7 @@ def attach_dataset(create_drb_user, create_user):
     # for one Dataset and letting it default for the other.
     with freeze_time("1970-01-01 00:42:00"):
         Dataset(
-            owner_id="3",
+            owner_id=str(create_drb_user.id),
             created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
             state=States.INDEXED,
@@ -324,7 +324,7 @@ def attach_dataset(create_drb_user, create_user):
             resource_id="random_md5_string1",
         ).add()
         Dataset(
-            owner_id="5",
+            owner_id=str(create_user.id),
             created=datetime.datetime(2002, 5, 16),
             state=States.INDEXED,
             name="test",

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -28,9 +28,11 @@ class TestDatasets:
         """Test dataset contructor"""
         user = create_user
         with freeze_time("1970-01-01"):
-            ds = Dataset(owner=user.username, name="fio", resource_id="f00b0ad")
+            ds = Dataset(
+                owner=user.username, owner_id="1", name="fio", resource_id="f00b0ad"
+            )
             ds.add()
-        assert ds.owner == user
+        assert ds.owner == user.username
         assert ds.name == "fio"
         assert ds.state == States.UPLOADING
         assert ds.resource_id == "f00b0ad"
@@ -90,11 +92,6 @@ class TestDatasets:
                 "run": {"controller": "node1.example.com"},
             },
         }
-
-    def test_construct_bad_owner(self, db_session):
-        """Test with a non-existent username"""
-        with pytest.raises(DatasetBadParameterType):
-            Dataset(owner="notme", name="fio")
 
     def test_construct_bad_state(self, db_session, create_user):
         """Test with a non-States state value"""

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -177,7 +177,7 @@ class TestDatasets:
         """Test that we can't advance to a state that's not a
         successor to the initial state.
         """
-        ds = Dataset(owner_id=(create_user.id), name="fio", resource_id="debead")
+        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="debead")
         ds.add()
         with pytest.raises(DatasetBadStateTransition):
             ds.advance(States.DELETED)
@@ -185,7 +185,7 @@ class TestDatasets:
     def test_advanced_terminal(self, db_session, create_user):
         """Test that we can't advance from a terminal state"""
         ds = Dataset(
-            owner_id=(create_user.id),
+            owner_id=str(create_user.id),
             name="fio",
             resource_id="beadde",
             state=States.DELETED,

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -28,11 +28,9 @@ class TestDatasets:
         """Test dataset contructor"""
         user = create_user
         with freeze_time("1970-01-01"):
-            ds = Dataset(
-                owner=user.username, owner_id="1", name="fio", resource_id="f00b0ad"
-            )
+            ds = Dataset(owner_id=str(user.id), name="fio", resource_id="f00b0ad")
             ds.add()
-        assert ds.owner == user.username
+        assert ds.owner_id == str(user.id)
         assert ds.name == "fio"
         assert ds.state == States.UPLOADING
         assert ds.resource_id == "f00b0ad"
@@ -45,12 +43,12 @@ class TestDatasets:
         assert ds.created is None
         assert ds.uploaded <= ds.transition
         assert ds.id is not None
-        assert "test(1)|fio" == str(ds)
+        assert "(1)|fio" == str(ds)
         assert ds.as_dict() == {
             "access": "private",
             "created": None,
             "name": "fio",
-            "owner": "test",
+            "owner_id": "1",
             "state": "Uploading",
             "transition": "1970-01-01T00:00:00+00:00",
             "uploaded": "1970-01-01T00:00:00+00:00",
@@ -62,7 +60,7 @@ class TestDatasets:
         user is removed.
         """
         user = create_user
-        ds = Dataset(owner=user.username, name="fio", resource_id="deadbeef")
+        ds = Dataset(owner_id=str(user.id), name="fio", resource_id="deadbeef")
         ds.add()
         User.delete(username=user.username)
         ds1 = Dataset.query(resource_id="deadbeef")
@@ -78,7 +76,7 @@ class TestDatasets:
             "access": "private",
             "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
-            "owner": "drb",
+            "owner_id": "3",
             "state": "Indexed",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
@@ -97,7 +95,7 @@ class TestDatasets:
         """Test with a non-States state value"""
         with pytest.raises(DatasetBadParameterType):
             Dataset(
-                owner=create_user.username,
+                owner_id=str(create_user.id),
                 name="fio",
                 resource_id="d00d",
                 state="notStates",
@@ -106,7 +104,7 @@ class TestDatasets:
     def test_attach_exists(self, db_session, create_user):
         """Test that we can attach to a dataset"""
         ds1 = Dataset(
-            owner=create_user.username,
+            owner_id=str(create_user.id),
             name="fio",
             resource_id="bib",
             state=States.INDEXING,
@@ -114,7 +112,7 @@ class TestDatasets:
         ds1.add()
 
         ds2 = Dataset.attach(resource_id=ds1.resource_id, state=States.INDEXED)
-        assert ds2.owner == ds1.owner
+        assert ds2.owner_id == ds1.owner_id
         assert ds2.name == ds1.name
         assert ds2.state == States.INDEXED
         assert ds2.resource_id is ds1.resource_id
@@ -130,7 +128,7 @@ class TestDatasets:
     def test_query_name(self, db_session, create_user):
         """Test that we can find a dataset by name alone"""
         ds1 = Dataset(
-            owner=create_user.username,
+            owner_id=str(create_user.id),
             resource_id="deed1e",
             name="fio",
             state=States.INDEXING,
@@ -139,7 +137,7 @@ class TestDatasets:
 
         ds2 = Dataset.query(name="fio")
         assert ds2.name == "fio"
-        assert ds2.owner == ds1.owner
+        assert ds2.owner_id == ds1.owner_id
         assert ds2.name == ds1.name
         assert ds2.state == ds1.state
         assert ds2.resource_id == ds1.resource_id
@@ -148,7 +146,9 @@ class TestDatasets:
     def test_advanced_good(self, db_session, create_user):
         """Test advancing the state of a dataset"""
         with freeze_time("2525-05-25T15:15"):
-            ds = Dataset(owner=create_user.username, name="fio", resource_id="beefeed")
+            ds = Dataset(
+                owner_id=str(create_user.id), name="fio", resource_id="beefeed"
+            )
             ds.created = datetime(2020, 1, 25, 23, 14)
             ds.add()
         with freeze_time("2525-08-25T15:25"):
@@ -159,7 +159,7 @@ class TestDatasets:
             "access": "private",
             "created": "2020-01-25T23:14:00+00:00",
             "name": "fio",
-            "owner": "test",
+            "owner_id": "1",
             "state": "Uploaded",
             "transition": "2525-08-25T15:25:00+00:00",
             "uploaded": "2525-05-25T15:15:00+00:00",
@@ -168,7 +168,7 @@ class TestDatasets:
 
     def test_advanced_bad_state(self, db_session, create_user):
         """Test with a non-States state value"""
-        ds = Dataset(owner=create_user.username, name="fio", resource_id="feebeed")
+        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="feebeed")
         ds.add()
         with pytest.raises(DatasetBadParameterType):
             ds.advance("notStates")
@@ -177,7 +177,7 @@ class TestDatasets:
         """Test that we can't advance to a state that's not a
         successor to the initial state.
         """
-        ds = Dataset(owner=create_user.username, name="fio", resource_id="debead")
+        ds = Dataset(owner_id=(create_user.id), name="fio", resource_id="debead")
         ds.add()
         with pytest.raises(DatasetBadStateTransition):
             ds.advance(States.DELETED)
@@ -185,7 +185,7 @@ class TestDatasets:
     def test_advanced_terminal(self, db_session, create_user):
         """Test that we can't advance from a terminal state"""
         ds = Dataset(
-            owner=create_user.username,
+            owner_id=(create_user.id),
             name="fio",
             resource_id="beadde",
             state=States.DELETED,
@@ -198,7 +198,7 @@ class TestDatasets:
         """Advance a dataset through the entire lifecycle using the state
         transition dict.
         """
-        ds = Dataset(owner=create_user.username, name="fio", resource_id="beaddee")
+        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="beaddee")
         ds.add()
         assert ds.state == States.UPLOADING
         beenthere = [ds.state]
@@ -219,7 +219,7 @@ class TestDatasets:
     def test_delete(self, db_session, create_user):
         """Test that we can delete a dataset"""
         ds1 = Dataset(
-            owner=create_user.username,
+            owner_id=str(create_user.id),
             name="foobar",
             resource_id="f00dea7",
             state=States.INDEXING,

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy import or_
 
 from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import (
@@ -34,7 +35,7 @@ class TestGetSetMetadata:
         assert m.dataset_ref == m1.dataset_ref
 
         # Check the str()
-        assert "drb(3)|drb>>global" == str(m)
+        assert "(3)|drb>>global" == str(m)
 
         # Try to get a metadata key that doesn't exist
         with pytest.raises(MetadataNotFound) as exc:
@@ -120,7 +121,7 @@ class TestInternalMetadata:
             "access": "private",
             "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
-            "owner": "drb",
+            "owner_id": "3",
             "state": "Indexed",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
@@ -188,37 +189,62 @@ class TestMetadataNamespace:
         # See if we can create a metadata row
         ds = Dataset.query(name="drb")
         user1 = User.query(username="drb")
+        metadata_db_query = Database.db_session.query(Metadata)
         assert ds.metadatas == []
-        t = Metadata.create(key="user", value=True, dataset=ds, user=user1.username)
+        t = Metadata.create(key="user", value=True, dataset=ds, user_id=user1.id)
         assert t is not None
         assert ds.metadatas == [t]
+        assert Database.db_session.query(Metadata).filter_by(
+            user_id=user1.id
+        ).all() == [t]
 
         user2 = User.query(username="test")
-        d = Metadata.create(key="user", value=False, dataset=ds, user=user2.username)
+        d = Metadata.create(key="user", value=False, dataset=ds, user_id=user2.id)
         assert d is not None
         assert ds.metadatas == [t, d]
+        assert metadata_db_query.filter_by(user_id=user2.id).all() == [d]
 
         g = Metadata.create(key="user", value="text", dataset=ds)
         assert g is not None
         assert ds.metadatas == [t, d, g]
+        assert metadata_db_query.filter_by(user_id=user1.id).all() == [t]
+        assert metadata_db_query.filter_by(user_id=user2.id).all() == [d]
 
         assert Metadata.get(key="user", dataset=ds).value == "text"
-        assert Metadata.get(key="user", dataset=ds, user=user1.username).value is True
-        assert Metadata.get(key="user", dataset=ds, user=user2.username).value is False
+        assert Metadata.get(key="user", dataset=ds, user_id=user1.id).value is True
+        assert Metadata.get(key="user", dataset=ds, user_id=user2.id).value is False
 
-        Metadata.remove(key="user", dataset=ds, user=user1.username)
+        Metadata.remove(key="user", dataset=ds, user_id=user1.id)
+        assert metadata_db_query.filter_by(user_id=user1.id).all() == []
+        assert metadata_db_query.filter_by(user_id=user2.id).all() == [d]
         assert ds.metadatas == [d, g]
 
         Metadata.remove(key="user", dataset=ds)
+        assert metadata_db_query.filter_by(user_id=user1.id).all() == []
+        assert metadata_db_query.filter_by(user_id=user2.id).all() == [d]
         assert ds.metadatas == [d]
 
-        Metadata.remove(key="user", dataset=ds, user=user2.username)
+        Metadata.remove(key="user", dataset=ds, user_id=user2.id)
+        assert metadata_db_query.filter_by(user_id=user1.id).all() == []
+        assert metadata_db_query.filter_by(user_id=user2.id).all() == []
         assert ds.metadatas == []
 
         # Peek under the carpet to look for orphaned metadata objects linked
         # to the Dataset or User
         metadata = (
             Database.db_session.query(Metadata).filter_by(dataset_ref=ds.id).first()
+        )
+        assert metadata is None
+        metadata = (
+            Database.db_session.query(Metadata)
+            .filter(
+                or_(
+                    Metadata.user_id == user1.id,
+                    Metadata.user_id == user2.id,
+                    Metadata.user_id is None,
+                )
+            )
+            .first()
         )
         assert metadata is None
 
@@ -253,7 +279,7 @@ class TestMetadataNamespace:
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'global.contact.email' in drb(3)|drb is not a JSON object"
+            == "Key 'contact' value for 'global.contact.email' in (3)|drb is not a JSON object"
         )
 
     def test_set_bad_path(self, attach_dataset):
@@ -266,7 +292,7 @@ class TestMetadataNamespace:
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
-            == "Key 'contact' value for 'global.contact.email' in drb(3)|drb is not a JSON object"
+            == "Key 'contact' value for 'global.contact.email' in (3)|drb is not a JSON object"
         )
 
     def test_get_outer_path(self, attach_dataset):
@@ -329,19 +355,19 @@ class TestMetadataNamespace:
         user2 = User.query(username="test")
         Metadata.setvalue(dataset=ds, key="user.contact", value="Barney")
         Metadata.setvalue(
-            dataset=ds, key="user.contact", value="Fred", user=user2.username
+            dataset=ds, key="user.contact", value="Fred", user_id=user2.id
         )
         Metadata.setvalue(
-            dataset=ds, key="user.contact", value="Wilma", user=user1.username
+            dataset=ds, key="user.contact", value="Wilma", user_id=user1.id
         )
 
-        assert Metadata.getvalue(dataset=ds, user=None, key="user") == {
+        assert Metadata.getvalue(dataset=ds, user_id=None, key="user") == {
             "contact": "Barney"
         }
-        assert Metadata.getvalue(dataset=ds, user=user2.username, key="user") == {
+        assert Metadata.getvalue(dataset=ds, user_id=user2.id, key="user") == {
             "contact": "Fred"
         }
-        assert Metadata.getvalue(dataset=ds, user=user1.username, key="user") == {
+        assert Metadata.getvalue(dataset=ds, user_id=user1.id, key="user") == {
             "contact": "Wilma"
         }
 
@@ -377,7 +403,7 @@ class TestMetadataNamespace:
             Metadata.setvalue(ds, "dataset.name", value)
         assert (
             str(exc.value)
-            == f"Metadata key 'dataset.name' value {value!r} for dataset drb(3)|drb must be a UTF-8 string of 1 to 32 characters"
+            == f"Metadata key 'dataset.name' value {value!r} for dataset (3)|drb must be a UTF-8 string of 1 to 32 characters"
         )
         assert Metadata.getvalue(ds, "dataset.name") == name
 
@@ -394,11 +420,11 @@ class TestMetadataNamespace:
         [
             (
                 "Not a date",
-                "Metadata key 'server.deletion' value 'Not a date' for dataset drb(3)|drb must be a date/time",
+                "Metadata key 'server.deletion' value 'Not a date' for dataset (3)|drb must be a date/time",
             ),
             (
                 "2040-12-25",
-                "Metadata key 'server.deletion' value '2040-12-25' for dataset drb(3)|drb must be a date/time before 2031-12-30",
+                "Metadata key 'server.deletion' value '2040-12-25' for dataset (3)|drb must be a date/time before 2031-12-30",
             ),
         ],
     )

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -153,13 +153,12 @@ class TestDatasetsDelete:
 
     def test_partial(
         self,
-        attach_dataset,
         caplog,
         client,
         get_document_map,
         monkeypatch,
-        pbench_token,
         server_config,
+        pbench_token,
     ):
         """
         Check the delete API when some document updates fail. We expect an
@@ -168,22 +167,29 @@ class TestDatasetsDelete:
         self.fake_elastic(monkeypatch, get_document_map, True)
         self.fake_filetree(monkeypatch)
 
-        response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/random_md5_string1",
-            headers={"authorization": f"Bearer {pbench_token}"},
-        )
+        # We have to keep the db session alive otherwise user instance created
+        # by the get_document_map fixture gets detached from the session
+        # resulting in sqlalchemy DetachedInstanceError. This happens because
+        # immediately upon the APIAbort call we close the db session.
+        # ref: https://docs.sqlalchemy.org/en/14/errors.html#error-bhk3
+        with client:
+            ds = Dataset.query(name="drb")
+            response = client.post(
+                f"{server_config.rest_uri}/datasets/delete/{ds.resource_id}",
+                headers={"authorization": f"Bearer {pbench_token}"},
+            )
 
-        # Verify the report and status
-        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
-        assert response.json["message"] == "Failed to update 3 out of 31 documents"
-        assert (
-            "pbench.server.api",
-            ERROR,
-            'DatasetsDelete:dataset (3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
-        ) in caplog.record_tuples
+            # Verify the report and status
+            assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+            assert response.json["message"] == "Failed to update 3 out of 31 documents"
+            assert (
+                "pbench.server.api",
+                ERROR,
+                'DatasetsDelete:dataset (3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+            ) in caplog.record_tuples
 
-        # Verify that the Dataset still exists
-        Dataset.query(name="drb")
+            # Verify that the Dataset still exists
+            Dataset.query(name="drb")
 
     def test_no_dataset(
         self, client, get_document_map, monkeypatch, pbench_token, server_config

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -160,6 +160,7 @@ class TestDatasetsDelete:
         monkeypatch,
         pbench_token,
         server_config,
+        current_user_drb,
     ):
         """
         Check the delete API when some document updates fail. We expect an

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -160,7 +160,6 @@ class TestDatasetsDelete:
         monkeypatch,
         pbench_token,
         server_config,
-        current_user_drb,
     ):
         """
         Check the delete API when some document updates fail. We expect an

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -180,7 +180,7 @@ class TestDatasetsDelete:
         assert (
             "pbench.server.api",
             ERROR,
-            'DatasetsDelete:dataset drb(3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+            'DatasetsDelete:dataset (3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
         ) in caplog.record_tuples
 
         # Verify that the Dataset still exists

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -163,7 +163,7 @@ class TestDatasetsPublish:
         assert (
             "pbench.server.api",
             ERROR,
-            'DatasetsPublish:dataset drb(3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
+            'DatasetsPublish:dataset (3)|drb: 28 successful document actions and 3 failures: {"Just kidding": {"unit-test.v6.run-data.2021-06": 1, "unit-test.v6.run-toc.2021-06": 1, "unit-test.v5.result-data-sample.2021-06": 1}, "ok": {"unit-test.v6.run-toc.2021-06": 9, "unit-test.v5.result-data-sample.2021-06": 19}}',
         ) in caplog.record_tuples
 
         # Verify that the Dataset access didn't change

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -160,7 +160,7 @@ class TestDatasetsMetadata:
                 "access": "private",
                 "created": "2020-02-15T00:00:00+00:00",
                 "name": "drb",
-                "owner": "drb",
+                "owner_id": "3",
                 "state": "Indexed",
                 "transition": "1970-01-01T00:42:00+00:00",
                 "uploaded": "2022-01-01T00:00:00+00:00",
@@ -353,7 +353,7 @@ class TestDatasetsMetadata:
         )
         assert (
             put.json["message"]
-            == "Metadata key 'dataset.name' value 1 for dataset drb(3)|drb must be a UTF-8 string of 1 to 32 characters"
+            == "Metadata key 'dataset.name' value 1 for dataset (3)|drb must be a UTF-8 string of 1 to 32 characters"
         )
 
         # verify that the values didn't change
@@ -389,7 +389,7 @@ class TestDatasetsMetadata:
         )
         assert (
             put.json["message"]
-            == "Metadata key 'server.deletion' value '1800-25-55' for dataset drb(3)|drb must be a date/time"
+            == "Metadata key 'server.deletion' value '1800-25-55' for dataset (3)|drb must be a date/time"
         )
 
         # verify that the values didn't change


### PR DESCRIPTION
Addresses [PBENCH-934](https://issues.redhat.com/browse/PBENCH-934) 

Our Metadata and Dataset tables have a Foreign Key relationship with the users table, and since the user table is going to get dropped we need to remove this dependency. This is an intermediary step for removing users table and improving unit tests mocks.