### PR TITLE
Capture functional test logs

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -62,7 +62,7 @@ pipeline {
                     sh 'curl --silent localhost:8080/api/v1/endpoints >/dev/null'
                 }
                 sh 'EXTRA_PODMAN_SWITCHES="--network host" jenkins/run server/exec_functests http://localhost:8080'
-                // sh 'podman pod stop ${PB_POD_NAME}'
+                sh 'podman pod stop ${PB_POD_NAME}'
             }
         }
     }

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -22,7 +22,7 @@ pipeline {
         PB_SERVER_IMAGE_TAG="""${sh(
             returnStdout: true,
             script: 'echo ${CHANGE_ID:-${BRANCH_NAME}}'
-            )}"""
+            )}""".trim()
         PB_SERVER_IMAGE="${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-pbenchserver"
         PB_POD_NAME="pbenchinacan_${PB_SERVER_IMAGE_TAG}"
         PB_DASHBOARD_DIR="${WORKSPACE}/dashboard/build/"
@@ -62,12 +62,17 @@ pipeline {
                     sh 'curl --silent localhost:8080/api/v1/endpoints >/dev/null'
                 }
                 sh 'EXTRA_PODMAN_SWITCHES="--network host" jenkins/run server/exec_functests http://localhost:8080'
-                sh 'podman pod stop ${PB_POD_NAME}'
+                // sh 'podman pod stop ${PB_POD_NAME}'
             }
         }
     }
     post {
         always {
+            // Try to capture the functional test container's log on completion.
+            // On success, the pod has already been shut down, so ignore errors.
+            // TODO: is there a more elegant way to do this?
+            sh 'podman exec ${PB_POD_NAME}-pbenchserver journalctl || true'
+
             // Remove the pod which we just created and ran; remove any
             // dangling containers; and then remove any dangling images.
             sh 'podman pod rm --force --ignore ${PB_POD_NAME} || true'


### PR DESCRIPTION
PBENCH-1008

Attempt to capture `journalctl` output in Jenkins log for analysis. This is a first pass attempt: in the future we should likely strive for a more "elegant" solution, e.g., exporting a more easily searchable document as a Jenkins artifact.