### PR TITLE
Fix favorite path

### DIFF
--- a/dashboard/src/assets/constants/overviewConstants.js
+++ b/dashboard/src/assets/constants/overviewConstants.js
@@ -7,5 +7,5 @@ export const DATASET_ACCESS = "dataset.access";
 export const DATASET_CREATED = "dataset.created";
 export const DATASET_OWNER = "dataset.owner";
 export const SERVER_DELETION = "server.deletion";
-export const USER_FAVORITE = "user.favorite";
+export const USER_FAVORITE = "user.dashboard.favorite";
 export const EXPIRATION_DAYS_LIMIT = 20;


### PR DESCRIPTION
PBENCH-974

We want to set a convention of clients carving out a second level namespace under "global" and "user". The dashboard already uses this convention for the global namespace; this adds the same convention for the "user" namespace.