### PR TITLE
Propagate exit code correctly from functional testing

### DIFF
--- a/server/exec_functests
+++ b/server/exec_functests
@@ -12,5 +12,8 @@ source /var/tmp/venv/bin/activate
 python3 -m pip install . -r client/requirements.txt
 
 PBENCH_SERVER=${1} python3 -m pytest ${PWD}/lib/pbench/test/functional/server
+rc=$?
 
 deactivate
+
+exit $rc

--- a/server/exec_functests
+++ b/server/exec_functests
@@ -12,7 +12,7 @@ source /var/tmp/venv/bin/activate
 python3 -m pip install . -r client/requirements.txt
 
 PBENCH_SERVER=${1} python3 -m pytest ${PWD}/lib/pbench/test/functional/server
-rc=$?
+rc=${?}
 
 deactivate
 


### PR DESCRIPTION
Currently, the exit code from functional testing is getting lost, so that the result always appears to be successful.

This change corrects that by capturing the result and using it as the exit code when the script exits.