### PR TITLE
Correct version of Python used by server to 3.9

### DIFF
--- a/agent/tool-scripts/datalog/pprof-datalog
+++ b/agent/tool-scripts/datalog/pprof-datalog
@@ -4,15 +4,6 @@ import sys
 import os
 import logging
 
-# Unfortunately the `ansible` module imported below will itself import the
-# `cryptography` module.  With Python 3.6 marked End-of-Life, the
-# `cryptography` module will emit a warning about deprecated support for
-# Python 3.6.  That output pollutes the test case causing it to fail.
-# Ignoring all warnings for this datalog is fine since the v0.69 branch is
-# also nearing End-of-Life.
-import warnings
-warnings.filterwarnings(action="ignore", category=Warning)
-
 PROG = os.path.basename(sys.argv[0])
 try:
     tool_output_dir = sys.argv[1]
@@ -57,13 +48,22 @@ else:
                 PROG, inv_file_param, exc)
         sys.exit(1)
 
-try:
-    from ansible.parsing.dataloader import DataLoader
-    from ansible.inventory.manager import InventoryManager
-except ImportError as exc:
-    logging.error("[%s]: required Ansible python3 modules not available, '%s'",
-            PROG, exc)
-    sys.exit(1)
+import warnings
+with warnings.catch_warnings():
+    # Unfortunately the `ansible` module imported below will itself import the
+    # `cryptography` module.  With Python 3.6 marked End-of-Life, the
+    # `cryptography` module will emit a warning about deprecated support for
+    # Python 3.6.  That output pollutes the test case causing it to fail.
+    # Ignoring all warnings for this datalog is fine since the v0.69 branch is
+    # also nearing End-of-Life.
+    warnings.filterwarnings(action="ignore", category=Warning)
+    try:
+        from ansible.parsing.dataloader import DataLoader
+        from ansible.inventory.manager import InventoryManager
+    except ImportError as exc:
+        logging.error("[%s]: required Ansible python3 modules not available, '%s'",
+                PROG, exc)
+        sys.exit(1)
 
 try:
     data_loader = DataLoader()

--- a/agent/tool-scripts/datalog/pprof-datalog
+++ b/agent/tool-scripts/datalog/pprof-datalog
@@ -4,6 +4,15 @@ import sys
 import os
 import logging
 
+# Unfortunately the `ansible` module imported below will itself import the
+# `cryptography` module.  With Python 3.6 marked End-of-Life, the
+# `cryptography` module will emit a warning about deprecated support for
+# Python 3.6.  That output pollutes the test case causing it to fail.
+# Ignoring all warnings for this datalog is fine since the v0.69 branch is
+# also nearing End-of-Life.
+import warnings
+warnings.filterwarnings(action="ignore", category=Warning)
+
 PROG = os.path.basename(sys.argv[0])
 try:
     tool_output_dir = sys.argv[1]

--- a/jenkins/python-setup.sh
+++ b/jenkins/python-setup.sh
@@ -17,6 +17,10 @@ if [[ ":${PATH:-}:" != *":${_pdir}:"* ]]; then
 fi
 
 while read -r _pdir; do
+    if [[ -z "${_pdir}" ]]; then
+        continue
+    fi
+    echo "Adding to PYTHONPATH: ${_pdir}"
     if [[ ":${PYTHONPATH:-}:" != *":${_pdir}:"* ]]; then
         PYTHONPATH=${_pdir}${PYTHONPATH:+:${PYTHONPATH}}
     fi

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -27,6 +27,10 @@ USE_GIT_SHA1 = yes
 sha1 := $(shell git rev-parse --short HEAD)
 seqno := $(shell if [ -e ./seqno ] ;then cat ./seqno ;else echo "1" ;fi)
 
+# Finally, we need to exclude Epel 7 builds for the Pbench Server, we don't
+# support it any more.
+CHROOTS = --exclude-chroot epel-7-x86_64
+
 # By default we only build a source RPM
 all: srpm
 

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -8,10 +8,18 @@ URL:            http://github.com/distributed-systems-analysis/pbench
 Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
