### PR TITLE
Correct use of Python 3.9 for the Server

### DIFF
--- a/server/bin/pbench-trampoline
+++ b/server/bin/pbench-trampoline
@@ -6,14 +6,14 @@ _basename=$(basename ${0})
 if [[ ! ":${PATH}:" =~ ":${_dirname}:" ]]; then
    PATH=${_dirname}${PATH:+:}${PATH}; export PATH
 fi
-if command -v python3 > /dev/null 2>&1 ;then
+if command -v python3.9 > /dev/null 2>&1 ;then
     _pythoncmd=""
 else
-    printf -- "${_basename}: pbench-trampoline needs python3\n" >&2
+    printf -- "${_basename}: pbench-trampoline needs python3.9\n" >&2
     exit 1
 fi
 _installdir=$(dirname ${_dirname})
-export PYTHONPATH=${_installdir}/lib:${_installdir}/lib/python3.8/site-packages:${PYTHONPATH}
+export PYTHONPATH=${_installdir}/lib:${_installdir}/lib/python3.9/site-packages:${_installdir}/lib64/python3.9/site-packages:${PYTHONPATH}
 if [[ -e ${_dirname}/${_basename}.py ]]; then
     # We don't use pbench-base.py to invoke python programs, they can use the
     # PbenchConfig class directly.


### PR DESCRIPTION
When using Python 3.9 on RHEL 8 and it derivatives, one must invoke Python 3.9 via `/usr/bin/python3.9`, and `python3` is either not there or potentially a symlink to `Python 3.6` (in one particular case because PCP was installed first).

We need to use the correct version of Python both in the command and in the `PYTHONPATH`, along with using the `lib64` site packages.