### PR TITLE
Avoid hard-coding PostgreSQL references

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -26,7 +26,6 @@ pass_cli_context = click.make_pass_decorator(CliContext, ensure=True)
 
 def config_setup(context: object) -> PbenchServerConfig:
     config = PbenchServerConfig(context.config)
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, None)
     return config

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -125,7 +125,7 @@ def main():
     try:
         host = str(server_config.get("pbench-server", "bind_host"))
         port = str(server_config.get("pbench-server", "bind_port"))
-        db = str(server_config.get("Postgres", "db_uri"))
+        db = str(server_config.get("database", "db_uri"))
         workers = str(server_config.get("pbench-server", "workers"))
         worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
         pbench_top_dir = server_config.get("pbench-server", "pbench-top-dir")
@@ -134,12 +134,12 @@ def main():
 
         # Multiple gunicorn workers will attempt to connect to the DB; rather
         # than attempt to synchronize them, detect a missing DB (from the
-        # postgres URI) and create it here. It's safer to do this here,
+        # database URI) and create it here. It's safer to do this here,
         # where we're single-threaded.
         if not database_exists(db):
-            logger.info("Postgres DB {} doesn't exist", db)
+            logger.info("Database {} doesn't exist", db)
             create_database(db)
-            logger.info("Created DB {}", db)
+            logger.info("Created database {}", db)
         Database.init_db(server_config, logger)
     except (NoOptionError, NoSectionError):
         logger.exception("Error fetching required configuration")

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -23,9 +23,7 @@ from pbench.server.database.models.datasets import Dataset, Metadata, MetadataEr
 
 
 class DatasetsList(ApiBase):
