### PR TITLE
First container-based Pbench Server functional test

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -6,12 +6,24 @@ pipeline {
         IMAGE_REPO="quay.io/pbench"
         IMAGE_ROLE="ci"
         NO_COLORS=0
-        PB_AGENT_CONTAINER_REG="quay.io"
-        PB_SERVER_CONTAINER_REG="images.paas.redhat.com"
-        PODMAN_AGENT=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
-        PODMAN_SERVER=credentials('12b404ca-3036-4960-9929-979148b9e49a')
+        PB_EXTERNAL_CONTAINER_REG=credentials('24a93506-ecd6-403a-b4f0-386f9cc943e9')
+        PB_INTERNAL_CONTAINER_REG=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
+        PODMAN_EXTERNAL=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
+        PODMAN_INTERNAL=credentials('12b404ca-3036-4960-9929-979148b9e49a')
         PY_COLORS=0
         TERM='dumb'
+
+        // Set the tag to the PR number (i.e., the Jenkins CHANGE_ID) if run for
+        // a PR; otherwise set it to the branch name (e.g., `main`).  Set a
+        // shorthand for the Pbench Server image path, and set a variable for
+        // the Server Pod name, based on the image tag, so that we don't
+        // interfere with other pods on this executor.
+        PB_SERVER_IMAGE_TAG="""${sh(
+            returnStdout: true,
+            script: 'echo ${CHANGE_ID:-${BRANCH_NAME}}'
+            )}"""
+        PB_SERVER_IMAGE="${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver"
+        PB_POD_NAME="pbenchinacan_${PB_SERVER_IMAGE_TAG}"
     }
     stages {
         stage('Agent Python3.6 Check') {
@@ -31,15 +43,33 @@ pipeline {
                 sh 'jenkins/run ./build.sh'
             }
         }
-        stage('Pbench Server Container build') {
+        stage('Build the Pbench Server Container') {
             steps {
-                sh 'buildah login -u="${PODMAN_SERVER_USR}" -p="${PODMAN_SERVER_PSW}" ${PB_SERVER_CONTAINER_REG}'
-                sh 'RPM_PATH=${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm OUTPUT_IMAGE_TAG=${CHANGE_ID:-${BRANCH_NAME}} bash -ex ./server/pbenchinacan/container-build.sh'
-                sh 'buildah push localhost/pbench-server:${CHANGE_ID:-${BRANCH_NAME}} ${PB_SERVER_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver:${CHANGE_ID:-${BRANCH_NAME}}'
+                sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_INTERNAL_CONTAINER_REG}'
+                sh 'RPM_PATH=${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm bash -ex ./server/pbenchinacan/container-build.sh'
+                sh 'buildah push localhost/pbench-server:${PB_SERVER_IMAGE_TAG} ${PB_SERVER_IMAGE}:${PB_SERVER_IMAGE_TAG}'
+            }
+        }
+        stage('Start, test, and stop the Pbench Server pod') {
+            steps {
+                sh 'envsubst < server/pbenchinacan/pod-nodata.yml | podman play kube -'
+                sleep 30
+                retry(count: 10) {
+                    sleep 10
+                    sh 'curl localhost:8001/api/v1/endpoints'
+                }
+                sh 'podman pod stop ${PB_POD_NAME}'
             }
         }
     }
     post {
+        always {
+            // Remove the pod which we just created and ran; remove any
+            // dangling containers; and then remove any dangling images.
+            sh 'podman pod rm -f ${PB_POD_NAME}'
+            sh 'podman container prune -f'
+            sh 'podman image prune -f'
+        }
         success {
             // Note that jenkins/run-pytests is executed inside the container
             // while the Cobertura plug-in is executed natively, so this poses
@@ -57,7 +87,7 @@ pipeline {
                 onlyStable: false,
                 sourceEncoding: 'ASCII',
                 zoomCoverageChart: false])
-            sh 'rm cov/report.xml'
+            sh 'rm -f cov/report.xml'
         }
     }
 }

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -13,6 +13,8 @@ from pbench.common.logger import get_pbench_logger
 from pbench.server.api import create_app, get_server_config
 from pbench.server.database.database import Database
 
