### PR TITLE
Send tarball with access param

### DIFF
--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -7,6 +7,8 @@ Options:
   -C, --config PATH       Path to a pbench-agent configuration file (defaults
                           to the '_PBENCH_AGENT_CONFIG' environment variable,
                           if defined)  [required]
+  -a, --access [public|private]  pbench tarball access permission
+			  public/private  [default: private]
   --controller TEXT       Override the default controller name
   --token TEXT            pbench server authentication token  [required]
   --delete / --no-delete  Remove local data after successful copy  [default:

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -4,21 +4,21 @@ Usage: pbench-results-move [OPTIONS]
   Move result directories to the configured Pbench server.
 
 Options:
-  -C, --config PATH       	  Path to a pbench-agent configuration file
-				  (defaults to the '_PBENCH_AGENT_CONFIG'
-				  environment variable, if defined)  [required]
+  -C, --config PATH              Path to a pbench-agent configuration file
+                                 (defaults to the '_PBENCH_AGENT_CONFIG'
+                                 environment variable, if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-			  	  public/private  [default: private]
-  --controller TEXT       	  Override the default controller name
-  --token TEXT            	  pbench server authentication token
-				  [required]
-  --delete / --no-delete  	  Remove local data after successful copy
-				  [default: delete]
-  --xz-single-threaded    	  Use single threaded compression with 'xz'
-  --show-server TEXT      	  Display information about the pbench server
-				  where the result(s) will be moved (Not
-				  implemented)
-  --help                  	  Show this message and exit.
+                                 public/private  [default: private]
+  --controller TEXT              Override the default controller name
+  --token TEXT                   pbench server authentication token
+                                 [required]
+  --delete / --no-delete         Remove local data after successful copy
+                                 [default: delete]
+  --xz-single-threaded           Use single threaded compression with 'xz'
+  --show-server TEXT             Display information about the pbench server
+                                 where the result(s) will be moved (Not
+                                 implemented)
+  --help                         Show this message and exit.
 --- Finished test-23 pbench-results-move (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -4,18 +4,20 @@ Usage: pbench-results-move [OPTIONS]
   Move result directories to the configured Pbench server.
 
 Options:
-  -C, --config PATH       	  Path to a pbench-agent configuration file (defaults
-                          	  to the '_PBENCH_AGENT_CONFIG' environment variable,
-                          	  if defined)  [required]
+  -C, --config PATH       	  Path to a pbench-agent configuration file
+				  (defaults to the '_PBENCH_AGENT_CONFIG'
+				  environment variable, if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
 			  	  public/private  [default: private]
   --controller TEXT       	  Override the default controller name
-  --token TEXT            	  pbench server authentication token  [required]
-  --delete / --no-delete  	  Remove local data after successful copy  [default:
-                          	  delete]
+  --token TEXT            	  pbench server authentication token
+				  [required]
+  --delete / --no-delete  	  Remove local data after successful copy
+				  [default: delete]
   --xz-single-threaded    	  Use single threaded compression with 'xz'
-  --show-server TEXT      	  Display information about the pbench server where
-                          	  the result(s) will be moved (Not implemented)
+  --show-server TEXT      	  Display information about the pbench server
+				  where the result(s) will be moved (Not
+				  implemented)
   --help                  	  Show this message and exit.
 --- Finished test-23 pbench-results-move (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -4,19 +4,19 @@ Usage: pbench-results-move [OPTIONS]
   Move result directories to the configured Pbench server.
 
 Options:
-  -C, --config PATH       Path to a pbench-agent configuration file (defaults
-                          to the '_PBENCH_AGENT_CONFIG' environment variable,
-                          if defined)  [required]
+  -C, --config PATH       	 Path to a pbench-agent configuration file (defaults
+                          	 to the '_PBENCH_AGENT_CONFIG' environment variable,
+                          	 if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-			  public/private  [default: private]
-  --controller TEXT       Override the default controller name
-  --token TEXT            pbench server authentication token  [required]
-  --delete / --no-delete  Remove local data after successful copy  [default:
-                          delete]
-  --xz-single-threaded    Use single threaded compression with 'xz'
-  --show-server TEXT      Display information about the pbench server where
-                          the result(s) will be moved (Not implemented)
-  --help                  Show this message and exit.
+			  	 public/private  [default: private]
+  --controller TEXT       	 Override the default controller name
+  --token TEXT            	 pbench server authentication token  [required]
+  --delete / --no-delete  	 Remove local data after successful copy  [default:
+                          	 delete]
+  --xz-single-threaded    	 Use single threaded compression with 'xz'
+  --show-server TEXT      	 Display information about the pbench server where
+                          	 the result(s) will be moved (Not implemented)
+  --help                  	 Show this message and exit.
 --- Finished test-23 pbench-results-move (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -4,19 +4,19 @@ Usage: pbench-results-move [OPTIONS]
   Move result directories to the configured Pbench server.
 
 Options:
-  -C, --config PATH       	 Path to a pbench-agent configuration file (defaults
-                          	 to the '_PBENCH_AGENT_CONFIG' environment variable,
-                          	 if defined)  [required]
+  -C, --config PATH       	  Path to a pbench-agent configuration file (defaults
+                          	  to the '_PBENCH_AGENT_CONFIG' environment variable,
+                          	  if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-			  	 public/private  [default: private]
-  --controller TEXT       	 Override the default controller name
-  --token TEXT            	 pbench server authentication token  [required]
-  --delete / --no-delete  	 Remove local data after successful copy  [default:
-                          	 delete]
-  --xz-single-threaded    	 Use single threaded compression with 'xz'
-  --show-server TEXT      	 Display information about the pbench server where
-                          	 the result(s) will be moved (Not implemented)
-  --help                  	 Show this message and exit.
+			  	  public/private  [default: private]
+  --controller TEXT       	  Override the default controller name
+  --token TEXT            	  pbench server authentication token  [required]
+  --delete / --no-delete  	  Remove local data after successful copy  [default:
+                          	  delete]
+  --xz-single-threaded    	  Use single threaded compression with 'xz'
+  --show-server TEXT      	  Display information about the pbench server where
+                          	  the result(s) will be moved (Not implemented)
+  --help                  	  Show this message and exit.
 --- Finished test-23 pbench-results-move (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -7,14 +7,14 @@ Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
   RESULT_TB_NAME is the path to the result tar ball.
 
 Options:
-  -C, --config PATH  		  Path to a pbench-agent configuration file
-				  (defaults to the '_PBENCH_AGENT_CONFIG'
-				  environment variable, if defined)  [required]
+  -C, --config PATH              Path to a pbench-agent configuration file
+                                 (defaults to the '_PBENCH_AGENT_CONFIG'
+                                 environment variable, if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-		     		  public/private  [default: private]
-  --token TEXT       		  pbench server authentication token (will
-				  prompt if unspecified)  [required]
-  --help             		  Show this message and exit.
+                                 public/private  [default: private]
+  --token TEXT                   pbench server authentication token (will
+                                 prompt if unspecified)  [required]
+  --help                         Show this message and exit.
 --- Finished test-24 pbench-results-push (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -7,13 +7,13 @@ Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
   RESULT_TB_NAME is the path to the result tar ball.
 
 Options:
-  -C, --config PATH  		  Path to a pbench-agent configuration file (defaults to
-                     		  the '_PBENCH_AGENT_CONFIG' environment variable, if
-                     		  defined)  [required]
+  -C, --config PATH  		  Path to a pbench-agent configuration file
+				  (defaults to the '_PBENCH_AGENT_CONFIG'
+				  environment variable, if defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
 		     		  public/private  [default: private]
-  --token TEXT       		  pbench server authentication token (will prompt if
-                     		  unspecified)  [required]
+  --token TEXT       		  pbench server authentication token (will
+				  prompt if unspecified)  [required]
   --help             		  Show this message and exit.
 --- Finished test-24 pbench-results-push (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -10,6 +10,8 @@ Options:
   -C, --config PATH  Path to a pbench-agent configuration file (defaults to
                      the '_PBENCH_AGENT_CONFIG' environment variable, if
                      defined)  [required]
+  -a, --access [public|private]  pbench tarball access permission
+		     public/private  [default: private]
   --token TEXT       pbench server authentication token (will prompt if
                      unspecified)  [required]
   --help             Show this message and exit.

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -7,14 +7,14 @@ Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
   RESULT_TB_NAME is the path to the result tar ball.
 
 Options:
-  -C, --config PATH  Path to a pbench-agent configuration file (defaults to
-                     the '_PBENCH_AGENT_CONFIG' environment variable, if
-                     defined)  [required]
+  -C, --config PATH  		 Path to a pbench-agent configuration file (defaults to
+                     		 the '_PBENCH_AGENT_CONFIG' environment variable, if
+                     		 defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-		     public/private  [default: private]
-  --token TEXT       pbench server authentication token (will prompt if
-                     unspecified)  [required]
-  --help             Show this message and exit.
+		     		 public/private  [default: private]
+  --token TEXT       		 pbench server authentication token (will prompt if
+                     		 unspecified)  [required]
+  --help             		 Show this message and exit.
 --- Finished test-24 pbench-results-push (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -7,14 +7,14 @@ Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
   RESULT_TB_NAME is the path to the result tar ball.
 
 Options:
-  -C, --config PATH  		 Path to a pbench-agent configuration file (defaults to
-                     		 the '_PBENCH_AGENT_CONFIG' environment variable, if
-                     		 defined)  [required]
+  -C, --config PATH  		  Path to a pbench-agent configuration file (defaults to
+                     		  the '_PBENCH_AGENT_CONFIG' environment variable, if
+                     		  defined)  [required]
   -a, --access [public|private]  pbench tarball access permission
-		     		 public/private  [default: private]
-  --token TEXT       		 pbench server authentication token (will prompt if
-                     		 unspecified)  [required]
-  --help             		 Show this message and exit.
+		     		  public/private  [default: private]
+  --token TEXT       		  pbench server authentication token (will prompt if
+                     		  unspecified)  [required]
+  --help             		  Show this message and exit.
 --- Finished test-24 pbench-results-push (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -311,20 +311,23 @@ class CopyResultTb:
         self.upload_url = f"{server_rest_url}/upload/{tbname}"
         self.logger = logger
 
-    def copy_result_tb(self, token: str) -> None:
+    def copy_result_tb(self, token: str, access: str) -> None:
         """Copies the tar ball from the agent to the configured server using upload
         API.
 
-        Args
-            token -- a token which establishes that the caller is
+        Args:
+            token: a token which establishes that the caller is
                 authorized to make the PUT request on behalf of a
                 specific user.
+            access: keyword that identifies whether a dataset needs
+                to be published public or private.
 
-        Raises
+        Raises:
             RuntimeError     if a connection to the server fails
             FileUploadError  if the tar ball failed to upload properly
 
         """
+        params = {"access": access}
         headers = {
             "Content-MD5": self.tarball_md5,
             "Authorization": f"Bearer {token}",
@@ -333,7 +336,7 @@ class CopyResultTb:
         with self.tarball.open("rb") as f:
             try:
                 request = requests.Request(
-                    "PUT", self.upload_url, data=f, headers=headers
+                    "PUT", self.upload_url, data=f, headers=headers, params=params
                 ).prepare()
 
                 # Per RFC 2616, a request must not contain both

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -103,7 +103,7 @@ class MoveResults(BaseCommand):
                         self.config,
                         self.logger,
                     )
-                    crt.copy_result_tb(self.context.token)
+                    crt.copy_result_tb(self.context.token, self.context.access)
                 except Exception as exc:
                     if isinstance(exc, (CopyResultTb.FileUploadError, RuntimeError)):
                         msg = "Error uploading file"
@@ -182,6 +182,12 @@ class MoveResults(BaseCommand):
     help="Override the default controller name",
 )
 @click.option(
+    "--access",
+    required=True,
+    prompt=True,
+    help="pbench tarball access permission public/private (will prompt if unspecified)",
+)
+@click.option(
     "--token",
     required=True,
     envvar="PBENCH_ACCESS_TOKEN",
@@ -210,6 +216,7 @@ class MoveResults(BaseCommand):
 def main(
     context: CliContext,
     controller: str,
+    access: str,
     token: str,
     delete: bool,
     xz_single_threaded: bool,
@@ -237,6 +244,7 @@ def main(
         clk_ctx.exit(1)
     context.controller = controller
 
+    context.access = access
     context.token = token
 
     if show_server:

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -8,6 +8,7 @@ import click
 from pbench.agent.base import BaseCommand
 from pbench.agent.results import CopyResultTb, MakeResultTb
 from pbench.cli.agent import CliContext, pass_cli_context
+from pbench.cli.agent.commands.results.results_options import results_common_options
 from pbench.cli.agent.options import common_options
 from pbench.common.exceptions import BadMDLogFormat
 from pbench.common.utils import validate_hostname
@@ -173,6 +174,7 @@ class MoveResults(BaseCommand):
 
 @click.command(name="pbench-results-move")
 @common_options
+@results_common_options
 @click.option(
     "--controller",
     required=False,
@@ -180,13 +182,6 @@ class MoveResults(BaseCommand):
     default="",
     prompt=False,
     help="Override the default controller name",
-)
-@click.option(
-    "--access",
-    default="private",
-    show_default=True,
-    type=click.Choice(["public", "private"], case_sensitive=False),
-    help="pbench tarball access permission public/private (will prompt if unspecified)",
 )
 @click.option(
     "--token",

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -183,8 +183,9 @@ class MoveResults(BaseCommand):
 )
 @click.option(
     "--access",
-    required=True,
-    prompt=True,
+    default="private",
+    show_default=True,
+    type=click.Choice(["public", "private"], case_sensitive=False),
     help="pbench tarball access permission public/private (will prompt if unspecified)",
 )
 @click.option(

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -23,7 +23,7 @@ class ResultsPush(BaseCommand):
             self.config,
             self.logger,
         )
-        crt.copy_result_tb(self.context.token)
+        crt.copy_result_tb(self.context.token, self.context.access)
         return 0
 
 
@@ -35,6 +35,12 @@ class ResultsPush(BaseCommand):
     prompt=True,
     envvar="PBENCH_ACCESS_TOKEN",
     help="pbench server authentication token (will prompt if unspecified)",
+)
+@click.option(
+    "--access",
+    required=True,
+    prompt=True,
+    help="pbench tarball access permission public/private (will prompt if unspecified)",
 )
 @click.argument("controller")
 @click.argument(
@@ -54,6 +60,7 @@ def main(
     controller: str,
     result_tb_name: str,
     token: str,
+    access: str,
 ):
     """Push a result tar ball to the configured Pbench server.
 
@@ -68,6 +75,7 @@ def main(
     context.controller = controller
     context.result_tb_name = result_tb_name
     context.token = token
+    context.access = access
 
     try:
         rv = ResultsPush(context).execute()

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -38,8 +38,9 @@ class ResultsPush(BaseCommand):
 )
 @click.option(
     "--access",
-    required=True,
-    prompt=True,
+    default="private",
+    show_default=True,
+    type=click.Choice(["public", "private"], case_sensitive=False),
     help="pbench tarball access permission public/private (will prompt if unspecified)",
 )
 @click.argument("controller")

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -5,6 +5,7 @@ import click
 from pbench.agent.base import BaseCommand
 from pbench.agent.results import CopyResultTb
 from pbench.cli.agent import CliContext, pass_cli_context
+from pbench.cli.agent.commands.results.results_options import results_common_options
 from pbench.cli.agent.options import common_options
 from pbench.common.utils import md5sum
 
@@ -29,19 +30,13 @@ class ResultsPush(BaseCommand):
 
 @click.command(name="pbench-results-push")
 @common_options
+@results_common_options
 @click.option(
     "--token",
     required=True,
     prompt=True,
     envvar="PBENCH_ACCESS_TOKEN",
     help="pbench server authentication token (will prompt if unspecified)",
-)
-@click.option(
-    "--access",
-    default="private",
-    show_default=True,
-    type=click.Choice(["public", "private"], case_sensitive=False),
-    help="pbench tarball access permission public/private (will prompt if unspecified)",
 )
 @click.argument("controller")
 @click.argument(

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -1,0 +1,26 @@
+import click
+
+from pbench.cli.agent import CliContext
+
+
+def results_common_options(f):
+    f = _results_options(f)
+    return f
+
+
+def _results_options(f):
+    """Common option for results command"""
+
+    def callback(ctx, _param, value):
+        clictx = ctx.ensure_object(CliContext)
+        clictx.config = value
+        return value
+
+    return click.option(
+        "-a",
+        "--access",
+        default="private",
+        show_default=True,
+        type=click.Choice(["public", "private"], case_sensitive=False),
+        help="pbench tarball access permission public/private (will prompt if unspecified)",
+    )(f)

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -22,5 +22,5 @@ def _results_options(f):
         default="private",
         show_default=True,
         type=click.Choice(["public", "private"], case_sensitive=False),
-        help="pbench tarball access permission public/private (will prompt if unspecified)",
+        help="pbench tarball access permission public/private",
     )(f)

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -38,7 +38,7 @@ class TestCopyResults:
             self.config,
             self.logger,
         )
-        crt.copy_result_tb("token")
+        crt.copy_result_tb("token", "access")
 
     @responses.activate
     def test_bad_tar(self, caplog):

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -39,13 +39,16 @@ class TestMoveResults:
 
     CTRL_SWITCH = "--controller"
     TOKN_SWITCH = "--token"
+    ACCESS_SWITCH = "--access"
     DELY_SWITCH = "--delete"
     DELN_SWITCH = "--no-delete"
     XZST_SWITCH = "--xz-single-threaded"
     SWSR_SWITCH = "--show-server"
     TOKN_PROMPT = "Token: "
+    ACCESS_PROMPT = "Access: "
     CTRL_TEXT = "ctrl"
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
+    ACCESS_TEXT = "public/private"
     SWSR_TEXT = None
     URL = "http://pbench.example.com/api/v1"
     ENDPOINT = "/login"
@@ -76,6 +79,8 @@ class TestMoveResults:
                 TestMoveResults.XZST_SWITCH,
                 TestMoveResults.SWSR_SWITCH,
                 TestMoveResults.SWSR_TEXT,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (
@@ -133,6 +138,8 @@ class TestMoveResults:
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
                 TestMoveResults.DELN_SWITCH,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (
@@ -154,6 +161,8 @@ class TestMoveResults:
                 TestMoveResults.CTRL_TEXT,
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (
@@ -173,6 +182,8 @@ class TestMoveResults:
                 TestMoveResults.CTRL_TEXT,
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -45,10 +45,9 @@ class TestMoveResults:
     XZST_SWITCH = "--xz-single-threaded"
     SWSR_SWITCH = "--show-server"
     TOKN_PROMPT = "Token: "
-    ACCESS_PROMPT = "Access: "
     CTRL_TEXT = "ctrl"
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
-    ACCESS_TEXT = "public/private"
+    ACCESS_TEXT = "private"
     SWSR_TEXT = None
     URL = "http://pbench.example.com/api/v1"
     ENDPOINT = "/login"
@@ -138,8 +137,6 @@ class TestMoveResults:
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
                 TestMoveResults.DELN_SWITCH,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (
@@ -161,8 +158,6 @@ class TestMoveResults:
                 TestMoveResults.CTRL_TEXT,
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (
@@ -182,8 +177,6 @@ class TestMoveResults:
                 TestMoveResults.CTRL_TEXT,
                 TestMoveResults.TOKN_SWITCH,
                 TestMoveResults.TOKN_TEXT,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
             ],
         )
         assert (

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -181,7 +181,7 @@ class TestResultsPush:
             ],
         )
         assert result.exit_code == 2, result.stderr
-        assert ("Error: Invalid value for '--access': 'public/private'") in str(
+        assert ("Error: Invalid value for '-a' / '--access': 'public/private'") in str(
             result.stderr
         )
 

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -16,6 +16,9 @@ class TestResultsPush:
     TOKN_SWITCH = "--token"
     TOKN_PROMPT = "Token: "
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
+    ACCESS_SWITCH = "--access"
+    ACCESS_PROMPT = "Access: "
+    ACCESS_TEXT = "public/private"
     URL = "http://pbench.example.com/api/v1"
 
     @staticmethod
@@ -94,6 +97,8 @@ class TestResultsPush:
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
                 TestResultsPush.CTRL_TEXT,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
                 tarball,
                 "extra-arg",
             ],
@@ -114,6 +119,8 @@ class TestResultsPush:
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
                 TestResultsPush.CTRL_TEXT,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
                 tarball,
             ],
         )
@@ -129,8 +136,33 @@ class TestResultsPush:
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
-            args=[TestResultsPush.CTRL_TEXT, tarball],
+            args=[
+                TestResultsPush.CTRL_TEXT,
+                tarball,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+            ],
             input=TestResultsPush.TOKN_TEXT + "\n",
+        )
+        assert result.exit_code == 0, result.stderr
+        assert result.stderr == "File uploaded successfully\n"
+
+    @staticmethod
+    @responses.activate
+    def test_access_prompt():
+        """Test normal operation when the access option is omitted"""
+
+        TestResultsPush.add_http_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.CTRL_TEXT,
+                tarball,
+                TestResultsPush.TOKN_SWITCH,
+                TestResultsPush.TOKN_TEXT,
+            ],
+            input=TestResultsPush.ACCESS_TEXT + "\n",
         )
         assert result.exit_code == 0, result.stderr
         assert result.stderr == "File uploaded successfully\n"
@@ -144,7 +176,15 @@ class TestResultsPush:
         TestResultsPush.add_http_mock_response()
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.CTRL_TEXT,
+                tarball,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+            ],
+        )
         assert result.exit_code == 0, result.stderr
         assert result.stderr == "File uploaded successfully\n"
 
@@ -157,7 +197,15 @@ class TestResultsPush:
         TestResultsPush.add_connectionerr_mock_response()
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.CTRL_TEXT,
+                tarball,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+            ],
+        )
         assert result.exit_code == 1
         assert str(result.stderr).startswith("Cannot connect to")
 
@@ -170,7 +218,15 @@ class TestResultsPush:
         TestResultsPush.add_http_mock_response(HTTPStatus.NOT_FOUND)
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.CTRL_TEXT,
+                tarball,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+            ],
+        )
         assert result.exit_code == 1
         assert (
             str(result.stderr).find("Not Found") > -1


### PR DESCRIPTION
PBENCH-1034

This PR will help us to send tarball with private/public access.

Public access will mean anyone can access that Tarball while private access will mean, only the owner of the tarball will be able to access that data.

`pbench-results-move --token="token" --access="public"`