### PR TITLE
Backport `metadata.log` interpolation fix

### DIFF
--- a/agent/util-scripts/pbench-add-metalog-option
+++ b/agent/util-scripts/pbench-add-metalog-option
@@ -13,7 +13,7 @@ import sys
 from configparser import ConfigParser, NoSectionError
 
 def main(lfile, section, option):
-    config = ConfigParser()
+    config = ConfigParser(interpolation=None)
     config.read(lfile)
     # python3
     # config[section][option] = ', '.join(sys.stdin.read().split())

--- a/server/bin/pbench-cull-unpacked-tarballs.py
+++ b/server/bin/pbench-cull-unpacked-tarballs.py
@@ -86,7 +86,7 @@ def fetch_username(tb_incoming_dir):
     """fetch_username - Return the pbench "run"'s "user" value from the
     `metadata.log` file, if it exists.
     """
-    config = ConfigParser()
+    config = ConfigParser(interpolation=None)
     try:
         config.read(os.path.join(tb_incoming_dir, "metadata.log"))
     except Exception:

--- a/server/lib/pbench/indexer.py
+++ b/server/lib/pbench/indexer.py
@@ -3929,7 +3929,7 @@ class PbenchTarBall(object):
         md5sum = open("%s.md5" % (self.tbname)).read().split()[0]
         # Construct the @metadata and run metadata dictionaries from the
         # metadata.log file.
-        self.mdconf = ConfigParser()
+        self.mdconf = ConfigParser(interpolation=None)
         mdf = os.path.join(self.extracted_root, metadata_log_path)
         try:
             # Read and parse the metadata.log file.


### PR DESCRIPTION
This is a backport of commit 97895ba6d (PR #3074).

We turn of interpolation of the values encountered in the `metadata.log` files since we don't use that feature and some values may contain a `%` character triggering the interpolation by default.