### PR TITLE
Restrict coverage reporting to only `pbench`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
 [run]
-parallel = True
+branch = True
+cover_pylib = False
 data_file = ${_PBENCH_COV_DIR}/coverage.db
+parallel = True
+relative_files = True
+omit = */pbench/test/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,4 +4,3 @@ cover_pylib = False
 data_file = ${_PBENCH_COV_DIR}/coverage.db
 parallel = True
 relative_files = True
-omit = */pbench/test/*

--- a/exec-unittests
+++ b/exec-unittests
@@ -139,13 +139,12 @@ if [[ -z "${subtst}" || "${subtst}" == "python" ]]; then
     done
 
     printf -- "\n\n\nRunning %s python3-based unit tests via pytest\n\n" "${major_list// /,}"
-    _pbench_sources=$(python3 -c 'import inspect, pathlib, pbench; print(pathlib.Path(inspect.getsourcefile(pbench)).parent.parent)')
+    _pbench_sources=$(python3 -c 'import inspect, pathlib, pbench; print(pathlib.Path(inspect.getsourcefile(pbench)).parent)')
     _PBENCH_COV_DIR="${_toxenvdir}/cov" _time pytest \
         ${pytest_jobs_arg} \
         --basetemp="${_toxenvdir}/tmp" \
+        --no-cov-on-fail \
         --cov=${_pbench_sources} \
-        --cov-branch \
-        --cov-append \
         --cov-report ${_cov_report} \
         ${posargs} \
         --pyargs ${_pytest_majors}
@@ -154,6 +153,12 @@ if [[ -z "${subtst}" || "${subtst}" == "python" ]]; then
         printf -- "\n%s pytest command failed with '%s'\n\n" "${_major^}" "${rc}"
     else
         printf -- "\n%s pytest command succeeded\n\n" "${_major^}"
+    fi
+
+    if [[ "${_cov_report_kind}" == "xml" && -n "${WORKSPACE}" ]]; then
+        # For the Jenkins CI we need to adjust the generated XML report to
+        # use WORKSPACE relative file name paths in the report.
+        sed -i "s;${_pbench_sources};${WORKSPACE}/lib/pbench;" ${_cov_report_name}
     fi
 fi
 

--- a/exec-unittests
+++ b/exec-unittests
@@ -143,7 +143,6 @@ if [[ -z "${subtst}" || "${subtst}" == "python" ]]; then
     _PBENCH_COV_DIR="${_toxenvdir}/cov" _time pytest \
         ${pytest_jobs_arg} \
         --basetemp="${_toxenvdir}/tmp" \
-        --no-cov-on-fail \
         --cov=${_pbench_sources} \
         --cov-report ${_cov_report} \
         ${posargs} \

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -27,11 +27,6 @@ pipeline {
                 sh 'if [[ ! -e agent/rpm/seqno ]] ; then echo "1" > agent/rpm/seqno ; fi'
                 sh 'if [[ ! -e server/rpm/seqno ]] ; then echo "1" > server/rpm/seqno ; fi'
 
-                // If there is somehow a symlink left over from a previous run's
-                // Cobertura processing, remove it, because it seems to confuse
-                // the coverage data collection.
-                sh 'rm -fv pbench'
-
                 // Run the "build" (lint, unit tests, etc.) in a container.
                 sh 'jenkins/run ./build.sh'
             }
@@ -46,14 +41,6 @@ pipeline {
     }
     post {
         success {
-            // This symlink somehow allows the Cobertura plug-in to find the
-            // sources referenced in the coverage report.  However, the presence
-            // of this link inside the container seems to confuse the coverage
-            // data collection, so we create it here and then remove it after
-            // generating the report. (We use the -f option just in case there's
-            // an old one hanging around.)
-            sh 'ln -sTf lib/pbench pbench'
-
             // Note that jenkins/run-pytests is executed inside the container
             // while the Cobertura plug-in is executed natively, so this poses
             // a challenge in terms of finding the coverage report file; we
@@ -70,7 +57,7 @@ pipeline {
                 onlyStable: false,
                 sourceEncoding: 'ASCII',
                 zoomCoverageChart: false])
-            sh 'rm cov/report.xml pbench'
+            sh 'rm cov/report.xml'
         }
     }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ passenv =
     USER
     PBENCH_UNITTEST_PARALLEL
     COV_REPORT_XML
+    WORKSPACE
 setenv =
     VIRTUAL_ENV = {envdir}
     XDG_CACHE_HOME = {envdir}


### PR DESCRIPTION
We also change to not report coverage on test failures, re-create the coverage data base for each `pytest` invocation, and move a few options to the coverage config file.

We want to re-create the coverage database each time because it is too easy to pollute with subsequent runs.  Note that we no longer capture coverage for the Agent `py36` run since the second invocation of `pytest` for the `py39` tox environment will over-write the coverage database.