### PR TITLE
Tweak canned Pbench Server pod definition

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -24,6 +24,7 @@ pipeline {
             )}"""
         PB_SERVER_IMAGE="${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver"
         PB_POD_NAME="pbenchinacan_${PB_SERVER_IMAGE_TAG}"
+        PB_DASHBOARD_DIR="${WORKSPACE}/dashboard/build/"
     }
     stages {
         stage('Agent Python3.6 Check') {

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -158,7 +158,7 @@ spec:
   volumes:
   - name: dashboard_deployment
     hostPath:
-      path: /home/pbench/html/dashboard
+      path: ${PB_DASHBOARD_DIR}
       type: DirectoryOrCreate
     workingDir: /
   dnsConfig: {}

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -136,6 +136,7 @@ spec:
     - name: container
       value: oci
     image: ${PB_SERVER_IMAGE}:${PB_SERVER_IMAGE_TAG}
+    imagePullPolicy: Always
     name: pbenchserver
     ports:
       - containerPort: 22
@@ -151,6 +152,14 @@ spec:
       privileged: false
       readOnlyRootFilesystem: false
       seLinuxOptions: {}
+    volumeMounts:
+    - mountPath: /var/www/html/dashboard
+      name: dashboard_deployment
+  volumes:
+  - name: dashboard_deployment
+    hostPath:
+      path: /home/pbench/html/dashboard
+      type: DirectoryOrCreate
     workingDir: /
   dnsConfig: {}
   restartPolicy: Never

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -166,7 +166,7 @@ spec:
   volumes:
   - name: dashboard_deployment
     hostPath:
-      path: /home/pbench/html/dashboard
+      path: ${PB_DASHBOARD_DIR}
       type: DirectoryOrCreate
     workingDir: /
   dnsConfig: {}

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -61,6 +61,7 @@ spec:
     - name: xpack.security.enabled
       value: "false"
     image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-elasticsearch:${PB_SERVER_IMAGE_TAG}
+    imagePullPolicy: Always
     name: elasticsearch
     ports:
       - containerPort: 9200
@@ -119,6 +120,7 @@ spec:
     - name: POSTGRESQL_DATABASE
       value: pbenchcontainer
     image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-postgresql:${PB_SERVER_IMAGE_TAG}
+    imagePullPolicy: Always
     name: postgresql
     ports:
       - containerPort: 5432
@@ -142,6 +144,7 @@ spec:
     - name: container
       value: oci
     image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver:${PB_SERVER_IMAGE_TAG}
+    imagePullPolicy: Always
     name: pbenchserver
     ports:
       - containerPort: 22
@@ -157,6 +160,14 @@ spec:
       privileged: false
       readOnlyRootFilesystem: false
       seLinuxOptions: {}
+    volumeMounts:
+    - mountPath: /var/www/html/dashboard
+      name: dashboard_deployment
+  volumes:
+  - name: dashboard_deployment
+    hostPath:
+      path: /home/pbench/html/dashboard
+      type: DirectoryOrCreate
     workingDir: /
   dnsConfig: {}
   restartPolicy: Never


### PR DESCRIPTION
Add a mapping to allow the Dashboard deployment to be pulled into the container from outside.

Also, add policies to always pull the Pbench Server container image (and, in the with-data pod, pull the other two container images as well).