### PR TITLE
PBENCH-895: Authentication on endpoints to use the tokens from identity provider

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -54,6 +54,7 @@ def register_endpoints(api, app, config):
     # Init the the authentication module
     token_auth = Auth()
     Auth.set_logger(logger)
+    Auth.set_oidc_client(server_config=config)
 
     logger.info("Registering service endpoints with base URI {}", base_uri)
 

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -54,7 +54,7 @@ def register_endpoints(api, app, config):
     # Init the the authentication module
     token_auth = Auth()
     Auth.set_logger(logger)
-    Auth.oidc_client = Auth.get_oidc_client(server_config=config)
+    Auth.set_oidc_client(server_config=config)
 
     logger.info("Registering service endpoints with base URI {}", base_uri)
 

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -54,7 +54,7 @@ def register_endpoints(api, app, config):
     # Init the the authentication module
     token_auth = Auth()
     Auth.set_logger(logger)
-    Auth.set_oidc_client(server_config=config)
+    Auth.oidc_client = Auth.get_oidc_client(server_config=config)
 
     logger.info("Registering service endpoints with base URI {}", base_uri)
 

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -282,7 +282,7 @@ class Logout(Resource):
                         "message": "failure message"
                     }
         """
-        auth_token = self.auth.get_auth_token(self.logger)
+        auth_token = self.auth.get_auth_token()
         user = Auth.verify_auth(auth_token=auth_token)
 
         # "None" user represents that either the token is not present in our database or it is an expired token.

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -132,8 +132,13 @@ class Auth:
         except Exception as e:
             Auth.logger.exception("Error {} getting JWT secret", e)
 
-    def get_auth_token(self):
-        # get auth token
+    def get_auth_token(self) -> str:
+        """
+        Returns bearer auth token extracted from the authentication header.
+
+        Returns:
+            Auth token string
+        """
         example = (
             "Please add Authorization header with Bearer token as,"
             " 'Authorization: Bearer <session_token>'"
@@ -165,9 +170,6 @@ class Auth:
     def verify_auth(auth_token: str) -> Optional[Union[User, InternalUser]]:
         """
         Validates the auth token.
-
-        :param auth_token:
-        :return: User object/None
 
         Args:
             auth_token: Authentication token string
@@ -251,6 +253,7 @@ class Auth:
             jwt.ExpiredSignatureError,
             jwt.InvalidTokenError,
             jwt.InvalidAudienceError,
+            jwt.InvalidAlgorithmError,
         ):
             return None
         except Exception:

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -233,9 +233,9 @@ class Auth:
             InternalUser object if the verification succeeds else None
         """
         try:
-            identity_provider_pubkey = oidc_client.get_oidc_public_key(auth_token)
+            identity_provider_pubkey = oidc_client.get_oidc_public_key()
         except Exception:
-            Auth.logger.info("Identity provider public key fetch failed")
+            Auth.logger.debug("Identity provider public key fetch failed")
             identity_provider_pubkey = Auth().get_secret_key()
         try:
             token_payload = oidc_client.token_introspect_offline(

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -45,7 +45,7 @@ class Auth:
         Auth.logger = logger
 
     @staticmethod
-    def get_oidc_client(server_config: PbenchServerConfig):
+    def set_oidc_client(server_config: PbenchServerConfig):
         """OIDC client initialization for third party token verification
 
         Args:
@@ -59,7 +59,7 @@ class Auth:
         client = server_config.get("authentication", "client")
         realm = server_config.get("authentication", "realm")
         secret = server_config.get("authentication", "secret", fallback=None)
