### PR TITLE
Move Pbench Server to Listen on port 8080

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -55,6 +55,7 @@ pipeline {
         stage('Deploy server and run functional tests') {
             steps {
                 sh 'envsubst < server/pbenchinacan/pod-nodata.yml | podman play kube -'
+                sleep 39
                 // Use curl to check when server is responding to API requests
                 retry(count: 600) {
                     sleep 1

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -55,10 +55,9 @@ pipeline {
         stage('Deploy server and run functional tests') {
             steps {
                 sh 'envsubst < server/pbenchinacan/pod-nodata.yml | podman play kube -'
-                sleep 30
                 // Use curl to check when server is responding to API requests
-                retry(count: 10) {
-                    sleep 10
+                retry(count: 600) {
+                    sleep 1
                     sh 'curl --silent localhost:8080/api/v1/endpoints >/dev/null'
                 }
                 sh 'EXTRA_PODMAN_SWITCHES="--network host" jenkins/run server/exec_functests http://localhost:8080'

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -188,17 +188,13 @@ def main():
     if site.ENABLE_USER_SITE:
         find_the_unicorn(logger)
     try:
-        host = str(server_config.get("pbench-server", "bind_host"))
+        host = server_config.get("pbench-server", "bind_host")
         port = str(server_config.get("pbench-server", "bind_port"))
-        db_uri = str(server_config.get("database", "uri"))
+        db_uri = server_config.get("database", "uri")
         db_wait_timeout = int(server_config.get("database", "wait_timeout"))
         workers = str(server_config.get("pbench-server", "workers"))
         worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
-        oidc_server = server_config.get(
-            "authentication",
-            "internal_server_url",
-            fallback=server_config.get("authentication", "server_url"),
-        )
+        oidc_server = server_config.get("authentication", "server_url")
         crontab_dir = server_config.get("pbench-server", "crontab-dir")
     except (NoOptionError, NoSectionError) as exc:
         logger.error("Error fetching required configuration: {}", exc)

--- a/server/lib/config/pbench.httpd.conf
+++ b/server/lib/config/pbench.httpd.conf
@@ -9,7 +9,7 @@
 # filter this file, replacing the local host placeholder with the full IP:
 # pay attention to server/pbenchinacan/container-build.sh when editing this!
 #
-<VirtualHost *:80>
+<VirtualHost *:8080>
     ProxyPreserveHost On
     ProxyPass /api/ http://localhost:8001/api/
     ProxyPassReverse /api/ http://localhost:8001/api/

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -120,6 +120,9 @@ sed -e "s/localhost/${HOSTNAME_F}/" ${PBINC_SERVER}/lib/config/pbench.httpd.conf
 buildah copy --chown root:root --chmod 0644 $container \
     /tmp/pbench.conf.${$} /etc/httpd/conf.d/pbench.conf
 rm /tmp/pbench.conf.${$}
+# We need to ensure HTTPD listens on port 8080 so container can be optionally
+# run with host networking from a non-root user.
+buildah run $container bash -c "sed -i -e 's/^Listen 80$/Listen 8080/' /etc/httpd/conf/httpd.conf"
 
 buildah run $container cp ${SERVER_LIB}/systemd/pbench-server.service \
     /etc/systemd/system/pbench-server.service

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -28,17 +28,12 @@ port = 9200
 [database]
 uri = postgresql://pbenchcontainer:pbench@pbenchinacan:5432/pbenchcontainer
 
-# User authentication section to use when authorizing the user with an OIDC identity provider
+# User authentication section to use when authorizing the user with an OIDC
+# identity provider.
 [authentication]
 
 # URL of the OIDC auth server
-server_url = http://localhost:8090
-
-# [optional] URL of the OIDC auth server for pbench-server service.
-# It is possible that the OIDC auth server may not be accessible on the same URL
-# as specified above for the pbench-server service. If that is the case specify
-# the URL that pbench-server can use for authentication.
-internal_server_url = http://localhost:8080
+server_url = http://pbenchinacan:8090
 
 # Realm name that is used for the authentication with OIDC
 realm = pbench
@@ -48,8 +43,6 @@ client = pbench-client
 
 # Client secret if the above client is not public
 secret = <keycloak_secret>
-
-# FIXME:  Do we need a [sosreports] section?
 
 ###########################################################################
 # crontab roles

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -24,7 +24,8 @@
 #  PB_SERVER_IMAGE - the <registry>/<repo>/<img_name> of the Pbench Server image
 #  PB_SERVER_IMAGE_TAG - the tag for the Pbench Server image
 #
-# The resulting pod exposes port 8080 for the Pbench Server and Dashboard.
+# The resulting pod exposes port 8080 for the Pbench Server and Dashboard, and
+# port 8090 for the KeyCloak broker.
 #
 apiVersion: v1
 kind: Pod
@@ -79,6 +80,7 @@ spec:
     name: keycloak
     ports:
       - containerPort: 8090
+        hostPort: 8090
     workingDir: /opt/keycloak
   - args:
     - run-postgresql

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -24,11 +24,7 @@
 #  PB_SERVER_IMAGE - the <registry>/<repo>/<img_name> of the Pbench Server image
 #  PB_SERVER_IMAGE_TAG - the tag for the Pbench Server image
 #
-# The resulting pod maps the following ports:
-#
-#   8090 - Keycloak authentication server
-#   8080 - HTTP web server (and Pbench Dashboard)
-#   9200 - Elasticsearch
+# The resulting pod exposes port 8080 for the Pbench Server and Dashboard.
 #
 apiVersion: v1
 kind: Pod
@@ -63,7 +59,6 @@ spec:
     name: elasticsearch
     ports:
       - containerPort: 9200
-        hostPort: 9200
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true
@@ -78,12 +73,12 @@ spec:
   - command:
     - /opt/keycloak/bin/kc.sh
     - start-dev
+    - --http-port=8090
     - --health-enabled=true
     image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-keycloak:latest
     name: keycloak
     ports:
-      - containerPort: 8080
-        hostPort: 8090
+      - containerPort: 8090
     workingDir: /opt/keycloak
   - args:
     - run-postgresql
@@ -154,7 +149,7 @@ spec:
     imagePullPolicy: Always
     name: pbenchserver
     ports:
-      - containerPort: 80
+      - containerPort: 8080
         hostPort: 8080
     resources: {}
     securityContext:

--- a/server/pbenchinacan/pod-nodata.yml
+++ b/server/pbenchinacan/pod-nodata.yml
@@ -24,8 +24,12 @@
 #  PB_SERVER_IMAGE - the <registry>/<repo>/<img_name> of the Pbench Server image
 #  PB_SERVER_IMAGE_TAG - the tag for the Pbench Server image
 #
-# The resulting pod exposes port 8080 for the Pbench Server and Dashboard, and
-# port 8090 for the KeyCloak broker.
+# The resulting pod maps the following ports:
+#
+#   5432 - PostgreSQL
+#   8080 - HTTP web server (and Pbench Dashboard)
+#   8090 - Keycloak authentication server
+#   9200 - Elasticsearch
 #
 apiVersion: v1
 kind: Pod
@@ -60,6 +64,7 @@ spec:
     name: elasticsearch
     ports:
       - containerPort: 9200
+        hostPort: 9200
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true
@@ -128,6 +133,7 @@ spec:
     name: postgresql
     ports:
       - containerPort: 5432
+      - hostPort: 5432
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -4,7 +4,7 @@
 # the Pbench Server and its associated Elasticsearch, PostgreSQL database, and
 # keycloak authentication servers.  The expectation is that the servers have
 # been pre-populated with data which has been persisted in their respective
-# container images and that the images have been pushed to a common repository 
+# container images and that the images have been pushed to a common repository
 # using a common tag.
 #
 # The four container images are named
@@ -26,8 +26,12 @@
 #  PB_INTERNAL_CONTAINER_REG - the FQDN of the container registry
 #  PB_SERVER_IMAGE_TAG - the tag for all three container images
 #
-# The resulting pod exposes port 8080 for the Pbench Server and Dashboard, and
-# port 8090 for the KeyCloak broker.
+# The resulting pod maps the following ports:
+#
+#   5432 - PostgreSQL
+#   8080 - HTTP web server (and Pbench Dashboard)
+#   8090 - keycloak authentication server
+#   9200 - Elasticsearch
 #
 apiVersion: v1
 kind: Pod
@@ -63,6 +67,7 @@ spec:
     name: elasticsearch
     ports:
       - containerPort: 9200
+        hostPort: 9200
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true
@@ -132,6 +137,7 @@ spec:
     name: postgresql
     ports:
       - containerPort: 5432
+      - hostPort: 5432
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -26,11 +26,7 @@
 #  PB_INTERNAL_CONTAINER_REG - the FQDN of the container registry
 #  PB_SERVER_IMAGE_TAG - the tag for all three container images
 #
-# The resulting pod maps the following ports:
-#
-#   8090 - keycloak authentication server
-#   8080 - HTTP web server (and Pbench Dashboard)
-#   9200 - Elasticsearch
+# The resulting pod exposes port 8080 for the Pbench Server and Dashboard.
 #
 apiVersion: v1
 kind: Pod
@@ -66,7 +62,6 @@ spec:
     name: elasticsearch
     ports:
       - containerPort: 9200
-        hostPort: 9200
     resources: {}
     securityContext:
       allowPrivilegeEscalation: true
@@ -81,12 +76,12 @@ spec:
   - command:
     - /opt/keycloak/bin/kc.sh
     - start-dev
+    - --http-port=8090
     - --health-enabled=true
     image: ${PB_INTERNAL_CONTAINER_REG}/pbench/pbenchinacan-keycloak:${PB_SERVER_IMAGE_TAG}
     name: keycloak
     ports:
-      - containerPort: 8080
-        hostPort: 8090
+      - containerPort: 8090
     workingDir: /opt/keycloak
   - args:
     - run-postgresql
@@ -158,7 +153,7 @@ spec:
     imagePullPolicy: Always
     name: pbenchserver
     ports:
-      - containerPort: 80
+      - containerPort: 8080
         hostPort: 8080
     resources: {}
     securityContext:

--- a/server/pbenchinacan/pod.yml
+++ b/server/pbenchinacan/pod.yml
@@ -26,7 +26,8 @@
 #  PB_INTERNAL_CONTAINER_REG - the FQDN of the container registry
 #  PB_SERVER_IMAGE_TAG - the tag for all three container images
 #
-# The resulting pod exposes port 8080 for the Pbench Server and Dashboard.
+# The resulting pod exposes port 8080 for the Pbench Server and Dashboard, and
+# port 8090 for the KeyCloak broker.
 #
 apiVersion: v1
 kind: Pod
@@ -82,6 +83,7 @@ spec:
     name: keycloak
     ports:
       - containerPort: 8090
+        hostPort: 8090
     workingDir: /opt/keycloak
   - args:
     - run-postgresql


### PR DESCRIPTION
Commit message for final squashed commit is:

----

    By moving to use port 8080 in the Pbench Server container, we allow for
    the case of the container deployed by a non-root user using host
    networking.

    In order to make this work inside the Pbench-in-a-Can pod, we must move
    the KeyCloak server to port 8090.  Within a pod, all containers are
    executing within the same network namespace.  So we can't have Apache2
    (httpd) and KeyCloak listening on port 8080, while only trying to map
    the KeyClock port to 8090 external to the pod.  We now use the same
    ports internally and externally for clarity and simplicity.

    Further, there is only one authentication server URL accessible by both
    clients and the Pbench Server.  The code does not need to detect a
    fallback, that is up to the entity depoying the Pbench Server to provide
    correctly in the configuration file.  The default use for the
    Pbench-in-a-Can environment is also updated.

    It should be noted that `hostPort` is required to expose a port outside
    of the pod even if `containerPort` has the same value.

    We also add back exposing the PostgreSQL port, default the KeyCloak
    server host name like we do for PostgreSQL, and wait for the Pbench
    Server pod to come up for 10 minutes in the CI pipline to provide a bit
    more time to debug.