### PR TITLE
Allow setting dataset access on upload

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -367,7 +367,12 @@ class PbenchServerClient:
         Returns:
             The PUT response object
         """
+        query_parameters = {}
+
         md5 = kwargs.get("md5", Dataset.md5(tarball))
+        access = kwargs.get("access", "private")
+        if access == "public":
+            query_parameters["access"] = access
         if "controller" in kwargs:
             controller = kwargs["controller"]
         else:
@@ -381,13 +386,18 @@ class PbenchServerClient:
             metadata.read_string(metafile)
             controller = metadata.get("run", "controller", fallback=None)
 
-        headers = {"Content-MD5": md5, "controller": controller}
+        headers = {
+            "Content-MD5": md5,
+            "controller": controller,
+            "content-type": "application/octet-stream",
+        }
 
         with tarball.open("rb") as f:
             return self.put(
                 api=API.UPLOAD,
                 uri_params={"filename": tarball.name},
                 headers=headers,
+                params=query_parameters,
                 data=f,
                 raise_error=False,
             )

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -2,21 +2,37 @@ import datetime
 import errno
 import hashlib
 from http import HTTPStatus
+from logging import Logger
 import os
 import shutil
 from typing import Optional
 
-from flask import jsonify, request
-from flask_restful import abort, Resource
+from flask import jsonify
+from flask.wrappers import Request, Response
 import humanize
 
 from pbench.common.utils import Cleanup, validate_hostname
+from pbench.server import PbenchServerConfig
+from pbench.server.api.resources import (
+    APIAbort,
+    ApiAuthorizationType,
+    ApiBase,
+    ApiContext,
+    APIInternalError,
+    ApiMethod,
+    ApiParams,
+    ApiSchema,
+    Parameter,
+    ParamType,
+    Schema,
+)
 from pbench.server.auth.auth import Auth
 from pbench.server.cache_manager import CacheManager
 from pbench.server.database.models.audit import (
     Audit,
     AuditReason,
     AuditStatus,
+    AuditType,
     OperationCode,
 )
 from pbench.server.database.models.datasets import (
@@ -26,7 +42,6 @@ from pbench.server.database.models.datasets import (
     Metadata,
     States,
 )
-from pbench.server.database.models.server_config import ServerConfig
 from pbench.server.sync import Operation, Sync
 from pbench.server.utils import filesize_bytes, UtcTimeHelper
 
@@ -42,8 +57,11 @@ class CleanupTime(Exception):
         self.status = status
         self.message = message
 
+    def __str__(self) -> str:
+        return self.message
 
-class Upload(Resource):
+
+class Upload(ApiBase):
     """
     Upload a dataset from an agent. This API accepts a tarball, controller
     name, and MD5 value from a client. After validation, it creates a new
@@ -55,9 +73,20 @@ class Upload(Resource):
     CHUNK_SIZE = 65536
     DEFAULT_RETENTION_DAYS = 90
 
