### PR TITLE
Prepare Agent container builds for use in the CI

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -7,6 +7,11 @@ FROM {{ image_repo }}/{{ image_name }}:{{ image_tag }}
 # Install the appropriate pbench repository file for {{ distro_name }}.
 COPY ./{{ pbench_repo_file }} /etc/yum.repos.d/pbench.repo
 
+# The package manager will install the Pbench Agent from {{ rpm_path }}:  that
+# reference can be either a local file in the container or a package name which
+# the package manager will look up in the repository which we set up above.  If
+# rpm_host_file is defined, then it points to a local binary RPM package file,
+# and we copy it from the build context to the right spot for the installation.
 {% if rpm_host_file %}
 COPY ./{{ rpm_host_file }} {{ rpm_path }}
 {% endif %}

--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -7,6 +7,10 @@ FROM {{ image_repo }}/{{ image_name }}:{{ image_tag }}
 # Install the appropriate pbench repository file for {{ distro_name }}.
 COPY ./{{ pbench_repo_file }} /etc/yum.repos.d/pbench.repo
 
+{% if rpm_host_file %}
+COPY ./{{ rpm_host_file }} {{ rpm_path }}
+{% endif %}
+
 # Install the pbench-agent RPM, which should have all its dependencies enumerated;
 # ... and make sure we have a proper pbench-agent.cfg file in place;
 # ... and finally, ensure the proper pbench-agent environment variables are set up.
@@ -21,9 +25,9 @@ RUN \
         {% if is_centos_8 %}--enablerepo powertools {% endif %} \
         {% if is_centos_9 %}--enablerepo crb {% endif %} \
         {% if is_centos_8 or is_centos_9 %} glibc-locale-source {% endif %} \
-        pbench-agent && \
+        {{ rpm_path }} && \
 {% if is_centos_8 or is_centos_9 %}
     localedef -i en_US -f UTF-8 en_US.UTF-8 && \
 {% endif %}
     {{ pkgmgr }} -y clean all && \
-    rm -rf /var/cache/{{ pkgmgr }}
+    rm -rf /var/cache/{{ pkgmgr }} {% if rpm_host_file %}{{ rpm_path }}{% endif %}

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -370,4 +370,4 @@ all-tags: pkgmgr-clean $(_DEFAULT_DISTROS:%=%-tags.lis)
 	curl -sSf "${_PROMETHEUS_REPO_URL}" > $@
 
 clean:
-	rm -f *.Dockerfile *.repo *.yml *-tags.lis
+	rm -f *.Dockerfile *.repo *.yml *-tags.lis pbench-agent-*-*.noarch.rpm.*

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -4,6 +4,10 @@
 #
 
 _PBENCH_TOP := $(shell git rev-parse --show-toplevel)
+_LOCAL_GIT_HASH := $(shell git rev-parse --short=9 HEAD)
+_LOCAL_VERSION := $(shell cat ${_PBENCH_TOP}/agent/VERSION)
+_LOCAL_MAJORMINOR := $(shell grep -oE '[0-9]+\.[0-9]+' ${_PBENCH_TOP}/agent/VERSION)
+_LOCAL_MAJOR_VER := $(firstword $(subst ., ,${_LOCAL_VERSION}))
 
 # Include definition of _DISTROS
 include ${_PBENCH_TOP}/utils/utils.mk
@@ -25,7 +29,7 @@ URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 # the final repo name would be "pbench-test".
 TEST =
 _TEST_SUFFIX = $(if $(TEST),-$(TEST),)
-_PBENCH_REPO_NAME = pbench-$(shell grep -oE '[0-9]+\.[0-9]+' ${_PBENCH_TOP}/agent/VERSION)${_TEST_SUFFIX}
+_PBENCH_REPO_NAME = pbench-${_LOCAL_MAJORMINOR}${_TEST_SUFFIX}
 
 # By default we use the pbench Quay.io organization for the image
 # repository.  You can override this default using an environment
@@ -230,6 +234,19 @@ $(_ALL_fedora_VERSIONS:%=%-tools) centos-7-tools centos-8-tools: %-tools: %-pcp.
 %-base: %-base.Dockerfile %-pbench.repo %-tags.lis
 	./build-image base $* $*-tags.lis
 
