### PR TITLE
Simplify user reg & dump progress in func tests

### DIFF
--- a/lib/pbench/test/functional/server/conftest.py
+++ b/lib/pbench/test/functional/server/conftest.py
@@ -24,7 +24,7 @@ def server_client():
     return client
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def register_test_user(server_client: PbenchServerClient):
     """Create a test user for functional tests."""
 
@@ -48,7 +48,9 @@ def register_test_user(server_client: PbenchServerClient):
 
 
 @pytest.fixture
-def login_user(server_client, register_test_user):
+def login_user(server_client: PbenchServerClient, register_test_user):
     """Log in the test user and return the authentication token"""
     server_client.login("tester", "123456")
     assert server_client.auth_token
+    yield
+    server_client.logout()

--- a/server/exec_functests
+++ b/server/exec_functests
@@ -12,7 +12,7 @@ virtualenv -p /usr/bin/python3 ${VENV}
 source ${VENV}/bin/activate
 python3 -m pip install . -r client/requirements.txt
 
-PBENCH_SERVER=${1} python3 -m pytest ${PWD}/lib/pbench/test/functional/server
+PYTHONUNBUFFERED=True PBENCH_SERVER=${1} python3 -m pytest -v -s ${PWD}/lib/pbench/test/functional/server
 rc=${?}
 
 deactivate


### PR DESCRIPTION
Suggested commit message:

    The register user fixture is promoted to "module" scope, since it only
    needs to happen once. This avoids repeated API calls to create a user
    for every test that uses the `login_user` fixture.

    Further, we change the `login_user` fixture to logout the user when the
    test finishes.

    Finally, we run the functional tests so that we can see the progress of
    the tests as they operate and execute.