-    def __init__(self, config, logger):
-        self.config = config
-        self.logger = logger
+    def __init__(self, config: PbenchServerConfig, logger: Logger):
+        super().__init__(
+            config,
+            logger,
+            ApiSchema(
+                ApiMethod.PUT,
+                OperationCode.CREATE,
+                uri_schema=Schema(Parameter("filename", ParamType.STRING)),
+                query_schema=Schema(Parameter("access", ParamType.ACCESS)),
+                audit_type=AuditType.NONE,
+                audit_name="upload",
+                authorization=ApiAuthorizationType.NONE,
+            ),
+        )
         self.max_content_length = filesize_bytes(
             self.config.get_conf(
                 __name__, "pbench-server", "rest_max_content_length", self.logger
@@ -67,16 +96,53 @@ class Upload(Resource):
         self.temporary.mkdir(mode=0o755, parents=True, exist_ok=True)
         self.logger.info("Configured PUT temporary directory as {}", self.temporary)
 
-    @Auth.token_auth.login_required()
-    def put(self, filename: str):
-        disabled = ServerConfig.get_disabled()
-        if disabled:
-            abort(HTTPStatus.SERVICE_UNAVAILABLE, **disabled)
+    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+        """Upload a dataset to the server.
+
+        The client must present an authentication bearer token for a registered
+        Pbench Server user.
+
+        We get the requested filename from the URI: /api/v1/upload/<filename>.
+
+        We get the originating controller nodename from a custom "controller"
+        HTTP header.
+
+        We get the dataset's resource ID (which is the tarball's MD5 checksum)
+        from the "content-md5" HTTP header.
+
+        We also check that the "content-length" header value is not 0, and that
+        it matches the final size of the uploaded tarball file.
+
+        We expect the dataset's tarball file to be uploaded as a data stream.
+
+        If the new dataset is created successfully, return 201 (CREATED).
+
+        The tarball name must be unique on the Pbench Server. If the name
+        given matches an existing dataset, and has an identical MD5 resource ID
+        value, return 200 (OK). If the identically named dataset does not have
+        the same MD5 resource ID, return 400 and a diagnostic message.
+
+        NOTE: This API audits internally, as we don't know the resource ID or
+        name of the dataset until we've processed the parameters. We also
+        authenticate internally as we only require that a registered user be
+        identified rather than authorizing against an existing resource.
+
+        Args:
+            filename:   A filename matching the metadata of the uploaded tarball
+        """
 
         # Used to record what steps have been completed during the upload, and
         # need to be undone on failure
         recovery = Cleanup(self.logger)
         audit: Optional[Audit] = None
+        username: Optional[str] = None
+        controller: Optional[str] = None
+        access = (
+            args.query["access"] if "access" in args.query else Dataset.PRIVATE_ACCESS
+        )
+        filename = args.uri["filename"]
+
+        self.logger.info("Uploading {} with {} access", filename, access)
 
         try:
             try:
@@ -84,6 +150,7 @@ class Upload(Resource):
                 username = Auth.token_auth.current_user().username
             except Exception:
                 username = None
+                user_id = None
                 raise CleanupTime(HTTPStatus.UNAUTHORIZED, "Verifying user_id failed")
 
             controller = request.headers.get("controller")
@@ -161,7 +228,7 @@ class Upload(Resource):
             )
 
             self.logger.info(
-                "PUT uploading {}:{} for user = (user_id: {}, username: {}) to {}",
+                "PUT uploading {}:{} for user_id {} (username: {}) to {}",
                 controller,
                 filename,
                 user_id,
@@ -175,6 +242,7 @@ class Upload(Resource):
                     owner_id=user_id,
                     name=Dataset.stem(tar_full_path),
                     resource_id=md5sum,
+                    access=access,
                 )
                 dataset.add()
             except DatasetDuplicate:
@@ -253,7 +321,7 @@ class Upload(Resource):
                     else:
                         raise CleanupTime(
                             HTTPStatus.INTERNAL_SERVER_ERROR,
-                            "Unexpected error encountered during file upload",
+                            f"Unexpected error {exc.errno} encountered during file upload",
                         )
                 except Exception:
                     raise CleanupTime(
@@ -399,28 +467,11 @@ class Upload(Resource):
                     f"Unable to finalize dataset {dataset}: {exc!s}",
                 )
         except Exception as e:
-            status = HTTPStatus.INTERNAL_SERVER_ERROR
-            abort_msg = "INTERNAL ERROR"
+            message = str(e)
             if isinstance(e, CleanupTime):
-                cause = e.__cause__ if e.__cause__ else e.__context__
-                if e.status == HTTPStatus.INTERNAL_SERVER_ERROR:
-                    log_func = self.logger.exception if cause else self.logger.error
-                    log_func(
-                        "{}:{}:{} error {}", username, controller, filename, e.message
-                    )
-                else:
-                    self.logger.warning(
-                        "{}:{}:{} error {} ({})",
-                        username,
-                        controller,
-                        filename,
-                        e.message,
-                        cause,
-                    )
-                    abort_msg = e.message
                 status = e.status
             else:
-                self.logger.exception("Unexpected exception in outer try")
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
 
             # NOTE: there are nested try blocks so we can't be 100% confident
             # here that an audit "root" object was created. We don't audit on
@@ -430,16 +481,21 @@ class Upload(Resource):
             if audit:
                 if status == HTTPStatus.INTERNAL_SERVER_ERROR:
                     reason = AuditReason.INTERNAL
+                    audit_msg = "INTERNAL ERROR"
                 else:
                     reason = AuditReason.CONSISTENCY
+                    audit_msg = message
                 Audit.create(
                     root=audit,
                     status=AuditStatus.FAILURE,
                     reason=reason,
-                    attributes={"message": abort_msg},
+                    attributes={"message": audit_msg},
                 )
             recovery.cleanup()
-            abort(status, message=abort_msg)
+            if status == HTTPStatus.INTERNAL_SERVER_ERROR:
+                raise APIInternalError(message) from e
+            else:
+                raise APIAbort(status, message) from e
 
         response = jsonify(dict(message="File successfully uploaded"))
         response.status_code = HTTPStatus.CREATED

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -80,7 +80,8 @@ class AuditType(enum.Enum):
     set."""
     CONFIG = enum.auto()
 
-    """A default when no resource is affected"""
+    """A default when no resource is affected, or when auditing will be done
+    internally by an API."""
     NONE = enum.auto()
 
     """An Elasticsearch template. The base template name will be recorded in

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -360,7 +360,6 @@ class Index:
                         idxctx.logger.info("Starting {} (size {:d})", tb, size)
                         audit = None
                         ptb = None
-                        userid = None
                         tb_res = error_code["OK"]
                         try:
                             path = os.path.realpath(tb)

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -397,12 +397,6 @@ class Index:
                                     dataset, f"Unable to advance dataset state: {e!r}"
                                 )
                                 continue
