### PR TITLE
PUT drains request stream to expose errors

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -358,6 +358,7 @@ class PbenchServerClient:
             kwargs: Use to override automatically generated headers
                 md5: override companion MD5 value
                 controller: override metadata.log controller
+                filename: override the actual filename to provoke an error
 
         Raises:
             FileNotFound: The file or the companion MD5 file is missing
@@ -376,7 +377,7 @@ class PbenchServerClient:
                     .read()
                     .decode()
                 )
-            metadata = ConfigParser()
+            metadata = ConfigParser(interpolation=None)
             metadata.read_string(metafile)
             controller = metadata.get("run", "controller", fallback=None)
 
@@ -385,7 +386,7 @@ class PbenchServerClient:
         with tarball.open("rb") as f:
             return self.put(
                 api=API.UPLOAD,
-                uri_params={"filename": tarball.name},
+                uri_params={"filename": kwargs.get("filename", tarball.name)},
                 headers=headers,
                 data=f,
                 raise_error=False,

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -113,14 +113,20 @@ class Sync:
             if did:
                 operations.discard(did.name)
 
-                # If we "did" something, the default message is "ok"
-                if not message:
-                    message = "ok"
+        # If we "did" something, the default message is "ok"
+        if did and not message:
+            message = "ok"
 
         if enabled:
             operations.update(o.name for o in enabled)
 
         try:
+            self.logger.info(
+                "Did {}, enabling {} with message {!r}",
+                did.name if did else "nothing",
+                [e.name for e in enabled] if enabled else "none",
+                message,
+            )
             Metadata.setvalue(dataset, Metadata.OPERATION, sorted(operations))
             if message:
                 Metadata.setvalue(dataset, "server.status." + self.component, message)

--- a/lib/pbench/server/unpack_tarballs.py
+++ b/lib/pbench/server/unpack_tarballs.py
@@ -129,4 +129,4 @@ class UnpackTarballs:
             try:
                 report.post_status(self.config.timestamp(), "status", reportfp.name)
             except Exception:
-                pass
+                self.logger.exception("{}: failure posting report", prog)

--- a/lib/pbench/test/functional/server/conftest.py
+++ b/lib/pbench/test/functional/server/conftest.py
@@ -24,7 +24,7 @@ def server_client():
     return client
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def register_test_user(server_client: PbenchServerClient):
     """Create a test user for functional tests."""
 
@@ -47,7 +47,7 @@ def register_test_user(server_client: PbenchServerClient):
     ), f"Register failed with {response.json()}"
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def login_user(server_client, register_test_user):
     """Log in the test user and return the authentication token"""
     server_client.login("tester", "123456")


### PR DESCRIPTION
PBENCH-972
PBENCH-491

In production mode, we run the Pbench server behind a reverse proxy. When using the `/api/v1/upload/{filename}` API, failures reported by the API can be obscured because the reverse proxy may fail with a 502 (bad gateway) error because the API terminated without consuming the request data stream.

This change adds code to drain the request stream before terminating with an error, and adds several functional test cases to demonstrate the improvement.

(Note that this problem never affected the Flask "unit" test enviroment since it doesn't go through a proxy service.)