### PR TITLE
Get OIDC client public key only at initialization

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -61,8 +61,14 @@ class OpenIDClient:
         self.headers = CaseInsensitiveDict([] if headers is None else headers)
         self.verify = verify
         self.connection = requests.session()
-        self.public_key = self._get_oidc_public_key()
+        self.public_key = None
+
+        # Warning: Note that the method we're calling now depends both on
+        # self.realm_name being set plus any attribute dependencies of
+        # self._get(). It is important to call set_well_known_endpoints after
+        # setting all the required instance variables above.
         # TODO: Think about a better way to set well known endpoints
+        #  https://github.com/distributed-system-analysis/pbench/issues/3102
         self.set_well_known_endpoints()
 
     def __repr__(self):
@@ -118,12 +124,14 @@ class OpenIDClient:
     def _get_oidc_public_key(self) -> str:
         """Returns the public key of the current OIDC client.
 
+        Note: Caller of this method could receive any exceptions
+        raised by self._get() in addition to the ones stated below.
+
         Returns:
             public key string
 
         Raises:
             KeyError: if public key not found in response payload
-            requests.exceptions: Requests session Exceptions
         """
 
         realm_public_key_uri = f"{self.server_url}/realms/{self.realm_name}"
@@ -138,6 +146,8 @@ class OpenIDClient:
         Returns the OIDC client public key that can be used for decoding
         tokens offline.
         """
+        if not self.public_key:
+            self.public_key = self._get_oidc_public_key()
         return self.public_key
 
     def token_introspect_online(self, token: str, token_info_uri: str) -> JSON:

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -122,16 +122,12 @@ class OpenIDClient:
 
         Raises:
             KeyError: if public key not found in response payload
-            Requests session object Exceptions
+            requests.exceptions: Requests session Exceptions
         """
 
         realm_public_key_uri = f"{self.server_url}/realms/{self.realm_name}"
         response_json = self._get(realm_public_key_uri).json()
-        try:
-            public_key = response_json["public_key"]
-        except KeyError:
-            self.logger.warning("OIDC Public key not found in {}", response_json)
-            raise
+        public_key = response_json["public_key"]
         OpenIDClient.PUBLIC_KEY = (
             "-----BEGIN PUBLIC KEY-----\n" + public_key + "\n-----END PUBLIC KEY-----"
         )

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -54,7 +54,11 @@ class Auth:
 
     def get_secret_key(self):
         try:
-            return os.getenv("SECRET_KEY", "my_precious")
+            return (
+                OpenIDClient.PUBLIC_KEY
+                if OpenIDClient.PUBLIC_KEY
+                else os.getenv("SECRET_KEY", "my_precious")
+            )
         except Exception as e:
             Auth.logger.exception("Error {} getting JWT secret", e)
 
@@ -140,11 +144,10 @@ class Auth:
         Returns:
             True if the verification succeeds else False
         """
-        identity_provider_pubkey = oidc_client.get_oidc_public_key(auth_token)
         try:
             oidc_client.token_introspect_offline(
                 token=auth_token,
-                key=identity_provider_pubkey,
+                key=Auth().get_secret_key(),
                 audience=oidc_client.client_id,
                 options={
                     "verify_signature": True,

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -54,11 +54,7 @@ class Auth:
 
     def get_secret_key(self):
         try:
-            return (
-                OpenIDClient.PUBLIC_KEY
-                if OpenIDClient.PUBLIC_KEY
-                else os.getenv("SECRET_KEY", "my_precious")
-            )
+            return os.getenv("SECRET_KEY", "my_precious")
         except Exception as e:
             Auth.logger.exception("Error {} getting JWT secret", e)
 
@@ -147,7 +143,7 @@ class Auth:
         try:
             oidc_client.token_introspect_offline(
                 token=auth_token,
-                key=Auth().get_secret_key(),
+                key=oidc_client.get_oidc_public_key(),
                 audience=oidc_client.client_id,
                 options={
                     "verify_signature": True,

--- a/lib/pbench/test/unit/server/auth/conftest.py
+++ b/lib/pbench/test/unit/server/auth/conftest.py
@@ -10,10 +10,8 @@ def mock_set_oidc_auth_endpoints(oidc_client):
     oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
 
 
-def mock_set_oidc_public_key(oidc_client):
-    oidc_client.PUBLIC_KEY = (
-        "-----BEGIN PUBLIC KEY-----\n" + "public_key" + "\n-----END PUBLIC KEY-----"
-    )
+def mock_get_oidc_public_key(oidc_client):
+    return "-----BEGIN PUBLIC KEY-----\n" + "public_key" + "\n-----END PUBLIC KEY-----"
 
 
 @pytest.fixture
@@ -22,7 +20,7 @@ def keycloak_oidc(server_config, monkeypatch):
     monkeypatch.setattr(
         OpenIDClient, "set_well_known_endpoints", mock_set_oidc_auth_endpoints
     )
-    monkeypatch.setattr(OpenIDClient, "set_oidc_public_key", mock_set_oidc_public_key)
+    monkeypatch.setattr(OpenIDClient, "_get_oidc_public_key", mock_get_oidc_public_key)
     oidc = OpenIDClient(
         server_url=server_config.get("authentication", "server_url"),
         realm_name="public_test_realm",

--- a/lib/pbench/test/unit/server/auth/conftest.py
+++ b/lib/pbench/test/unit/server/auth/conftest.py
@@ -7,8 +7,13 @@ from pbench.server.auth import OpenIDClient
 
 def mock_set_oidc_auth_endpoints(oidc_client):
     oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
-    oidc_client.JWKS_ENDPOINT = "https://oidc_jwks_endpoint.example.com"
     oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
+
+
+def mock_set_oidc_public_key(oidc_client):
+    oidc_client.PUBLIC_KEY = (
+        "-----BEGIN PUBLIC KEY-----\n" + "public_key" + "\n-----END PUBLIC KEY-----"
+    )
 
 
 @pytest.fixture
@@ -17,6 +22,7 @@ def keycloak_oidc(server_config, monkeypatch):
     monkeypatch.setattr(
         OpenIDClient, "set_well_known_endpoints", mock_set_oidc_auth_endpoints
     )
+    monkeypatch.setattr(OpenIDClient, "set_oidc_public_key", mock_set_oidc_public_key)
     oidc = OpenIDClient(
         server_url=server_config.get("authentication", "server_url"),
         realm_name="public_test_realm",


### PR DESCRIPTION
When fetching the OIDC client (Keycloak) public key I was using an authentication token to extract the signing key first. Each time a new token is presented that would require fetching the public key from the beginning. This will not be efficient going forward. We need to archive the public key at the OIDC client and Pbench server initialization and then reuse it every time we want to decode the token offline. 

The change proposed here enables us to extract the public key at the server initialization.