### PR TITLE
Promote access parameter to query param

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -755,7 +755,7 @@ class ElasticBulkBase(ApiBase):
             try:
                 results = helpers.streaming_bulk(
                     elastic,
-                    self.generate_actions(params.body, dataset, map),
+                    self.generate_actions(params, dataset, map),
                     raise_on_exception=False,
                     raise_on_error=False,
                 )
@@ -779,7 +779,7 @@ class ElasticBulkBase(ApiBase):
 
         # Let the subclass complete the operation
         try:
-            self.complete(dataset, params.body, summary)
+            self.complete(dataset, params, summary)
         except Exception as e:
             self.logger.exception(
                 "{}: exception {} occurred during bulk operation completion",

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -21,6 +21,8 @@ class DatasetsPublish(ElasticBulkBase):
     Change the "access" authorization of a Pbench dataset by modifying the
     "authorization": {"access": value} subdocument of each Elasticsearch
     document associated with the specified dataset.
+
+    Called as `POST /api/v1/datasets/publish/{resource_id}?access=public`
     """
 
     def __init__(self, config: PbenchServerConfig, logger: Logger):
@@ -33,7 +35,7 @@ class DatasetsPublish(ElasticBulkBase):
                 uri_schema=Schema(
                     Parameter("dataset", ParamType.DATASET, required=True)
                 ),
-                body_schema=Schema(
+                query_schema=Schema(
                     Parameter("access", ParamType.ACCESS, required=True),
                 ),
                 authorization=API_AUTHORIZATION.DATASET,
@@ -51,14 +53,14 @@ class DatasetsPublish(ElasticBulkBase):
         dataset document map.
 
         Args:
-            params: API request body parameters
+            params: API parameters
             dataset: the Dataset object
             map: Elasticsearch index document map
 
         Returns:
             A generator for Elasticsearch bulk update actions
         """
-        access = params["access"]
+        access = params.query["access"]
         self.logger.info("Starting publish operation for dataset {}", dataset)
 
         # Generate a series of bulk update documents, which will be passed to
@@ -93,5 +95,5 @@ class DatasetsPublish(ElasticBulkBase):
                 failure: count of failures
         """
         if summary["failure"] == 0:
-            dataset.access = params["access"]
+            dataset.access = params.query["access"]
             dataset.update()

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_publish.py
@@ -127,7 +127,7 @@ class TestDatasetsPublish:
         response = client.post(
             f"{server_config.rest_uri}/datasets/publish/{ds.resource_id}",
             headers=build_auth_header["header"],
-            json=self.PAYLOAD,
+            query_string=self.PAYLOAD,
         )
         assert response.status_code == expected_status
         if expected_status == HTTPStatus.OK:
@@ -154,7 +154,7 @@ class TestDatasetsPublish:
         response = client.post(
             f"{server_config.rest_uri}/datasets/publish/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
+            query_string=self.PAYLOAD,
         )
 
         # Verify the report and status
@@ -180,7 +180,7 @@ class TestDatasetsPublish:
         response = client.post(
             f"{server_config.rest_uri}/datasets/publish/badwolf",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
+            query_string=self.PAYLOAD,
         )
 
         # Verify the report and status
@@ -200,7 +200,7 @@ class TestDatasetsPublish:
         response = client.post(
             f"{server_config.rest_uri}/datasets/publish/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
+            query_string=self.PAYLOAD,
         )
 
         # Verify the report and status
@@ -238,7 +238,7 @@ class TestDatasetsPublish:
         response = client.post(
             f"{server_config.rest_uri}/datasets/publish/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_token}"},
-            json=self.PAYLOAD,
+            query_string=self.PAYLOAD,
         )
 
         # Verify the failure


### PR DESCRIPTION
PBENCH-1020

An overdue API cleanup I'd like to get in before the dashboard implements a "Publish" control. This just moves the "access" parameter from the JSON request body up to a URI query parameter. This will make it visible in the HTTP/gunicorn log and makes it more consistent with our newer APIs.