+PROG = "pbench-shell"
+
 
 def app():
     try:
@@ -23,14 +25,16 @@ def app():
     return create_app(server_config)
 
 
-def find_the_unicorn(logger: Logger) -> str:
-    local = Path(site.getuserbase()) / "bin"
-    if (local / "gunicorn").exists():
-        # Use a `pip install --user` version of gunicorn
-        os.environ["PATH"] = str(local) + ":" + os.environ["PATH"]
-        logger.info(
-            "Found a local unicorn: augmenting server PATH to {}", os.environ["PATH"]
-        )
+def find_the_unicorn(logger: Logger):
+    if site.ENABLE_USER_SITE:
+        local = Path(site.getuserbase()) / "bin"
+        if (local / "gunicorn").exists():
+            # Use a `pip install --user` version of gunicorn
+            os.environ["PATH"] = str(local) + ":" + os.environ["PATH"]
+            logger.info(
+                "Found a local unicorn: augmenting server PATH to {}",
+                os.environ["PATH"],
+            )
 
 
 def main():
@@ -42,7 +46,7 @@ def main():
     except (ConfigFileNotSpecified, BadConfig) as e:
         print(e)
         sys.exit(1)
-    logger = get_pbench_logger(__name__, server_config)
+    logger = get_pbench_logger(PROG, server_config)
     find_the_unicorn(logger)
     try:
         host = str(server_config.get("pbench-server", "bind_host"))
@@ -50,6 +54,8 @@ def main():
         db = str(server_config.get("Postgres", "db_uri"))
         workers = str(server_config.get("pbench-server", "workers"))
         worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
+        pbench_top_dir = server_config.get("pbench-server", "pbench-top-dir")
+        pbench_install = server_config.get("pbench-server", "install-dir")
         logger.info("Pbench server using database {}", db)
 
         # Multiple gunicorn workers will attempt to connect to the DB; rather
@@ -62,24 +68,40 @@ def main():
             logger.info("Created DB {}", db)
         Database.init_db(server_config, logger)
     except (NoOptionError, NoSectionError):
-        logger.exception(f"{__name__}: ERROR")
+        logger.exception(f"{PROG}: ERROR")
         sys.exit(1)
 
-    subprocess.run(
-        [
-            "gunicorn",
-            "--workers",
-            workers,
-            "--timeout",
-            worker_timeout,
-            "--pid",
-            "/run/pbench-server/gunicorn.pid",
-            "--bind",
-            f"{host}:{port}",
-            "--access-logfile",
-            "/var/log/pbench-server/access_log",
-            "--error-logfile",
-            "/var/log/pbench-server/error_log",
-            "pbench.cli.server.shell:app()",
-        ]
-    )
+    cmd_line = [
+        "gunicorn",
+        "--workers",
+        workers,
+        "--timeout",
+        worker_timeout,
+        "--pid",
+        "/run/pbench-server/gunicorn.pid",
+        "--bind",
+        f"{host}:{port}",
+        "--access-logfile",
+        "/var/log/pbench-server/access_log",
+        "--error-logfile",
+        "/var/log/pbench-server/error_log",
+    ]
+
+    # When installed via RPM, the shebang in the gunicorn script includes a -s
+    # which prevents Python from implicitly including the user site packages in
+    # the sys.path configuration.  (Note that, when installed via Pip, the
+    # shebang does not include this switch.)  This means that gunicorn itself,
+    # but, more importantly, the user application which it runs, won't be able
+    # to use any packages installed with the Pip --user switch, like our
+    # requirements.txt contents. However, gunicorn provides the --pythonpath
+    # switch which adds entries to the PYTHONPATH used to run the application.
+    # So, we request that gunicorn add our current user site packages location
+    # to the app's PYTHONPATH so that it can actually find the locally installed
+    # packages as well as the pbench.pth file which points to the Pbench Server
+    # package.
+    if site.ENABLE_USER_SITE:
+        adds = site.getusersitepackages() + "," + f"{pbench_install}/lib"
+        cmd_line += ["--pythonpath", adds]
+
+    cmd_line.append("pbench.cli.server.shell:app()")
+    subprocess.run(cmd_line, cwd=f"{pbench_top_dir}/logs")

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -28,7 +28,7 @@ GITTOP=${GITTOP:-$(git rev-parse --show-toplevel)}
 PBINC_DIR=${GITTOP}/server/pbenchinacan
 
 # Image tag determined from jenkins/branch.name
