### PR TITLE
Add support for building Agent containers to the CI

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -371,3 +371,5 @@ all-tags: pkgmgr-clean $(_DEFAULT_DISTROS:%=%-tags.lis)
 
 clean:
 	rm -f *.Dockerfile *.repo *.yml *-tags.lis pbench-agent-*-*.noarch.rpm.*
+
+.PHONY: all baseimage clean everything push repofix tds tm

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -51,7 +51,8 @@ _PBENCH_REPO_NAME = pbench-${_LOCAL_MAJORMINOR}${_TEST_SUFFIX}
 # By default we use the pbench Quay.io organization for the image
 # repository.  You can override this default using an environment
 # variable as appropriate.
-IMAGE_REPO = docker://quay.io/pbench
+IMAGE_REPO ?= docker://quay.io/pbench
+IMAGE_TAG ?= latest
 
 # Convenience reference to the repo template in the pbench tree.
 # Not intended to be overridden with an environment variable.
@@ -292,6 +293,15 @@ centos-7-base.Dockerfile: _PKGMGR = yum
 #+
 # Push local images for the given tag and distribution.
 #-
+
+# Special push target for the CI which pushes a full set of the various container
+# images for the distribution to the specified registry with the specified tag.
+$(_DEFAULT_DISTROS:%=%-push-ci): %-push-ci:
+	for image in base tools tool-meister tool-data-sink workloads all; do \
+	  buildah push \
+	    localhost/pbench-agent-$${image}-${*}:${_LOCAL_GIT_HASH} \
+	    ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} ; \
+	done
 
 define _PUSH_RULE
 %-push-$(1): %-tags.lis

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -10,26 +10,18 @@ pipeline {
         PY_COLORS=0
         TERM='dumb'
 
-        // The remaining variables are for `jenkins/run-server-func-tests`.
-
+        // Configuration for remote container registries
         PODMAN_INTERNAL=credentials('12b404ca-3036-4960-9929-979148b9e49a')
-        KEYCLOAK_CLIENT_SECRET=credentials('5cf0304d-8a00-48a4-ade5-9f59cb37ba68')
-        PB_CONTAINER_REG=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
-
+        PODMAN_EXTERNAL=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
+        PB_INTERNAL_CONTAINER_REG=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
+        PB_EXTERNAL_CONTAINER_REG=credentials('24a93506-ecd6-403a-b4f0-386f9cc943e9')
         PB_ORG_NAME="pbench"
-
         PB_SERVER_IMAGE_NAME="pbench-server-ci"
-        // Set the tag to the PR number (i.e., the Jenkins CHANGE_ID) if run for
-        // a PR; otherwise set it to the branch name (e.g., `main`).  Set a
-        // shorthand for the Pbench Server image path, and set a variable for
-        // the Server Pod name, based on the image tag, so that we don't
-        // interfere with other pods on this executor.
-        PB_SERVER_IMAGE_TAG="""${sh(
-            returnStdout: true,
-            script: 'echo ${CHANGE_ID:-${BRANCH_NAME}}'
-            )}""".trim()
-
-        PB_DASHBOARD_DIR="${WORKSPACE}/dashboard/build/"
+        // If we are executing for a PR, as opposed to executing for a branch
+        // like `main`, the CHANGE_ID will be defined to the PR number.  If it
+        // is defined we'll use its value for the container image tag;
+        // otherwise we set it to the branch name (e.g., `main`).
+        PB_IMAGE_TAG="${env.CHANGE_ID ?: env.BRANCH_NAME}"
     }
     stages {
         stage('Agent Python3.6 Check') {
@@ -50,14 +42,54 @@ pipeline {
             }
         }
         stage('Build the Pbench Server Container') {
+            environment {
+                KEYCLOAK_CLIENT_SECRET=credentials('5cf0304d-8a00-48a4-ade5-9f59cb37ba68')
+                PB_SERVER_IMAGE_TAG="${PB_IMAGE_TAG}"
+                RPM_PATH="${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm"
+            }
             steps {
-                sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_CONTAINER_REG}'
-                sh 'RPM_PATH=${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm bash -ex ./server/pbenchinacan/container-build-ci.sh'
-                sh 'buildah push localhost/pbench-server:${PB_SERVER_IMAGE_TAG} ${PB_CONTAINER_REG}/${PB_ORG_NAME}/pbench-server:${PB_SERVER_IMAGE_TAG}'
-                sh 'buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG} ${PB_CONTAINER_REG}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}'
+                sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_INTERNAL_CONTAINER_REG}'
+                sh 'bash -ex ./server/pbenchinacan/container-build-ci.sh'
+                sh 'buildah push localhost/pbench-server:${PB_IMAGE_TAG} ${PB_INTERNAL_CONTAINER_REG}/${PB_ORG_NAME}/pbench-server:${PB_IMAGE_TAG}'
+                sh 'buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG} ${PB_INTERNAL_CONTAINER_REG}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
+            }
+        }
+        stage('Build the Pbench Agent Containers') {
+            environment {
+                // If CHANGE_ID is defined, then we are building a PR, so use
+                // the internal container registry; otherwise, we are building
+                // a branch (like `main`), so use the external registry.
+                PB_AGENT_CONTAINER_REG="${env.CHANGE_ID ? env.PB_INTERNAL_CONTAINER_REG : env.PB_EXTERNAL_CONTAINER_REG}"
+                PB_AGENT_DISTRO="fedora-36"
+            }
+            stages {
+                stage('Login to external container registry') {
+                    when { equals expected: env.PB_EXTERNAL_CONTAINER_REG, actual: env.PB_AGENT_CONTAINER_REG }
+                    steps {
+                        sh 'buildah login -u="${PODMAN_EXTERNAL_USR}" -p="${PODMAN_EXTERNAL_PSW}" ${PB_EXTERNAL_CONTAINER_REG}'
+                    }
+                }
+                stage('Login to internal container registry') {
+                    when { equals expected: env.PB_INTERNAL_CONTAINER_REG, actual: env.PB_AGENT_CONTAINER_REG }
+                    steps {
+                        sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_INTERNAL_CONTAINER_REG}'
+                    }
+                }
+                stage('Do the build') {
+                    steps {
+                        sh '/usr/bin/python3 -m pip install --user jinja2-cli'
+                        sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean ${PB_AGENT_DISTRO}-everything'
+                        sh 'make -C agent/containers/images IMAGE_REPO=${PB_AGENT_CONTAINER_REG}/${PB_ORG_NAME} IMAGE_TAG=${PB_IMAGE_TAG} ${PB_AGENT_DISTRO}-push-ci'
+                    }
+                }
             }
         }
         stage('Deploy server and run functional tests') {
+            environment {
+                PB_CONTAINER_REG="${PB_INTERNAL_CONTAINER_REG}"
+                PB_DASHBOARD_DIR="${WORKSPACE}/dashboard/build/"
+                PB_SERVER_IMAGE_TAG="${PB_IMAGE_TAG}"
+            }
             steps {
                 sh 'jenkins/run-server-func-tests --cleanup'
             }

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -11,17 +11,15 @@ pipeline {
         TERM='dumb'
 
         // Configuration for remote container registries
-        PODMAN_INTERNAL=credentials('12b404ca-3036-4960-9929-979148b9e49a')
-        PODMAN_EXTERNAL=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
-        PB_INTERNAL_CONTAINER_REG=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
-        PB_EXTERNAL_CONTAINER_REG=credentials('24a93506-ecd6-403a-b4f0-386f9cc943e9')
+        PB_CI_REGISTRY=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
+        PB_CI_REG_CRED=credentials('12b404ca-3036-4960-9929-979148b9e49a')
         PB_ORG_NAME="pbench"
-        PB_SERVER_IMAGE_NAME="pbench-server-ci"
         // If we are executing for a PR, as opposed to executing for a branch
         // like `main`, the CHANGE_ID will be defined to the PR number.  If it
         // is defined we'll use its value for the container image tag;
         // otherwise we set it to the branch name (e.g., `main`).
         PB_IMAGE_TAG="${env.CHANGE_ID ?: env.BRANCH_NAME}"
+        PB_SERVER_IMAGE_NAME="pbench-server-ci"
     }
     stages {
         stage('Agent Python3.6 Check') {
@@ -48,45 +46,26 @@ pipeline {
                 RPM_PATH="${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm"
             }
             steps {
-                sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_INTERNAL_CONTAINER_REG}'
+                sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'
                 sh 'bash -ex ./server/pbenchinacan/container-build-ci.sh'
-                sh 'buildah push localhost/pbench-server:${PB_IMAGE_TAG} ${PB_INTERNAL_CONTAINER_REG}/${PB_ORG_NAME}/pbench-server:${PB_IMAGE_TAG}'
-                sh 'buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG} ${PB_INTERNAL_CONTAINER_REG}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
+                sh 'buildah push localhost/pbench-server:${PB_IMAGE_TAG} ${PB_CI_REGISTRY}/${PB_ORG_NAME}/pbench-server:${PB_IMAGE_TAG}'
+                sh 'buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG} ${PB_CI_REGISTRY}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
             }
         }
         stage('Build the Pbench Agent Containers') {
             environment {
-                // If CHANGE_ID is defined, then we are building a PR, so use
-                // the internal container registry; otherwise, we are building
-                // a branch (like `main`), so use the external registry.
-                PB_AGENT_CONTAINER_REG="${env.CHANGE_ID ? env.PB_INTERNAL_CONTAINER_REG : env.PB_EXTERNAL_CONTAINER_REG}"
                 PB_AGENT_DISTRO="fedora-36"
             }
-            stages {
-                stage('Login to external container registry') {
-                    when { equals expected: env.PB_EXTERNAL_CONTAINER_REG, actual: env.PB_AGENT_CONTAINER_REG }
-                    steps {
-                        sh 'buildah login -u="${PODMAN_EXTERNAL_USR}" -p="${PODMAN_EXTERNAL_PSW}" ${PB_EXTERNAL_CONTAINER_REG}'
-                    }
-                }
-                stage('Login to internal container registry') {
-                    when { equals expected: env.PB_INTERNAL_CONTAINER_REG, actual: env.PB_AGENT_CONTAINER_REG }
-                    steps {
-                        sh 'buildah login -u="${PODMAN_INTERNAL_USR}" -p="${PODMAN_INTERNAL_PSW}" ${PB_INTERNAL_CONTAINER_REG}'
-                    }
-                }
-                stage('Do the build') {
-                    steps {
-                        sh '/usr/bin/python3 -m pip install --user jinja2-cli'
-                        sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean ${PB_AGENT_DISTRO}-everything'
-                        sh 'make -C agent/containers/images IMAGE_REPO=${PB_AGENT_CONTAINER_REG}/${PB_ORG_NAME} IMAGE_TAG=${PB_IMAGE_TAG} ${PB_AGENT_DISTRO}-push-ci'
-                    }
-                }
+            steps {
+                sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'
+                sh '/usr/bin/python3 -m pip install --user jinja2-cli'
+                sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean ${PB_AGENT_DISTRO}-everything'
+                sh 'make -C agent/containers/images IMAGE_REPO=${PB_CI_REGISTRY}/${PB_ORG_NAME} IMAGE_TAG=${PB_IMAGE_TAG} ${PB_AGENT_DISTRO}-push-ci'
             }
         }
         stage('Deploy server and run functional tests') {
             environment {
-                PB_CONTAINER_REG="${PB_INTERNAL_CONTAINER_REG}"
+                PB_CONTAINER_REG="${PB_CI_REGISTRY}"
                 PB_DASHBOARD_DIR="${WORKSPACE}/dashboard/build/"
                 PB_SERVER_IMAGE_TAG="${PB_IMAGE_TAG}"
             }


### PR DESCRIPTION
This PR adds support to the CI for building a single set of Agent containers suitable for running functional tests.

The CI pipeline builds a full set of Agent containers (`base`, `tools`, `tool-meister`, `tool-data-sink`, `workloads`, and `all`) for a single distro (currently Fedora-36) and pushes them to the container registry.  For PR builds, it pushes them to the internal registry; for branch builds (like `main`), it pushes them to the external registry.

Details:
- Modify the Agent containers Makefile:
  - allow the image repository and the image tag to be specified by command line arguments
  - add a special target for use by the CI for pushing images to the repository: this target pushes the target distribution's container-set to the specified repository using the specified tag, without adding further complexity to the existing push script (i.e., without adding another entry in the `TAG_TYPES` list)
  - explicitly declare as "phony" all the phony targets
- Modify the Jenkins Pipeline:
  - add support for referencing both internal and external container image registries
  - make use of per-stage environment directives where appropriate instead of defining variables for the entire pipeline
rename the local references of `PB_SERVER_IMAGE_TAG` to `PB_IMAGE_TAG` so it can be used for both the Server and Agent container images; define `PB_SERVER_IMAGE_TAG` to the value of `PB_IMAGE_TAG` in the stages which need it; use a better idiom to generate its value
  - add a stage which builds the Agent container images and pushes them to the registry


PBENCH-332