### PR TITLE
PBENCH-901: Fix unit tests to mock Keycloak interaction for register/login/logout

### DIFF
--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -41,7 +41,7 @@ class Auth:
         Returns:
             JWT token string
         """
-        current_utc = datetime.datetime.utcnow()
+        current_utc = datetime.datetime.now(datetime.timezone.utc)
         payload = {
             "iat": current_utc,
             "exp": current_utc + time_delta,
@@ -87,7 +87,11 @@ class Auth:
     @token_auth.verify_token
     def verify_auth(auth_token):
         """
-        Validates the auth token
+        Validates the auth token.
+        Note: Since we are not encoding 'aud' claim in our JWT tokens
+        we need to set 'verify_aud' to False while validating the token.
+        With issue https://issues.redhat.com/browse/PBENCH-895 we can
+        set it to True when we start validating third party OIDC tokens.
         :param auth_token:
         :return: User object/None
         """
@@ -116,9 +120,7 @@ class Auth:
                     e,
                 )
         except jwt.InvalidTokenError:
-            Auth.logger.warning(
-                "Internal token verification failed, trying OIDC token verification"
-            )
+            pass  # Ignore this silently; client is unauthenticated
         except Exception as e:
             Auth.logger.exception(
                 "Unexpected exception occurred while verifying the auth token {!r}: {}",

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -96,6 +96,11 @@ class Auth:
                 auth_token,
                 os.getenv("SECRET_KEY", "my_precious"),
                 algorithms="HS256",
+                options={
+                    "verify_signature": True,
+                    "verify_aud": False,
+                    "verify_exp": True,
+                },
             )
             user_id = payload["sub"]
             if ActiveTokens.valid(auth_token):
@@ -111,7 +116,9 @@ class Auth:
                     e,
                 )
         except jwt.InvalidTokenError:
-            pass  # Ignore this silently; client is unauthenticated
+            Auth.logger.warning(
+                "Internal token verification failed, trying OIDC token verification"
+            )
         except Exception as e:
             Auth.logger.exception(
                 "Unexpected exception occurred while verifying the auth token {!r}: {}",

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -764,10 +764,6 @@ def generate_token(
     # Current time to encode in the token payload
     current_utc = datetime.datetime.now(datetime.timezone.utc)
 
-    # Expired epoch time to use as a token expiry in case the caller
-    # wants an invalid token.
-    EXPIRY = "1667187770"
-
     if not user:
         user = User.query(username=username)
     assert user

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -729,6 +729,21 @@ def pbench_token_invalid(client, create_drb_user):
     return generate_token(username="drb", user=create_drb_user, valid=False)
 
 
+@pytest.fixture()
+def get_token(pbench_admin_token):
+    """
+    Get OIDC token for any user specified by the username.
+    """
+
+    def token(username: str) -> str:
+        val = pbench_admin_token
+        if username != admin_username:
+            val = generate_token(username=username)
+        return val
+
+    return token
+
+
 def generate_token(
     username: str,
     user: Optional[User] = None,

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -1,18 +1,18 @@
 from configparser import ConfigParser
 import datetime
 import hashlib
-from http import HTTPStatus
 import os
 from pathlib import Path
 from posix import stat_result
 import shutil
 from stat import ST_MTIME
 import tarfile
-from typing import Dict
+from typing import Dict, List, Optional
 import uuid
 
 from email_validator import EmailNotValidError, ValidatedEmail
 from freezegun import freeze_time
+import jwt
 import pytest
 
 from pbench.common.logger import get_pbench_logger
@@ -20,6 +20,7 @@ from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
 from pbench.server.auth.auth import Auth
 from pbench.server.database.database import Database
+from pbench.server.database.models.active_tokens import ActiveTokens
 from pbench.server.database.models.datasets import Dataset, Metadata, States
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
@@ -52,7 +53,7 @@ index_prefix = unit-test
 [authentication]
 server_url = keycloak.example.com:0000
 realm = pbench
-client = pbench-dashboard
+client = pbench-client
 
 ###########################################################################
 # The rest will come from the default config file.
@@ -64,6 +65,7 @@ files = pbench-server-default.cfg
 admin_username = "test_admin"
 admin_email = "test_admin@example.com"
 generic_password = "12345"
+jwt_secret = "my_precious"
 
 
 def do_setup(tmp_d: Path) -> Path:
@@ -172,34 +174,6 @@ def db_session(server_config, make_logger):
     Database.init_db(server_config, make_logger)
     yield
     Database.db_session.remove()
-
-
-def register_user(
-    client, server_config, email, username, password, firstname, lastname
-):
-    """
-    Helper function to register a user using register API
-    """
-    return client.post(
-        f"{server_config.rest_uri}/register",
-        json={
-            "email": email,
-            "password": password,
-            "username": username,
-            "first_name": firstname,
-            "last_name": lastname,
-        },
-    )
-
-
-def login_user(client, server_config, username, password, token_expiry=None):
-    """
-    Helper function to generate a user authentication token
-    """
-    return client.post(
-        f"{server_config.rest_uri}/login",
-        json={"username": username, "password": password, "token_expiry": token_expiry},
-    )
 
 
 @pytest.fixture()
@@ -716,16 +690,6 @@ def find_template(monkeypatch, fake_mtime):
 
 
 @pytest.fixture()
-def pbench_admin_token(client, server_config, create_admin_user):
-    # Login admin user to get valid pbench token
-    response = login_user(client, server_config, admin_username, generic_password)
-    assert response.status_code == HTTPStatus.OK
-    data = response.json
-    assert data["auth_token"]
-    return data["auth_token"]
-
-
-@pytest.fixture()
 def create_drb_user(client, server_config, fake_email_validator):
     # Create a user
     drb = User(
@@ -741,17 +705,109 @@ def create_drb_user(client, server_config, fake_email_validator):
 
 
 @pytest.fixture()
-def pbench_token(client, server_config, create_drb_user):
-    # Login user to get valid pbench token
-    response = login_user(client, server_config, "drb", generic_password)
-    assert response.status_code == HTTPStatus.OK
-    data = response.json
-    assert data["auth_token"]
-    return data["auth_token"]
+def pbench_admin_token(client, create_admin_user):
+    return generate_token(
+        user=create_admin_user,
+        username=admin_username,
+        pbench_client_roles=["ADMIN"],
+    )
+
+
+@pytest.fixture()
+def pbench_token(client, create_drb_user):
+    """
+    OIDC valid token for the 'drb' user.
+    """
+    return generate_token(username="drb", user=create_drb_user)
+
+
+@pytest.fixture()
+def pbench_token_invalid(client, create_drb_user):
+    """
+    OIDC invalid token for the 'drb' user
+    """
+    return generate_token(username="drb", user=create_drb_user, valid=False)
+
+
+def generate_token(
+    username: str,
+    user: Optional[User] = None,
+    pbench_client_roles: Optional[List[str]] = None,
+    valid: Optional[bool] = True,
+):
+    """
+    Generates an OIDC JWT token that mimics the real OIDC token obtained
+    from the OIDC complaint client login.
+    Args:
+        username: username to include in the token payload
+        user: user attributes will be extracted from the user to include in
+            the token payload, if not provided it will be queried from the User
+            table. It is a responsibility of the consumer to make sure the
+            user exists in the 'User' table until we remove the User table
+            completely.
+        pbench_client_roles: List of any roles to add in the token payload
+        valid: If True, the generated token will be valid for 10 mins.
+               If False, generated token would be invalid and expired
+    TODO: When we remove the User table we need to update this functionality's
+        dependance on user table.
+    :return:
+    """
+    current_utc = datetime.datetime.utcnow()
+    if not user:
+        user = User.query(username=username)
+    if valid:
+        exp = current_utc + datetime.timedelta(minutes=10)
+    else:
+        exp = "1667187770"
+    payload = {
+        "exp": exp,
+        "iat": current_utc,
+        "jti": "541777b5-7127-408d-9dfb-71790f36c4c2",
+        "iss": "https://auth-server.com/realms/pbench",
+        "aud": ["broker", "account", "pbench-client"],
+        "sub": user.id,
+        "typ": "Bearer",
+        "azp": "pbench-client",
+        "session_state": "1988612e-774d-43b8-8d4a-bbc05ee55edb",
+        "acr": "1",
+        "realm_access": {
+            "roles": ["default-roles-pbench-cli", "offline_access", "uma_authorization"]
+        },
+        "resource_access": {
+            "broker": {"roles": ["read-token"]},
+            "account": {
+                "roles": ["manage-account", "manage-account-links", "view-profile"]
+            },
+        },
+        "scope": "openid profile email",
+        "sid": "1988612e-774d-43b8-8d4a-bbc05ee55edb",
+        "email_verified": True,
+        "name": user.first_name + " " + user.last_name,
+        "preferred_username": username,
+        "given_name": user.first_name,
+        "family_name": user.last_name,
+        "email": user.email,
+    }
+    if pbench_client_roles:
+        payload.update()
+        payload["resource_access"].update(
+            {"pbench-client": {"roles": pbench_client_roles}}
+        )
+    token_str = jwt.encode(payload, jwt_secret, algorithm="HS256")
+    token = ActiveTokens(token=token_str)
+    user.update(auth_tokens=token)
+    return token_str
 
 
 @pytest.fixture(params=[header for header in HeaderTypes])
-def build_auth_header(request, server_config, pbench_token, pbench_admin_token, client):
+def build_auth_header(
+    request,
+    server_config,
+    pbench_token,
+    pbench_admin_token,
+    pbench_token_invalid,
+    client,
+):
     if request.param == HeaderTypes.VALID_ADMIN:
         header = {"Authorization": "Bearer " + pbench_admin_token}
 
@@ -759,13 +815,7 @@ def build_auth_header(request, server_config, pbench_token, pbench_admin_token, 
         header = {"Authorization": "Bearer " + pbench_token}
 
     elif request.param == HeaderTypes.INVALID:
-        # Create an invalid token by logging the user out
-        response = client.post(
-            f"{server_config.rest_uri}/logout",
-            headers=dict(Authorization="Bearer " + pbench_token),
-        )
-        assert response.status_code == HTTPStatus.OK
-        header = {"Authorization": "Bearer " + pbench_token}
+        header = {"Authorization": "Bearer " + pbench_token_invalid}
 
     elif request.param == HeaderTypes.EMPTY:
         header = {}

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -731,17 +731,12 @@ def pbench_token_invalid(client, create_drb_user):
 
 @pytest.fixture()
 def get_token(pbench_admin_token):
+    """This fixture yields a function value which can be called to get
+    an OIDC token for the user corresponding to the specified username.
     """
-    Get OIDC token for any user specified by the username.
-    """
-
-    def token(username: str) -> str:
-        val = pbench_admin_token
-        if username != admin_username:
-            val = generate_token(username=username)
-        return val
-
-    return token
+    return lambda user: (
+        pbench_admin_token if user == admin_username else generate_token(username=user)
+    )
 
 
 def generate_token(
@@ -781,7 +776,7 @@ def generate_token(
 
     if not user:
         user = User.query(username=username)
-    assert user
+        assert user
     offset = datetime.timedelta(minutes=10)
     exp = current_utc + (offset if valid else -offset)
     payload = {

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -203,7 +203,7 @@ class Commons:
         ("drb", "pp"),
     )
     def test_accessing_user_data_with_invalid_token(
-        self, client, server_config, pbench_token, user
+        self, client, server_config, pbench_token_invalid, user
     ):
         """
         Test behavior when expired authentication token is provided.
@@ -224,18 +224,11 @@ class Commons:
             pytest.skip(
                 "skipping " + self.test_accessing_user_data_with_invalid_token.__name__
             )
-        # valid token logout
-        response = self.make_request_call(
-            client,
-            server_config.rest_uri + "/logout",
-            {"Authorization": "Bearer " + pbench_token},
-        )
-        assert response.status_code == HTTPStatus.OK
         self.payload[userp.parameter.name] = user
         response = self.make_request_call(
             client,
             server_config.rest_uri + self.pbench_endpoint,
-            {"Authorization": "Bearer " + pbench_token},
+            {"Authorization": "Bearer " + pbench_token_invalid},
             json=self.payload,
         )
         assert response.status_code == HTTPStatus.UNAUTHORIZED

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -6,8 +6,8 @@ from pbench.server.api.resources import API_METHOD
 from pbench.server.api.resources.query_apis.datasets.datasets_detail import (
     DatasetsDetail,
 )
+from pbench.test.unit.server.conftest import generate_token
 from pbench.test.unit.server.query_apis.commons import Commons
-from pbench.test.unit.server.test_user_auth import login_user
 
 
 class TestDatasetsDetail(Commons):
@@ -61,9 +61,7 @@ class TestDatasetsDetail(Commons):
             if user == "test_admin":
                 token = pbench_admin_token
             else:
-                response = login_user(client, server_config, user, "12345")
-                assert response.status_code == HTTPStatus.OK
-                token = response.json["auth_token"]
+                token = generate_token(username=user)
             assert token
             headers = {"authorization": f"bearer {token}"}
 

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -7,7 +7,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import generate_token
+from pbench.test.unit.server.conftest import generate_token, admin_username
 
 
 class TestDatasetsDateRange:
@@ -33,7 +33,10 @@ class TestDatasetsDateRange:
         def query_api(
             payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = self.token(username)
+            token = generate_token(
+                username=username,
+                pbench_client_roles=["ADMIN"] if username == admin_username else None,
+            )
             response = client.get(
                 f"{server_config.rest_uri}/datasets/daterange",
                 headers={"authorization": f"bearer {token}"},
@@ -43,12 +46,6 @@ class TestDatasetsDateRange:
             return response
 
         return query_api
-
-    def token(self, user: str) -> str:
-        roles = None
-        if user == "test_admin":
-            roles = ["ADMIN"]
-        return generate_token(username=user, pbench_client_roles=roles)
 
     def get_results(self, name_list: List[str]) -> Dict[str, datetime.datetime]:
         """

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -18,7 +18,9 @@ class TestDatasetsDateRange:
     """
 
     @pytest.fixture()
-    def query_as(self, client, server_config, more_datasets, provide_metadata):
+    def query_as(
+        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+    ):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -33,10 +35,7 @@ class TestDatasetsDateRange:
         def query_api(
             payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = generate_token(
-                username=username,
-                pbench_client_roles=["ADMIN"] if username == admin_username else None,
-            )
+            token = self.token(pbench_admin_token, username)
             response = client.get(
                 f"{server_config.rest_uri}/datasets/daterange",
                 headers={"authorization": f"bearer {token}"},
@@ -67,6 +66,13 @@ class TestDatasetsDateRange:
             to_time = max(dataset.created, to_time)
             from_time = min(dataset.created, from_time)
         return {"from": from_time.isoformat(), "to": to_time.isoformat()}
+
+    def token(self, pbench_admin_token, user: str) -> str:
+        return (
+            pbench_admin_token
+            if user == admin_username
+            else generate_token(username=user)
+        )
 
     @pytest.mark.parametrize(
         "login,query,results",

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -5,8 +5,9 @@ from typing import Dict, List
 import pytest
 import requests
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
+from pbench.test.unit.server.conftest import generate_token
 
 
 class TestDatasetsDateRange:
@@ -32,7 +33,7 @@ class TestDatasetsDateRange:
         def query_api(
             payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = self.token(client, server_config, username)
+            token = self.token(username)
             response = client.get(
                 f"{server_config.rest_uri}/datasets/daterange",
                 headers={"authorization": f"bearer {token}"},
@@ -43,15 +44,11 @@ class TestDatasetsDateRange:
 
         return query_api
 
-    def token(self, client, config: PbenchServerConfig, user: str) -> str:
-        response = client.post(
-            f"{config.rest_uri}/login",
-            json={"username": user, "password": "12345"},
-        )
-        assert response.status_code == HTTPStatus.OK
-        data = response.json
-        assert data["auth_token"]
-        return data["auth_token"]
+    def token(self, user: str) -> str:
+        roles = None
+        if user == "test_admin":
+            roles = ["ADMIN"]
+        return generate_token(username=user, pbench_client_roles=roles)
 
     def get_results(self, name_list: List[str]) -> Dict[str, datetime.datetime]:
         """

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -7,7 +7,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import generate_token, admin_username
+from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsDateRange:

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -7,7 +7,6 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsDateRange:
@@ -19,7 +18,7 @@ class TestDatasetsDateRange:
 
     @pytest.fixture()
     def query_as(
-        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+        self, client, server_config, more_datasets, provide_metadata, get_token
     ):
         """
         Helper fixture to perform the API query and validate an expected
@@ -30,12 +29,13 @@ class TestDatasetsDateRange:
             server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
+            get_token: Pbench token fixture
         """
 
         def query_api(
             payload: JSON, username: str, expected_status: HTTPStatus
         ) -> requests.Response:
-            token = self.token(pbench_admin_token, username)
+            token = get_token(username)
             response = client.get(
                 f"{server_config.rest_uri}/datasets/daterange",
                 headers={"authorization": f"bearer {token}"},
@@ -66,13 +66,6 @@ class TestDatasetsDateRange:
             to_time = max(dataset.created, to_time)
             from_time = min(dataset.created, from_time)
         return {"from": from_time.isoformat(), "to": to_time.isoformat()}
-
-    def token(self, pbench_admin_token, user: str) -> str:
-        return (
-            pbench_admin_token
-            if user == admin_username
-            else generate_token(username=user)
-        )
 
     @pytest.mark.parametrize(
         "login,query,results",

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -6,8 +6,9 @@ from urllib.parse import urlencode
 import pytest
 import requests
 
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
+from pbench.test.unit.server.conftest import generate_token
 
 
 class TestDatasetsList:
@@ -48,7 +49,7 @@ class TestDatasetsList:
             """
             headers = None
             if username:
-                token = self.token(client, server_config, username)
+                token = self.token(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/list",
@@ -60,15 +61,11 @@ class TestDatasetsList:
 
         return query_api
 
-    def token(self, client, config: PbenchServerConfig, user: str) -> str:
-        response = client.post(
-            f"{config.rest_uri}/login",
-            json={"username": user, "password": "12345"},
-        )
-        assert response.status_code == HTTPStatus.OK
-        data = response.json
-        assert data["auth_token"]
-        return data["auth_token"]
+    def token(self, user: str) -> str:
+        roles = None
+        if user == "test_admin":
+            roles = ["ADMIN"]
+        return generate_token(username=user, pbench_client_roles=roles)
 
     def get_results(self, name_list: List[str], query: JSON, server_config) -> JSON:
         """

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -8,7 +8,6 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsList:
@@ -20,7 +19,7 @@ class TestDatasetsList:
 
     @pytest.fixture()
     def query_as(
-        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+        self, client, server_config, more_datasets, provide_metadata, get_token
     ):
         """
         Helper fixture to perform the API query and validate an expected
@@ -31,6 +30,7 @@ class TestDatasetsList:
             server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
+            get_token: Pbench token fixture
         """
 
         def query_api(
@@ -51,7 +51,7 @@ class TestDatasetsList:
             """
             headers = None
             if username:
-                token = self.token(pbench_admin_token, username)
+                token = get_token(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/list",
@@ -62,13 +62,6 @@ class TestDatasetsList:
             return response
 
         return query_api
-
-    def token(self, pbench_admin_token, user: str) -> str:
-        return (
-            pbench_admin_token
-            if user == admin_username
-            else generate_token(username=user)
-        )
 
     def get_results(self, name_list: List[str], query: JSON, server_config) -> JSON:
         """

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -8,7 +8,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import generate_token, admin_username
+from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsList:

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -19,7 +19,9 @@ class TestDatasetsList:
     """
 
     @pytest.fixture()
-    def query_as(self, client, server_config, more_datasets, provide_metadata):
+    def query_as(
+        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+    ):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -49,12 +51,7 @@ class TestDatasetsList:
             """
             headers = None
             if username:
-                token = generate_token(
-                    username=username,
-                    pbench_client_roles=["ADMIN"]
-                    if username == admin_username
-                    else None,
-                )
+                token = self.token(pbench_admin_token, username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/list",
@@ -66,11 +63,12 @@ class TestDatasetsList:
 
         return query_api
 
-    def token(self, user: str) -> str:
-        roles = None
-        if user == "test_admin":
-            roles = ["ADMIN"]
-        return generate_token(username=user, pbench_client_roles=roles)
+    def token(self, pbench_admin_token, user: str) -> str:
+        return (
+            pbench_admin_token
+            if user == admin_username
+            else generate_token(username=user)
+        )
 
     def get_results(self, name_list: List[str], query: JSON, server_config) -> JSON:
         """

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -8,7 +8,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
-from pbench.test.unit.server.conftest import generate_token
+from pbench.test.unit.server.conftest import generate_token, admin_username
 
 
 class TestDatasetsList:
@@ -49,7 +49,12 @@ class TestDatasetsList:
             """
             headers = None
             if username:
-                token = self.token(username)
+                token = generate_token(
+                    username=username,
+                    pbench_client_roles=["ADMIN"]
+                    if username == admin_username
+                    else None,
+                )
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/list",

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -5,7 +5,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
-from pbench.test.unit.server.conftest import generate_token
+from pbench.test.unit.server.conftest import generate_token, admin_username
 
 
 class TestDatasetsMetadata:
@@ -31,7 +31,12 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = self.token(username)
+                token = generate_token(
+                    username=username,
+                    pbench_client_roles=["ADMIN"]
+                    if username == admin_username
+                    else None,
+                )
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -73,7 +78,12 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = self.token(username)
+                token = generate_token(
+                    username=username,
+                    pbench_client_roles=["ADMIN"]
+                    if username == admin_username
+                    else None,
+                )
                 headers = {"authorization": f"bearer {token}"}
             response = client.put(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -92,12 +102,6 @@ class TestDatasetsMetadata:
             return response
 
         return query_api
-
-    def token(self, user: str) -> str:
-        roles = None
-        if user == "test_admin":
-            roles = ["ADMIN"]
-        return generate_token(username=user, pbench_client_roles=roles)
 
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -5,7 +5,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
-from pbench.test.unit.server.conftest import generate_token, admin_username
+from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsMetadata:

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -10,7 +10,9 @@ from pbench.test.unit.server.conftest import admin_username, generate_token
 
 class TestDatasetsMetadata:
     @pytest.fixture()
-    def query_get_as(self, client, server_config, more_datasets, provide_metadata):
+    def query_get_as(
+        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+    ):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -31,12 +33,7 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = generate_token(
-                    username=username,
-                    pbench_client_roles=["ADMIN"]
-                    if username == admin_username
-                    else None,
-                )
+                token = self.token(pbench_admin_token, username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -57,7 +54,9 @@ class TestDatasetsMetadata:
         return query_api
 
     @pytest.fixture()
-    def query_put_as(self, client, server_config, more_datasets, provide_metadata):
+    def query_put_as(
+        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+    ):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -78,12 +77,7 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = generate_token(
-                    username=username,
-                    pbench_client_roles=["ADMIN"]
-                    if username == admin_username
-                    else None,
-                )
+                token = self.token(pbench_admin_token, username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.put(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -102,6 +96,13 @@ class TestDatasetsMetadata:
             return response
 
         return query_api
+
+    def token(self, pbench_admin_token, user: str) -> str:
+        return (
+            pbench_admin_token
+            if user == admin_username
+            else generate_token(username=user)
+        )
 
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -5,13 +5,12 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
-from pbench.test.unit.server.conftest import admin_username, generate_token
 
 
 class TestDatasetsMetadata:
     @pytest.fixture()
     def query_get_as(
-        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+        self, client, server_config, more_datasets, provide_metadata, get_token
     ):
         """
         Helper fixture to perform the API query and validate an expected
@@ -22,6 +21,7 @@ class TestDatasetsMetadata:
             server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
+            get_token: Pbench token fixture
         """
 
         def query_api(
@@ -33,7 +33,7 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = self.token(pbench_admin_token, username)
+                token = get_token(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -55,7 +55,7 @@ class TestDatasetsMetadata:
 
     @pytest.fixture()
     def query_put_as(
-        self, client, server_config, more_datasets, provide_metadata, pbench_admin_token
+        self, client, server_config, more_datasets, provide_metadata, get_token
     ):
         """
         Helper fixture to perform the API query and validate an expected
@@ -66,6 +66,7 @@ class TestDatasetsMetadata:
             server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
+            get_token: Pbench token fixture
         """
 
         def query_api(
@@ -77,7 +78,7 @@ class TestDatasetsMetadata:
             except DatasetNotFound:
                 dataset = ds_name  # Allow passing deliberately bad value
             if username:
-                token = self.token(pbench_admin_token, username)
+                token = get_token(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.put(
                 f"{server_config.rest_uri}/datasets/metadata/{dataset}",
@@ -96,13 +97,6 @@ class TestDatasetsMetadata:
             return response
 
         return query_api
-
-    def token(self, pbench_admin_token, user: str) -> str:
-        return (
-            pbench_admin_token
-            if user == admin_username
-            else generate_token(username=user)
-        )
 
     def test_get_no_dataset(self, query_get_as):
         response = query_get_as(

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -242,7 +242,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.UNAUTHORIZED
         for record in caplog.records:
-            assert record.levelname in ["DEBUG", "INFO", "ERROR"]
+            assert record.levelname in ["DEBUG", "INFO"]
         assert not self.cachemanager_created
 
     def test_empty_upload(
@@ -335,7 +335,7 @@ class TestUpload:
         assert dataset.name in self.cachemanager_created
 
         for record in caplog.records:
-            assert record.levelname in ["WARNING", "DEBUG", "INFO"]
+            assert record.levelname in ["DEBUG", "INFO"]
 
     def test_upload_duplicate(
         self,

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -5,7 +5,35 @@ import time
 from pbench.server.database.database import Database
 from pbench.server.database.models.active_tokens import ActiveTokens
 from pbench.server.database.models.users import User
-from pbench.test.unit.server.conftest import admin_username, login_user, register_user
+from pbench.test.unit.server.conftest import admin_username
+
+
+def register_user(
+    client, server_config, email, username, password, firstname, lastname
+):
+    """
+    Helper function to register a user using register API
+    """
+    return client.post(
+        f"{server_config.rest_uri}/register",
+        json={
+            "email": email,
+            "password": password,
+            "username": username,
+            "first_name": firstname,
+            "last_name": lastname,
+        },
+    )
+
+
+def login_user(client, server_config, username, password, token_expiry=None):
+    """
+    Helper function to generate a user authentication token
+    """
+    return client.post(
+        f"{server_config.rest_uri}/login",
+        json={"username": username, "password": password, "token_expiry": token_expiry},
+    )
 
 
 class TestUserAuthentication:


### PR DESCRIPTION
1. Refactor unit tests to remove register/login/logout API dependency (except for `test_user_auth.py`, that will be removed when we remove the `User` and `Active_tokens` table)
2. Mock Keycloak tokens

PBENCH-901