### PR TITLE
Add a method to wait for PostgreSQL to show up

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -156,7 +156,7 @@ def main():
         host = str(server_config.get("pbench-server", "bind_host"))
         port = str(server_config.get("pbench-server", "bind_port"))
         db_uri = str(server_config.get("database", "uri"))
-        db_wait_timeout = str(server_config.get("database", "wait_timeout"))
+        db_wait_timeout = int(server_config.get("database", "wait_timeout"))
         workers = str(server_config.get("pbench-server", "workers"))
         worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
         oidc_server = server_config.get(

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -17,15 +17,12 @@ class Database:
         engine_uri = None
         try:
             engine_uri = config.get("database", "uri")
-        except NoSectionError:
-            msg = "Failed to find [database] section in configuration file."
-        except NoOptionError:
-            msg = "Failed to find 'uri' value in [database] section of configuration file."
-        if engine_uri is None:
+        except (NoSectionError, NoOptionError) as exc:
+            msg = "Error in configuration file: {}"
             if logger:
-                logger.error(msg)
+                logger.error(msg, exc)
             else:
-                print(msg, file=sys.stderr)
+                print(msg.format(exc), file=sys.stderr)
         return engine_uri
 
     @staticmethod

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -16,11 +16,11 @@ class Database:
     def get_engine_uri(config, logger):
         engine_uri = None
         try:
-            engine_uri = config.get("database", "db_uri")
+            engine_uri = config.get("database", "uri")
         except NoSectionError:
             msg = "Failed to find [database] section in configuration file."
         except NoOptionError:
-            msg = "Failed to find 'db_uri' value in [database] section of configuration file."
+            msg = "Failed to find 'uri' value in [database] section of configuration file."
         if engine_uri is None:
             if logger:
                 logger.error(msg)

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -35,7 +35,7 @@ default-host = pbench.example.com
 pbench-top-dir = {TMP}/srv/pbench
 
 [database]
-db_uri = sqlite:///:memory:
+uri = sqlite:///:memory:
 
 [elasticsearch]
 host = elasticsearch.example.com

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -127,9 +127,9 @@ lowerbound = 820
 # host =
 # port =
 
-# These should be overridden in the env-specific config file.
-# [database]
-# db_uri = driver://user:password@hostname/dbname
+[database]
+# uri = driver://user:password@hostname/dbname
+wait_timeout = 120
 
 # We need to install some stuff in the apache document root so we
 # either get it directly or look in the config file.

--- a/server/lib/systemd/pbench-server.service
+++ b/server/lib/systemd/pbench-server.service
@@ -13,6 +13,7 @@ Type = simple
 User = pbench
 Group = pbench
 RuntimeDirectory = pbench-server
+Environment = _PBENCH_SERVER_CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
 PIDFile = /run/pbench-server/gunicorn.pid
 ExecStart = /opt/pbench-server/bin/pbench-server
 ExecStop = /bin/kill -s TERM $MAINPID

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -26,7 +26,7 @@ host = pbenchinacan
 port = 9200
 
 [database]
-uri = postgresql://pbenchcontainer:pbench@pbenchinacan/pbenchcontainer
+uri = postgresql://pbenchcontainer:pbench@pbenchinacan:5432/pbenchcontainer
 
 # User authentication section to use when authorizing the user with an OIDC identity provider
 [authentication]

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -26,7 +26,7 @@ host = pbenchinacan
 port = 9200
 
 [database]
-db_uri = postgresql://pbenchcontainer:pbench@pbenchinacan/pbenchcontainer
+uri = postgresql://pbenchcontainer:pbench@pbenchinacan/pbenchcontainer
 
 # User authentication section to use when authorizing the user with an OIDC identity provider
 [authentication]


### PR DESCRIPTION
We add a method to wait for the configured `host`:`port` for the PostgreSQL database to accept socket connection.  We'll only wait at most N seconds before giving up (configurable).

We also tackle the following items:

 * Add doc strings and type hints where applicable
 * Consolidate the server configuration gathering to one location
   * Stream-lining the use of the `PbenchServerConfig` object
 * Keep the `site.ENABLE_USER_SITE` checks in `main()`
 * Narrow exception handling
 * Pass along the final gunicorn exit code