+_PKGMGR = dnf
+centos-7-base.Dockerfile: _PKGMGR = yum
+%-base.Dockerfile: _FANCY_NAME = $(if $(filter fedora,${DIST_NAME}),Fedora,$(if $(filter centos,${DIST_NAME}),CentOS,${DISTNAME}))
+
+%-base.Dockerfile: Dockerfile.base.j2
+	jinja2 Dockerfile.base.j2 -o $@ \
+        -D distro_name="${_FANCY_NAME} ${DIST_VERSION}" \
+        -D image_name=${DIST_NAME} \
+        -D image_repo=quay.io/${DIST_NAME} \
+        -D image_rev=${DIST_VERSION} \
+        -D pbench_repo_file=${DIST_NAME}-${DIST_VERSION}-pbench.repo \
+        -D pkgmgr=${_PKGMGR}
+
 #+
 # Push local images for the given tag and distribution.
 #-
@@ -277,26 +294,6 @@ $(foreach tagtype,${_TAG_TYPES},$(eval $(call _TAG_RULE,${tagtype})))  # Define 
 pkgmgr-clean:
 	dnf clean all
 
-#+
-# For the following rules, the various CentOS "base" images need a mapping
-# between the distribution name and the repo name, which for CentOS images
-# is "epel".  And for both CentOS and Fedora, the distribution image
-# reference, the package manager (dnf vs yum), and image name, also require
-# mappings (e.g. centos-7 -> yum, centos:7, CentOS 7; or fedora-## -> dnf,
-# fedora:##, Fedora ##).
-#-
-_PKGMGR = dnf
-centos-7-base.Dockerfile: _PKGMGR = yum
-
-centos-%-base.Dockerfile: Dockerfile.base.j2
-	jinja2 Dockerfile.base.j2 -D pbench_repo_file=centos-$*-pbench.repo \
-        -D pkgmgr=${_PKGMGR} -D distro_name="CentOS $*" -o $@ \
-        -D image_repo=quay.io/centos -D image_name=centos -D image_rev=$*
-
-fedora-%-base.Dockerfile: Dockerfile.base.j2
-	jinja2 Dockerfile.base.j2 -D pbench_repo_file=fedora-$*-pbench.repo \
-        -D pkgmgr=dnf -D distro_name="Fedora $*" -o $@ \
-        -D image_repo=quay.io/fedora -D image_name=fedora -D image_rev=$*
 
 # Helper target to build each distro's ".repo" and ".Dockerfile"
 all-dockerfiles: \

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -80,7 +80,10 @@ _WORKLOAD_RPMS = fio uperf
 _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 
 # By default we only build images for the following distributions.
-_DEFAULT_DISTROS = centos-7 centos-8 centos-9 fedora-35 fedora-36
+_DEFAULT_DISTROS = \
+	centos-9 centos-8 centos-7 \
+	fedora-36 fedora-35
+#	rhel-9 rhel-8 rhel-7
 
 # By default we build the Tool Data Sink and Tool Meister images as well.
 everything: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
@@ -94,6 +97,9 @@ tds: all-tags $(_DEFAULT_DISTROS:%=%-tool-data-sink-tagged)
 
 # Convenience target to only build the Tool Meister images.
 tm: all-tags $(_DEFAULT_DISTROS:%=%-tool-meister-tagged)
+
+# Convenience target to only build the base images.
+baseimage: all-tags $(_DEFAULT_DISTROS:%=%-base-tagged)
 
 #+
 # For the following rule patterns, the "%" represents the "distribution" name,
@@ -113,6 +119,8 @@ $(_DISTROS:%=%-everything): %-everything: pkgmgr-clean %-all-tagged
 $(_DISTROS:%=%-tds): %-tds: pkgmgr-clean %-tool-data-sink-tagged
 
 $(_DISTROS:%=%-tm): %-tm: pkgmgr-clean %-tool-meister-tagged
+
+$(_DISTROS:%=%-baseimage): %-baseimage: pkgmgr-clean %-base-tagged
 
 # For any given target, extract the distribution name and version from the
 # first two fields, e.g., fedora-35-tds would yield values "fedora" and "35"

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -30,17 +30,10 @@ URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 #   - ${CI_RPM_LOC}:  the local directory tree for the Agent RPM package file
 #   - ${_RPM_PATH}:  the full path to the package file
 #   - ${_RPM_FILE}:  the name of the package file, without the directory path
