### PR TITLE
Add verify host names method used by Tool Meister

### DIFF
--- a/lib/pbench/agent/tool_group.py
+++ b/lib/pbench/agent/tool_group.py
@@ -4,6 +4,8 @@ import re
 import shutil
 from typing import Iterable, Optional
 
+from pbench.agent.utils import LocalRemoteHost
+
 
 class BadToolGroup(Exception):
     """Exception representing a tool group that does not exist or is invalid."""
@@ -133,6 +135,19 @@ class ToolGroup:
                     tool not in self.hostnames[host]
                 ), f"Logic error!  {tool} in {self.hostnames[host]!r}"
                 self.hostnames[host][tool] = tool_opts
+
+    def verify_hostnames(self):
+        """verify all registered host names properly resolve their host
+        information.
+        """
+        lr = LocalRemoteHost()
+        for host in self.hostnames:
+            try:
+                lr.resolve(host)
+            except Exception as exc:
+                raise BadToolGroup(
+                    f"Bad tool group, '{self.name}': '{host}' did not resolve"
+                ) from exc
 
     def get_tools(self, host):
         """get_tools - given a target host, return a dictionary with the list

--- a/lib/pbench/agent/tool_meister_start.py
+++ b/lib/pbench/agent/tool_meister_start.py
@@ -806,6 +806,11 @@ def start(_prog: str, cli_params: Namespace) -> int:
             # If a tool group has no tools registered, then there will be no
             # host names on which to start Tool Meisters.
             return ReturnCode.SUCCESS
+        try:
+            tool_group.verify_hostnames()
+        except BadToolGroup as exc:
+            logger.error(str(exc))
+            return ReturnCode.BADTOOLGROUP
 
     sysinfo, bad_l = cli_verify_sysinfo(cli_params.sysinfo)
     if bad_l:

--- a/lib/pbench/test/unit/agent/test_utils.py
+++ b/lib/pbench/test/unit/agent/test_utils.py
@@ -2,7 +2,6 @@
 """
 import os
 import signal
-import socket
 import time
 
 import ifaddr
@@ -243,7 +242,7 @@ class TestLocalRemoteHost:
 
         # An unresolvable host isn't usable for benchmarking; we expect name
         # resolution to fail, and the exception should propagate to the caller.
-        with pytest.raises(socket.gaierror):
+        with pytest.raises(lrh.Error):
             lrh.is_local("testhost.example.com")
         assert not lrh.is_local("example.com"), "'example.com' should be remote"
         assert lrh.is_local("localhost"), "'localhost' should be local"


### PR DESCRIPTION
The Tool Meister sub-system now verifies that the host names in the requested tool group are valid before proceeding.