### PR TITLE
Correct datasets list API `next_url` value

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Tuple
 from urllib.parse import urlencode, urlparse
 
 from flask.json import jsonify
@@ -20,6 +20,14 @@ from pbench.server.api.resources import (
 )
 from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import Dataset, Metadata, MetadataError
+
+
+def urlencode_json(json: Dict[str, Any]) -> str:
+    """We must properly encode the metadata query parameter as a list of keys."""
+    new_json = {}
+    for k, v in sorted(json.items()):
+        new_json[k] = ",".join(v) if k == "metadata" else v
+    return urlencode(new_json)
 
 
 class DatasetsList(ApiBase):
@@ -93,7 +101,7 @@ class DatasetsList(ApiBase):
         if next_offset < total_count:
             json["offset"] = next_offset
             parsed_url = urlparse(url)
-            next_url = parsed_url._replace(query=urlencode(json)).geturl()
+            next_url = parsed_url._replace(query=urlencode_json(json)).geturl()
         else:
             next_url = ""
 

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Dict, List, Tuple
 from urllib.parse import urlencode, urlparse
 
 from flask.json import jsonify
@@ -22,7 +22,7 @@ from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import Dataset, Metadata, MetadataError
 
 
-def urlencode_json(json: Dict[str, Any]) -> str:
+def urlencode_json(json: JSON) -> str:
     """We must properly encode the metadata query parameter as a list of keys."""
     new_json = {}
     for k, v in sorted(json.items()):

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -362,6 +362,10 @@ def more_datasets(
         test    private 2002-05-16  test
         drb     public  2020-02-15  fio_1
         test    public  2002-05-16  fio_2
+        test    private 2022-12-08  uperf_1
+        test    private 2022-12-09  uperf_2
+        test    private 2022-12-10  uperf_3
+        test    private 2022-12-11  uperf_4
 
     Args:
         client: Provide a Flask API client
@@ -387,6 +391,38 @@ def more_datasets(
             name="fio_2",
             access="public",
             resource_id="random_md5_string4",
+        ).add()
+        Dataset(
+            owner_id=str(create_user.id),
+            created=datetime.datetime(2022, 12, 8),
+            state=States.INDEXED,
+            name="uperf_1",
+            access="private",
+            resource_id="random_md5_string5",
+        ).add()
+        Dataset(
+            owner_id=str(create_user.id),
+            created=datetime.datetime(2022, 12, 9),
+            state=States.INDEXED,
+            name="uperf_2",
+            access="private",
+            resource_id="random_md5_string6",
+        ).add()
+        Dataset(
+            owner_id=str(create_user.id),
+            created=datetime.datetime(2022, 12, 10),
+            state=States.INDEXED,
+            name="uperf_3",
+            access="private",
+            resource_id="random_md5_string7",
+        ).add()
+        Dataset(
+            owner_id=str(create_user.id),
+            created=datetime.datetime(2020, 12, 11),
+            state=States.INDEXED,
+            name="uperf_4",
+            access="private",
+            resource_id="random_md5_string8",
         ).add()
 
 

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -74,8 +74,25 @@ class TestDatasetsDateRange:
             ("drb", {"access": "public"}, ["drb", "fio_2"]),
             ("test_admin", {"owner": "drb"}, ["drb"]),
             ("drb", {}, ["drb", "fio_1", "fio_2"]),
-            ("test", {}, ["test", "fio_1", "fio_2"]),
-            ("test_admin", {}, ["drb", "test", "fio_1", "fio_2"]),
+            (
+                "test",
+                {},
+                ["test", "fio_1", "fio_2", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
+            ),
+            (
+                "test_admin",
+                {},
+                [
+                    "drb",
+                    "test",
+                    "fio_1",
+                    "fio_2",
+                    "uperf_1",
+                    "uperf_2",
+                    "uperf_3",
+                    "uperf_4",
+                ],
+            ),
         ],
     )
     def test_dataset_daterange(self, query_as, login, query, results):


### PR DESCRIPTION
Suggested commit message:

    When results are paginated, the `next_url` value was blindly URL
    encoded, but the `metadata` `list` object should be formatted as a
    string of comma separated values.