-# (otherwise, these variables are not used).
 #
-# When run under the CI, we will copy the package from ${_RPM_PATH} to the
-# current directory and name it ${_RPM_FILE} -- this is necessary to make it
-# available to the container build, which is limited to just the current
-# directory tree -- the container build will copy the RPM file from the build
-# context into the container.
-#
-# The package manager installs the Agent, either from the local file (when run
-# under the CI) or (when not running under the CI) by looking up the package by
-# name in the repository pointed at by the .repo file (e.g., from COPR).
+# When not run under the CI, these variables are not used; however, ${_RPM_FILE}
+# is tested (and found to be "false"), which results in appropriate default
+# values being used, instead.
 ifdef CI
 CI_RPM_ROOT ?= ${HOME}
 CI_RPM_LOC = ${CI_RPM_ROOT}/rpmbuild-${DIST_NAME}-${DIST_VERSION}/RPMS/noarch
@@ -260,6 +253,16 @@ $(_ALL_fedora_VERSIONS:%=%-tools) centos-7-tools centos-8-tools: %-tools: %-pcp.
 %-base-tagged: %-base %-tags.lis
 	./apply-tags pbench-agent-base-$* $*-tags.lis
 
+# When run under the CI, we copy the package file from ${_RPM_PATH} to the
+# current directory and name it ${_RPM_FILE}.<distro> -- this is necessary to
+# make it available to the container build, which is limited to just the current
+# directory tree -- the container build will copy the RPM file from the build
+# context into the container.  (Adding the distro-specific suffix allows builds
+# of different distros to proceed without interfering with each other.)
+#
+# The package manager installs the Agent, either from the local file (when run
+# under the CI) or (when not running under the CI) by looking up the package by
+# name in the repository pointed at by the .repo file (e.g., from COPR).
 %-base: %-base.Dockerfile %-pbench.repo %-tags.lis
 ifdef CI
 	if [[ -z "${_RPM_PATH}" ]] ; then echo "No RPM found with ID ${_LOCAL_GIT_HASH} for ${_LOCAL_MAJORMINOR} in ${CI_RPM_LOC}" >&2 ; exit 2 ; fi

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -24,6 +24,30 @@ COPR_USER = ndokos
 # using an environment variable as appropriate.
 URL_PREFIX = https://copr-be.cloud.fedoraproject.org/results/${COPR_USER}
 
+# When run under the CI,
+#   - ${CI_RPM_ROOT}:  the root of the directory tree for the Agent RPM package
+#     file -- set to ${HOME} if not specified on the Make command line
+#   - ${CI_RPM_LOC}:  the local directory tree for the Agent RPM package file
+#   - ${_RPM_PATH}:  the full path to the package file
+#   - ${_RPM_FILE}:  the name of the package file, without the directory path
+# (otherwise, these variables are not used).
+#
+# When run under the CI, we will copy the package from ${_RPM_PATH} to the
+# current directory and name it ${_RPM_FILE} -- this is necessary to make it
+# available to the container build, which is limited to just the current
+# directory tree -- the container build will copy the RPM file from the build
+# context into the container.
+#
+# The package manager installs the Agent, either from the local file (when run
+# under the CI) or (when not running under the CI) by looking up the package by
+# name in the repository pointed at by the .repo file (e.g., from COPR).
+ifdef CI
+CI_RPM_ROOT ?= ${HOME}
+CI_RPM_LOC = ${CI_RPM_ROOT}/rpmbuild-${DIST_NAME}-${DIST_VERSION}/RPMS/noarch
+_RPM_PATH = $(wildcard ${CI_RPM_LOC}/pbench-agent-${_LOCAL_MAJORMINOR}*${_LOCAL_GIT_HASH}.noarch.rpm)
+_RPM_FILE = $(notdir ${_RPM_PATH})
+endif
+
 # By default we use non-"test" COPR repos named "pbench".  We expect
 # test COPR repos to have a suffix added, typically "test", so that
 # the final repo name would be "pbench-test".
