### PR TITLE
Linting tweaks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,7 @@ filename =
 exclude = .venv,.git,.tox,dist,doc,*lib/python*,*egg,build,*web-server/*,
         *agent/bench-scripts/test-bin/fio-histo-log-pctiles.py,
         *agent/bench-scripts/tests/pbench-trafficgen/test-39.trafficgen/*,
-        *agent/bench-scripts/tests/pbench-trafficgen/test-40.trafficgen/*
+        *agent/bench-scripts/tests/pbench-trafficgen/test-40.trafficgen/*,
+        *dashboard/node_modules/*
 ignore = E121,E123,E126,E203,E226,E501,W503,E704
 max-line-length = 88

--- a/build.sh
+++ b/build.sh
@@ -24,11 +24,13 @@ fi
 mkdir -p ${HOME}/.config
 ( cd dashboard && rm -rf node_modules package-lock.json && npm install )
 
-# Test for code style and lint
+# Test for code style and lint (echo the commands before executing them)
+set -x
 black --check .
 flake8 .
 isort --check .
-( cd dashboard && npx eslint "src/**" --max-warnings 0 )
+( cd dashboard && npx eslint --max-warnings 0 "src/**" )
+set +x
 
 # Run unit tests
 tox                                     # Agent and Server unit tests and legacy tests

--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -7,7 +7,9 @@
         "plugin:react/recommended",
         "google",
         "plugin:react-hooks/recommended",
-        "prettier"
+        "prettier",
+        "react-app",
+        "react-app/jest"
     ],
     "parserOptions": {
         "ecmaFeatures": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -50,12 +50,6 @@
   },
   "proxy": "http://localhost:3001",
   "homepage": ".",
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "jest": {
     "transform": {
       "^.+\\.[t|j]sx?$": "babel-jest"

--- a/dashboard/src/modules/components/OverviewComponent/SavedRunsComponent.jsx
+++ b/dashboard/src/modules/components/OverviewComponent/SavedRunsComponent.jsx
@@ -20,6 +20,7 @@ import {
   USER_FAVORITE,
 } from "assets/constants/overviewConstants";
 import {
+  deleteDataset,
   publishDataset,
   setSelectedRuns,
   updateDataset,

--- a/dashboard/src/modules/components/TableOfContent/index.jsx
+++ b/dashboard/src/modules/components/TableOfContent/index.jsx
@@ -103,10 +103,9 @@ const TableOfContent = () => {
     setActiveMenu(toMenuId);
   };
   const getDropDown = (moreBreadCrumbs) => {
-    const dropDownArray = moreBreadCrumbs.map((label, index) => {
-      if (index < moreBreadCrumbs.length - 1) {
-        return (
-          <DropdownItem
+    const dropDownArray = moreBreadCrumbs.map((label, index) =>
+      index < moreBreadCrumbs.length - 1 ? (
+        <DropdownItem
             key="dropdown-start"
             component="button"
             icon={<AngleLeftIcon />}
@@ -129,12 +128,13 @@ const TableOfContent = () => {
                   appGroupingBreadcrumb(false, updatedBreadCrumbLabels)
                 );
             }}
-          >
+        >
             {label}
-          </DropdownItem>
-        );
-      }
-    });
+        </DropdownItem>
+      ) : (
+        <></>
+      )
+    );
     dropDownArray.pop();
     return dropDownArray;
   };
@@ -202,7 +202,7 @@ const TableOfContent = () => {
   };
   const updateHighlightedRow = (index) => {
     const newPage = Math.floor(index / perPage);
-    if (newPage + 1 != page) {
+    if (newPage + 1 !== page) {
       setPage(newPage + 1);
     }
     setActiveFile(index);
@@ -262,6 +262,8 @@ const TableOfContent = () => {
                                     {data}
                                   </MenuItem>
                                 );
+                              } else {
+                                return <></>;
                               }
                             })}
 
@@ -278,6 +280,8 @@ const TableOfContent = () => {
                                     {data.name}
                                   </MenuItem>
                                 );
+                              } else {
+                                return <></>;
                               }
                             })}
                           </DrilldownMenu>

--- a/dashboard/src/utils/filterDataset.js
+++ b/dashboard/src/utils/filterDataset.js
@@ -1,3 +1,5 @@
+import { DATASET_CREATED } from "assets/constants/overviewConstants";
+
 /**
  * Filter the List of Datasets based on Date Range and Dataset Name
  * @function
@@ -7,8 +9,8 @@
  * @param {string} searchKey - Dataset Name entered in the search box
  * @return {Array} - Array of filtered Datasets
  */
-export const filterData = (dataArray, startDate, endDate, searchKey) => {
-  return dataArray.filter((data) => {
+export const filterData = (dataArray, startDate, endDate, searchKey) =>
+  dataArray.filter((data) => {
     const datasetDate = new Date(data.metadata[DATASET_CREATED]);
     return (
       data.name.includes(searchKey) &&
@@ -16,4 +18,3 @@ export const filterData = (dataArray, startDate, endDate, searchKey) => {
       datasetDate <= endDate
     );
   });
-};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ include = '''
 extend-exclude = '''
 (
 fio-histo-log-pctiles\.py$
-| web-server/v0\.3/demo\.py$
+| ^/dashboard/node_modules/
+| ^/web-server/v0\.3/demo\.py$
 )
 '''


### PR DESCRIPTION
PR #3021 hit some lint objections which turned to be confusing.  Since they were in `node_modules`, we assumed that the objections were coming from ESLint; however, it turns out that they were coming from Flake8 -- the objectionable modules were actually Python code and not JavaScript -- and we were none the wiser because `build.sh` wasn't giving any indication of which output came from which tool.

So, this PR addresses these problems and more:
- Tweak `build.sh` to echo the lint commands as they are issued; also, change the order of arguments in the `eslint` command to match its documentation.
- Tell Black and Flake to ignore `dashboard/node_modules/*`
- Move ESLint config from `package.json` to `.eslintrc.json`:  the latter overrides the former, so the stuff in the former was (presumably) being ignored.  (@MVarshini, please let me know if I should keep this change or just drop the previously-ignored config options.)

With the additional lint rules come additional objections, which this PR also fixes:
- Missing `import`'s
- "Arrow functions" which return no value in `map()` where a value is required
- Use of `!=` instead of `!==`

(And, while I was at it, I modified a couple of the arrow functions which yielded a block containing a `return` statement to make them yield expressions, instead.)

@MVarshini, I have no idea whether any of these changes are correct or appropriate...please review!