-# NOTE: we add the "six" and "urllib3" Python 3.8 RPM requirements so that
-# we don't end up pip installing those modules in the /opt/pbench-server/lib
-# tree.
-Requires: python38 python38-six python38-urllib3
+# NOTE: The Pbench Server requires a RHEL 8 environment with the Python 3.9
+# module enabled.  We add the "six" and "urllib3" Python 3.9 RPM requirements
+# so that we don't end up pip installing those modules in the
+# /opt/pbench-server/lib tree.
+Requires: python39 python39-six python39-urllib3
+
+# NOTE: these are build requirements which do NOT use `python39` because they
+# are packages that need to be present on the host building RPMs, which is not
+# running RHEL 8.
+BuildRequires: python3-rpm-macros python3-devel
+
+%define __python3  /usr/bin/python3.9
 
 # policycoreutils for semanage and restorecon - used in pbench-server-activate-create-results-dir
 Requires: policycoreutils
@@ -28,8 +36,6 @@ Requires: npm
 
 %define installdir opt/pbench-server
 %define static html/static
-
-%define __python python3
 
 %description
 The pbench server scripts.
@@ -52,9 +58,11 @@ cp -a ./web-server/* %{buildroot}/%{installdir}/%{static}
 # for the npm install below
 mv %{buildroot}/%{installdir}/%{static}/package.json %{buildroot}/%{installdir}
 
+%py3_shebang_fix  %{buildroot}/%{installdir}/bin %{buildroot}/%{installdir}/bin/pbench-pp-status
+
 %post
 # Install python dependencies
-pip3 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log
+pip3.9 --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3.9-install.log
 
 # install node.js modules under the installation directory
 cd /%{installdir}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 skip_missing_interpreters = True
 isolated_build = True
 toxworkdir = {env:TOXWORKDIR:/tmp/{env:USER}/tox}
-envlist = lint,server,agent,py3-server
+envlist = lint,agent,py3-server,server
 
 [testenv]
 usedevelop = True
@@ -29,6 +29,7 @@ whitelist_externals =
 
 [testenv:server]
 description = Runs all server unit/functional tests
+basepython = python3.9
 passenv = PBENCH_UNITTEST_SERVER_MODE
 deps =
     -r{toxinidir}/test-requirements.txt
@@ -38,6 +39,7 @@ commands =
 
 [testenv:agent]
 description = Runs all agent unit/functional tests
+basepython = python3.6
 deps =
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/agent/test-requirements.txt
@@ -46,6 +48,7 @@ commands =
 
 [testenv:py3-server]
 description = Runs all Python3-based server unit and functional tests
+basepython = python3.9
 setenv =
     PYTHONPATH = {env:PYTHONPATH:}:{toxinidir}/server/lib:{toxinidir}/lib
 deps =
@@ -65,6 +68,6 @@ skip_install = true
 usedevelop = false
 
 [testenv:jenkins-unittests]
-description = Runs all external tests from one tox environment
+description = Runs all tests under the environment provided by Jenkins
 commands =
     bash -c "./jenkins/run-unittests {envdir}"


### PR DESCRIPTION
While inspecting the current production deployment we have of the v0.69.* Pbench Server we found that it was using Python 3.6 instead of the intended 3.8.

However, the Jenkins unit test environment will execute the tests under Python 3.9 since the support for running under Python 3.6 is precluded by the Fedora 33 environment used.

We fix the version of Python for the Pbench Server by moving to Python 3.9, using `%py3_shebang_fix` to explicitly use `/usr/bin/python3.9` in the command line interface headers, and using `pip3.9` to do the local module installs.

With an additional correction to the `tox` environments for the Pbench Server, `server` and `py3-server`, all server tests are executed under Python 3.9, since the default for Fedora 33 (the CI container in use) is also Python 3.9.

The minimum version of Python required for the Pbench Agent is 3.6, which comes from the fact we support RHEL 7.  To that end, we make a change to force the `tox -e agent` environment to run under 3.6.

But, the Pbench Agent tests under the CI will still use the default version of Python 3 provided by Fedora 33, which is Python 3.9.