@@ -128,7 +152,12 @@ $(_DISTROS:%=%-baseimage): %-baseimage: pkgmgr-clean %-base-tagged
 
 # For any given target, extract the distribution name and version from the
 # first two fields, e.g., fedora-35-tds would yield values "fedora" and "35"
-# for DIST_NAME and DIST_VERSION, respectively.
+# for DIST_NAME and DIST_VERSION, respectively.  NOTE:  in these definitions,
+# the '%' is a wildcard for the (entire) current target, and it does NOT
+# contribute to the value of $* used here -- that value is provided by the '%'
+# in the target of the pattern rule whose recipe is referencing these values;
+# so, these definitions only work properly when that target's '%' matches
+# something which starts with <dist>-<version>.
 %: DIST_NAME = $(wordlist 1, 1, $(subst -, ,$*))
 %: DIST_VERSION = $(wordlist 2, 2, $(subst -, ,$*))
 
@@ -232,7 +261,15 @@ $(_ALL_fedora_VERSIONS:%=%-tools) centos-7-tools centos-8-tools: %-tools: %-pcp.
 	./apply-tags pbench-agent-base-$* $*-tags.lis
 
 %-base: %-base.Dockerfile %-pbench.repo %-tags.lis
+ifdef CI
+	if [[ -z "${_RPM_PATH}" ]] ; then echo "No RPM found with ID ${_LOCAL_GIT_HASH} for ${_LOCAL_MAJORMINOR} in ${CI_RPM_LOC}" >&2 ; exit 2 ; fi
+	if grep ' ' <<< ${_RPM_PATH} ; then echo "Multiple RPMs found:  ${_RPM_PATH}" >&2 ; exit 2 ; fi
+	cp ${_RPM_PATH} ./${_RPM_FILE}.${*}
+endif
 	./build-image base $* $*-tags.lis
+ifdef CI
+	rm -f ./${_RPM_FILE}.${*}
+endif
 
 _PKGMGR = dnf
 centos-7-base.Dockerfile: _PKGMGR = yum
@@ -245,7 +282,9 @@ centos-7-base.Dockerfile: _PKGMGR = yum
         -D image_repo=quay.io/${DIST_NAME} \
         -D image_rev=${DIST_VERSION} \
         -D pbench_repo_file=${DIST_NAME}-${DIST_VERSION}-pbench.repo \
-        -D pkgmgr=${_PKGMGR}
+        -D pkgmgr=${_PKGMGR} \
+        -D rpm_host_file="$(if ${_RPM_FILE},./${_RPM_FILE}.${*},)" \
+        -D rpm_path=$(if ${_RPM_FILE},./${_RPM_FILE},pbench-agent)
 
 #+
 # Push local images for the given tag and distribution.
@@ -284,7 +323,15 @@ $(foreach tagtype,${_TAG_TYPES},$(eval $(call _TAG_RULE,${tagtype})))  # Define 
 
 # Build the tags file for the given distribution. (We rename "centos" to "epel".)
 %-tags.lis:
+ifdef CI
+	if [[ -z "${_RPM_PATH}" ]] ; then echo "No RPM found with ID ${_LOCAL_GIT_HASH} for ${_LOCAL_MAJORMINOR} in ${CI_RPM_LOC}" >&2 ; exit 2 ; fi
+	if grep ' ' <<< ${_RPM_PATH} ; then echo "Multiple RPMs found:  ${_RPM_PATH}" >&2 ; exit 2 ; fi
+	printf -- "%s\n" ${_LOCAL_GIT_HASH} > ${@}
+	printf -- "v%s\n" "$(shell grep -Eo '[0-9]+\.[0-9]+\.([0-9]+(-[0-9]+)?)?' <<< "${_RPM_PATH}")" >> ${@}
+	printf -- "v%s-latest v%s-latest\n" ${_LOCAL_MAJOR_VER} ${_LOCAL_MAJORMINOR} >> ${@}
+else
 	./gen-tags-from-rpm "${URL_PREFIX}" "$(subst centos,epel,$*)" "${_ARCH}" "${_PBENCH_REPO_NAME}" > ${@}
+endif
 
 # This file takes a long time to generate, so preserve it between builds (it can
 # be removed explicitly via the `clean` target).

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -108,6 +108,7 @@ enough to push the actual image only once.
 These act on the default platforms' containers:
 
  * `everything` (default):  make every image for the default platforms
