### PR TITLE
Support browser reload of React component URL

### DIFF
--- a/server/lib/config/pbench.httpd.conf
+++ b/server/lib/config/pbench.httpd.conf
@@ -3,6 +3,12 @@
 # To run with local Apache reverse proxy and Dashboard mapping, customize this
 # file as necessary and copy to /etc/https/conf.d/pbench.conf then restart the
 # httpd service.
+#
+# NOTE: while this file should work as-is, using the routable hostname
+# or IP is highly recommended. The pbench-in-a-can container deployment will
+# filter this file, replacing the local host placeholder with the full IP:
+# pay attention to server/pbenchinacan/container-build.sh when editing this!
+#
 <VirtualHost *:80>
     ProxyPreserveHost On
     ProxyPass /api/ http://localhost:8001/api/

--- a/server/lib/config/pbench.httpd.conf.example
+++ b/server/lib/config/pbench.httpd.conf.example
@@ -1,0 +1,26 @@
+# Example Apache configuration file
+#
+# To run with local Apache reverse proxy and Dashboard mapping, customize this
+# file as necessary and copy to /etc/https/conf.d/pbench.conf then restart the
+# httpd service.
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass /api/ http://localhost:8001/api/
+    ProxyPassReverse /api/ http://localhost:8001/api/
+
+    # Route all dashboard React component paths to the dashboard App; e.g.,
+    # http//<host>/dashboard/login
+    <Directory "/var/www/html/dashboard" >
+            Options FollowSymLinks MultiViews
+            AllowOverride None
+            Order allow,deny
+            allow from all
+
+        RewriteEngine on
+        RewriteCond %{REQUEST_FILENAME} -f [OR]
+        RewriteCond %{REQUEST_FILENAME} -d
+        RewriteRule ^ - [L]
+        RewriteRule ^ index.html [L]
+    </Directory>
+    ProxyPass / !
+</VirtualHost>

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -103,28 +103,7 @@ buildah run $container chown --recursive pbench:pbench /srv/pbench
 
 buildah run $container crontab -u pbench ${SERVER_LIB}/crontab/crontab
 
-echo >/tmp/pbench.conf.${$} \
-"<VirtualHost *:80>
-    ProxyPreserveHost On
-    ProxyPass /api/ http://${HOSTNAME_F}:8001/api/
-    ProxyPassReverse /api/ http://${HOSTNAME_F}:8001/api/
-    ProxyPass / !
-
-    # Route all dashboard React component paths to the dashboard App; e.g.,
-    # http//<host>/dashboard/login
-    <Directory "/var/www/html/dashboard" >
-            Options FollowSymLinks MultiViews
-            AllowOverride None
-            Order allow,deny
-            allow from all
-
-        RewriteEngine on
-        RewriteCond %{REQUEST_FILENAME} -f [OR]
-        RewriteCond %{REQUEST_FILENAME} -d
-        RewriteRule ^ - [L]
-        RewriteRule ^ index.html [L]
-    </Directory>
-</VirtualHost>"
+sed -e "s/localhost/${HOSTNAME_F}/" server/lib/config/pbench.httpd.conf >/tmp/pbench.conf.${$}
 buildah copy --chown root:root --chmod 0644 $container \
     /tmp/pbench.conf.${$} /etc/httpd/conf.d/pbench.conf
 rm /tmp/pbench.conf.${$}

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -109,6 +109,21 @@ echo >/tmp/pbench.conf.${$} \
     ProxyPass /api/ http://${HOSTNAME_F}:8001/api/
     ProxyPassReverse /api/ http://${HOSTNAME_F}:8001/api/
     ProxyPass / !
+
+    # Route all dashboard React component paths to the dashboard App; e.g.,
+    # http//<host>/dashboard/login
+    <Directory "/var/www/html/dashboard" >
+            Options FollowSymLinks MultiViews
+            AllowOverride None
+            Order allow,deny
+            allow from all
+
+        RewriteEngine on
+        RewriteCond %{REQUEST_FILENAME} -f [OR]
+        RewriteCond %{REQUEST_FILENAME} -d
+        RewriteRule ^ - [L]
+        RewriteRule ^ index.html [L]
+    </Directory>
 </VirtualHost>"
 buildah copy --chown root:root --chmod 0644 $container \
     /tmp/pbench.conf.${$} /etc/httpd/conf.d/pbench.conf

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -25,7 +25,8 @@ HOSTNAME_F=pbenchinacan
 
 # Locations on the host
 GITTOP=${GITTOP:-$(git rev-parse --show-toplevel)}
-PBINC_DIR=${GITTOP}/server/pbenchinacan
+PBINC_SERVER=${GITTOP}/server
+PBINC_DIR=${PBINC_SERVER}/pbenchinacan
 
 # Image tag determined from jenkins/branch.name
 PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
@@ -54,7 +55,7 @@ then
 fi
 
 buildah copy $container ${RPM_PATH} /tmp/pbench-server.rpm
-buildah copy $container server/requirements.txt /tmp
+buildah copy $container ${PBINC_SERVER}/requirements.txt /tmp
 buildah run $container dnf update -y
 buildah run $container dnf install -y --setopt=tsflags=nodocs \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -103,7 +104,7 @@ buildah run $container chown --recursive pbench:pbench /srv/pbench
 
 buildah run $container crontab -u pbench ${SERVER_LIB}/crontab/crontab
 
-sed -e "s/localhost/${HOSTNAME_F}/" server/lib/config/pbench.httpd.conf >/tmp/pbench.conf.${$}
+sed -e "s/localhost/${HOSTNAME_F}/" ${PBINC_SERVER}/lib/config/pbench.httpd.conf >/tmp/pbench.conf.${$}
 buildah copy --chown root:root --chmod 0644 $container \
     /tmp/pbench.conf.${$} /etc/httpd/conf.d/pbench.conf
 rm /tmp/pbench.conf.${$}


### PR DESCRIPTION
PBENCH-778

When viewing a Dashboard component page, React displays a pseudo URL path in the browser location bar; however this URL, for example `/dashboard/login`, is not a distinct file on the host system and can't be loaded.

This change introduces a "pbench-in-a-can" Apache config file change that will cause Apache to "rewrite" all URLs under `/dashboard` to redirect to the React App code. The React infrastructure takes care of launching the component.

Since we used to install a `/etc/http/conf.d/pbench.conf` file as part of the Ansible server configuration, and we no longer have server Ansible setup, this also adds an "example" HTTPD configuration file that can be copied during installation. (Note that we probably don't want to automatically install this in the RPM spec file as it won't be used with an external NGINX, but that will require similar mechanism. Which I'm willing to include in the sample NGINX config if someone can tell me how that would look.)

Note that the `<Directory>` spec here is taken mostly intact from a web search and may have excessive verbiage. I haven't experimented too much, but any improvements are welcome.