### PR TITLE
Fix React loading path

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -49,6 +49,7 @@
     "test": "react-scripts test"
   },
   "proxy": "http://localhost:3001",
+  "homepage": ".",
   "eslintConfig": {
     "extends": [
       "react-app",


### PR DESCRIPTION
PBENCH-966

We need a "homepage" setting in package.json so that React knows where to load artifacts. The "." will load relative to where we put it, although "dashboard" would probably work as well.