+ * `baseimage`: make Agent base images for the default platforms
  * `tds`:  make Tool Data Sink images for the default platforms
  * `tm`:  make Tool Meister images for the default platforms
  * `tag-<TYPE>` (e.g., "tag-latest"):  apply specified tag to every image for
@@ -120,6 +121,7 @@ These act on the default platforms' containers:
 These act on the indicated distribution's containers:
 
  * `<DISTRO>` (e.g., "fedora-34"):  make every image kind for the distribution
+ * `<DISTRO>-baseimage` (e.g., "fedora-34-baseimage"):  make the Agent base image for the distro
  * `<DISTRO>-tds` (e.g., "fedora-34-tds"):  make the TDS image for the distro
  * `<DISTRO>-tm` (e.g., "fedora-34-tm"):  make the TM image for the distro
  * `<DISTRO>-tag-<TYPE>` (e.g., "fedora-34-tag-alpha"):  apply the specified

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -43,7 +43,8 @@ ifeq ($(origin seqno), undefined)
   seqno := $(call get_sequence_number,./seqno)
 endif
 
-export  # Export the definitions above in the invocation of the sub-make.
+# Export the definitions above in the invocation of the sub-make.
+export CHROOTS component subcomps seqno
 
 # For historical compatibility, this is the default target.
 all: srpm

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -30,21 +30,17 @@ ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 component = agent
 subcomps = agent
 
+include ../../utils/utils.mk
+
 # Generate a sequence number to be used for the RPMs:  by default, the number
-# will be 1; if the ./seqno file exists, use the number from the file and
+# will be 1; if the ./seqno file exists, use the number from the file and then
 # increment it.  However, do this only if `seqno` is not already defined, and
 # use a "simple assignment" to ensure that it is not incremented more than once.
 # ("Conditional assignment" (?=) apparently produces a "recursive assignment",
 # which gets re-evaluated each time the variable is referenced, which results in
 # multiple increments.)
 ifeq ($(origin seqno), undefined)
-  seqno := $(shell \
-	s=1 ; \
-	if [[ -e ./seqno ]] ; then \
-	  s=$$(< ./seqno) ; \
-	  echo $$((s+1)) >./seqno ; \
-	fi ; \
-	echo $$s )
+  seqno := $(call get_sequence_number,./seqno)
 endif
 
 export  # Export the definitions above in the invocation of the sub-make.
@@ -72,4 +68,4 @@ FORCE: ;
 
 # This recipe does nothing, other than to avoid running the catch-all recipe
 # when Make does the implicit Makefile target check.
-Makefile: ;
+Makefile ../../utils/utils.mk: ;

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -23,8 +23,8 @@ CHROOTS =
 # These targets build the binary RPM for the specified distro version; the "ci"
 # target builds them all.
 RHEL_RPMS = rhel-9-rpm rhel-8-rpm rhel-7-rpm
-CENTOS_RPMS = centos-9-rpm centos-8-rpm
-FEDORA_RPMS = fedora-34-rpm fedora-35-rpm fedora-36-rpm
+CENTOS_RPMS = centos-9-rpm centos-8-rpm centos-7-rpm
+FEDORA_RPMS = fedora-36-rpm fedora-35-rpm
 ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 
 component = agent

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -30,6 +30,23 @@ ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 component = agent
 subcomps = agent
 
+# Generate a sequence number to be used for the RPMs:  by default, the number
+# will be 1; if the ./seqno file exists, use the number from the file and
+# increment it.  However, do this only if `seqno` is not already defined, and
+# use a "simple assignment" to ensure that it is not incremented more than once.
+# ("Conditional assignment" (?=) apparently produces a "recursive assignment",
+# which gets re-evaluated each time the variable is referenced, which results in
+# multiple increments.)
+ifeq ($(origin seqno), undefined)
+  seqno := $(shell \
+	s=1 ; \
+	if [[ -e ./seqno ]] ; then \
+	  s=$$(< ./seqno) ; \
+	  echo $$((s+1)) >./seqno ; \
+	fi ; \
+	echo $$s )
+endif
+
 export  # Export the definitions above in the invocation of the sub-make.
 
 # For historical compatibility, this is the default target.
