### PR TITLE
Fix the returned user_id type to str

### DIFF
--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -29,7 +29,7 @@ class Auth:
         user_id = None
         user = Auth.token_auth.current_user()
         if user:
-            user_id = user.id
+            user_id = str(user.id)
         return user_id
 
     def encode_auth_token(self, time_delta: datetime.timedelta, user_id: int) -> str:


### PR DESCRIPTION
Bug found during the Pbench Hack-a-Thon, where the auth module `get_user_id` is not returning `user_id` as `str` which is what our dataset and metadata tables expect it.