-    """
-    API class to list datasets based on PostgreSQL metadata
-    """
+    """API class to list datasets based on database metadata."""
 
     def __init__(self, config: PbenchServerConfig, logger: logging.Logger):
         super().__init__(

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -117,9 +117,9 @@ class ElasticBase(ApiBase):
         port = config.get("elasticsearch", "port")
 
         # TODO: For future flexibility, we should consider reading this entire
-        # Elasticsearch URI from the config file as we do for PostgreSQL rather
-        # than stitching it together. This would allow backend control over
-        # authentication and http vs https for example.
+        # Elasticsearch URI from the config file as we do for the database
+        # rather than stitching it together. This would allow backend control
+        # over authentication and http vs https for example.
         self.es_url = f"http://{host}:{port}"
 
     def _build_elasticsearch_query(
@@ -567,9 +567,9 @@ class ElasticBulkBase(ApiBase):
         api_name = self.__class__.__name__
 
         # TODO: For future flexibility, we should consider reading this entire
-        # Elasticsearch URI from the config file as we do for PostgreSQL rather
-        # than stitching it together. This would allow backend control over
-        # authentication and http vs https for example.
+        # Elasticsearch URI from the config file as we do for the database
+        # rather than stitching it together. This would allow backend control
+        # over authentication and http vs https for example.
         self.elastic_uri = f"http://{host}:{port}"
         self.config = config
         self.action = action

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -22,7 +22,7 @@ class DatasetsDelete(ElasticBulkBase):
     Delete the specified dataset.
 
     This includes all Elasticsearch documents associated with the dataset, plus
-    the PostgreSQL representation, the tarball and MD5 file in the ARCHIVE file
+    the database representation, the tarball and MD5 file in the ARCHIVE file
     system tree, the unpacked tarball from the INCOMING file system tree, and the
     reference link in the RESULTS file system tree. If there is a BACKUP of the
     tarball file (which there should be, if configured), this will not touch the
@@ -93,5 +93,5 @@ class DatasetsDelete(ElasticBulkBase):
             self.logger.info("Deleting dataset {} file system representation", dataset)
             cache_m = CacheManager(self.config, self.logger)
             cache_m.delete(dataset.resource_id)
-            self.logger.info("Deleting dataset {} PostgreSQL representation", dataset)
+            self.logger.info("Deleting dataset {} database representation", dataset)
             dataset.delete()

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -14,16 +14,19 @@ class Database:
 
     @staticmethod
     def get_engine_uri(config, logger):
+        engine_uri = None
         try:
-            psql = config.get("Postgres", "db_uri")
-            return psql
-        except (NoSectionError, NoOptionError):
-            msg = "Failed to find a [Postgres] section in configuration file."
+            engine_uri = config.get("database", "db_uri")
+        except NoSectionError:
+            msg = "Failed to find [database] section in configuration file."
+        except NoOptionError:
+            msg = "Failed to find 'db_uri' value in [database] section of configuration file."
+        if engine_uri is None:
             if logger:
                 logger.error(msg)
             else:
                 print(msg, file=sys.stderr)
-            return None
+        return engine_uri
 
     @staticmethod
     def init_db(server_config, logger):

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -801,11 +801,10 @@ class Metadata(Database.Base):
     # {"user.dashboard.favorite": True}
     USER = "user"
 
-    # "Native" keys are the value of the PostgreSQL "key" column in the SQL
-    # table. We support hierarchical nested keys of the form "server.indexed",
-    # but the first element of any nested key path must be one of these. The
-    # METALOG key is special, representing the Metadata table portion of the
-    # DATASET
+    # "Native" keys are the value of the database "key" column in the SQL table.
+    # We support hierarchical nested keys of the form "server.indexed", but the
+    # first element of any nested key path must be one of these. The METALOG key
+    # is special, representing the Metadata table portion of the DATASET.
     METALOG = "metalog"
     NATIVE_KEYS = [GLOBAL, METALOG, SERVER, USER]
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -34,7 +34,7 @@ default-host = pbench.example.com
 [pbench-server]
 pbench-top-dir = {TMP}/srv/pbench
 
-[Postgres]
+[database]
 db_uri = sqlite:///:memory:
 
 [elasticsearch]

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -192,11 +192,10 @@ class TestDatasetsDetail(Commons):
         provide_metadata,
         pbench_token,
     ):
-        """
-        This is nearly a repeat of the basic `test_query`; while that focuses
+        """This is nearly a repeat of the basic `test_query`; while that focuses
         on validating the transformation of Elasticsearch data, this tries to
-        focus on the PostgreSQL dataset metadata... but necessarily has to
-        borrow much of the setup.
+        focus on the database dataset metadata... but necessarily has to borrow
+        much of the setup.
         """
         query_params = {"metadata": ["global.seen", "server.deletion"]}
 

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -424,8 +424,7 @@ def main(cfg_name):
 
     logger = get_pbench_logger(_NAME_, config)
 
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, logger)
 
     # Add a BACKUP and QDIR field to the config object

--- a/server/bin/pbench-cull-unpacked-tarballs
+++ b/server/bin/pbench-cull-unpacked-tarballs
@@ -322,8 +322,7 @@ def main(options):
 
     logger = get_pbench_logger(_NAME_, config)
 
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, logger)
 
     archivepath = config.ARCHIVE

--- a/server/bin/pbench-index
+++ b/server/bin/pbench-index
@@ -100,10 +100,10 @@ def main(options, name):
 
     idxctx = None
     try:
-        # We're going to need the Postgres DB to track dataset state, so setup
-        # DB access. We need to do this before we create the IdxContext, since
-        # that will need the template DB; so we create a PbenchServerConfig and
-        # Logger independently.
+        # We're going to need the DB to track dataset state, so setup DB access.
+        # We need to do this before we create the IdxContext, since that will
+        # need the template DB; so we create a PbenchServerConfig and Logger
+        # independently.
         config = PbenchServerConfig(options.cfg_name)
         logger = get_pbench_logger(name, config)
         init_db(config, logger)

--- a/server/bin/pbench-reindex
+++ b/server/bin/pbench-reindex
@@ -173,8 +173,7 @@ def main(options):
 
     logger = get_pbench_logger(_NAME_, config)
 
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, logger)
 
     archive_p = config.ARCHIVE

--- a/server/bin/pbench-unpack-tarballs
+++ b/server/bin/pbench-unpack-tarballs
@@ -51,8 +51,7 @@ def main(cfg_name):
 
     logger = get_pbench_logger(prog, config)
 
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, logger)
 
     # Initiate the unpacking

--- a/server/bin/pbench-verify-backup-tarballs
+++ b/server/bin/pbench-verify-backup-tarballs
@@ -290,8 +290,7 @@ def main():
 
     logger = get_pbench_logger(_NAME_, config)
 
-    # We're going to need the Postgres DB to track dataset state, so setup
-    # DB access.
+    # We're going to need the DB to track dataset state, so setup DB access.
     init_db(config, logger)
 
     # add a BACKUP field to the config object

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -127,8 +127,8 @@ lowerbound = 820
 # host =
 # port =
 
-# # These should be overridden in the env-specific config file.
-# [postgres]
+# These should be overridden in the env-specific config file.
+# [database]
 # db_uri = driver://user:password@hostname/dbname
 
 # We need to install some stuff in the apache document root so we

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -25,7 +25,7 @@ bulk_action_count = 2000
 host = pbenchinacan
 port = 9200
 
-[Postgres]
+[database]
 db_uri = postgresql://pbenchcontainer:pbench@pbenchinacan/pbenchcontainer
 
 # User authentication section to use when authorizing the user with an OIDC identity provider


### PR DESCRIPTION
Strictly textual change to avoid needless mention of the specific DB backend.