### PR TITLE
Add a `.gitleaks` to quiet the Red Hat spam bot

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,13 @@
+[allowlist]
+  description = "Global Allow List"
+
+  # Ignore based on any subset of the file path
+  paths = [
+    # Ignore the Pbench-in-a-Can server configuration file because the user
+    # name and password contained there-in is only for accessing the PostgreSQL
+    # instance inside the created ephemeral container.
+    '''server\/pbenchinacan\/etc\/pbench-server\/pbench-server\.cfg$''',
+
+    # Ignore the .gitleaks.toml (this file).
+    '''\.gitleaks\.toml$''',
+  ]


### PR DESCRIPTION
Add a `.gitleaks` to quiet the Red Hat spam bot.  Some how Red Hat's information security team has identified the `server/pbenchinacan/etc/pbench-server/pbench-server.cfg` file as being a potential "leak" of secure information.

It only contains a user name / password combination for the Pbench Server Gunicorn process running in one container of the ephemeral Pbench-in-a-Can pod to access the PostgreSQL container running in the same pod.

The information security bot apparently is emailing only one person, me, and not all the other forks of the upstream pbench repository, and has only identified branches of my PRs I have created.

I am told this file will stop those from happening, but I remain unconvinced since nothing has been shown to read the upstream pbench repository at all.