@@ -52,3 +69,7 @@ ci: ${ALL_RPMS} ;
 
 # This recipe does nothing, other than to force the previous one to run.
 FORCE: ;
+
+# This recipe does nothing, other than to avoid running the catch-all recipe
+# when Make does the implicit Makefile target check.
+Makefile: ;

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -22,7 +22,7 @@ include ../utils/utils.mk
 RPMBUILD_BASEIMAGE_DEFAULTS = \
 	rhel-9 rhel-8 rhel-7 \
 	fedora-36 fedora-35 \
-	centos-9 centos-8
+	centos-9 centos-8 centos-7
 
 # All Fedora images are based on Fedora 35
 FEDORA_BASE_IMAGE_REF = quay.io/fedora/fedora:35
@@ -89,6 +89,9 @@ ${_DISTROS:%=push-rpmbuild-%}: push-rpmbuild-%:
 	buildah push localhost/pbench-rpmbuild:${*} ${RPMBUILD_IMAGE_REPO}/pbench-rpmbuild:${*}
 
 image-rpmbuild-rhel-7 : PKGMGR = yum
+image-rpmbuild-centos-7 : PKGMGR = yum
+image-rpmbuild-centos-7 : RPMBUILD_BASEIMAGE_centos = quay.io/centos/centos:centos7
+
 ${_DISTROS:%=image-rpmbuild-%}: image-rpmbuild-%:
 	container=$$(buildah from ${RPMBUILD_BASEIMAGE_REPO}) && \
 		buildah run $$container ${PKGMGR} install -y ${RPMBUILD_PACKAGES} && \

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -21,21 +21,17 @@ CHROOTS = --chroot rhel-9.dev-x86_64
 component = server
 subcomps = server web-server
 
+include ../../utils/utils.mk
+
 # Generate a sequence number to be used for the RPMs:  by default, the number
-# will be 1; if the ./seqno file exists, use the number from the file and
+# will be 1; if the ./seqno file exists, use the number from the file and then
 # increment it.  However, do this only if `seqno` is not already defined, and
 # use a "simple assignment" to ensure that it is not incremented more than once.
 # ("Conditional assignment" (?=) apparently produces a "recursive assignment",
 # which gets re-evaluated each time the variable is referenced, which results in
 # multiple increments.)
 ifeq ($(origin seqno), undefined)
-  seqno := $(shell \
-	s=1 ; \
-	if [[ -e ./seqno ]] ; then \
-	  s=$$(< ./seqno) ; \
-	  echo $$((s+1)) >./seqno ; \
-	fi ; \
-	echo $$s )
+  seqno := $(call get_sequence_number,./seqno)
 endif
 
 include ../../utils/rpm.mk

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -21,6 +21,23 @@ CHROOTS = --chroot rhel-9.dev-x86_64
 component = server
 subcomps = server web-server
 
+# Generate a sequence number to be used for the RPMs:  by default, the number
+# will be 1; if the ./seqno file exists, use the number from the file and
+# increment it.  However, do this only if `seqno` is not already defined, and
+# use a "simple assignment" to ensure that it is not incremented more than once.
+# ("Conditional assignment" (?=) apparently produces a "recursive assignment",
+# which gets re-evaluated each time the variable is referenced, which results in
+# multiple increments.)
+ifeq ($(origin seqno), undefined)
+  seqno := $(shell \
+	s=1 ; \
+	if [[ -e ./seqno ]] ; then \
+	  s=$$(< ./seqno) ; \
+	  echo $$((s+1)) >./seqno ; \
+	fi ; \
+	echo $$s )
+endif
+
 include ../../utils/rpm.mk
 
 ci: rhel-9-rpm

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -60,7 +60,7 @@ RPMSRPM = ${BLD_DIR}/SRPMS
 RPMSPEC = ${BLD_DIR}/SPECS
 RPMTMP = ${BLD_DIR}/TMP
 
-sha1 := $(shell git rev-parse --short HEAD)
+sha1 := $(shell git rev-parse --short=9 HEAD)
 seqno := $(shell if [ -e ./seqno ] ;then cat ./seqno ;else echo "1" ;fi)
 
 $(info Building ${MAKECMDGOALS} for ${prog}-${VERSION} from ${TBDIR} to ${BLD_DIR})