-        return OpenIDClient(
+        Auth.oidc_client = OpenIDClient(
             server_url=server_url,
             client_id=client,
             logger=Auth.logger,
@@ -211,9 +211,9 @@ class Auth:
                  InternalUser object
             """
             roles = []
-            audiences = token_payload.get("resource_access")
+            audiences = token_payload.get("resource_access", {})
             if client_id in audiences:
-                roles = audiences.get(client_id).get("roles")
+                roles = audiences[client_id].get("roles")
             return InternalUser(
                 id=token_payload.get("sub"),
                 username=token_payload.get("preferred_username"),

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -1,5 +1,15 @@
-from jwt.exceptions import InvalidAudienceError
+import datetime
+
+import jwt
+from jwt.exceptions import (
+    ExpiredSignatureError,
+    InvalidAlgorithmError,
+    InvalidAudienceError,
+    InvalidTokenError,
+)
 import pytest
+
+from pbench.server.auth import OpenIDClient
 
 
 class TestUserTokenManagement:
@@ -34,3 +44,58 @@ class TestUserTokenManagement:
                 options=options,
             )
         assert str(e.value) == "Invalid audience"
+
+    def test_token_introspect_invalid_algorithm(
+        self, keycloak_oidc, keycloak_mock_token
+    ):
+        options = {"verify_signature": True, "verify_aud": True, "verify_exp": True}
+        with pytest.raises(InvalidAlgorithmError) as e:
+            keycloak_oidc.token_introspect_offline(
+                token=keycloak_mock_token,
+                key="some_secret",
+                algorithms=["INVALID_ALGORITHM"],
+                audience="wrong_client",
+                options=options,
+            )
+        assert str(e.value) == "The specified alg value is not allowed"
+
+    def test_token_introspect_expired_signature(self, keycloak_oidc):
+        current_utc = datetime.datetime.now(datetime.timezone.utc)
+        payload = {
+            "iat": current_utc,
+            "exp": current_utc - datetime.timedelta(minutes=1),  # expired token
+            "sub": "12345",
+            "aud": "test_client",
+        }
+
+        # Get jwt key
+        token = jwt.encode(payload, key="some_secret", algorithm="HS256")
+        options = {"verify_signature": True, "verify_aud": True, "verify_exp": True}
+        with pytest.raises(ExpiredSignatureError) as e:
+            keycloak_oidc.token_introspect_offline(
+                token=token,
+                key="some_secret",
+                algorithms=["HS256"],
+                audience="wrong_client",
+                options=options,
+            )
+        assert str(e.value) == "Signature has expired"
+
+    def test_token_introspect_invalid_token(self, monkeypatch, keycloak_oidc):
+        def offline_token_introspection_exception(
+            self, token: str, key: str, audience: str
+        ):
+            raise InvalidTokenError("Invalid token")
+
+        monkeypatch.setattr(
+            OpenIDClient,
+            "token_introspect_offline",
+            offline_token_introspection_exception,
+        )
+        with pytest.raises(InvalidTokenError) as e:
+            keycloak_oidc.token_introspect_offline(
+                token="token",
+                key="some_secret",
+                audience="wrong_client",
+            )
+        assert str(e.value) == "Invalid token"

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -140,9 +140,7 @@ def set_oidc_well_known_endpoints(monkeypatch):
 
 
 @pytest.fixture()
-def client(
-    monkeypatch, server_config, fake_email_validator, set_oidc_well_known_endpoints
-):
+def client(server_config, fake_email_validator, set_oidc_well_known_endpoints):
     """A test client for the app.
 
     Fixtures:

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -129,18 +129,7 @@ def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
 
 
 @pytest.fixture()
-def fake_well_known_auth_endpoints(monkeypatch):
-    def fake_well_known(oidc_client):
-
-        oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
-        oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
-        oidc_client.JWKS_URI = "https://oidc_jwks_endpoint.example.com"
-
-    monkeypatch.setattr(OpenIDClient, "set_well_known_endpoints", fake_well_known)
-
-
-@pytest.fixture()
-def client(server_config, fake_email_validator, fake_well_known_auth_endpoints):
+def client(monkeypatch, server_config, fake_email_validator):
     """A test client for the app.
 
     Fixtures:
@@ -154,6 +143,15 @@ def client(server_config, fake_email_validator, fake_well_known_auth_endpoints):
     For test cases that require the DB but not a full Flask app context, use
     the db_session fixture instead, which adds DB cleanup after the test.
     """
+
+    def fake_well_known(oidc_client):
+
+        oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
+        oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
+        oidc_client.JWKS_URI = "https://oidc_jwks_endpoint.example.com"
+
+    monkeypatch.setattr(OpenIDClient, "set_well_known_endpoints", fake_well_known)
+
     app = create_app(server_config)
 
     app_client = app.test_client()

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -129,7 +129,20 @@ def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
 
 
 @pytest.fixture()
-def client(monkeypatch, server_config, fake_email_validator):
+def set_oidc_well_known_endpoints(monkeypatch):
+    def fake_well_known(oidc_client):
+
+        oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
+        oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
+        oidc_client.JWKS_URI = "https://oidc_jwks_endpoint.example.com"
+
+    monkeypatch.setattr(OpenIDClient, "set_well_known_endpoints", fake_well_known)
+
+
+@pytest.fixture()
+def client(
+    monkeypatch, server_config, fake_email_validator, set_oidc_well_known_endpoints
+):
     """A test client for the app.
 
     Fixtures:
@@ -143,14 +156,6 @@ def client(monkeypatch, server_config, fake_email_validator):
     For test cases that require the DB but not a full Flask app context, use
     the db_session fixture instead, which adds DB cleanup after the test.
     """
-
-    def fake_well_known(oidc_client):
-
-        oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
-        oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
-        oidc_client.JWKS_URI = "https://oidc_jwks_endpoint.example.com"
-
-    monkeypatch.setattr(OpenIDClient, "set_well_known_endpoints", fake_well_known)
 
     app = create_app(server_config)
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -140,7 +140,9 @@ def set_oidc_well_known_endpoints(monkeypatch):
 
 
 @pytest.fixture()
-def client(server_config, fake_email_validator, set_oidc_well_known_endpoints):
+def client(
+    monkeypatch, server_config, fake_email_validator, set_oidc_well_known_endpoints
+):
     """A test client for the app.
 
     Fixtures:
@@ -154,6 +156,11 @@ def client(server_config, fake_email_validator, set_oidc_well_known_endpoints):
     For test cases that require the DB but not a full Flask app context, use
     the db_session fixture instead, which adds DB cleanup after the test.
     """
+
+    def mock_get_oidc_public_key(oidc_client):
+        return jwt_secret
+
+    monkeypatch.setattr(OpenIDClient, "_get_oidc_public_key", mock_get_oidc_public_key)
 
     app = create_app(server_config)
 

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -13,6 +13,7 @@ from pbench.server.api.resources import (
     ApiParams,
     ApiSchema,
 )
+from pbench.server.auth.auth import Auth
 from pbench.server.database.models.server_config import ServerConfig
 
 
@@ -84,12 +85,18 @@ class OptionsMethod(ApiBase):
 class TestApiBase:
     """Verify internal methods of the API base class."""
 
-    def test_method_validation(self, server_config, monkeypatch):
+    def test_method_validation(
+        self, server_config, monkeypatch, set_oidc_well_known_endpoints
+    ):
         # Create the temporary flask application.
         app = Flask("test-api-server")
         app.debug = True
         app.testing = True
         app.logger = get_pbench_logger("test-api-server", server_config)
+
+        token_auth = Auth()
+        token_auth.set_logger(app.logger)
+        Auth.set_oidc_client(server_config=server_config)
 
         # Mimic our normal use of ApiBase with our sub-classed instances.
         api = Api(app)


### PR DESCRIPTION
This commit is currently rebased on PR https://github.com/distributed-system-analysis/pbench/pull/3055 "Fix unit tests to mock Keycloak interaction for register/login/logout"

The commit in this PR enables the use of an OIDC token for user authentication. 
Note: This will break the current deployment of the Pbench-server if the following sections are missing from the server config file
```
[authentication]
server_url = keycloak.example.com:0000
realm = pbench
client = pbench-client
``` 
Not only do these sections need to be present but also the auth server URL needs to be active with the specified `realm` and `client` configuration.

Users can use the tokens obtained from the OIDC client (In our case Keycloak broker) and pass them to access the dataset resources they own. However, this commit does not replace the current user APIs provided through the `Users` and `Active_tokens` tables. Users can still Register/login/logout using the Pbench APIs. 

Note: If the user used an OIDC client token and if the dataset is owned by the same user when registered via Pbench registration API, the dataset can not be accessed and vice versa (but this problem will no longer be there when we remove the user APIs from the Pbench server)