-                            else:
-                                # NOTE: we index the owner_id foreign key not the username.
-                                # Although this is technically an integer, I'm clinging to
-                                # the notion that we want to keep this as a "keyword" (string)
-                                # field.
-                                userid = str(dataset.owner_id)
 
                             audit = Audit.create(
                                 operation=OperationCode.UPDATE,
@@ -414,7 +408,7 @@ class Index:
 
                             # "Open" the tar ball represented by the tar ball object
                             idxctx.logger.debug("open tar ball")
-                            ptb = PbenchTarBall(idxctx, userid, path, tmpdir, unpacked)
+                            ptb = PbenchTarBall(idxctx, dataset, path, tmpdir, unpacked)
 
                             # Construct the generator for emitting all actions.
                             # The `idxctx` dictionary is passed along to each

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -44,17 +44,14 @@ class TestUpload:
             "Authorization": "Bearer " + auth_token,
             "controller": self.controller,
             "Content-MD5": md5,
+            "Content-Type": "application/octet-stream",
         }
         return headers
 
     @staticmethod
-    def verify_logs(caplog, warning_msg):
-        found = False
+    def verify_logs(caplog):
         for record in caplog.records:
             assert record.levelname not in ("ERROR", "CRITICAL")
-            if record.levelname == "WARNING" and warning_msg in record.message:
-                found = True
-        assert found, f"Failed to find expected warning message, {warning_msg!r}"
 
     @pytest.fixture(scope="function", autouse=True)
     def fake_cache_manager(self, monkeypatch):
@@ -120,7 +117,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_missing_md5sum_header_upload(
@@ -136,7 +133,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_missing_filename_extension(
@@ -154,7 +151,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_missing_length_header_upload(
@@ -171,7 +168,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.LENGTH_REQUIRED
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_bad_length_header_upload(
@@ -189,7 +186,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.LENGTH_REQUIRED
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_bad_controller_upload(
@@ -207,7 +204,7 @@ class TestUpload:
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_mismatched_md5sum_header(
@@ -225,7 +222,7 @@ class TestUpload:
             )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
         with pytest.raises(DatasetNotFound):
             Dataset.query(name="log")
@@ -253,7 +250,7 @@ class TestUpload:
             )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_invalid_authorization_upload(
@@ -288,7 +285,7 @@ class TestUpload:
             )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == expected_message
-        self.verify_logs(caplog, expected_message)
+        self.verify_logs(caplog)
         assert not self.cachemanager_created
 
     def test_upload_cachemanager_error(


### PR DESCRIPTION
PBENCH-1029

The 0.69 "pass-through" compatibility server will be uploading datasets to the 1.0 server under a fixed username, which means these datasets won't be visible to other users.

This adds an "access" query parameter to `PUT` that allows the put-shim server to upload all datasets as "public" so that they're visible to be analyzed and claimed.

(NOTE that this implies some follow-on Agent work in pbench-results-move and supporting classes to allow put-shim to specify the new query parameter.)

To "easily" accomplish this, I refactored the upload class on top of our `ApiBase` to handle parameter processing. Some changes were necessary to avoid consuming the entire data stream during validation, but this also allows `PUT` to participate in the new `APIInternalError` UUID mechanism cleanup. `PUT` continues to handle auditing itself as we have no resource ID to log at the beginning of `_dispatch`.