-OUTPUT_IMAGE_TAG=${OUTPUT_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
+PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
 
 # Open a copy of the base container.  Docker format is required in order to set
 # the hostname.
@@ -40,10 +40,10 @@ container=$(buildah from --format=docker ${BASE_IMAGE})
 
 # Consider adding -v datavolume for the Server data, and perhaps SQL and ES data
 buildah config \
-    --label maintainer="Nick Dokos <ndokos@redhat.com>" \
+    --label maintainer="Webb Scales <wscales@redhat.com>" \
     --hostname $HOSTNAME_F \
     --stop-signal SIGINT \
-    --port 22:55555  `# sshd` \
+    --port 22        `# sshd` \
     --port 8001      `# pbench-server` \
     $container
 
@@ -121,4 +121,4 @@ buildah run $container systemctl enable httpd
 buildah run $container systemctl enable pbench-server
 
 # Create the container image
-buildah commit $container localhost/pbench-server:${OUTPUT_IMAGE_TAG}
+buildah commit $container localhost/pbench-server:${PB_SERVER_IMAGE_TAG}

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -14,6 +14,8 @@ environment = container
 max-unpacked-age = 36500
 maximum-dataset-retention-days = 36500
 default-dataset-retention-days = 730
+# Override the roles this pbench server takes on -- omit pbench-prep.
+roles = pbench-maintenance, pbench-results, pbench-backup
 
 [Indexing]
 index_prefix = container-pbench
@@ -25,6 +27,21 @@ port = 9200
 
 [Postgres]
 db_uri = postgresql://pbenchcontainer:pbench@pbenchinacan/pbenchcontainer
+
+# User authentication section to use when authorizing the user with an OIDC identity provider
+[authentication]
+
+# URL of the OIDC auth server with port
+server_url = keycloak.example.com:0000
+
+# Realm name that is used for the authentication with OIDC
+realm = Pbench
+
+# Client entity name requesting OIDC to authenticate a user
+client = Pbench-dashboard
+
+# Client secret if the above client is not public
+secret = client-secret
 
 # FIXME:  Do we need a [sosreports] section?
 

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -1,11 +1,37 @@
-# Created with podman-3.2.2
+#
+# This configuration is intended to create a brand new (empty) Pbench Server
+# deployment.  The resulting pod consists of three containers: the Pbench Server
+# and its associated Elasticsearch and PostgreSQL database servers.
+#
+# The Elasticsearch and PostgreSQL container images have specific versions and
+# are pulled from cached images in an internal registry; the Pbench Server
+# container image is pulled from the same registry with a configurable tag.
+#
+# The pod should be invoked via the following command
+#
+#    envsubst < server/pbenchinacan/pod-nodata.yml | podman play kube -
+#
+# with the following environment variables defined:
+#
+#  PB_POD_NAME - the name to be used for the pod
+#  PB_INTERNAL_CONTAINER_REG - the FQDN of the container registry
+#  PB_SERVER_IMAGE - the <registry>/<repo>/<img_name> of the Pbench Server image
+#  PB_SERVER_IMAGE_TAG - the tag for the Pbench Server image
+#
+# The resulting pod maps the following ports:
+#
+#   8080 - HTTP web server (and Pbench Dashboard)
+#   8001 - Pbench Server RESTful API
+#   9200 - Elasticsearch
+#  55555 - ssh
+#
 apiVersion: v1
 kind: Pod
 metadata:
   creationTimestamp: "2021-10-29T21:13:14Z"
   labels:
     app: pbenchserverinacan
-  name: pbenchinacan
+  name: ${PB_POD_NAME}
 spec:
   hostname: "pbenchinacan"
   containers:
@@ -28,7 +54,7 @@ spec:
       value: "single-node"
     - name: xpack.security.enabled
       value: "false"
-    image: registry.connect.redhat.com/elastic/elasticsearch:7.13.3
+    image: ${PB_INTERNAL_CONTAINER_REG}/pbench/elasticsearch:7.13.3
     name: elasticsearch
     ports:
       - containerPort: 9200
@@ -44,30 +70,6 @@ spec:
       - name: vm.max_map_count
         value: "262144"
     workingDir: /usr/share/elasticsearch
-  - command:
-    - /sbin/init
-    env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: oci
-    image: localhost/pbench-server:latest
-    name: pbenchserver
-    ports:
-      - containerPort: 8001
-        hostPort: 8001
-      - containerPort: 80
-        hostPort: 8080
-    resources: {}
-    securityContext:
-      allowPrivilegeEscalation: true
-      capabilities: {}
-      privileged: false
-      readOnlyRootFilesystem: false
-      seLinuxOptions: {}
-    workingDir: /
   - args:
     - run-postgresql
     command:
@@ -110,7 +112,7 @@ spec:
       value: pbench
     - name: POSTGRESQL_DATABASE
       value: pbenchcontainer
-    image: registry.redhat.io/rhel8/postgresql-13:latest
+    image: ${PB_INTERNAL_CONTAINER_REG}/pbench/postgresql-13:latest
     name: postgresql
     ports:
       - containerPort: 5432
@@ -124,6 +126,32 @@ spec:
       runAsUser: 26
       seLinuxOptions: {}
     workingDir: /opt/app-root/src
+  - command:
+    - /sbin/init
+    env:
+    - name: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    - name: TERM
+      value: xterm
+    - name: container
+      value: oci
+    image: ${PB_SERVER_IMAGE}:${PB_SERVER_IMAGE_TAG}
+    name: pbenchserver
+    ports:
+      - containerPort: 22
+        hostPort: 55555
+      - containerPort: 80
+        hostPort: 8080
+      - containerPort: 8001
+        hostPort: 8001
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities: {}
+      privileged: false
+      readOnlyRootFilesystem: false
+      seLinuxOptions: {}
+    workingDir: /
   dnsConfig: {}
   restartPolicy: Never
 status: {}

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -1,11 +1,43 @@
-# Created with podman-3.2.2
+#
+# This configuration is intended to create a Pbench Server deployment containing
+# pre-created users and data.  The resulting pod consists of three containers:
+# the Pbench Server and its associated Elasticsearch and PostgreSQL database
+# servers.  The expectation is that the servers have been pre-populated with
+# data which has been persisted in their respective container images and that
+# the images have been pushed to a common repository using a common tag.
+#
+# The three container images are named
+#
+#   pbenchinacan-pbenchserver
+#   pbenchinacan-elasticsearch
+#   pbenchinacan-postgresql
+#
+# and they are pulled from the `pbench` repository in a configurable registry.
+#
+# The pod should be invoked via the following command
+#
+#    envsubst < server/pbenchinacan/pod.yml | podman play kube -
+#
+# with the following environment variables defined:
+#
+#  PB_POD_NAME - the name to be used for the pod
+#  PB_INTERNAL_CONTAINER_REG - the FQDN of the container registry
+#  PB_SERVER_IMAGE_TAG - the tag for all three container images
+#
+# The resulting pod maps the following ports:
+#
+#   8080 - HTTP web server (and Pbench Dashboard)
+#   8001 - Pbench Server RESTful API
+#   9200 - Elasticsearch
+#  55555 - ssh
+#
 apiVersion: v1
 kind: Pod
 metadata:
   creationTimestamp: "2021-10-29T21:13:14Z"
   labels:
     app: pbenchserverinacan
-  name: pbenchinacan
+  name: ${PB_POD_NAME}
 spec:
   hostname: "pbenchinacan"
   containers:
@@ -28,7 +60,7 @@ spec:
       value: "single-node"
     - name: xpack.security.enabled
       value: "false"
-    image: quay.io/pbench/pbenchinacan-elasticsearch:latest
+    image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-elasticsearch:${PB_SERVER_IMAGE_TAG}
     name: elasticsearch
     ports:
       - containerPort: 9200
@@ -44,30 +76,6 @@ spec:
       - name: vm.max_map_count
         value: "262144"
     workingDir: /usr/share/elasticsearch
-  - command:
-    - /sbin/init
-    env:
-    - name: PATH
-      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - name: TERM
-      value: xterm
-    - name: container
-      value: oci
-    image: quay.io/pbench/pbenchinacan-pbenchserver:latest
-    name: pbenchserver
-    ports:
-      - containerPort: 8001
-        hostPort: 8001
-      - containerPort: 80
-        hostPort: 8080
-    resources: {}
-    securityContext:
-      allowPrivilegeEscalation: true
-      capabilities: {}
-      privileged: false
-      readOnlyRootFilesystem: false
-      seLinuxOptions: {}
-    workingDir: /
   - args:
     - run-postgresql
     command:
@@ -110,7 +118,7 @@ spec:
       value: pbench
     - name: POSTGRESQL_DATABASE
       value: pbenchcontainer
-    image: quay.io/pbench/pbenchinacan-postgresql:latest
+    image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-postgresql:${PB_SERVER_IMAGE_TAG}
     name: postgresql
     ports:
       - containerPort: 5432
@@ -124,6 +132,32 @@ spec:
       runAsUser: 26
       seLinuxOptions: {}
     workingDir: /opt/app-root/src
+  - command:
+    - /sbin/init
+    env:
+    - name: PATH
+      value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    - name: TERM
+      value: xterm
+    - name: container
+      value: oci
+    image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver:${PB_SERVER_IMAGE_TAG}
+    name: pbenchserver
+    ports:
+      - containerPort: 22
+        hostPort: 55555
+      - containerPort: 80
+        hostPort: 8080
+      - containerPort: 8001
+        hostPort: 8001
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: true
+      capabilities: {}
+      privileged: false
+      readOnlyRootFilesystem: false
+      seLinuxOptions: {}
+    workingDir: /
   dnsConfig: {}
   restartPolicy: Never
 status: {}


### PR DESCRIPTION
This PR extends the CI pipeline by adding a stage which stands up the Pbench Server "pod", performs a trivial functional test (hitting the API to fetch the endpoints), and then shuts it down.  It also removes the pod, its containers, any "dangling" containers, and any "dangling" container images.

Details:
- `Pipeline.gy`
  - The container registries' FQDNs are now stored in Jenkins "secrets" instead of being included in the `Pipeline.gy` and script files, and they are referred to in terms of "internal" vs. "external", and the credentials variables are renamed to match.  Unfortunately, when I set the `${PB_SERVER_IMAGE}` value from `${PB_INTERNAL_CONTAINER_REG}` (which is a secret), it triggers a Jenkins warning about a potential leak.  I don't see an actual leak, but we'll need to figure out how to address the warning.
  - I copied the Elasticsearch and PostgreSQL container images to our internal Quay registry so that we can access them with the same credentials that we use for the rest of the Pbench Server containers.  This avoids the need for personal credentials which are required for the common internal sources, and it avoids the bandwidth limitations imposed on us when pulling from the official external sources.  (And, we can get by with a single set of credentials, at least for the Pbench Server builds.)
  - The functional test involves starting a pod containing three containers for, respectively, the Pbench Server, an Elasticsearch server, and a PostgreSQL server.  The test is a simple request via `curl` for the Pbench Server endpoints list.  It requires 30-40 seconds for the Pbench Server to get to a point where it can service requests (most of this time is waiting for the PostgreSQL server to get to where _it_ can service requests).  Therefore, the pipeline waits for 30 seconds and then waits for 10 seconds more before issuing the test request.  In the event that the Server isn't up, the pipeline again waits for 10 seconds and the retries.  If it is unsuccessful after 10 attempts, the build will fail.  If it is successful, then the pipeline shuts down the pod.
  - This PR adds a new stage to the "post" which is always performed.  This stage forcibly removes the pod (which should remove it even if the functional test has failed and neglected to shut it down).  It then checks for "dangling" containers and prunes them.  Finally, it checks for "dangling" images and prunes them, as well.  So, hopefuly, we won't have an unsightly build-up of unused containers or images.
  - This PR adds a `-f` to the removal of the Cobertura file.  Without it, if for some reason no file is produced (like because I commented-out the unit test run...), we get a nasty error when the "post" stage incurs an error and the run fails.  Adding the `-f` doesn't hurt anything, and it addresses this problem.
- `shell.py`
  - The previous attempt to use `__name__` to initialize the logger resulted in none of the messages being logged.  We don't know why, but Dave discovered that if he changed it to a literal, then we started getting messages!  So, this PR introduces a new, custom global variable `PROG`, which is explicitly set to `"pbench-shell"`, which codifies his discovery.  (If we don't like the static assignment, we can do something fancier, but this addresses the problem, and we're now getting messages like we should.)
  - According to the docs, we're supposed to consult `site.ENABLE_USER_SITE` before we try to fetch the user "base" prefix or the user site packages directory string...so, now we do.
  - We now add the `--pythonpath` switch to the `gunicorn` invocation to address the fact that, when `gunicorn` is installed via RPM the script's shebang includes the `-s` switch which prevents it from including the user site packages in the subprocess `PYTHONPATH` (or, `sys.path`, at least), which prevents it from finding the Pbench Server code as well as the Python packages which we install using `pip install --user`.  So, we request that `gunicorn` add the user site packages location as well as the Pbench Server installation location to the path, and this enables things to work.
  - We now provide a `cwd` for `gunicorn` so that it will run in a useful (and writable) directory, so if it happens to create any files there we can find them.  (Previously, it was running in `/` (the filesystem root).)
- `container-build.sh`
  - Renamed the environment variable used to specify the tag for the Pbench Server container image.  The new name is better for use in a wider context.
  - Removed the port-mapping-syntax from the container configuration.  I don't think it belongs there (the mapping is an attribute of the deployment, not the image), and now `buildah` seems to object to it (I'm not sure how it was working previously).
  - And, I changed the "maintainer" from Nick to me (I don't think he enjoyed that claim to fame...).
- `server/pbenchinacan/etc/pbench-server/pbench-server.cfg`
  - I removed the `pbench-prep` role from the canned server, since it doesn't do that sort of thing
  - I added the `[authentication]` section which, for some surprising and unfortunate reason, seems to be required, now.
- `pod.yml` and `pod-nodata.yml`
  - Replaced the largely useless comment at the top with text which explains what the files are for, how to use them, and sort of how they "work".  Moved the `pbench-server` section to the end, so that we know where to find it (and so that maybe the PostgreSQL server will get a head start...).  
  - Added parameterization so that container registry, image name, and image tag can be specified externally.  Also, the pod name is parameterized so that we can run multiple pods on the same Jenkins executor without them interfering.

PBENCH-722