### PR TITLE
Leverage the existing `MetadataLog` class

### DIFF
--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -1,4 +1,3 @@
-from configparser import ConfigParser
 from logging import Logger
 from pathlib import Path
 import shlex
@@ -7,7 +6,7 @@ import subprocess
 import tarfile
 from typing import Dict, Optional, Union
 
-from pbench.common import selinux
+from pbench.common import MetadataLog, selinux
 from pbench.server import JSONOBJECT, PbenchServerConfig
 from pbench.server.database.models.datasets import Dataset
 from pbench.server.utils import get_tarball_md5
@@ -299,7 +298,7 @@ class Tarball:
         """
         if not self.metadata:
             data = self.extract(f"{self.name}/metadata.log")
-            metadata = ConfigParser(interpolation=None)
+            metadata = MetadataLog()
             metadata.read_string(data)
             self.metadata = {s: dict(metadata.items(s)) for s in metadata.sections()}
         return self.metadata

--- a/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
+++ b/lib/pbench/test/unit/agent/task/test_add_metalog_option.py
@@ -1,6 +1,5 @@
-import configparser
-
 from pbench.cli.agent.commands.log import add_metalog_option
+from pbench.common import MetadataLog
 
 
 class TestAddMetalogOption:
@@ -15,7 +14,7 @@ class TestAddMetalogOption:
         # New section, new option
         add_metalog_option(mdlog, "new", "new_option", "420")
 
-        cfg = configparser.ConfigParser()
+        cfg = MetadataLog()
         cfg.read(mdlog)
 
         sections = cfg.sections()
@@ -32,7 +31,7 @@ class TestAddMetalogOption:
         # Existing section, new option
         add_metalog_option(mdlog, "existing", "new_option", "142")
 
-        cfg = configparser.ConfigParser()
+        cfg = MetadataLog()
         cfg.read(mdlog)
 
         sections = cfg.sections()
@@ -50,7 +49,7 @@ class TestAddMetalogOption:
         # Existing section, existing option
         add_metalog_option(mdlog, "existing", "existing_option", "42")
 
-        cfg = configparser.ConfigParser()
+        cfg = MetadataLog()
         cfg.read(mdlog)
 
         sections = cfg.sections()

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -1,4 +1,3 @@
-from configparser import ConfigParser
 import datetime
 import hashlib
 import os
@@ -15,6 +14,7 @@ from freezegun import freeze_time
 import jwt
 import pytest
 
+from pbench.common import MetadataLog
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
@@ -878,7 +878,7 @@ def tarball(tmp_path):
     """
     filename = "pbench-user-benchmark_some + config_2021.05.01T12.42.42.tar.xz"
     datafile = tmp_path / filename
-    metadata = ConfigParser(interpolation=None)
+    metadata = MetadataLog()
     metadata.add_section("pbench")
     metadata.set("pbench", "date", "2002-05-16")
     metadata_file = tmp_path / "metadata.log"


### PR DESCRIPTION
Furthering work from PR #3074, we use the `MetadataLog` class we already had to encapsulate the `metadata.log` manipulation going forward.