### PR TITLE
Avoid ConfigParser interpolation

### DIFF
--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -299,7 +299,7 @@ class Tarball:
         """
         if not self.metadata:
             data = self.extract(f"{self.name}/metadata.log")
-            metadata = ConfigParser()
+            metadata = ConfigParser(interpolation=None)
             metadata.read_string(data)
             self.metadata = {s: dict(metadata.items(s)) for s in metadata.sections()}
         return self.metadata

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -878,7 +878,7 @@ def tarball(tmp_path):
     """
     filename = "pbench-user-benchmark_some + config_2021.05.01T12.42.42.tar.xz"
     datafile = tmp_path / filename
-    metadata = ConfigParser()
+    metadata = ConfigParser(interpolation=None)
     metadata.add_section("pbench")
     metadata.set("pbench", "date", "2002-05-16")
     metadata_file = tmp_path / "metadata.log"


### PR DESCRIPTION
PBENCH-978

A dataset may be gathered on a host with a scoped IPv6 address (represented in a format like `0::0%eth0`). The default `ConfigParser` used to read the dataset `metadata.log` interprets `%` characters as a substitution of another config value, and raises an exception because the "eth0" key doesn't exist.

Any `ConfigParser` instance used to process `metadata.log` rather than actual config files chould be created with `interpolation=None`.