### PR TITLE
Add a simple server functional test framework

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=6.2.5
+requests

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -50,14 +50,16 @@ pipeline {
                 sh 'buildah push localhost/pbench-server:${PB_SERVER_IMAGE_TAG} ${PB_SERVER_IMAGE}:${PB_SERVER_IMAGE_TAG}'
             }
         }
-        stage('Start, test, and stop the Pbench Server pod') {
+        stage('Deploy server and Run functional tests') {
             steps {
                 sh 'envsubst < server/pbenchinacan/pod-nodata.yml | podman play kube -'
                 sleep 30
+                // Use curl to check when server is responding to API requests
                 retry(count: 10) {
                     sleep 10
-                    sh 'curl localhost:8001/api/v1/endpoints'
+                    sh 'curl --silent localhost:8080/api/v1/endpoints >/dev/null'
                 }
+                sh 'EXTRA_PODMAN_SWITCHES="--network host" jenkins/run server/exec_functests http://localhost:8080'
                 sh 'podman pod stop ${PB_POD_NAME}'
             }
         }
@@ -66,9 +68,10 @@ pipeline {
         always {
             // Remove the pod which we just created and ran; remove any
             // dangling containers; and then remove any dangling images.
-            sh 'podman pod rm -f ${PB_POD_NAME} || true'
+            sh 'podman pod rm --force --ignore ${PB_POD_NAME} || true'
             sh 'podman container prune -f || true'
             sh 'podman image prune -f || true'
+            sh 'podman container cleanup --all --rm'
         }
         success {
             // Note that jenkins/run-pytests is executed inside the container

--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -115,6 +115,7 @@ class PbenchServerClient:
         uri_params: Optional[JSONOBJECT] = None,
         *,
         headers: Optional[Dict[str, str]] = None,
+        raise_error: bool = True,
         **kwargs,
     ) -> requests.Response:
         """
@@ -135,7 +136,8 @@ class PbenchServerClient:
         """
         url = self._uri(api, uri_params)
         response = self.session.get(url, headers=self._headers(headers), **kwargs)
-        response.raise_for_status()
+        if raise_error:
+            response.raise_for_status()
         return response
 
     def head(
@@ -144,6 +146,7 @@ class PbenchServerClient:
         uri_params: Optional[JSONOBJECT] = None,
         *,
         headers: Optional[Dict[str, str]] = None,
+        raise_error: bool = True,
         **kwargs,
     ) -> requests.Response:
         """
@@ -165,7 +168,8 @@ class PbenchServerClient:
         """
         url = self._uri(api, uri_params)
         response = self.session.head(url, headers=self._headers(headers), **kwargs)
-        response.raise_for_status()
+        if raise_error:
+            response.raise_for_status()
         return response
 
     def put(
@@ -175,6 +179,7 @@ class PbenchServerClient:
         *,
         json: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
+        raise_error: bool = True,
         **kwargs,
     ) -> requests.Response:
         """
@@ -199,7 +204,8 @@ class PbenchServerClient:
         response = self.session.put(
             url, json=json, headers=self._headers(headers), **kwargs
         )
-        response.raise_for_status()
+        if raise_error:
+            response.raise_for_status()
         return response
 
     def post(
@@ -209,6 +215,7 @@ class PbenchServerClient:
         *,
         json: Optional[Dict[str, str]] = None,
         headers: Optional[Dict[str, str]] = None,
+        raise_error: bool = True,
         **kwargs,
     ) -> requests.Response:
         """
@@ -233,7 +240,8 @@ class PbenchServerClient:
         response = self.session.post(
             url, json=json, headers=self._headers(headers), **kwargs
         )
-        response.raise_for_status()
+        if raise_error:
+            response.raise_for_status()
         return response
 
     def delete(
@@ -242,6 +250,7 @@ class PbenchServerClient:
         uri_params: Optional[JSONOBJECT] = None,
         *,
         headers: Optional[Dict[str, str]] = None,
+        raise_error: bool = True,
         **kwargs,
     ) -> requests.Response:
         """
@@ -262,7 +271,8 @@ class PbenchServerClient:
         """
         url = self._uri(api, uri_params)
         response = self.session.delete(url, headers=self._headers(headers), **kwargs)
-        response.raise_for_status()
+        if raise_error:
+            response.raise_for_status()
         return response
 
     def connect(self, headers: Optional[Dict[str, str]] = None) -> None:

--- a/lib/pbench/test/functional/server/test_connect.py
+++ b/lib/pbench/test/functional/server/test_connect.py
@@ -21,6 +21,7 @@ class TestConnect:
         "login",
         "logout",
         "register",
+        "server_configuration",
         "upload",
         "user",
     )

--- a/lib/pbench/test/functional/server/test_user.py
+++ b/lib/pbench/test/functional/server/test_user.py
@@ -39,14 +39,14 @@ class TestUser:
                 "first_name": "Test",
                 "last_name": "Account",
                 "password": PASSWORD,
-                "email": f"{USERNAME1}@example.com",
+                "email": f"{USERNAME1}@gmail.com",
             },
             {
                 "username": USERNAME2,
                 "first_name": "Tester",
                 "last_name": "Accountant",
                 "password": PASSWORD,
-                "email": f"{USERNAME2}@example.com",
+                "email": f"{USERNAME2}@gmail.com",
             },
         ],
     )
@@ -56,8 +56,10 @@ class TestUser:
 
         NOTE: This will fail if the username already exists.
         """
-        response = pbench_server_client.post("register", json=json)
-        assert response.status_code == HTTPStatus.CREATED
+        response = pbench_server_client.post("register", json=json, raise_error=False)
+        assert (
+            response.status_code == HTTPStatus.CREATED
+        ), f"Register failed with {response.json()}"
 
     def test_register_redux(self, pbench_server_client: PbenchServerClient):
         """
@@ -68,7 +70,7 @@ class TestUser:
             "first_name": "Repeat",
             "last_name": "Redux",
             "password": PASSWORD,
-            "email": f"{USERNAME1}@example.com",
+            "email": f"{USERNAME1}@gmail.com",
         }
         with pytest.raises(
             HTTPError,

--- a/server/exec_functests
+++ b/server/exec_functests
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Very simple server functional test script
+#
+# Install the Pbench package inside a temporary virtual environment, activate
+# that virtual environment to get access to the pbench.client package (we have
+# no other dependencies here), run the server functional tests, and then
+# deactivate the virtual environment.
+# 
+virtualenv -p /usr/bin/python3 /var/tmp/venv
+source /var/tmp/venv/bin/activate
+python3 -m pip install . -r client/requirements.txt
+
+PBENCH_SERVER=${1} python3 -m pytest ${PWD}/lib/pbench/test/functional/server
+
+deactivate


### PR DESCRIPTION
PBENCH-960

Add a script to install the pbench module so that we can import it normally, then use pytest to execute the functional tests against the server container.

This is invoked by the Jenkins pipeline after activating the pod.

Right now there are only a few functional tests, primarily dealing with the user resource (including login and logout); but they run.