### PR TITLE
Removed secure attribute in cookies

### DIFF
--- a/dashboard/src/actions/authActions.js
+++ b/dashboard/src/actions/authActions.js
@@ -25,14 +25,12 @@ export const makeLoginRequest =
         const expiryTime = keepUser
           ? CONSTANTS.EXPIRY_KEEPUSER_DAYS
           : CONSTANTS.EXPIRY_DEFAULT_DAYS;
-        Cookies.set("isLoggedIn", true, { expires: expiryTime, secure: true });
+        Cookies.set("isLoggedIn", true, { expires: expiryTime });
         Cookies.set("token", response.data?.auth_token, {
           expires: expiryTime,
-          secure: true,
         });
         Cookies.set("username", response.data?.username, {
           expires: expiryTime,
-          secure: true,
         });
         const loginDetails = {
           isLoggedIn: true,


### PR DESCRIPTION
A cookie with the Secure attribute is only sent to the server with an encrypted request over the HTTPS protocol.

As our server is of HTTP protocol, the cookies are not being set. These cookies are used to get the user login details. 

With KeyCloak integration, the entire mechanism for maintain the user login details will be changed so there will be no need to maintain these cookies. 