### PR TITLE
Move Apache2 logs to journald

### DIFF
--- a/server/lib/config/pbench.httpd.conf
+++ b/server/lib/config/pbench.httpd.conf
@@ -30,3 +30,9 @@
     </Directory>
     ProxyPass / !
 </VirtualHost>
+
+# Our use of the Apache2 instance in our local setup will send logs to syslog.
+ErrorLog  "| /usr/bin/logger -thttpd -plocal6.err"
+<IfModule log_config_module>
+    CustomLog "| /usr/bin/logger -thttpd -plocal6.notice" combined
+</IfModule>

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -9,7 +9,7 @@ Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
 
-Requires: python3 python3-devel cronie tar xz
+Requires: python3 python3-devel cronie tar xz util-linux-core
 
 # policycoreutils for semanage and restorecon - used in pbench-server-activate-create-results-dir
 Requires:       policycoreutils


### PR DESCRIPTION
The additional RPM dependency on `util-linux-core` ensures we have the proper `/usr/bin/logger` command installed.