### PR TITLE
Add xz dependency

### DIFF
--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -9,7 +9,7 @@ Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
 
-Requires: python3 python3-devel cronie
+Requires: python3 python3-devel cronie tar xz
 
 # policycoreutils for semanage and restorecon - used in pbench-server-activate-create-results-dir
 Requires:       policycoreutils


### PR DESCRIPTION
PBENCH-971

Our Pbench Server container doesn't have the xz utility installed, which breaks our unpacker. While I'm at it, I added an explicit `tar` dependency, though there may be others we should have.