--- a/utils/rpm.mk
+++ b/utils/rpm.mk
@@ -61,7 +61,9 @@ RPMSPEC = ${BLD_DIR}/SPECS
 RPMTMP = ${BLD_DIR}/TMP
 
 sha1 := $(shell git rev-parse --short=9 HEAD)
-seqno ?= 1
+ifeq ($(origin seqno), undefined)
+  seqno := 1
+endif
 
 RPM_NAME = ${prog}-${VERSION}-${seqno}g${sha1}
 PATCH_FILES = $(wildcard ./patches/*)

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -26,7 +26,7 @@ _empty:=
 _space:= ${_empty} ${_empty}
 
 # This is a "function" which is intended to produce a sequence number managed in
-# in the specified file.  If the file does not exist, the function returns 1;
+# the specified file.  If the file does not exist, the function returns 1;
 # otherwise, it reads the current value from the file, increments it, writes it
 # back to the file, and returns the originally read number.
 get_sequence_number = $(shell \

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -24,3 +24,15 @@ _DISTROS := $(foreach d,${_ALL_DISTRO_NAMES},${_ALL_${d}_VERSIONS})
 # then use that as a delimiter around a space character, and viola.
 _empty:=
 _space:= ${_empty} ${_empty}
+
+# This is a "function" which is intended to produce a sequence number managed in
+# in the specified file.  If the file does not exist, the function returns 1;
+# otherwise, it reads the current value from the file, increments it, writes it
+# back to the file, and returns the originally read number.
+get_sequence_number = $(shell \
+	s=1 ; \
+	if [[ -e $(1) ]] ; then \
+	  s=$$(< $(1)) ; \
+	  echo $$((s+1)) >$(1) ; \
+	fi ; \
+	echo $$s )

--- a/utils/utils.mk
+++ b/utils/utils.mk
@@ -36,3 +36,8 @@ get_sequence_number = $(shell \
 	  echo $$((s+1)) >$(1) ; \
 	fi ; \
 	echo $$s )
+
+# Make sure that the get_sequence_number variable is _not_ exported to any
+# sub-makes:  the process of exporting a variable includes evaluating it, and
+# we don't want it evaluated except when it is explicitly $(CALL)'d.
+unexport get_sequence_number


### PR DESCRIPTION
This PR is a sequence of commits which prepare the Agent container builds for use in the CI.  (Actually updating the CI pipeline will come in a subsequent PR.)

 -  Housekeeping for building Agent containers
    - Make the default-distros lists consistent across the rpmbuild container builds, the builds of the RPMs, and the build of the containerized Agents
    - Add `baseimage` convenience targets for the Agent base containers for all default distros
    - Enable building the CentOS-7 rpmbuild container
    - Force the use of (at least) 9 digits for the Git hash (e.g. on CentOS-7)
 -  Agent container build tweaks
     - Rework version management
     - Combine the `%-base.Dockerfile` rules into a single rule
 -  Enable Agent container build to use a local RPM instead of COPR
     - Tweak the base image Dockerfile template to allow the location of the Agent RPM to be specified by the Makefile
     - For a local RPM file, arrange to have it copied into the container context and into the container for installation
     - Provide an alternative generation of the `*-tags.lis` files for local RPMs
 - Generate and update the sequence number for the RPMs in the parent Makefiles instead of doing it in `util/rpm.mk`:  this allows the CI (e.g.) to use a single number for all of the distro binary RPMs.  The number is generated conditionally so that it can be provided externally, and the nested Make invocation now takes advantage of this.
 -  Rework the RPM build Makefile
     - Replace the phony targets `patches`, `rpm`, `srpm`, `spec`, and `tarball` with the corresponding real targets.  (We still provide targets `rpm` and `srpm` for user convenience, and we retain `patches` as an implementation convenience.)
     - Rework the dependencies of many of the targets to correct the relationships.  E.g., since the binary RPM does not depend on the source RPM (they are each built from the spec-file/tar-ball), this commit removes that dependency specification.  Nevertheless, since the tarball creation depends on the subcomponent targets, which are phony targets, the build will normally "do everything" every time it is run; but, in the case of the CI builds, we will no longer be building the source RPM _eight_ times.

If all the changes are approved, I propose squashing all of these changes into a single commit.

PBENCH-721