### PR TITLE
Leverage context variables for config and logger

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -1,9 +1,12 @@
+from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.database import init_db
+from pbench.server.globals import init_server_ctx
 
 
-def config_setup(context: object) -> PbenchServerConfig:
+def config_setup(context: object, logger_name: str):
     config = PbenchServerConfig.create(context.config)
+    logger = get_pbench_logger(logger_name, config)
+    init_server_ctx(config, logger)
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, None)
-    return config
+    init_db()

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -1,5 +1,4 @@
 from configparser import NoOptionError, NoSectionError
-from logging import Logger
 import os
 from pathlib import Path
 import site
@@ -11,11 +10,11 @@ from flask import Flask
 from pbench.common import wait_for_uri
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
-from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
 from pbench.server.auth import OpenIDClient
 from pbench.server.database import init_db
 from pbench.server.database.database import Database
+from pbench.server.globals import init_server_ctx, server
 from pbench.server.indexer import init_indexing
 
 PROG = "pbench-shell"
@@ -26,7 +25,7 @@ def app() -> Flask:
     return create_app(get_server_config())
 
 
-def find_the_unicorn(logger: Logger):
+def find_the_unicorn():
     """Add the location of the `pip install --user` version of gunicorn to the
     PATH if it exists.
     """
@@ -34,15 +33,13 @@ def find_the_unicorn(logger: Logger):
     if (local / "gunicorn").exists():
         # Use a `pip install --user` version of gunicorn
         os.environ["PATH"] = ":".join([str(local), os.environ["PATH"]])
-        logger.info(
+        server.logger.info(
             "Found a local unicorn: augmenting server PATH to {}",
             os.environ["PATH"],
         )
 
 
-def generate_crontab_if_necessary(
-    crontab_dir: str, bin_dir: Path, cwd: str, logger: Logger
-) -> int:
+def generate_crontab_if_necessary(crontab_dir: str, bin_dir: Path, cwd: str) -> int:
     """Generate and install the crontab for the Pbench Server.
 
     If a crontab file already exists, no action is taken, otherwise a crontab
@@ -51,7 +48,13 @@ def generate_crontab_if_necessary(
 
     If either of those operations fail, the crontab file is removed.
 
-    Return 0 on success, 1 on failure.
+    Args:
+        crontab_dir : directory where crontab files are stored
+        bin_dir : directory where pbench commands are stored
+        cwd : the current working directory to use when generating files
+
+    Returns:
+        0 on success, 1 on failure.
     """
     ret_val = 0
     crontab_f = Path(crontab_dir) / "crontab"
@@ -60,7 +63,7 @@ def generate_crontab_if_necessary(
         # Create the crontab file from the server configuration.
         cp = subprocess.run(["pbench-create-crontab", crontab_dir], cwd=cwd)
         if cp.returncode != 0:
-            logger.error(
+            server.logger.error(
                 "Failed to create crontab file from configuration: {}", cp.returncode
             )
             ret_val = 1
@@ -68,37 +71,37 @@ def generate_crontab_if_necessary(
             # Install the created crontab file.
             cp = subprocess.run(["crontab", f"{crontab_dir}/crontab"], cwd=cwd)
             if cp.returncode != 0:
-                logger.error("Failed to install crontab file: {}", cp.returncode)
+                server.logger.error("Failed to install crontab file: {}", cp.returncode)
                 ret_val = 1
     if ret_val != 0:
         crontab_f.unlink(missing_ok=True)
     return ret_val
 
 
-def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
+def run_gunicorn() -> int:
     """Setup of the Gunicorn Pbench Server Flask application.
 
     Returns:
         1 on error, or the gunicorn sub-process status code
     """
     if site.ENABLE_USER_SITE:
-        find_the_unicorn(logger)
+        find_the_unicorn()
     try:
-        host = server_config.get("pbench-server", "bind_host")
-        port = str(server_config.get("pbench-server", "bind_port"))
-        db_uri = server_config.get("database", "uri")
-        db_wait_timeout = int(server_config.get("database", "wait_timeout"))
-        es_uri = server_config.get("Indexing", "uri")
-        es_wait_timeout = int(server_config.get("Indexing", "wait_timeout"))
-        workers = str(server_config.get("pbench-server", "workers"))
-        worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
-        crontab_dir = server_config.get("pbench-server", "crontab-dir")
-        server_config.get("flask-app", "secret-key")
+        host = server.config.get("pbench-server", "bind_host")
+        port = str(server.config.get("pbench-server", "bind_port"))
+        db_uri = server.config.get("database", "uri")
+        db_wait_timeout = int(server.config.get("database", "wait_timeout"))
+        es_uri = server.config.get("Indexing", "uri")
+        es_wait_timeout = int(server.config.get("Indexing", "wait_timeout"))
+        workers = str(server.config.get("pbench-server", "workers"))
+        worker_timeout = str(server.config.get("pbench-server", "worker_timeout"))
+        crontab_dir = server.config.get("pbench-server", "crontab-dir")
+        server.config.get("flask-app", "secret-key")
     except (NoOptionError, NoSectionError) as exc:
-        logger.error("Error fetching required configuration: {}", exc)
+        server.logger.error("Error fetching required configuration: {}", exc)
         return 1
 
-    logger.info(
+    server.logger.info(
         "Waiting at most {:d} seconds for database instance {} to become available.",
         db_wait_timeout,
         db_uri,
@@ -106,13 +109,13 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     try:
         wait_for_uri(db_uri, db_wait_timeout)
     except BadConfig as exc:
-        logger.error(f"{exc}")
+        server.logger.error(f"{exc}")
         return 1
     except ConnectionRefusedError:
-        logger.error("Database {} not responding", db_uri)
+        server.logger.error("Database {} not responding", db_uri)
         return 1
 
-    logger.info(
+    server.logger.info(
         "Waiting at most {:d} seconds for the Elasticsearch instance {} to become available.",
         es_wait_timeout,
         es_uri,
@@ -120,29 +123,29 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     try:
         wait_for_uri(es_uri, es_wait_timeout)
     except BadConfig as exc:
-        logger.error(f"{exc}")
+        server.logger.error(f"{exc}")
         return 1
     except ConnectionRefusedError:
-        logger.error("Elasticsearch {} not responding", es_uri)
+        server.logger.error("Elasticsearch {} not responding", es_uri)
         return 1
 
     try:
-        oidc_server = OpenIDClient.wait_for_oidc_server(server_config, logger)
+        oidc_server = OpenIDClient.wait_for_oidc_server()
     except OpenIDClient.NotConfigured as exc:
-        logger.warning("OpenID Connect client not configured, {}", exc)
+        server.logger.warning("OpenID Connect client not configured, {}", exc)
     else:
-        logger.info("Pbench server using OIDC server {}", oidc_server)
+        server.logger.info("Pbench server using OIDC server {}", oidc_server)
 
     # Multiple gunicorn workers will attempt to connect to the DB; rather than
     # attempt to synchronize them, detect a missing DB (from the database URI)
     # and create it here. It's safer to do this here, where we're
     # single-threaded.
-    logger.info("Performing database setup")
-    Database.create_if_missing(db_uri, logger)
+    server.logger.info("Performing database setup")
+    Database.create_if_missing(db_uri)
     try:
-        init_db(server_config, logger)
+        init_db()
     except (NoOptionError, NoSectionError) as exc:
-        logger.error("Invalid database configuration: {}", exc)
+        server.logger.error("Invalid database configuration: {}", exc)
         return 1
 
     # Multiple cron jobs will attempt to file reports with the Elasticsearch
@@ -150,16 +153,16 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     # initialize the templates in the Indexing sub-system.  To avoid race
     # conditions that can create stack traces, we initialize the indexing sub-
     # system before we start the cron jobs.
-    logger.info("Performing Elasticsearch indexing setup")
+    server.logger.info("Performing Elasticsearch indexing setup")
     try:
-        init_indexing(PROG, server_config, logger)
+        init_indexing(PROG)
     except (NoOptionError, NoSectionError) as exc:
-        logger.error("Invalid indexing configuration: {}", exc)
+        server.logger.error("Invalid indexing configuration: {}", exc)
         return 1
 
-    logger.info("Generating new crontab file, if necessary")
+    server.logger.info("Generating new crontab file, if necessary")
     ret_val = generate_crontab_if_necessary(
-        crontab_dir, server_config.BINDIR, server_config.log_dir, logger
+        crontab_dir, server.config.BINDIR, server.config.log_dir
     )
     if ret_val != 0:
         return ret_val
@@ -193,13 +196,15 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     # packages as well as the pbench.pth file which points to the Pbench Server
     # package.
     if site.ENABLE_USER_SITE:
-        adds = f"{site.getusersitepackages()},{server_config.LIBDIR}"
+        adds = f"{site.getusersitepackages()},{server.config.LIBDIR}"
         cmd_line += ["--pythonpath", adds]
 
     cmd_line.append("pbench.cli.server.shell:app()")
-    logger.info("Starting Gunicorn Pbench Server application")
-    cp = subprocess.run(cmd_line, cwd=server_config.log_dir)
-    logger.info("Gunicorn Pbench Server application exited with {}", cp.returncode)
+    server.logger.info("Starting Gunicorn Pbench Server application")
+    cp = subprocess.run(cmd_line, cwd=server.config.log_dir)
+    server.logger.info(
+        "Gunicorn Pbench Server application exited with {}", cp.returncode
+    )
     return cp.returncode
 
 
@@ -211,14 +216,15 @@ def main() -> int:
         0 on success, 1 on error
     """
     try:
-        server_config = get_server_config()
-        logger = get_pbench_logger(PROG, server_config)
+        config = get_server_config()
+        logger = get_pbench_logger(PROG, config)
+        init_server_ctx(config, logger)
     except Exception as exc:
         print(exc, file=sys.stderr)
         return 1
 
     try:
-        return run_gunicorn(server_config, logger)
+        return run_gunicorn()
     except Exception:
         logger.exception("Unhandled exception running gunicorn")
         return 1

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -3,9 +3,9 @@ import click
 from pbench.cli import pass_cli_context
 from pbench.cli.server import config_setup
 from pbench.cli.server.options import common_options
-from pbench.common.logger import get_pbench_logger
 from pbench.server import BadConfig
 from pbench.server.cache_manager import CacheManager
+from pbench.server.globals import server
 
 
 def print_tree(tree: CacheManager):
@@ -48,15 +48,14 @@ def tree_manage(context: object, display: bool):
         display: Print a simplified representation of the hierarchy
     """
     try:
-        config = config_setup(context)
-        logger = get_pbench_logger("cachemanager", config)
-        cache_m = CacheManager(config, logger)
+        config_setup(context, "cachemanager")
+        cache_m = CacheManager()
         cache_m.full_discovery()
         if display:
             print_tree(cache_m)
         rv = 0
     except Exception as exc:
-        logger.exception("An error occurred discovering the file tree: {}", exc)
+        server.logger.exception("An error occurred discovering the file tree: {}", exc)
         click.echo(exc, err=True)
         rv = 2 if isinstance(exc, BadConfig) else 1
 

--- a/lib/pbench/cli/server/user_management.py
+++ b/lib/pbench/cli/server/user_management.py
@@ -70,7 +70,7 @@ def user_create(
     role: str,
 ) -> None:
     try:
-        config_setup(context)
+        config_setup(context, "user-create")
         user = User(
             username=username,
             password=password,
@@ -100,7 +100,7 @@ def user_create(
 def user_delete(context: object, username: str) -> None:
     try:
         # Delete the the user with specified username
-        config_setup(context)
+        config_setup(context, "user-delete")
         User.delete(username=username)
         rv = 0
     except Exception as exc:
@@ -116,7 +116,7 @@ def user_delete(context: object, username: str) -> None:
 @pass_cli_context
 def user_list(context: object) -> None:
     try:
-        config_setup(context)
+        config_setup(context, "user-list")
         click.echo(USER_LIST_HEADER_ROW)
 
         # Query all the users
@@ -182,7 +182,7 @@ def user_update(
     role: str,
 ) -> None:
     try:
-        config_setup(context)
+        config_setup(context, "user-update")
         # Query the user
         user = User.query(username=updateuser)
 

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -12,7 +12,7 @@ from flask.wrappers import Request, Response
 from flask_restful import abort, Resource
 from sqlalchemy.orm.query import Query
 
-from pbench.server import JSON, JSONOBJECT, JSONVALUE, OperationCode, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT, JSONVALUE, OperationCode
 import pbench.server.auth.auth as Auth
 from pbench.server.database.models.audit import (
     Audit,
@@ -1137,15 +1137,12 @@ class ApiBase(Resource):
 
     def __init__(
         self,
-        config: PbenchServerConfig,
         *schemas: ApiSchema,
         always_enabled: bool = False,
     ):
         """Base class constructor.
 
         Args:
-            config : server configuration
-            logger : logger object
             schemas : ApiSchema objects to provide parameter validation for the
                 various HTTP methods the API module supports. For example, for
                 GET, PUT, and DELETE.
@@ -1154,7 +1151,6 @@ class ApiBase(Resource):
                 be usable.
         """
         super().__init__()
-        self.config = config
         self.schemas = ApiSchemaSet(*schemas)
         self.always_enabled = always_enabled
 

--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -2,7 +2,7 @@ from flask.json import jsonify
 from flask.wrappers import Request, Response
 from sqlalchemy import func
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiBase,
@@ -14,8 +14,8 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import Dataset
+from pbench.server.globals import server
 
 
 class DatasetsDateRange(ApiBase):
@@ -23,9 +23,11 @@ class DatasetsDateRange(ApiBase):
     API class to retrieve the available date range of accessible datasets.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_daterange"
+    urls = ["datasets/daterange"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -56,7 +58,7 @@ class DatasetsDateRange(ApiBase):
         owner = params.query.get("owner")
 
         # Build a SQLAlchemy Query object expressing all of our constraints
-        query = Database.db_session.query(
+        query = server.db_session.query(
             func.min(Dataset.uploaded), func.max(Dataset.uploaded)
         )
         query = self._build_sql_query(owner, access, query)

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,10 +1,10 @@
 from http import HTTPStatus
 from urllib.request import Request
 
-from flask import current_app, send_file
+from flask import send_file
 from flask.wrappers import Response
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorizationType,
@@ -25,9 +25,15 @@ class DatasetsInventory(ApiBase):
     API class to retrieve inventory files from a dataset
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_inventory"
+    urls = [
+        "datasets/inventory/<string:dataset>",
+        "datasets/inventory/<string:dataset>/",
+        "datasets/inventory/<string:dataset>/<path:target>",
+    ]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -60,7 +66,7 @@ class DatasetsInventory(ApiBase):
         dataset = params.uri["dataset"]
         target = params.uri.get("target")
 
-        cache_m = CacheManager(self.config, current_app.logger)
+        cache_m = CacheManager()
         try:
             tarball = cache_m.find_dataset(dataset.resource_id)
         except TarballNotFound as e:

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorization,
@@ -31,9 +31,11 @@ class DatasetsMetadata(ApiBase):
     API class to retrieve and mutate Dataset metadata.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_metadata"
+    urls = ["datasets/metadata/<string:dataset>"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.PUT,
                 OperationCode.UPDATE,

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -11,11 +11,11 @@ from urllib.request import Request
 from dateutil import rrule
 from dateutil.relativedelta import relativedelta
 from elasticsearch import Elasticsearch, helpers, VERSION
-from flask import current_app, jsonify
+from flask import jsonify
 from flask.wrappers import Response
 import requests
 
-from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorizationType,
@@ -42,6 +42,7 @@ from pbench.server.database.models.datasets import (
 )
 from pbench.server.database.models.templates import Template
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 
 
 class MissingBulkSchemaParameters(SchemaError):
@@ -92,16 +93,11 @@ class ElasticBase(ApiBase):
     and postprocess methods.
     """
 
-    def __init__(
-        self,
-        config: PbenchServerConfig,
-        *schemas: ApiSchema,
-    ):
+    def __init__(self, *schemas: ApiSchema):
         """
         Base class constructor.
 
         Args:
-            config: server configuration
             schemas: List of API schemas: for example,
                 ApiSchema(
                     ApiMethod.GET,
@@ -116,9 +112,9 @@ class ElasticBase(ApiBase):
                     uri_schema=Schema(Parameter("dataset", ParamType.DATASET))
                 )
         """
-        super().__init__(config, *schemas)
-        self.prefix = config.get("Indexing", "index_prefix")
-        self.es_url = config.get("Indexing", "uri")
+        super().__init__(*schemas)
+        self.prefix = server.config.get("Indexing", "index_prefix")
+        self.es_url = server.config.get("Indexing", "uri")
 
     def _build_elasticsearch_query(
         self, user: Optional[str], access: Optional[str], terms: List[JSON]
@@ -199,7 +195,7 @@ class ElasticBase(ApiBase):
         is_admin = authorized_user.is_admin() if authorized_user else False
 
         filter = terms.copy()
-        current_app.logger.debug(
+        server.logger.debug(
             "QUERY auth ID {}, user {!r}, access {!r}, admin {}",
             authorized_id,
             user,
@@ -234,14 +230,12 @@ class ElasticBase(ApiBase):
         # constraint or with no constraint at all.
         if not authorized_user or (user and user != authorized_id and not is_admin):
             access_term = {"term": {"authorization.access": Dataset.PUBLIC_ACCESS}}
-            current_app.logger.debug("QUERY: not self public: {}", access_term)
+            server.logger.debug("QUERY: not self public: {}", access_term)
         elif access:
             access_term = {"term": {"authorization.access": access}}
             if not user and access == Dataset.PRIVATE_ACCESS and not is_admin:
                 user_term = {"term": {"authorization.owner": authorized_id}}
-            current_app.logger.debug(
-                "QUERY: user: {}, access: {}", user_term, access_term
-            )
+            server.logger.debug("QUERY: user: {}, access: {}", user_term, access_term)
         elif not user and not is_admin:
             combo_term = {
                 "dis_max": {
@@ -251,11 +245,11 @@ class ElasticBase(ApiBase):
                     ]
                 }
             }
-            current_app.logger.debug("QUERY: {{}} self + public: {}", combo_term)
+            server.logger.debug("QUERY: {{}} self + public: {}", combo_term)
         else:
             # Either "user" was specified and will be added to the filter,
             # or client is ADMIN and no access restrictions are required.
-            current_app.logger.debug("QUERY: {{}} default, user: {}", user_term)
+            server.logger.debug("QUERY: {{}} default, user: {}", user_term)
 
         # We control the order of terms here to allow stable unit testing.
         if combo_term:
@@ -382,7 +376,7 @@ class ElasticBase(ApiBase):
         klasname = self.__class__.__name__
         try:
             self.preprocess(params, context)
-            current_app.logger.debug("PREPROCESS returns {}", context)
+            server.logger.debug("PREPROCESS returns {}", context)
         except UnauthorizedAccess as e:
             raise APIAbort(e.http_status, str(e))
         except KeyError as e:
@@ -392,7 +386,7 @@ class ElasticBase(ApiBase):
             es_request = self.assemble(params, context)
             path = es_request.get("path")
             url = urljoin(self.es_url, path)
-            current_app.logger.info(
+            server.logger.info(
                 "ASSEMBLE returned URL {!r}, {!r}",
                 url,
                 es_request.get("kwargs").get("json"),
@@ -403,7 +397,7 @@ class ElasticBase(ApiBase):
         try:
             # perform the Elasticsearch query
             es_response = method(url, **es_request["kwargs"])
-            current_app.logger.debug(
+            server.logger.debug(
                 "ES query response {}:{}",
                 es_response.reason,
                 es_response.status_code,
@@ -411,7 +405,7 @@ class ElasticBase(ApiBase):
             es_response.raise_for_status()
             json_response = es_response.json()
         except requests.exceptions.HTTPError as e:
-            current_app.logger.error(
+            server.logger.error(
                 "{} HTTP error {} from Elasticsearch request: {}",
                 klasname,
                 e,
@@ -422,14 +416,14 @@ class ElasticBase(ApiBase):
                 f"Elasticsearch query failure {e.response.reason} ({e.response.status_code})",
             )
         except requests.exceptions.ConnectionError:
-            current_app.logger.error(
+            server.logger.error(
                 "{}: connection refused during the Elasticsearch request", klasname
             )
             raise APIAbort(
                 HTTPStatus.BAD_GATEWAY, "Network problem, could not reach Elasticsearch"
             )
         except requests.exceptions.Timeout:
-            current_app.logger.error(
+            server.logger.error(
                 "{}: connection timed out during the Elasticsearch request", klasname
             )
             raise APIAbort(
@@ -446,7 +440,7 @@ class ElasticBase(ApiBase):
             return self.postprocess(json_response, context)
         except PostprocessError as e:
             msg = f"{klasname}: {str(e)}"
-            current_app.logger.error("{}", msg)
+            server.logger.error("{}", msg)
             raise APIAbort(e.status, msg)
         except Exception as e:
             raise APIInternalError("Unexpected backend exception") from e
@@ -510,7 +504,6 @@ class ElasticBulkBase(ApiBase):
 
     def __init__(
         self,
-        config: PbenchServerConfig,
         *schemas: ApiSchema,
         action: Optional[str] = None,
         require_stable: bool = False,
@@ -524,7 +517,6 @@ class ElasticBulkBase(ApiBase):
         in the subclass schema.
 
         Args:
-            config: server configuration
             schemas: List of API schemas: for example,
                 ApiSchema(
                     ApiMethod.GET,
@@ -542,12 +534,11 @@ class ElasticBulkBase(ApiBase):
             require_stable: if True, fail if dataset state is mutating (-ing state)
             require_map: if True, fail if the dataset has no index map
         """
-        super().__init__(config, *schemas)
+        super().__init__(*schemas)
 
         api_name = self.__class__.__name__
 
-        self.elastic_uri = config.get("Indexing", "uri")
-        self.config = config
+        self.elastic_uri = server.config.get("Indexing", "uri")
         self.action = action
         self.require_stable = require_stable
         self.require_map = require_map
@@ -741,7 +732,7 @@ class ElasticBulkBase(ApiBase):
         if map:
             # Build an Elasticsearch instance to manage the bulk update
             elastic = Elasticsearch(self.elastic_uri)
-            current_app.logger.info("Elasticsearch {} [{}]", elastic, VERSION)
+            server.logger.info("Elasticsearch {} [{}]", elastic, VERSION)
 
             # NOTE: because both generate_actions and streaming_bulk return
             # generators, the entire sequence is inside a single try block.

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -1,8 +1,6 @@
 from typing import AnyStr, List, NoReturn, Union
 
-from flask import current_app
-
-from pbench.server import JSON, PbenchServerConfig
+from pbench.server import JSON
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiContext,
@@ -15,6 +13,7 @@ from pbench.server.api.resources import (
 from pbench.server.api.resources.query_apis import ElasticBase
 from pbench.server.database.models.datasets import Dataset, Metadata, MetadataError
 from pbench.server.database.models.templates import Template
+from pbench.server.globals import server
 
 
 class MissingDatasetNameParameter(SchemaError):
@@ -80,7 +79,7 @@ class IndexMapBase(ElasticBase):
         "contents": {"index": "run-toc", "whitelist": ["directory", "files"]},
     }
 
-    def __init__(self, config: PbenchServerConfig, *schemas: ApiSchema):
+    def __init__(self, *schemas: ApiSchema):
         api_name = self.__class__.__name__
         assert (
             len(schemas) == 1
@@ -96,7 +95,7 @@ class IndexMapBase(ElasticBase):
             schemas[0].authorization == ApiAuthorizationType.DATASET
         ), f"{api_name}: schema authorization is not by dataset"
 
-        super().__init__(config, *schemas)
+        super().__init__(*schemas)
         self._method = schemas[0].method
 
     def preprocess(self, params: ApiParams, context: ApiContext) -> NoReturn:
@@ -119,18 +118,18 @@ class IndexMapBase(ElasticBase):
         try:
             index_map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
         except MetadataError as exc:
-            current_app.logger.error("{}", exc)
+            server.logger.error("{}", exc)
             raise APIInternalError(f"Required metadata {Metadata.INDEX_MAP} missing")
 
         if index_map is None:
-            current_app.logger.error("Index map metadata has no value")
+            server.logger.error("Index map metadata has no value")
             raise APIInternalError(
                 f"Required metadata {Metadata.INDEX_MAP} has no value"
             )
 
         index_keys = [key for key in index_map if root_index_name in key]
         indices = ",".join(index_keys)
-        current_app.logger.debug(f"Indices from metadata , {indices!r}")
+        server.logger.debug(f"Indices from metadata , {indices!r}")
         return indices
 
     def get_aggregatable_fields(

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -1,8 +1,6 @@
 from http import HTTPStatus
 
-from flask import current_app
-
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiMethod,
@@ -15,6 +13,7 @@ from pbench.server.api.resources import (
 )
 from pbench.server.api.resources.query_apis import ApiContext, PostprocessError
 from pbench.server.api.resources.query_apis.datasets import IndexMapBase
+from pbench.server.globals import server
 
 
 class DatasetsContents(IndexMapBase):
@@ -24,10 +23,14 @@ class DatasetsContents(IndexMapBase):
     """
 
     MAX_SIZE = 10000
+    endpoint = "datasets_contents"
+    urls = [
+        "datasets/contents/<string:dataset>/",
+        "datasets/contents/<string:dataset>/<path:target>",
+    ]
 
-    def __init__(self, config: PbenchServerConfig):
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -56,7 +59,7 @@ class DatasetsContents(IndexMapBase):
 
         dataset = context["dataset"]
 
-        current_app.logger.info(
+        server.logger.info(
             "Discover dataset {} Contents, directory {}",
             dataset.name,
             target,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 from flask import jsonify
 
-from pbench.server import JSON, OperationCode, PbenchServerConfig
+from pbench.server import JSON, OperationCode
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorizationType,
@@ -28,9 +28,11 @@ class DatasetsDetail(IndexMapBase):
     Get detailed data from the run document for a dataset by name.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_detail"
+    urls = ["datasets/detail/<string:dataset>"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -1,7 +1,7 @@
 from flask import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiBase,
@@ -65,9 +65,11 @@ class DatasetsMappings(ApiBase):
     }
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_mappings"
+    urls = ["datasets/mappings/<string:dataset_view>"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -1,8 +1,6 @@
 from http import HTTPStatus
 
-from flask import current_app
-
-from pbench.server import JSON, OperationCode, PbenchServerConfig
+from pbench.server import JSON, OperationCode
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     APIInternalError,
@@ -17,6 +15,7 @@ from pbench.server.api.resources.query_apis import ApiContext, PostprocessError
 from pbench.server.api.resources.query_apis.datasets import IndexMapBase
 from pbench.server.database.models.datasets import Dataset
 from pbench.server.database.models.templates import TemplateNotFound
+from pbench.server.globals import server
 
 
 class SampleNamespace(IndexMapBase):
@@ -27,9 +26,11 @@ class SampleNamespace(IndexMapBase):
     selecting for certain fields or certain values within those fields.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_namespace"
+    urls = ["datasets/namespace/<string:dataset>/<string:dataset_view>"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -67,7 +68,7 @@ class SampleNamespace(IndexMapBase):
 
         document_index = document["index"]
 
-        current_app.logger.info(
+        server.logger.info(
             "Return {} namespace for dataset {}, prefix {}",
             document_index,
             dataset,
@@ -180,10 +181,11 @@ class SampleValues(IndexMapBase):
 
     DOCUMENT_SIZE = 10000  # Number of documents to return in one page
     SCROLL_EXPIRY = "1m"  # Scroll id expires in 1 minute
+    endpoint = "datasets_values"
+    urls = ["datasets/values/<string:dataset>/<string:dataset_view>"]
 
-    def __init__(self, config: PbenchServerConfig):
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.POST,
                 OperationCode.READ,
@@ -249,7 +251,7 @@ class SampleValues(IndexMapBase):
 
         document_index = document["index"]
 
-        current_app.logger.info(
+        server.logger.info(
             "Return {} rows {} for dataset {}, prefix {}",
             document_index,
             "next page " if scroll_id else "",
@@ -342,7 +344,7 @@ class SampleValues(IndexMapBase):
         try:
             count = int(es_json["hits"]["total"]["value"])
             if count == 0:
-                current_app.logger.info("No data returned by Elasticsearch")
+                server.logger.info("No data returned by Elasticsearch")
                 return {}
 
             results = [hit["_source"] for hit in es_json["hits"]["hits"]]

--- a/lib/pbench/server/api/resources/query_apis/datasets_update.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_update.py
@@ -1,8 +1,6 @@
 from typing import Any, Iterator
 
-from flask import current_app
-
-from pbench.server import JSONOBJECT, OperationCode, PbenchServerConfig
+from pbench.server import JSONOBJECT, OperationCode
 from pbench.server.api.resources import (
     ApiAuthorizationType,
     ApiMethod,
@@ -34,9 +32,11 @@ class DatasetsUpdate(ElasticBulkBase):
     Called as `POST /api/v1/datasets/{resource_id}?access=public&owner=user`
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "datasets_publish"
+    urls = ["datasets/publish/<string:dataset>"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.POST,
                 OperationCode.UPDATE,
@@ -77,7 +77,7 @@ class DatasetsUpdate(ElasticBulkBase):
             A generator for Elasticsearch bulk update actions
         """
 
-        sync = Sync(logger=current_app.logger, component=OperationName.UPDATE)
+        sync = Sync(component=OperationName.UPDATE)
         sync.update(dataset=dataset, state=OperationState.WORKING)
         context["sync"] = sync
 

--- a/lib/pbench/server/api/resources/server_audit.py
+++ b/lib/pbench/server/api/resources/server_audit.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorizationType,
@@ -30,9 +30,11 @@ class ServerAudit(ApiBase):
     API class to retrieve audit records.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "server_audit"
+    urls = ["server/audit"]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/server_settings.py
+++ b/lib/pbench/server/api/resources/server_settings.py
@@ -4,7 +4,7 @@ from flask import current_app
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
-from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server import OperationCode
 from pbench.server.api.resources import (
     APIAbort,
     ApiAuthorizationType,
@@ -31,9 +31,15 @@ class ServerSettings(ApiBase):
     API class to retrieve and mutate server settings.
     """
 
-    def __init__(self, config: PbenchServerConfig):
+    endpoint = "server_configuration"
+    urls = [
+        "server/configuration",
+        "server/configuration/",
+        "server/configuration/<string:key>",
+    ]
+
+    def __init__(self):
         super().__init__(
-            config,
             ApiSchema(
                 ApiMethod.PUT,
                 OperationCode.UPDATE,

--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -13,6 +13,7 @@ from pbench.server.database.database import Database
 from pbench.server.database.models.auth_tokens import AuthToken
 from pbench.server.database.models.server_settings import ServerSetting
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 
 
 class RegisterUser(Resource):
@@ -20,8 +21,8 @@ class RegisterUser(Resource):
     Abstracted pbench API for registering a new user
     """
 
-    def __init__(self, config):
-        self.server_config = config
+    endpoint = "register"
+    urls = ["register"]
 
     def post(self):
         """
@@ -141,9 +142,11 @@ class Login(Resource):
     Pbench API for User Login or generating an auth token
     """
 
-    def __init__(self, config):
-        self.server_config = config
-        self.token_expire_duration = self.server_config.get(
+    endpoint = "login"
+    urls = ["login"]
+
+    def __init__(self):
+        self.token_expire_duration = server.config.get(
             "pbench-server", "token_expiration_duration"
         )
 
@@ -266,8 +269,8 @@ class Logout(Resource):
     Pbench API for User logout and deleting an auth token
     """
 
-    def __init__(self, config):
-        self.server_config = config
+    endpoint = "logout"
+    urls = ["logout"]
 
     def post(self):
         """
@@ -318,6 +321,9 @@ class UserAPI(Resource):
     """
     Abstracted pbench API to get user data
     """
+
+    endpoint = "user"
+    urls = ["user/<string:target_username>"]
 
     TargetUser = NamedTuple(
         "TargetUser",

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -3,12 +3,11 @@ import enum
 from http import HTTPStatus
 from typing import Optional, Tuple, Union
 
-from flask import current_app, Flask, request
+from flask import current_app, request
 from flask_httpauth import HTTPTokenAuth
 from flask_restful import abort
 import jwt
 
-from pbench.server import PbenchServerConfig
 from pbench.server.auth import (
     InternalUser,
     OpenIDClient,
@@ -17,6 +16,7 @@ from pbench.server.auth import (
 )
 from pbench.server.database.models.auth_tokens import AuthToken
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 
 # Module private constants
 _TOKEN_ALG_INT = "HS256"
@@ -26,7 +26,7 @@ token_auth = HTTPTokenAuth("Bearer")
 oidc_client: OpenIDClient = None
 
 
-def setup_app(app: Flask, server_config: PbenchServerConfig):
+def setup_app():
     """Setup the given Flask app from the given Pbench Server configuration
     object.
 
@@ -35,15 +35,12 @@ def setup_app(app: Flask, server_config: PbenchServerConfig):
 
     We attempt to construct an OpenID Client object for third party token
     verification if the configuration is provided.
-
-    Args:
-        server_config : Parsed Pbench server configuration
     """
-    app.secret_key = server_config.get("flask-app", "secret-key")
+    current_app.secret_key = server.config.get("flask-app", "secret-key")
 
     global oidc_client
     try:
-        oidc_client = OpenIDClient.construct_oidc_client(server_config)
+        oidc_client = OpenIDClient.construct_oidc_client()
     except OpenIDClient.NotConfigured:
         oidc_client = None
 

--- a/lib/pbench/server/database/__init__.py
+++ b/lib/pbench/server/database/__init__.py
@@ -12,7 +12,7 @@ from pbench.server.database.models.templates import Template  # noqa F401
 from pbench.server.database.models.users import User  # noqa F401
 
 
-def init_db(configuration, logger):
+def init_db():
     """Utility method for initializing the database.
 
     In order to register all the tables properly in our database, the db
@@ -25,4 +25,4 @@ def init_db(configuration, logger):
     standalone db access should invoke this function instead of directly
     invoking Database.init_db().
     """
-    Database.init_db(server_config=configuration, logger=logger)
+    Database.init_db()

--- a/lib/pbench/server/database/models/audit.py
+++ b/lib/pbench/server/database/models/audit.py
@@ -11,6 +11,7 @@ from pbench.server.database.database import Database
 from pbench.server.database.models import TZDateTime
 from pbench.server.database.models.datasets import Dataset
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 
 
 class AuditError(Exception):
@@ -317,7 +318,7 @@ class Audit(Database.Base):
         """
 
         try:
-            query = Database.db_session.query(Audit)
+            query = server.db_session.query(Audit)
             if start:
                 query = query.filter(Audit.timestamp >= start)
             if end:
@@ -369,10 +370,10 @@ class Audit(Database.Base):
     def add(self):
         """Add the Audit object to the database."""
         try:
-            Database.db_session.add(self)
-            Database.db_session.commit()
+            server.db_session.add(self)
+            server.db_session.commit()
         except Exception as e:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             if isinstance(e, IntegrityError):
                 raise self._decode(e) from e
             raise AuditSqlError("adding", self.as_json(), str(e)) from e

--- a/lib/pbench/server/database/models/auth_tokens.py
+++ b/lib/pbench/server/database/models/auth_tokens.py
@@ -4,6 +4,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 
 from pbench.server.database.database import Database
+from pbench.server.globals import server
 
 
 class AuthToken(Database.Base):
@@ -33,7 +34,7 @@ class AuthToken(Database.Base):
             An AuthToken object if found, otherwise None
         """
         # We currently only query token database for a specific token.
-        dbs = Database.db_session
+        dbs = server.db_session
         return dbs.query(AuthToken).filter_by(token=auth_token).first()
 
     @staticmethod
@@ -45,13 +46,13 @@ class AuthToken(Database.Base):
         Args:
             auth_token : the auth token to delete
         """
-        dbs = Database.db_session
+        dbs = server.db_session
         try:
             token = dbs.query(AuthToken).filter_by(token=auth_token)
             if not token:
                 return
             token.delete()
-            Database.db_session.commit()
+            dbs.commit()
         except Exception:
             dbs.rollback()
             raise

--- a/lib/pbench/server/database/models/templates.py
+++ b/lib/pbench/server/database/models/templates.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.sql.sqltypes import DateTime, JSON
 
 from pbench.server.database.database import Database
+from pbench.server.globals import server
 
 
 class TemplateError(Exception):
@@ -137,7 +138,7 @@ class Template(Database.Base):
             Template : a template object with the specified base name
         """
         try:
-            template = Database.db_session.query(Template).filter_by(name=name).first()
+            template = server.db_session.query(Template).filter_by(name=name).first()
         except SQLAlchemyError as e:
             raise TemplateSqlError("finding", name, str(e))
 
@@ -177,13 +178,13 @@ class Template(Database.Base):
     def add(self):
         """Add the Template object to the database."""
         try:
-            Database.db_session.add(self)
-            Database.db_session.commit()
+            server.db_session.add(self)
+            server.db_session.commit()
         except IntegrityError as e:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise self._decode(e)
         except Exception as e:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise TemplateSqlError("adding", self.name, str(e))
 
     def update(self):
@@ -191,12 +192,12 @@ class Template(Database.Base):
         Template object.
         """
         try:
-            Database.db_session.commit()
+            server.db_session.commit()
         except IntegrityError as e:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise self._decode(e)
         except Exception as e:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise TemplateSqlError("updating", self.name, str(e))
 
 

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from pbench.server.database.database import Database
 from pbench.server.database.models.auth_tokens import AuthToken
+from pbench.server.globals import server
 
 
 class Roles(enum.Enum):
@@ -63,26 +64,26 @@ class User(Database.Base):
             A User object if a user is found, None otherwise.
         """
         if id:
-            user = Database.db_session.query(User).filter_by(id=id).first()
+            user = server.db_session.query(User).filter_by(id=id).first()
         elif username:
-            user = Database.db_session.query(User).filter_by(username=username).first()
+            user = server.db_session.query(User).filter_by(username=username).first()
         elif email:
-            user = Database.db_session.query(User).filter_by(email=email).first()
+            user = server.db_session.query(User).filter_by(email=email).first()
         else:
             user = None
         return user
 
     @staticmethod
     def query_all() -> list["User"]:
-        return Database.db_session.query(User).all()
+        return server.db_session.query(User).all()
 
     def add(self):
         """Add the current user object to the database."""
         try:
-            Database.db_session.add(self)
-            Database.db_session.commit()
+            server.db_session.add(self)
+            server.db_session.commit()
         except Exception:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise
 
     @validates("role")
@@ -110,10 +111,10 @@ class User(Database.Base):
         """
         try:
             self.auth_tokens.append(auth_token)
-            Database.db_session.add(auth_token)
-            Database.db_session.commit()
+            server.db_session.add(auth_token)
+            server.db_session.commit()
         except Exception:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise
 
     def update(self, **kwargs):
@@ -121,9 +122,9 @@ class User(Database.Base):
         try:
             for key, value in kwargs.items():
                 setattr(self, key, value)
-            Database.db_session.commit()
+            server.db_session.commit()
         except Exception:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise
 
     @staticmethod
@@ -133,14 +134,14 @@ class User(Database.Base):
         Args:
             username : the username to delete
         """
-        user_query = Database.db_session.query(User).filter_by(username=username)
+        user_query = server.db_session.query(User).filter_by(username=username)
         if user_query.count() == 0:
             raise NoResultFound(f"User {username} does not exist")
         try:
             user_query.delete()
-            Database.db_session.commit()
+            server.db_session.commit()
         except Exception:
-            Database.db_session.rollback()
+            server.db_session.rollback()
             raise
 
     def is_admin(self) -> bool:

--- a/lib/pbench/server/globals.py
+++ b/lib/pbench/server/globals.py
@@ -1,0 +1,58 @@
+"""Pbench Server Context Variables
+
+A simple module for providing a "server" namespace for context variables.
+"""
+from contextvars import ContextVar
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import scoped_session
+from werkzeug.local import LocalProxy
+
+from pbench.server import PbenchServerConfig
+
+
+class _ServerCtx:
+    """A simple context object for our server execution environment.
+
+    The three attributes of server are:
+
+        config : PbenchServerConfig
+        logger : logging.Logger, as constructed by pbench.common.logger.get_pbench_logger()
+        db_session : The current database session in play
+
+    Typicaly use:
+
+        from pbench.server.globals import server
+        server.logger.info("hi")
+    """
+
+    def __init__(
+        self, config: PbenchServerConfig = None, logger: logging.Logger = None
+    ):
+        self.config: PbenchServerConfig = config
+        self.logger: logging.Logger = logger
+        self.db_session: Optional[scoped_session] = None
+
+
+_server_var = ContextVar("server", default=None)
+server = LocalProxy(_server_var)
+
+
+def init_server_ctx(config: PbenchServerConfig = None, logger: logging.Logger = None):
+    """Set the server context variable to an instance of the _ServerCtx object."""
+    cur_val = _server_var.get()
+    assert cur_val is None, f"Server context already set: server = {cur_val!r}"
+    _server_var.set(_ServerCtx(config, logger))
+
+
+def destroy_server_ctx():
+    """Destroy the current server context by setting it to `None`.
+
+    Only used by the unit tests.
+    """
+    cur_val = _server_var.get()
+    assert isinstance(
+        cur_val, _ServerCtx
+    ), f"Server context corrupted: server = {cur_val!r}"
+    _server_var.set(None)

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -24,6 +24,7 @@ from pbench.server.database.models.datasets import (
     OperationName,
     OperationState,
 )
+from pbench.server.globals import server
 from pbench.server.indexer import es_index, IdxContext, PbenchTarBall, VERSION
 from pbench.server.report import Report
 from pbench.server.sync import Sync
@@ -151,10 +152,10 @@ class Index:
 
         # We'll use a cache manager instance to find the INCOMING directory for the
         # unpacked tarballs.
-        self.cache_manager: CacheManager = CacheManager(idxctx.config, idxctx.logger)
+        self.cache_manager: CacheManager = CacheManager()
 
         # Manage synchronization between components
-        self.sync: Sync = Sync(idxctx.logger, self.operation)  # Build a sync object
+        self.sync: Sync = Sync(self.operation)  # Build a sync object
 
     def collect_tb(self) -> Tuple[int, List[TarballData]]:
         """Collect tarballs that need indexing
@@ -172,7 +173,6 @@ class Index:
         """
 
         tarballs: List[TarballData] = []
-        idxctx = self.idxctx
         error_code = self.error_code
         try:
             for dataset in self.sync.next():
@@ -196,7 +196,7 @@ class Index:
             # exception handling below.
             raise
         except Exception as e:
-            idxctx.logger.error(
+            server.logger.error(
                 "{} generating list of tar balls to process: {}",
                 error_code["GENERIC_ERROR"].message,
                 str(e),
@@ -205,7 +205,7 @@ class Index:
             return (error_code["GENERIC_ERROR"].value, [])
         else:
             if not tarballs:
-                idxctx.logger.info("No tar balls found that need processing")
+                server.logger.info("No tar balls found that need processing")
 
         return (error_code["OK"].value, sorted(tarballs, key=lambda t: t.size))
 
@@ -216,7 +216,7 @@ class Index:
 
         Args
             logger_method -- Reference to a method of a Python logger object,
-                            like idxctx.logger.warning
+                            like server.logger.warning
             error -- An error code name from the Errors collection, like "OK"
             exception -- the original exception leading to the error
 
@@ -244,21 +244,21 @@ class Index:
         try:
             # Now that we are ready to begin the actual indexing step, ensure we
             # have the proper index templates in place.
-            idxctx.logger.debug("update_templates [start]")
+            server.logger.debug("update_templates [start]")
             idxctx.templates.update_templates(idxctx.es)
         except TemplateError as e:
-            res = self.emit_error(idxctx.logger.error, "TEMPLATE_CREATION_ERROR", e)
+            res = self.emit_error(server.logger.error, "TEMPLATE_CREATION_ERROR", e)
         except SigTermException:
             # Re-raise a SIGTERM to avoid it being lumped in with general
             # exception handling below.
             raise
         except Exception:
-            idxctx.logger.exception(
+            server.logger.exception(
                 "update_templates [end]: Unexpected template" " processing error"
             )
             res = error_code["GENERIC_ERROR"]
         else:
-            idxctx.logger.debug("update_templates [end]")
+            server.logger.debug("update_templates [end]")
             res = error_code["OK"]
 
         if not res.success:
@@ -266,7 +266,6 @@ class Index:
             return res
 
         self.report = Report(
-            idxctx.config,
             self.name,
             es=idxctx.es,
             pid=idxctx.getpid(),
@@ -286,7 +285,7 @@ class Index:
             # exception handling below.
             raise
         except Exception:
-            idxctx.logger.error("Failed to post initial report status")
+            server.logger.error("Failed to post initial report status")
             return error_code["GENERIC_ERROR"]
         else:
             idxctx.set_tracking_id(tracking_id)
@@ -310,15 +309,15 @@ class Index:
 
         res = self.load_templates()
         if not res.success:
-            idxctx.logger.info("Load templates {!r}", res)
+            server.logger.info("Load templates {!r}", res)
             return res.value
 
-        idxctx.logger.debug("Preparing to index {:d} tar balls", len(tb_deque))
+        server.logger.debug("Preparing to index {:d} tar balls", len(tb_deque))
 
         with tempfile.TemporaryDirectory(
-            prefix=f"{self.name}.", dir=idxctx.config.TMP
+            prefix=f"{self.name}.", dir=server.config.TMP
         ) as tmpdir:
-            idxctx.logger.debug("start processing list of tar balls")
+            server.logger.debug("start processing list of tar balls")
             tb_list = Path(tmpdir, f"{self.name}.{idxctx.TS}.list")
             try:
                 with tb_list.open(mode="w") as lfp:
@@ -359,7 +358,7 @@ class Index:
                         tb = tbinfo.tarball
                         count_processed_tb += 1
 
-                        idxctx.logger.info("Starting {} (size {:d})", tb, size)
+                        server.logger.info("Starting {} (size {:d})", tb, size)
                         audit = None
                         ptb = None
                         tb_res = error_code["OK"]
@@ -374,7 +373,7 @@ class Index:
                                     dataset.resource_id
                                 )
                                 if not tarobj.unpacked:
-                                    idxctx.logger.warning(
+                                    server.logger.warning(
                                         "{} has not been unpacked", dataset
                                     )
                                     continue
@@ -395,14 +394,14 @@ class Index:
                             )
 
                             # "Open" the tar ball represented by the tar ball object
-                            idxctx.logger.debug("open tar ball")
+                            server.logger.debug("open tar ball")
                             ptb = PbenchTarBall(idxctx, dataset, path, tmpdir, unpacked)
 
                             # Construct the generator for emitting all actions.
                             # The `idxctx` dictionary is passed along to each
                             # generator so that it can add its context for
                             # error handling to the list.
-                            idxctx.logger.debug("generator setup")
+                            server.logger.debug("generator setup")
                             if self.options.index_tool_data:
                                 actions = ptb.mk_tool_data_actions()
                             else:
@@ -412,18 +411,17 @@ class Index:
                             # record all indexing errors that can't/won't be
                             # retried.
                             with ie_filepath.open(mode="w") as fp:
-                                idxctx.logger.debug("begin indexing")
+                                server.logger.debug("begin indexing")
                                 try:
                                     signal.signal(signal.SIGINT, sigint_handler)
                                     es_res = es_index(
                                         idxctx.es,
                                         actions,
                                         fp,
-                                        idxctx.logger,
                                         idxctx._dbg,
                                     )
                                 except SigIntException:
-                                    idxctx.logger.exception(
+                                    server.logger.exception(
                                         "Indexing interrupted by SIGINT, continuing to next tarball"
                                     )
                                     continue
@@ -432,32 +430,32 @@ class Index:
                                     signal.signal(signal.SIGINT, signal.SIG_IGN)
                         except UnsupportedTarballFormat as e:
                             tb_res = self.emit_error(
-                                idxctx.logger.warning, "TB_META_ABSENT", e
+                                server.logger.warning, "TB_META_ABSENT", e
                             )
                         except BadDate as e:
                             tb_res = self.emit_error(
-                                idxctx.logger.warning, "BAD_DATE", e
+                                server.logger.warning, "BAD_DATE", e
                             )
                         except FileNotFoundError as e:
                             tb_res = self.emit_error(
-                                idxctx.logger.warning, "FILE_NOT_FOUND_ERROR", e
+                                server.logger.warning, "FILE_NOT_FOUND_ERROR", e
                             )
                         except BadMDLogFormat as e:
                             tb_res = self.emit_error(
-                                idxctx.logger.warning, "BAD_METADATA", e
+                                server.logger.warning, "BAD_METADATA", e
                             )
                         except SigTermException:
-                            idxctx.logger.exception(
+                            server.logger.exception(
                                 "Indexing interrupted by SIGTERM, terminating"
                             )
                             break
                         except Exception as e:
                             tb_res = self.emit_error(
-                                idxctx.logger.exception, "GENERIC_ERROR", e
+                                server.logger.exception, "GENERIC_ERROR", e
                             )
                         else:
                             beg, end, successes, duplicates, failures, retries = es_res
-                            idxctx.logger.info(
+                            server.logger.info(
                                 "done indexing (start ts: {}, end ts: {}, duration:"
                                 " {:.2f}s, successes: {:d}, duplicates: {:d},"
                                 " failures: {:d}, retries: {:d})",
@@ -501,17 +499,17 @@ class Index:
                                                 dataset, Metadata.INDEX_MAP, map
                                             )
                                         except Exception as e:
-                                            idxctx.logger.exception(
+                                            server.logger.exception(
                                                 "Unexpected Metadata error on {}: {}",
                                                 ptb.tbname,
                                                 e,
                                             )
                                 except DatasetError as e:
-                                    idxctx.logger.exception(
+                                    server.logger.exception(
                                         "Dataset error on {}: {}", ptb.tbname, e
                                     )
                                 except Exception as e:
-                                    idxctx.logger.exception(
+                                    server.logger.exception(
                                         "Unexpected error on {}: {}", ptb.tbname, e
                                     )
                             if audit:
@@ -535,7 +533,7 @@ class Index:
                             # general exception handling below.
                             raise
                         except Exception:
-                            idxctx.logger.exception(
+                            server.logger.exception(
                                 "Unexpected error handling" " indexing errors file: {}",
                                 ie_filepath,
                             )
@@ -547,7 +545,7 @@ class Index:
                                         tstos(end), "errors", ie_filepath
                                     )
                                 except Exception:
-                                    idxctx.logger.exception(
+                                    server.logger.exception(
                                         "Unexpected error issuing"
                                         " report status with errors: {}",
                                         ie_filepath,
@@ -571,7 +569,7 @@ class Index:
                         # the error in the `server.errors.index` metadata and
                         # leave the dataset in INDEXING state.
                         if tb_res.success:
-                            idxctx.logger.info(
+                            server.logger.info(
                                 "{}: {}: success",
                                 idxctx.TS,
                                 os.path.basename(tb),
@@ -602,7 +600,7 @@ class Index:
                             with erred.open(mode="a") as fp:
                                 print(tb, file=fp)
                             self.sync.error(dataset, f"{tb_res.value}:{tb_res.message}")
-                        idxctx.logger.info(
+                        server.logger.info(
                             "Finished{} {} (size {:d})",
                             "[SIGQUIT]" if sigquit_interrupt[0] else "",
                             tb,
@@ -615,12 +613,12 @@ class Index:
                             status, new_tb = self.collect_tb()
                             if status == 0:
                                 if not set(new_tb).issuperset(tb_deque):
-                                    idxctx.logger.info(
+                                    server.logger.info(
                                         "Tarballs previously marked for indexing are no longer present",
                                         set(tb_deque).difference(new_tb),
                                     )
                                 tb_deque = deque(sorted(new_tb))
-                            idxctx.logger.info(
+                            server.logger.info(
                                 "SIGHUP status (Current tar ball indexed: ({}), Remaining: {}, Completed: {}, Errors_encountered: {}, Status: {})",
                                 Path(tb).name,
                                 len(tb_deque),
@@ -631,7 +629,7 @@ class Index:
                             sighup_interrupt[0] = False
                             continue
                 except SigTermException:
-                    idxctx.logger.exception(
+                    server.logger.exception(
                         "Indexing interrupted by SIGQUIT, stop processing tarballs"
                     )
                 finally:
@@ -643,7 +641,7 @@ class Index:
                 # exception handling below.
                 raise
             except Exception:
-                idxctx.logger.exception(error_code["GENERIC_ERROR"].message)
+                server.logger.exception(error_code["GENERIC_ERROR"].message)
                 res = error_code["GENERIC_ERROR"]
             else:
                 # No exceptions while processing tar balls, success.
@@ -651,13 +649,13 @@ class Index:
             finally:
                 if idxctx:
                     idxctx.dump_opctx()
-                idxctx.logger.debug("stopped processing list of tar balls")
+                server.logger.debug("stopped processing list of tar balls")
 
                 idx = _count_lines(indexed)
                 skp = _count_lines(skipped)
                 err = _count_lines(erred)
 
-                idxctx.logger.info(
+                server.logger.info(
                     "{}.{}: indexed {:d} (skipped {:d}) results," " {:d} errors",
                     self.name,
                     idxctx.TS,

--- a/lib/pbench/server/templates.py
+++ b/lib/pbench/server/templates.py
@@ -2,7 +2,6 @@ from collections import Counter
 import copy
 from datetime import datetime
 import json
-from logging import Logger
 from pathlib import Path
 import re
 import sys
@@ -24,6 +23,7 @@ from pbench.server.database.models.templates import (
     TemplateDuplicate,
     TemplateNotFound,
 )
+from pbench.server.globals import server
 
 
 class JsonFile:
@@ -320,7 +320,6 @@ class TemplateFile:
         prefix: str,
         mappings: Path,
         settings: JsonFile,
-        logger: Logger,
         skeleton: Optional[JsonFile] = None,
         tool: Optional[str] = None,
     ):
@@ -345,7 +344,6 @@ class TemplateFile:
         """
         self.prefix = prefix
         self.settings = settings
-        self.logger = logger
         if tool:
             self.mappings = JsonToolFile(mappings)
             self.key = tool
@@ -407,7 +405,7 @@ class TemplateFile:
             prefix=self.prefix, version=idxver, idxname=self.idxname
         )
         self.index_template = ip["template"]
-        self.logger.info("Loaded template {} version {}", self.name, self.version)
+        server.logger.info("Loaded template {} version {}", self.name, self.version)
 
         # Add a standard "authorization" sub-document into the document
         # template if this document type is "owned" by a Pbench user.
@@ -494,7 +492,7 @@ class TemplateFile:
                 # same time. They'll be identical, so ignoring the error is
                 # safe; we log a warning just to record that it happened since
                 # this has caused problems.
-                self.logger.warning("Duplicate add for {}", self.name)
+                server.logger.warning("Duplicate add for {}", self.name)
         else:
             template.version = self.version
             template.mappings = self.mappings.json
@@ -560,7 +558,6 @@ class PbenchTemplates:
         self,
         lib_dir: Path,
         idx_prefix: str,
-        logger: Logger,
         known_tool_handlers: JSONOBJECT = None,
         _dbg: int = 0,
     ):
@@ -577,7 +574,6 @@ class PbenchTemplates:
         Args:
             lib_dir:              The Pbench server library directory
             idx_prefix:           The server's Elasticsearch index prefix
-            logger:               A Python Logger
             known_tool_handlers:  Describes the set of tools that will have
                                   templates generated from a common tool-data
                                   skeleton.
@@ -589,7 +585,6 @@ class PbenchTemplates:
 
         self.templates: Dict[str, TemplateFile] = {}
         self.idx_prefix: str = idx_prefix
-        self.logger: Logger = logger
         self.known_tool_handlers: JSONOBJECT = known_tool_handlers
         self._dbg: int = _dbg
         self.counters: Counter = Counter()
@@ -600,7 +595,6 @@ class PbenchTemplates:
                 prefix=idx_prefix,
                 mappings=mapping_dir / "server-reports.json",
                 settings=JsonFile(setting_dir / "server-reports.json"),
-                logger=self.logger,
             )
         )
 
@@ -611,7 +605,6 @@ class PbenchTemplates:
                     prefix=idx_prefix,
                     mappings=mapping_dir / mapping_fn,
                     settings=run_settings,
-                    logger=self.logger,
                 )
             )
 
@@ -622,7 +615,6 @@ class PbenchTemplates:
                     prefix=idx_prefix,
                     mappings=mapping_dir / mapping_fn,
                     settings=result_settings,
-                    logger=self.logger,
                 )
             )
 
@@ -634,7 +626,6 @@ class PbenchTemplates:
                     prefix=idx_prefix,
                     mappings=mapping_dir / mapping_fn,
                     settings=tool_settings,
-                    logger=self.logger,
                     skeleton=skeleton,
                     tool="tool-data",
                 )
@@ -765,7 +756,7 @@ class PbenchTemplates:
                 retries += _retries
             finally:
                 Audit.create(root=audit, status=completion, attributes=attrs)
-        log_action = self.logger.warning if retries > 0 else self.logger.debug
+        log_action = server.logger.warning if retries > 0 else server.logger.debug
         log_action(
             "done templates (start ts: {}, end ts: {}, duration: {:.2f}s,"
             " successes: {:d}, retries: {:d})",

--- a/lib/pbench/test/unit/server/database/test_audit_db.py
+++ b/lib/pbench/test/unit/server/database/test_audit_db.py
@@ -6,7 +6,6 @@ import pytest
 from sqlalchemy.exc import DatabaseError, IntegrityError
 
 from pbench.server import OperationCode
-from pbench.server.database.database import Database
 from pbench.server.database.models.audit import (
     Audit,
     AuditDuplicate,
@@ -16,27 +15,22 @@ from pbench.server.database.models.audit import (
 )
 from pbench.server.database.models.datasets import Dataset
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 from pbench.test.unit.server.database import FakeDBOrig, FakeRow, FakeSession
 
 
 class TestAudit:
-    session = None
+    @pytest.fixture(autouse=True, scope="function")
+    def fake_db(self, server_config):
+        """Fixture to mock a DB session for testing."""
+        session = FakeSession(Audit)
+        assert server.db_session is None
+        server.db_session = session
+        yield
+        assert server.db_session == session
+        server.db_session = None
 
-    @pytest.fixture()
-    def fake_db(self, monkeypatch, server_config):
-        """
-        Fixture to mock a DB session for testing.
-
-        We patch the SQLAlchemy db_session to our fake session. We also store a
-        server configuration object directly on the Database.Base (normally
-        done during DB initialization) because that can't be monkeypatched.
-        """
-        __class__.session = FakeSession(Audit)
-        monkeypatch.setattr(Database, "db_session", __class__.session)
-        Database.Base.config = server_config
-        yield monkeypatch
-
-    def test_construct(self, fake_db):
+    def test_construct(self):
         """Test Audit record constructor"""
         audit = Audit(
             name="mine", operation=OperationCode.CREATE, status=AuditStatus.BEGIN
@@ -44,9 +38,9 @@ class TestAudit:
         assert audit.name == "mine"
         assert audit.operation is OperationCode.CREATE
         assert audit.status is AuditStatus.BEGIN
-        self.session.check_session()
+        server.db_session.check_session()
 
-    def test_create(self, fake_db):
+    def test_create(self):
         """Test Audit record creation"""
         audit = Audit.create(
             name="mine", operation=OperationCode.CREATE, status=AuditStatus.BEGIN
@@ -54,36 +48,36 @@ class TestAudit:
         assert audit.name == "mine"
         assert audit.operation == OperationCode.CREATE
         assert audit.status == AuditStatus.BEGIN
-        self.session.check_session(committed=[FakeRow.clone(audit)])
+        server.db_session.check_session(committed=[FakeRow.clone(audit)])
 
-    def test_construct_null(self, fake_db):
+    def test_construct_null(self):
         """Test handling of Audit record null value error"""
-        self.session.raise_on_commit = IntegrityError(
+        server.db_session.raise_on_commit = IntegrityError(
             statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
         )
         with pytest.raises(AuditNullKey, match="'operation': 'CREATE'"):
             Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(rolledback=1)
+        server.db_session.check_session(rolledback=1)
 
-    def test_construct_duplicate(self, fake_db):
+    def test_construct_duplicate(self):
         """Test handling of Audit record duplicate value error"""
-        self.session.raise_on_commit = IntegrityError(
+        server.db_session.raise_on_commit = IntegrityError(
             statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
         )
         with pytest.raises(AuditDuplicate, match="'id': 1"):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(rolledback=1)
+        server.db_session.check_session(rolledback=1)
 
-    def test_construct_error(self, fake_db):
+    def test_construct_error(self):
         """Test handling of Audit record create with a general error"""
-        self.session.raise_on_commit = DatabaseError(
+        server.db_session.raise_on_commit = DatabaseError(
             statement="", params="", orig=FakeDBOrig("something else")
         )
         with pytest.raises(AuditSqlError, match="'id': 1"):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
-        self.session.check_session(rolledback=1)
+        server.db_session.check_session(rolledback=1)
 
-    def test_sequence(self, fake_db):
+    def test_sequence(self):
         attr = {"message": "the framistan is borked"}
         ds = Dataset(id=1, name="test", resource_id="hash")
         with freeze_time("2022-01-01 00:00:00 UTC") as f:
@@ -95,11 +89,11 @@ class TestAudit:
             )
             f.tick(delta=datetime.timedelta(hours=5))
             other = Audit.create(root=root, status=AuditStatus.FAILURE, attributes=attr)
-        self.session.check_session(
+        server.db_session.check_session(
             committed=[FakeRow.clone(root), FakeRow.clone(other)]
         )
 
-    def test_override(self, fake_db):
+    def test_override(self):
         attr = {"message": "the framistan is borked"}
         ds = Dataset(id=1, name="test", resource_id="md5")
         with freeze_time("2022-01-01 00:00:00 UTC") as f:
@@ -133,20 +127,20 @@ class TestAudit:
             "user_id": None,
             "user_name": "tester",
         }
-        self.session.check_session(
+        server.db_session.check_session(
             committed=[FakeRow.clone(root), FakeRow.clone(other)]
         )
 
-    def test_exceptional_query(self, fake_db):
+    def test_exceptional_query(self):
         FakeSession.throw_query = True
         with pytest.raises(
             AuditSqlError,
             match=r"Error finding {'user_name': 'imme'}: \('test', 'because'\)",
         ):
             Audit.query(user_name="imme")
-        self.session.reset_context()
+        server.db_session.reset_context()
 
-    def test_queries(self, fake_db):
+    def test_queries(self):
         attr1 = {"message": "the framistan is borked"}
         attr2 = {"message": "OK", "updated": {"dataset.access": "public"}}
         ds1 = Dataset(id=1, name="testy", resource_id="md5.1")
@@ -191,32 +185,32 @@ class TestAudit:
         ]
 
         Audit.query(user_name="imme")
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1, committed=expected_commits, filters=["user_name=imme"]
         )
 
         Audit.query(object_name="testy")
 
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1, committed=expected_commits, filters=["object_name=testy"]
         )
 
         Audit.query(dataset=ds1)
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1,
             committed=None,
             filters=["audit.object_type = AuditType.DATASET, audit.object_id = md5.1"],
         )
 
         Audit.query(timestamp=dateutil.parser.parse("2022-01-01 00:00:00 UTC"))
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1,
             committed=expected_commits,
             filters=["timestamp=2022-01-01 00:00:00+00:00"],
         )
 
         Audit.query(start=dateutil.parser.parse("2022-01-01 04:00:00 UTC"))
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1,
             committed=expected_commits,
             filters=["audit.timestamp >= 2022-01-01 04:00:00+00:00"],
@@ -226,7 +220,7 @@ class TestAudit:
             start=dateutil.parser.parse("2022-01-01 01:00:00 UTC"),
             end=dateutil.parser.parse("2022-01-01 04:00:00 UTC"),
         )
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1,
             committed=expected_commits,
             filters=[
@@ -240,7 +234,7 @@ class TestAudit:
             start=dateutil.parser.parse("2022-01-01 01:00:00 UTC"),
             end=dateutil.parser.parse("2022-01-01 04:00:00 UTC"),
         )
-        self.session.check_session(
+        server.db_session.check_session(
             queries=1,
             committed=expected_commits,
             filters=[

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -7,7 +7,7 @@ from pbench.test.unit.server import DRB_USER_ID
 
 
 class TestDatasets:
-    def test_construct(self, db_session, create_user):
+    def test_construct(self, create_user):
         """Test dataset contructor"""
         user = create_user
         with freeze_time("1970-01-01"):
@@ -27,7 +27,7 @@ class TestDatasets:
             "operations": {},
         }
 
-    def test_dataset_survives_user(self, db_session, create_user):
+    def test_dataset_survives_user(self, create_user):
         """The Dataset isn't automatically removed when the referenced
         user is removed.
         """
@@ -38,7 +38,7 @@ class TestDatasets:
         ds1 = Dataset.query(resource_id="deadbeef")
         assert ds1 == ds
 
-    def test_dataset_metadata_log(self, db_session, create_user, provide_metadata):
+    def test_dataset_metadata_log(self, create_user, provide_metadata):
         """
         Test that `as_dict` provides the mocked metadata.log contents along
         with the Dataset object.
@@ -61,7 +61,7 @@ class TestDatasets:
             "operations": {},
         }
 
-    def test_query_name(self, db_session, create_user):
+    def test_query_name(self, create_user):
         """Test that we can find a dataset by name alone"""
         ds1 = Dataset(owner_id=str(create_user.id), resource_id="deed1e", name="fio")
         ds1.add()
@@ -73,7 +73,7 @@ class TestDatasets:
         assert ds2.resource_id == ds1.resource_id
         assert ds2.id == ds1.id
 
-    def test_delete(self, db_session, create_user):
+    def test_delete(self, create_user):
         """Test that we can delete a dataset"""
         ds1 = Dataset(
             owner_id=str(create_user.id), name="foobar", resource_id="f00dea7"

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -7,11 +7,12 @@ import responses
 
 from pbench.server import JSON
 from pbench.server.api.resources import ApiMethod
+from pbench.server.globals import server
 
 
 @pytest.fixture
 @responses.activate
-def query_api(client, server_config, provide_metadata):
+def query_api(client, provide_metadata):
     """
     Help controller queries that want to interact with a mocked
     Elasticsearch service.
@@ -39,7 +40,7 @@ def query_api(client, server_config, provide_metadata):
         query_params: JSON = None,
         **kwargs,
     ) -> requests.Response:
-        base_uri = server_config.get("Indexing", "uri")
+        base_uri = server.config.get("Indexing", "uri")
         es_url = f"{base_uri}{expected_index}{es_uri}"
         assert request_method in (ApiMethod.GET, ApiMethod.POST)
         if request_method == ApiMethod.GET:
@@ -65,7 +66,7 @@ def query_api(client, server_config, provide_metadata):
             ):
                 rsp.add(es_method, es_url, **kwargs)
             response = client_method(
-                f"{server_config.rest_uri}{pbench_uri}",
+                f"{server.config.rest_uri}{pbench_uri}",
                 headers=headers,
                 json=payload,
                 query_string=query_params,

--- a/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
+++ b/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 import pytest
 
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
+from pbench.server.globals import server
 from pbench.test.unit.server.query_apis.commons import Commons
 
 
@@ -18,7 +19,7 @@ class TestDatasetSummary(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=DatasetsSearch(client.config),
+            cls_obj=DatasetsSearch(),
             pbench_endpoint="/datasets/search",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={
@@ -38,7 +39,6 @@ class TestDatasetSummary(Commons):
     def test_query(
         self,
         client,
-        server_config,
         query_api,
         find_template,
         build_auth_header,
@@ -124,7 +124,7 @@ class TestDatasetSummary(Commons):
             },
         }
         index = self.build_index(
-            server_config, self.date_range(payload["start"], payload["end"])
+            server.config, self.date_range(payload["start"], payload["end"])
         )
         expected_status = self.get_expected_status(
             payload, build_auth_header["header_param"]

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_delete.py
@@ -8,6 +8,7 @@ import pytest
 from pbench.server import JSON, PbenchServerConfig
 from pbench.server.cache_manager import CacheManager
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
+from pbench.server.globals import server
 from pbench.test.unit.server.headertypes import HeaderTypes
 
 
@@ -114,7 +115,6 @@ class TestDatasetsDelete:
         get_document_map,
         monkeypatch,
         owner,
-        server_config,
     ):
         """
         Check behavior of the delete API with various combinations of dataset
@@ -135,7 +135,7 @@ class TestDatasetsDelete:
         ds = Dataset.query(name=owner)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/delete/{ds.resource_id}",
             headers=build_auth_header["header"],
         )
         assert response.status_code == expected_status
@@ -157,7 +157,6 @@ class TestDatasetsDelete:
         capinternal,
         get_document_map,
         monkeypatch,
-        server_config,
         pbench_drb_token,
     ):
         """
@@ -168,7 +167,7 @@ class TestDatasetsDelete:
         self.fake_cache_manager(monkeypatch)
         ds = Dataset.query(name="drb")
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/delete/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
         )
         assert response.status_code == HTTPStatus.OK
@@ -177,14 +176,12 @@ class TestDatasetsDelete:
         # Verify that the Dataset still exists
         Dataset.query(name="drb")
 
-    def test_no_dataset(
-        self, client, get_document_map, monkeypatch, pbench_drb_token, server_config
-    ):
+    def test_no_dataset(self, client, get_document_map, monkeypatch, pbench_drb_token):
         """
         Check the delete API if the dataset doesn't exist.
         """
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/badwolf",
+            f"{server.config.rest_uri}/datasets/delete/badwolf",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
         )
 
@@ -192,9 +189,7 @@ class TestDatasetsDelete:
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.json["message"] == "Dataset 'badwolf' not found"
 
-    def test_no_index(
-        self, client, monkeypatch, attach_dataset, pbench_drb_token, server_config
-    ):
+    def test_no_index(self, client, monkeypatch, attach_dataset, pbench_drb_token):
         """
         Check the delete API if the dataset has no INDEX_MAP. It should
         succeed without tripping over Elasticsearch.
@@ -202,7 +197,7 @@ class TestDatasetsDelete:
         self.fake_cache_manager(monkeypatch)
         ds = Dataset.query(name="drb")
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/delete/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
         )
 
@@ -220,7 +215,6 @@ class TestDatasetsDelete:
         monkeypatch,
         get_document_map,
         pbench_drb_token,
-        server_config,
     ):
         """
         Check the delete API response if the bulk helper throws an exception.
@@ -240,7 +234,7 @@ class TestDatasetsDelete:
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/delete/random_md5_string1",
+            f"{server.config.rest_uri}/datasets/delete/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
         )
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -22,7 +22,7 @@ class TestDatasetsDetail(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=DatasetsDetail(client.config),
+            cls_obj=DatasetsDetail(),
             pbench_endpoint="/datasets/detail/random_md5_string1",
             elastic_endpoint="/_search?ignore_unavailable=true",
             index_from_metadata="run-data",
@@ -43,7 +43,6 @@ class TestDatasetsDetail(Commons):
     def test_query(
         self,
         client,
-        server_config,
         query_api,
         find_template,
         pbench_admin_token,
@@ -186,7 +185,6 @@ class TestDatasetsDetail(Commons):
     def test_metadata(
         self,
         client,
-        server_config,
         query_api,
         find_template,
         provide_metadata,
@@ -326,7 +324,6 @@ class TestDatasetsDetail(Commons):
     def test_empty_query(
         self,
         client,
-        server_config,
         query_api,
         find_template,
         build_auth_header,
@@ -362,9 +359,7 @@ class TestDatasetsDetail(Commons):
         if response.status_code == HTTPStatus.BAD_REQUEST:
             assert response.json["message"].find("dataset has gone missing") != -1
 
-    def test_nonunique_query(
-        self, client, server_config, query_api, find_template, pbench_drb_token
-    ):
+    def test_nonunique_query(self, client, query_api, find_template, pbench_drb_token):
         """
         Check the handling of a query that returns too much data.
         """

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_mappings.py
@@ -1,5 +1,7 @@
 from http import HTTPStatus
 
+from pbench.server.globals import server
+
 
 class TestDatasetsMappings:
     """
@@ -10,13 +12,13 @@ class TestDatasetsMappings:
     constructor and `post` service.
     """
 
-    def test_run_template_query(self, client, server_config, find_template):
+    def test_run_template_query(self, client, find_template):
         """
         Check the construction of index mappings API and filtering of the
         response body.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/datasets/mappings/summary")
+            response = client.get(f"{server.config.rest_uri}/datasets/mappings/summary")
             assert response.status_code == HTTPStatus.OK
             res_json = response.json
             assert res_json == {
@@ -64,14 +66,14 @@ class TestDatasetsMappings:
                 ],
             }
 
-    def test_result_template_query(self, client, server_config, find_template):
+    def test_result_template_query(self, client, find_template):
         """
         Check the construction of index mappings API and filtering of the
         response body.
         """
         with client:
             response = client.get(
-                f"{server_config.rest_uri}/datasets/mappings/iterations"
+                f"{server.config.rest_uri}/datasets/mappings/iterations"
             )
             assert response.status_code == HTTPStatus.OK
             res_json = response.json
@@ -89,14 +91,14 @@ class TestDatasetsMappings:
                 "benchmark": ["name", "bs", "filename", "frame_size"],
             }
 
-    def test_with_no_index_document(self, client, server_config):
+    def test_with_no_index_document(self, client):
         """
         Check the index mappings API if there is no index document (specified by the index name in the URI)
         present in the database.
         """
         with client:
             response = client.get(
-                f"{server_config.rest_uri}/datasets/mappings/bad_data_object_view"
+                f"{server.config.rest_uri}/datasets/mappings/bad_data_object_view"
             )
             assert response.status_code == HTTPStatus.BAD_REQUEST
             assert (
@@ -104,10 +106,10 @@ class TestDatasetsMappings:
                 == "Unrecognized keyword ['bad_data_object_view'] for parameter dataset_view; allowed keywords are ['contents', 'iterations', 'summary', 'timeseries']"
             )
 
-    def test_with_db_error(self, capinternal, client, server_config):
+    def test_with_db_error(self, capinternal, client):
         """
         Check the index mappings API if there is an error connecting to sql database.
         """
         with client:
-            response = client.get(f"{server_config.rest_uri}/datasets/mappings/summary")
+            response = client.get(f"{server.config.rest_uri}/datasets/mappings/summary")
             capinternal("Unexpected template error", response)

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
@@ -6,6 +6,7 @@ import pytest
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
+from pbench.server.globals import server
 from pbench.test.unit.server.headertypes import HeaderTypes
 
 
@@ -99,7 +100,6 @@ class TestDatasetsUpdate:
         get_document_map,
         monkeypatch,
         pbench_drb_token,
-        server_config,
     ):
         """
         Check the datasets_update API when some document updates fail. We expect an
@@ -108,7 +108,7 @@ class TestDatasetsUpdate:
         self.fake_elastic(monkeypatch, get_document_map, True)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/random_md5_string1",
+            f"{server.config.rest_uri}/datasets/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
             query_string=self.PAYLOAD,
         )
@@ -119,15 +119,13 @@ class TestDatasetsUpdate:
         dataset = Dataset.query(name="drb")
         assert dataset.access == Dataset.PRIVATE_ACCESS
 
-    def test_no_dataset(
-        self, client, get_document_map, monkeypatch, pbench_drb_token, server_config
-    ):
+    def test_no_dataset(self, client, get_document_map, monkeypatch, pbench_drb_token):
         """
         Check the datasets_update API if the dataset doesn't exist.
         """
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/badwolf",
+            f"{server.config.rest_uri}/datasets/badwolf",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
             query_string=self.PAYLOAD,
         )
@@ -136,9 +134,7 @@ class TestDatasetsUpdate:
         assert response.status_code == HTTPStatus.NOT_FOUND
         assert response.json["message"] == "Dataset 'badwolf' not found"
 
-    def test_no_index(
-        self, attach_dataset, client, monkeypatch, pbench_drb_token, server_config
-    ):
+    def test_no_index(self, attach_dataset, client, monkeypatch, pbench_drb_token):
         """
         Check the datasets_update API if the dataset has no INDEX_MAP. It should
         fail with a CONFLICT error.
@@ -147,7 +143,7 @@ class TestDatasetsUpdate:
 
         ds = Dataset.query(name="drb")
         response = client.post(
-            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
             query_string=self.PAYLOAD,
         )
@@ -166,7 +162,6 @@ class TestDatasetsUpdate:
         monkeypatch,
         get_document_map,
         pbench_drb_token,
-        server_config,
     ):
         """
         Check the datasets_update API response if the bulk helper throws an exception.
@@ -186,7 +181,7 @@ class TestDatasetsUpdate:
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/random_md5_string1",
+            f"{server.config.rest_uri}/datasets/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
             query_string=self.PAYLOAD,
         )
@@ -209,7 +204,6 @@ class TestDatasetsUpdate:
         get_document_map,
         monkeypatch,
         owner,
-        server_config,
     ):
         """
         Check behavior of the datasets_update API with various combinations of dataset
@@ -238,7 +232,7 @@ class TestDatasetsUpdate:
 
         ds = Dataset.query(name=ds_name)
         response = client.post(
-            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/{ds.resource_id}",
             headers=build_auth_header["header"],
             query_string=query_json,
         )
@@ -258,7 +252,6 @@ class TestDatasetsUpdate:
         get_document_map,
         monkeypatch,
         pbench_admin_token,
-        server_config,
     ):
         """
         Check the datasets_update API response if the "owner" attribute is invalid.
@@ -266,7 +259,7 @@ class TestDatasetsUpdate:
 
         ds = Dataset.query(name="drb")
         response = client.post(
-            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
+            f"{server.config.rest_uri}/datasets/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_admin_token}"},
             query_string={"owner": str("invalid_owner")},
         )

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -8,6 +8,7 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleValues,
 )
 from pbench.server.database.models.datasets import Dataset, Metadata
+from pbench.server.globals import server
 from pbench.test.unit.server.query_apis.commons import Commons
 
 
@@ -22,24 +23,22 @@ class TestSampleNamespace(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=SampleNamespace(client.config),
+            cls_obj=SampleNamespace(),
             pbench_endpoint="/datasets/namespace/random_md5_string1/iterations",
             elastic_endpoint="/_search",
             index_from_metadata="result-data-sample",
             empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
-    def test_with_no_index_document(
-        self, client, server_config, pbench_drb_token, attach_dataset
-    ):
+    def test_with_no_index_document(self, client, pbench_drb_token, attach_dataset):
         """Check the Namespace API when no index name is provided."""
         # remove the last component of the pbench_endpoint
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-1])
-        response = client.get(f"{server_config.rest_uri}{incorrect_endpoint}")
+        response = client.get(f"{server.config.rest_uri}{incorrect_endpoint}")
         assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_with_incorrect_index_document(
-        self, client, server_config, pbench_drb_token, attach_dataset
+        self, client, pbench_drb_token, attach_dataset
     ):
         """Check the Namespace API when an incorrect index name is provided.
 
@@ -48,7 +47,7 @@ class TestSampleNamespace(Commons):
         """
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-1]) + "/test"
         response = client.get(
-            f"{server_config.rest_uri}{incorrect_endpoint}",
+            f"{server.config.rest_uri}{incorrect_endpoint}",
             headers={"Authorization": "Bearer " + pbench_drb_token},
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
@@ -103,7 +102,6 @@ class TestSampleNamespace(Commons):
 
     def test_query(
         self,
-        server_config,
         query_api,
         pbench_drb_token,
         build_auth_header,
@@ -404,7 +402,7 @@ class TestSampleValues(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=SampleValues(client.config),
+            cls_obj=SampleValues(),
             pbench_endpoint="/datasets/values/random_md5_string1/iterations",
             elastic_endpoint="/_search",
             payload={},
@@ -415,7 +413,6 @@ class TestSampleValues(Commons):
     @pytest.mark.parametrize("filters", ({"sample.name": "sample1"}, {}, None))
     def test_rows_query_without_scroll(
         self,
-        server_config,
         query_api,
         pbench_drb_token,
         build_auth_header,
@@ -588,7 +585,6 @@ class TestSampleValues(Commons):
     @pytest.mark.parametrize("filters", ({"sample.name": "sample1"}, {}, None))
     def test_scroll_id_return(
         self,
-        server_config,
         query_api,
         pbench_drb_token,
         build_auth_header,
@@ -652,7 +648,6 @@ class TestSampleValues(Commons):
 
     def test_rows_query_with_scroll_id(
         self,
-        server_config,
         query_api,
         pbench_drb_token,
         build_auth_header,

--- a/lib/pbench/test/unit/server/query_apis/test_query_builder.py
+++ b/lib/pbench/test/unit/server/query_apis/test_query_builder.py
@@ -11,7 +11,7 @@ from pbench.test.unit.server import ADMIN_USER_ID, DRB_USER_ID, TEST_USER_ID
 class TestQueryBuilder:
     @pytest.fixture()
     def elasticbase(self, client) -> ElasticBase:
-        return ElasticBase(client.config, ApiSchema(ApiMethod.POST, OperationCode.READ))
+        return ElasticBase(ApiSchema(ApiMethod.POST, OperationCode.READ))
 
     @staticmethod
     def assemble(term: JSON, user: Optional[str], access: Optional[str]) -> JSON:
@@ -48,7 +48,7 @@ class TestQueryBuilder:
             (ADMIN_USER_ID, "public"),
         ],
     )
-    def test_admin(self, elasticbase, server_config, current_user_admin, user, access):
+    def test_admin(self, elasticbase, current_user_admin, user, access):
         """
         Test the query builder when we have an authenticated admin user; all of
         these build query terms matching the input terms since we impose no
@@ -84,7 +84,7 @@ class TestQueryBuilder:
             ),
         ],
     )
-    def test_auth(self, elasticbase, server_config, current_user_drb, ask, expect):
+    def test_auth(self, elasticbase, current_user_drb, ask, expect):
         """
         Test the query builder when we have an authenticated user.
 
@@ -115,7 +115,7 @@ class TestQueryBuilder:
             ),
         ],
     )
-    def test_noauth(self, elasticbase, server_config, current_user_none, ask, expect):
+    def test_noauth(self, elasticbase, current_user_none, ask, expect):
         """
         Test the query builder when we have an unauthenticated client.
         """
@@ -126,7 +126,7 @@ class TestQueryBuilder:
         filter = self.assemble(term, expect.get("user"), expect.get("access"))
         assert query == {"bool": {"filter": filter}}
 
-    def test_neither_auth(self, elasticbase, server_config, current_user_drb):
+    def test_neither_auth(self, elasticbase, current_user_drb):
         """
         Test the query builder for {} when the client is authenticated with a
         non-admin account. This is the most complicated query, translating to

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -17,17 +17,16 @@ from pbench.server.database.models.server_settings import ServerSetting
 
 
 class OnlyGet(ApiBase):
-    def __init__(self, server_config):
-        super().__init__(server_config, ApiSchema(ApiMethod.GET, OperationCode.READ))
+    def __init__(self):
+        super().__init__(ApiSchema(ApiMethod.GET, OperationCode.READ))
 
     def _get(self, args: ApiParams, request: Request, context: ApiContext) -> str:
         return "OK - Only GET"
 
 
 class Always(ApiBase):
-    def __init__(self, server_config):
+    def __init__(self):
         super().__init__(
-            server_config,
             ApiSchema(ApiMethod.GET, OperationCode.READ),
             always_enabled=True,
         )
@@ -37,9 +36,8 @@ class Always(ApiBase):
 
 
 class All(ApiBase):
-    def __init__(self, server_config):
+    def __init__(self):
         super().__init__(
-            server_config,
             ApiSchema(ApiMethod.GET, OperationCode.READ),
             ApiSchema(ApiMethod.HEAD, OperationCode.READ),
             ApiSchema(ApiMethod.POST, OperationCode.CREATE),
@@ -66,11 +64,8 @@ class All(ApiBase):
 
 
 class OptionsMethod(ApiBase):
-    def __init__(self, server_config):
-        super().__init__(
-            server_config,
-            ApiSchema(99, OperationCode.READ),
-        )
+    def __init__(self):
+        super().__init__(ApiSchema(99, OperationCode.READ))
 
     def options(self, **kwargs) -> Response:
         return self._dispatch(99, kwargs)
@@ -94,25 +89,21 @@ class TestApiBase:
             OnlyGet,
             "/api/v1/onlyget",
             endpoint="onlyget",
-            resource_class_args=(server_config,),
         )
         api.add_resource(
             Always,
             "/api/v1/always",
             endpoint="always",
-            resource_class_args=(server_config,),
         )
         api.add_resource(
             All,
             "/api/v1/all",
             endpoint="all",
-            resource_class_args=(server_config,),
         )
         api.add_resource(
             OptionsMethod,
             "/api/v1/other",
             endpoint="other",
-            resource_class_args=(server_config,),
         )
 
         # Flask-provided test client

--- a/lib/pbench/test/unit/server/test_authorization.py
+++ b/lib/pbench/test/unit/server/test_authorization.py
@@ -27,7 +27,7 @@ class TestAuthorization:
 
     @pytest.fixture()
     def apibase(self, client) -> ApiBase:
-        return ApiBase(client.config, ApiSchema(ApiMethod.GET, OperationCode.READ))
+        return ApiBase(ApiSchema(ApiMethod.GET, OperationCode.READ))
 
     @pytest.mark.parametrize(
         "ask",
@@ -42,9 +42,7 @@ class TestAuthorization:
             {"user": None, "access": "public", "role": OperationCode.READ},
         ],
     )
-    def test_allowed_admin(
-        self, apibase, server_config, create_drb_user, current_user_admin, ask
-    ):
+    def test_allowed_admin(self, apibase, create_drb_user, current_user_admin, ask):
         user = self.get_user_id(ask["user"])
         apibase._check_authorization(
             ApiAuthorization(
@@ -61,7 +59,7 @@ class TestAuthorization:
             {"user": None, "access": "public", "role": OperationCode.DELETE},
         ],
     )
-    def test_disallowed_admin(self, apibase, server_config, current_user_admin, ask):
+    def test_disallowed_admin(self, apibase, current_user_admin, ask):
         user = self.get_user_id(ask["user"])
         access = ask["access"]
         with pytest.raises(UnauthorizedAccess) as exc:
@@ -90,7 +88,6 @@ class TestAuthorization:
     def test_allowed_auth(
         self,
         apibase,
-        server_config,
         create_user,
         create_drb_user,
         current_user_drb,
@@ -117,9 +114,7 @@ class TestAuthorization:
             {"user": "test", "access": "private", "role": OperationCode.READ},
         ],
     )
-    def test_disallowed_auth(
-        self, apibase, server_config, create_user, current_user_drb, ask
-    ):
+    def test_disallowed_auth(self, apibase, create_user, current_user_drb, ask):
         user = self.get_user_id(ask["user"])
         access = ask["access"]
         with pytest.raises(UnauthorizedAccess) as exc:
@@ -142,7 +137,6 @@ class TestAuthorization:
     def test_allowed_noauth(
         self,
         apibase,
-        server_config,
         create_user,
         create_drb_user,
         current_user_none,
@@ -165,9 +159,7 @@ class TestAuthorization:
             {"user": "test", "access": "private", "role": OperationCode.READ},
         ],
     )
-    def test_disallowed_noauth(
-        self, apibase, server_config, create_user, current_user_none, ask
-    ):
+    def test_disallowed_noauth(self, apibase, create_user, current_user_none, ask):
         user = self.get_user_id(ask["user"])
         access = ask["access"]
         with pytest.raises(UnauthorizedAccess) as exc:
@@ -179,7 +171,7 @@ class TestAuthorization:
         assert exc.value.owner == (ask["user"] if ask["user"] else "none")
         assert exc.value.user is None
 
-    def test_admin_unauth(self, apibase, server_config, current_user_none):
+    def test_admin_unauth(self, apibase, current_user_none):
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
                 ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
@@ -189,7 +181,7 @@ class TestAuthorization:
             == "Unauthenticated client is not authorized to CREATE a server administrative resource"
         )
 
-    def test_admin_user(self, apibase, server_config, current_user_drb):
+    def test_admin_user(self, apibase, current_user_drb):
         with pytest.raises(UnauthorizedAccess) as exc:
             apibase._check_authorization(
                 ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
@@ -199,7 +191,7 @@ class TestAuthorization:
             == "User drb is not authorized to CREATE a server administrative resource"
         )
 
-    def test_admin_admin(self, apibase, server_config, current_user_admin):
+    def test_admin_admin(self, apibase, current_user_admin):
         apibase._check_authorization(
             ApiAuthorization(ApiAuthorizationType.ADMIN, OperationCode.CREATE)
         )

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -18,6 +18,7 @@ from pbench.server.cache_manager import (
     TarballUnpackError,
 )
 from pbench.server.database.models.datasets import Dataset, DatasetBadName
+from pbench.server.globals import server
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -26,7 +27,7 @@ def file_sweeper(server_config):
     Make sure that the required directory trees exist before each test case,
     and clean up afterwards.
     """
-    trees = [server_config.ARCHIVE, server_config.INCOMING, server_config.RESULTS]
+    trees = [server.config.ARCHIVE, server.config.INCOMING, server.config.RESULTS]
 
     for tree in trees:
         tree.mkdir(parents=True, exist_ok=True)
@@ -66,11 +67,11 @@ def fake_get_metadata(tb_path):
 
 
 class TestCacheManager:
-    def test_create(self, server_config, make_logger):
+    def test_create(self, server_config, server_logger):
         """
         Create an empty CacheManager object and check the properties
         """
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         assert cm is not None
         assert not cm.datasets  # No datasets expected
         assert not cm.tarballs  # No datasets expected
@@ -83,21 +84,21 @@ class TestCacheManager:
         assert str(cm.incoming_root) == root + "/srv/pbench/public_html/incoming"
         assert str(cm.results_root) == root + "/srv/pbench/public_html/results"
 
-    def test_discover_empties(self, server_config, make_logger):
+    def test_discover_empties(self, server_config, server_logger):
         """
         Full discovery with no controllers or datasets
         """
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         cm.full_discovery()
         assert not cm.datasets  # No datasets expected
         assert not cm.tarballs  # No datasets expected
         assert not cm.controllers  # No controllers expected
 
-    def test_empty_controller(self, server_config, make_logger):
+    def test_empty_controller(self, server_config, server_logger):
         """
         Discover a "controller" directory with no datasets
         """
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         test_controller = cm.archive_root / "TEST"
         test_controller.mkdir()
         cm.full_discovery()
@@ -105,11 +106,11 @@ class TestCacheManager:
         assert not cm.tarballs  # No datasets expected
         assert list(cm.controllers.keys()) == ["TEST"]
 
-    def test_clean_empties(self, server_config, make_logger):
+    def test_clean_empties(self, server_config, server_logger):
         """
         Test that empty controller directories are removed
         """
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         controllers = ["PLUGH", "XYZZY"]
         roots = [cm.archive_root, cm.incoming_root, cm.results_root]
         for c in controllers:
@@ -194,7 +195,7 @@ class TestCacheManager:
         assert tarball.metadata == fake_get_metadata(tarball.tarball_path)
 
     def test_create_bad(
-        self, monkeypatch, selinux_disabled, server_config, make_logger, tarball
+        self, monkeypatch, selinux_disabled, server_config, server_logger, tarball
     ):
         """
         Test several varieties of dataset errors:
@@ -203,8 +204,8 @@ class TestCacheManager:
         2) Attempt to create a new dataset from a non-existent file
         3) Attempt to create a dataset that already exists
         """
+        cm = CacheManager()
         source_tarball, source_md5, md5 = tarball
-        cm = CacheManager(server_config, make_logger)
         monkeypatch.setattr(Tarball, "_get_metadata", fake_get_metadata)
 
         # Attempting to create a dataset from the md5 file should result in
@@ -234,16 +235,15 @@ class TestCacheManager:
         assert exc.value.tarball == tarball.name
 
     def test_duplicate(
-        self, monkeypatch, selinux_disabled, server_config, make_logger, tarball
+        self, monkeypatch, selinux_disabled, server_config, server_logger, tarball
     ):
         """
         Test behavior when we try to create a new dataset but the tarball file
         name already exists
         """
-
+        cm = CacheManager()
         source_tarball, source_md5, md5 = tarball
         monkeypatch.setattr(Tarball, "_get_metadata", fake_get_metadata)
-        cm = CacheManager(server_config, make_logger)
 
         # Create a tarball file in the expected destination directory
         controller = cm.archive_root / "ABC"
@@ -537,7 +537,7 @@ class TestCacheManager:
             assert tb.results_link == results / tb.name
 
     def test_find(
-        self, selinux_enabled, server_config, make_logger, tarball, monkeypatch
+        self, monkeypatch, selinux_enabled, server_config, server_logger, tarball
     ):
         """
         Create a dataset, check the cache manager state, and test that we can find it
@@ -553,7 +553,7 @@ class TestCacheManager:
         monkeypatch.setattr(Tarball, "_get_metadata", fake_get_metadata)
         source_tarball, source_md5, md5 = tarball
         dataset_name = Dataset.stem(source_tarball)
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         cm.create(source_tarball)
 
         # The original files should have been removed
@@ -604,7 +604,7 @@ class TestCacheManager:
 
         # We should be able to find the tarball even in a new cache manager
         # that hasn't been fully discovered.
-        new = CacheManager(server_config, make_logger)
+        new = CacheManager()
         assert md5 not in new
 
         tarball = new.find_dataset(md5)
@@ -622,7 +622,7 @@ class TestCacheManager:
         assert list(new.tarballs) == [dataset_name]
 
     def test_lifecycle(
-        self, selinux_enabled, server_config, make_logger, tarball, monkeypatch
+        self, selinux_enabled, server_config, server_logger, tarball, monkeypatch
     ):
         """
         Create a dataset, unpack it, remove the unpacked version, and finally
@@ -636,7 +636,7 @@ class TestCacheManager:
             )
 
         source_tarball, source_md5, md5 = tarball
-        cm = CacheManager(server_config, make_logger)
+        cm = CacheManager()
         archive = cm.archive_root / "ABC"
         incoming = cm.incoming_root / "ABC"
         results = cm.results_root / "ABC"
@@ -688,7 +688,7 @@ class TestCacheManager:
         assert cm.datasets[md5].results_link == results_link
 
         # Re-discover, with all the files in place, and compare
-        newcm = CacheManager(server_config, make_logger)
+        newcm = CacheManager()
         newcm.full_discovery()
 
         assert newcm.archive_root == cm.archive_root

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -7,6 +7,7 @@ import requests
 
 from pbench.server import JSON
 from pbench.server.database.models.datasets import Dataset
+from pbench.server.globals import server
 
 
 class TestDatasetsDateRange:
@@ -17,16 +18,13 @@ class TestDatasetsDateRange:
     """
 
     @pytest.fixture()
-    def query_as(
-        self, client, server_config, more_datasets, provide_metadata, get_token_func
-    ):
+    def query_as(self, client, more_datasets, provide_metadata, get_token_func):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
 
         Args:
             client: Flask test API client fixture
-            server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
             get_token_func: Pbench token fixture
@@ -37,7 +35,7 @@ class TestDatasetsDateRange:
         ) -> requests.Response:
             token = get_token_func(username)
             response = client.get(
-                f"{server_config.rest_uri}/datasets/daterange",
+                f"{server.config.rest_uri}/datasets/daterange",
                 headers={"authorization": f"bearer {token}"},
                 query_string=payload,
             )

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -7,18 +7,18 @@ import werkzeug.utils
 
 from pbench.server.cache_manager import CacheManager
 from pbench.server.database.models.datasets import Dataset, DatasetNotFound
+from pbench.server.globals import server
 
 
 class TestDatasetsAccess:
     @pytest.fixture()
-    def query_get_as(self, client, server_config, more_datasets, pbench_drb_token):
+    def query_get_as(self, client, more_datasets, pbench_drb_token):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
 
         Args:
             client: Flask test API client fixture
-            server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             pbench_drb_token: Authenticated user token fixture
         """
@@ -33,7 +33,7 @@ class TestDatasetsAccess:
             headers = {"authorization": f"bearer {pbench_drb_token}"}
             k = "" if target is None else f"/{target}"
             response = client.get(
-                f"{server_config.rest_uri}/datasets/inventory/{dataset_id}{k}",
+                f"{server.config.rest_uri}/datasets/inventory/{dataset_id}{k}",
                 headers=headers,
             )
             assert response.status_code == expected_status

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -8,6 +8,7 @@ import requests
 from pbench.server import JSON
 from pbench.server.api.resources.datasets_list import urlencode_json
 from pbench.server.database.models.datasets import Dataset
+from pbench.server.globals import server
 
 
 class TestUrlencodeJson:
@@ -40,15 +41,12 @@ class TestDatasetsList:
     """
 
     @pytest.fixture()
-    def query_as(
-        self, client, server_config, more_datasets, provide_metadata, get_token_func
-    ):
+    def query_as(self, client, more_datasets, provide_metadata, get_token_func):
         """Helper fixture to perform the API query and validate an expected
         return status.
 
         Args:
             client: Flask test API client fixture
-            server_config: Pbench config fixture
             more_datasets: Dataset construction fixture
             provide_metadata: Dataset metadata fixture
             get_token_func: Pbench token fixture
@@ -74,7 +72,7 @@ class TestDatasetsList:
                 token = get_token_func(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
-                f"{server_config.rest_uri}/datasets/list",
+                f"{server.config.rest_uri}/datasets/list",
                 headers=headers,
                 query_string=payload,
             )
@@ -83,7 +81,7 @@ class TestDatasetsList:
 
         return query_api
 
-    def get_results(self, name_list: List[str], query: JSON, server_config) -> JSON:
+    def get_results(self, name_list: List[str], query: JSON) -> JSON:
         """Translate a list of names into a list of expected results of the
         abbreviated form returned by `datasets/list`: name, controller, run_id,
         and metadata.
@@ -91,7 +89,6 @@ class TestDatasetsList:
         Args:
             name_list: List of dataset names
             query: A JSON representation of the query parameters
-            server_config: Pbench config fixture
 
         Returns:
             Paginated JSON object containing list of dataset values
@@ -108,7 +105,7 @@ class TestDatasetsList:
             else:
                 query["offset"] = next_offset
                 next_url = (
-                    f"http://localhost{server_config.rest_uri}/datasets/list?"
+                    f"http://localhost{server.config.rest_uri}/datasets/list?"
                     + urlencode_json(query)
                 )
         else:
@@ -176,7 +173,7 @@ class TestDatasetsList:
             ("drb", {"end": "1970-09-01"}, []),
         ],
     )
-    def test_dataset_list(self, query_as, login, query, results, server_config):
+    def test_dataset_list(self, query_as, login, query, results):
         """Test the operation of `datasets/list` against our set of test
         datasets.
 
@@ -189,7 +186,7 @@ class TestDatasetsList:
         """
         query.update({"metadata": ["dataset.uploaded"]})
         result = query_as(query, login, HTTPStatus.OK)
-        assert result.json == self.get_results(results, query, server_config)
+        assert result.json == self.get_results(results, query)
 
     @pytest.mark.parametrize(
         "login,query,results",
@@ -203,7 +200,7 @@ class TestDatasetsList:
             ),
         ],
     )
-    def test_dataset_list_w_limit(self, query_as, login, query, results, server_config):
+    def test_dataset_list_w_limit(self, query_as, login, query, results):
         """Test the operation of `datasets/list` with limits against our set of
         test datasets.
 
@@ -216,7 +213,7 @@ class TestDatasetsList:
         """
         query.update({"metadata": ["dataset.uploaded"], "limit": 5})
         result = query_as(query, login, HTTPStatus.OK)
-        assert result.json == self.get_results(results, query, server_config)
+        assert result.json == self.get_results(results, query)
 
     def test_unauth_dataset_list(self, query_as):
         """Test the operation of `datasets/list` when the client doesn't have

--- a/lib/pbench/test/unit/server/test_schema.py
+++ b/lib/pbench/test/unit/server/test_schema.py
@@ -24,7 +24,8 @@ from pbench.server.api.resources import (
     UnverifiedUser,
 )
 from pbench.server.api.resources.query_apis import PostprocessError
-from pbench.server.database.models.users import User
+from pbench.server.database.models.user import User
+from pbench.server.globals import server
 
 
 class TestExceptions:
@@ -80,9 +81,9 @@ class TestExceptions:
         assert str(p) == "Postprocessing error returning 400: 'really bad' [None]"
         assert p.status == HTTPStatus.BAD_REQUEST
 
-    def test_internal_error(self, capinternal, make_logger):
+    def test_internal_error(self, capinternal, server_logger):
         x = APIInternalError("my error")
-        make_logger.error(f"TEST {x.details}")
+        server.logger.error(f"TEST {x.details}")
         r = Response(
             response=json.dumps({"message": x.message}),
             mimetype="application/json",

--- a/lib/pbench/test/unit/server/test_server_audit.py
+++ b/lib/pbench/test/unit/server/test_server_audit.py
@@ -9,11 +9,12 @@ import requests
 
 from pbench.server import JSONOBJECT, OperationCode
 from pbench.server.database.models.audit import Audit, AuditStatus
+from pbench.server.globals import server
 
 
 class TestServerAudit:
     @pytest.fixture()
-    def query_get(self, client, server_config, pbench_admin_token):
+    def query_get(self, client, pbench_admin_token):
         """
         Helper fixture to perform the API query and validate an expected
         return status.
@@ -21,7 +22,6 @@ class TestServerAudit:
         Args:
 
             client: Flask test API client fixture
-            server_config: Pbench config fixture
             pbench_admin_token: ADMIN authorization fixture
         """
 
@@ -31,7 +31,7 @@ class TestServerAudit:
             token: str = pbench_admin_token,
         ) -> requests.Response:
             response = client.get(
-                f"{server_config.rest_uri}/server/audit",
+                f"{server.config.rest_uri}/server/audit",
                 query_string=params,
                 headers={"authorization": f"Bearer {token}"},
             )

--- a/lib/pbench/test/unit/server/test_unpack_tarballs.py
+++ b/lib/pbench/test/unit/server/test_unpack_tarballs.py
@@ -1,12 +1,11 @@
 from dataclasses import dataclass
 import datetime
-from logging import Logger
 from pathlib import Path
 from typing import Optional, Union
 
 import pytest
 
-from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
+from pbench.server import JSON, JSONOBJECT
 from pbench.server.cache_manager import TarballUnpackError
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -105,9 +104,8 @@ class MockSync:
     record: dict[str, JSONOBJECT] = {}
     errors: dict[str, JSONOBJECT] = {}
 
-    def __init__(self, logger: Logger, component: OperationName):
+    def __init__(self, component: OperationName):
         self.component = component
-        self.logger = logger
 
     def next(self) -> list[Dataset]:
         return [x.dataset for x in datasets]
@@ -138,7 +136,7 @@ class FakePbenchTemplates:
     templates_updated = False
     failure: Optional[Exception] = None
 
-    def __init__(self, basepath, idx_prefix, logger, known_tool_handlers=None, _dbg=0):
+    def __init__(self, basepath, idx_prefix, known_tool_handlers=None, _dbg=0):
         pass
 
     def update_templates(self, es_instance):
@@ -159,7 +157,6 @@ class FakeReport:
 
     def __init__(
         self,
-        config,
         name,
         es=None,
         pid=None,
@@ -169,7 +166,6 @@ class FakeReport:
         version=None,
         templates=None,
     ):
-        self.config = config
         self.name = name
 
     def post_status(
@@ -195,9 +191,8 @@ class MockCacheManager:
     fails: list[str] = []
     unpacked: list[str] = []
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
-        self.config = config
-        self.logger = logger
+    def __init__(self):
+        pass
 
     def unpack(self, id: str):
         if id in __class__.fails:
@@ -242,11 +237,11 @@ class TestUnpackTarballs:
             (0, 900, ["md5.1", "md5.2"]),  # upper is strict <
         ],
     )
-    def test_buckets(self, mocks, make_logger, min_size, max_size, targets):
+    def test_buckets(self, mocks, server_logger, min_size, max_size, targets):
         """Test that the tarbal list is filtered by the unpack bucket size
         configuration."""
 
-        obj = UnpackTarballs(MockConfig(), make_logger)
+        obj = UnpackTarballs()
         result = obj.unpack_tarballs(min_size, max_size)
         assert result.total == len(targets)
         assert result.success == len(targets)
@@ -260,11 +255,11 @@ class TestUnpackTarballs:
     @pytest.mark.parametrize(
         "fail", [["md5.1"], ["md5.1", "md5.2"], ["md5.1", "md5.2", "md5.3"]]
     )
-    def test_failures(self, make_logger, fail, mocks):
+    def test_failures(self, server_logger, fail, mocks):
         """Test that tarball evaluation continues when resolution of one or
         more fails."""
 
-        obj = UnpackTarballs(MockConfig(), make_logger)
+        obj = UnpackTarballs()
         MockPath._fail_on(fail)
         result = obj.unpack_tarballs(0.0, float("inf"))
         assert result.total == len(datasets) - len(fail)
@@ -282,11 +277,11 @@ class TestUnpackTarballs:
     @pytest.mark.parametrize(
         "fail", [["md5.1"], ["md5.2"], ["md5.3"], ["md5.1", "md5.2", "md5.3"]]
     )
-    def test_unpack_exception(self, make_logger, mocks, fail):
+    def test_unpack_exception(self, server_logger, mocks, fail):
         """Show that when unpack module raises TarballUnpackError exception
         it is being handled properly."""
 
-        obj = UnpackTarballs(MockConfig, make_logger)
+        obj = UnpackTarballs()
         MockCacheManager._fail_on(fail)
 
         result = obj.unpack_tarballs(0.0, float("inf"))
@@ -306,8 +301,8 @@ class TestUnpackTarballs:
         assert sorted(MockSync.record.keys()) == success_ids
         assert sorted(MockSync.errors.keys()) == fail_ids
 
-    def test_unpack_report(self, make_logger, mocks):
-        obj = UnpackTarballs(MockConfig, make_logger)
+    def test_unpack_report(self, server_logger, mocks):
+        obj = UnpackTarballs()
         obj.report("done", "done done")
         assert FakeReport.reported
         assert FakeReport.inited

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -2,20 +2,18 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 import time
 
-from pbench.server.database.database import Database
 from pbench.server.database.models.auth_tokens import AuthToken
 from pbench.server.database.models.users import User
+from pbench.server.globals import server
 from pbench.test.unit.server.conftest import admin_username
 
 
-def register_user(
-    client, server_config, email, username, password, firstname, lastname
-):
+def register_user(client, email, username, password, firstname, lastname):
     """
     Helper function to register a user using register API
     """
     return client.post(
-        f"{server_config.rest_uri}/register",
+        f"{server.config.rest_uri}/register",
         json={
             "email": email,
             "password": password,
@@ -26,25 +24,24 @@ def register_user(
     )
 
 
-def login_user(client, server_config, username, password, token_expiry=None):
+def login_user(client, username, password, token_expiry=None):
     """
     Helper function to generate a user authentication token
     """
     return client.post(
-        f"{server_config.rest_uri}/login",
+        f"{server.config.rest_uri}/login",
         json={"username": username, "password": password, "token_expiry": token_expiry},
     )
 
 
 class TestUserAuthentication:
     @staticmethod
-    def test_registration(client, server_config, tmp_path):
+    def test_registration(client, tmp_path):
         client.config["SESSION_FILE_DIR"] = tmp_path
         """ Test for user registration """
         with client:
             response = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -55,11 +52,11 @@ class TestUserAuthentication:
             assert response.status_code, HTTPStatus.CREATED
 
     @staticmethod
-    def test_registration_missing_fields(client, server_config):
+    def test_registration_missing_fields(client):
         """Test for user registration missing fields"""
         with client:
             response = client.post(
-                f"{server_config.rest_uri}/register",
+                f"{server.config.rest_uri}/register",
                 json={
                     "email": "user@domain.com",
                     "password": "12345",
@@ -72,12 +69,11 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.BAD_REQUEST
 
     @staticmethod
-    def test_registration_email_validity(client, server_config):
+    def test_registration_email_validity(client):
         """Test for validating an email field during registration"""
         with client:
             response = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -90,7 +86,7 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.BAD_REQUEST
 
     @staticmethod
-    def test_registration_with_registered_user(client, server_config):
+    def test_registration_with_registered_user(client):
         """Test registration with already registered email"""
         user = User(
             email="user@domain.com",
@@ -99,12 +95,11 @@ class TestUserAuthentication:
             first_name="firstname",
             last_name="lastname",
         )
-        Database.db_session.add(user)
-        Database.db_session.commit()
+        server.db_session.add(user)
+        server.db_session.commit()
         with client:
             response = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -117,13 +112,12 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.FORBIDDEN
 
     @staticmethod
-    def test_user_login(client, server_config):
+    def test_user_login(client):
         """Test for login of registered-user login"""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -132,7 +126,7 @@ class TestUserAuthentication:
             )
             assert resp_register.status_code == HTTPStatus.CREATED
             # registered user login
-            response = login_user(client, server_config, "user", "12345")
+            response = login_user(client, "user", "12345")
             data = response.json
             assert data["auth_token"]
             assert data["username"] == "user"
@@ -140,13 +134,12 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_user_relogin(client, server_config):
+    def test_user_relogin(client):
         """Test for login of registered-user login"""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -156,7 +149,7 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # registered user login
-            response = login_user(client, server_config, "user", "12345")
+            response = login_user(client, "user", "12345")
             data = response.json
             assert data["auth_token"]
             assert response.content_type == "application/json"
@@ -166,7 +159,7 @@ class TestUserAuthentication:
             # Re-login with auth header
             time.sleep(1)
             response = client.post(
-                f"{server_config.rest_uri}/login",
+                f"{server.config.rest_uri}/login",
                 headers=dict(Authorization=f"Bearer {first_auth_token}"),
                 json={"username": "user", "password": "12345"},
             )
@@ -179,7 +172,7 @@ class TestUserAuthentication:
             # Re-login without auth header
             time.sleep(1)
             response = client.post(
-                f"{server_config.rest_uri}/login",
+                f"{server.config.rest_uri}/login",
                 json={"username": "user", "password": "12345"},
             )
             assert response.status_code == HTTPStatus.OK
@@ -192,14 +185,13 @@ class TestUserAuthentication:
             ), "Third login returned second token"
 
     @staticmethod
-    def test_login_removes_expired_tokens(client, server_config):
+    def test_login_removes_expired_tokens(client):
         """Test to ensure on a new login previously expired tokens are
         removed."""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="me",
                 firstname="first name",
                 lastname="last name",
@@ -218,7 +210,7 @@ class TestUserAuthentication:
                 user.add_token(token)
 
             response = client.post(
-                f"{server_config.rest_uri}/login",
+                f"{server.config.rest_uri}/login",
                 json={"username": "me", "password": "12345"},
             )
             assert response.status_code == HTTPStatus.OK
@@ -228,13 +220,12 @@ class TestUserAuthentication:
                 assert token is None
 
     @staticmethod
-    def test_user_login_with_wrong_password(client, server_config):
+    def test_user_login_with_wrong_password(client):
         """Test for login of registered-user login"""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -244,18 +235,18 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # registered user login
-            response = login_user(client, server_config, "user", "123456")
+            response = login_user(client, "user", "123456")
             data = response.json
             assert data["message"] == "Bad login"
             assert response.content_type == "application/json"
             assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     @staticmethod
-    def test_login_without_password(client, server_config):
+    def test_login_without_password(client):
         """Test for login of non-registered user"""
         with client:
             response = client.post(
-                f"{server_config.rest_uri}/login",
+                f"{server.config.rest_uri}/login",
                 json={"username": "username"},
             )
             data = response.json
@@ -263,21 +254,20 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.BAD_REQUEST
 
     @staticmethod
-    def test_non_registered_user_login(client, server_config):
+    def test_non_registered_user_login(client):
         """Test for login of non-registered user"""
         with client:
-            response = login_user(client, server_config, "username", "12345")
+            response = login_user(client, "username", "12345")
             data = response.json
             assert data["message"] == "Bad login"
             assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     @staticmethod
-    def test_get_user(client, server_config):
+    def test_get_user(client):
         """Test for get user api"""
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -286,11 +276,11 @@ class TestUserAuthentication:
             )
             assert resp_register.status_code == HTTPStatus.CREATED
 
-            response = login_user(client, server_config, "username", "12345")
+            response = login_user(client, "username", "12345")
             assert response.status_code == HTTPStatus.OK
             data_login = response.json
             response = client.get(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             data = response.json
@@ -301,12 +291,11 @@ class TestUserAuthentication:
             assert data["first_name"] == "firstname"
 
     @staticmethod
-    def test_update_user(client, server_config):
+    def test_update_user(client):
         """Test for get user api"""
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -315,13 +304,13 @@ class TestUserAuthentication:
             )
             assert resp_register.status_code == HTTPStatus.CREATED
 
-            response = login_user(client, server_config, "username", "12345")
+            response = login_user(client, "username", "12345")
             assert response.status_code == HTTPStatus.OK
             data_login = response.json
 
             new_registration_time = datetime.now()
             response = client.put(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 json={"registered_on": new_registration_time, "first_name": "newname"},
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
@@ -331,7 +320,7 @@ class TestUserAuthentication:
 
             # Test password update
             response = client.put(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 json={"password": "newpass"},
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
@@ -340,16 +329,15 @@ class TestUserAuthentication:
             assert data["first_name"] == "firstname"
             assert data["email"] == "user@domain.com"
             time.sleep(1)
-            response = login_user(client, server_config, "username", "newpass")
+            response = login_user(client, "username", "newpass")
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_external_token_update(client, server_config):
+    def test_external_token_update(client):
         """Test for external attempt at updating auth token"""
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -358,12 +346,12 @@ class TestUserAuthentication:
             )
             assert resp_register.status_code == HTTPStatus.CREATED
 
-            response = login_user(client, server_config, "username", "12345")
+            response = login_user(client, "username", "12345")
             assert response.status_code == HTTPStatus.OK
             data_login = response.json
 
             response = client.put(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 json={"auth_tokens": "external_auth_token"},
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
@@ -372,12 +360,11 @@ class TestUserAuthentication:
             assert data["message"] == "Invalid fields in update request payload"
 
     @staticmethod
-    def test_malformed_auth_token(client, server_config):
+    def test_malformed_auth_token(client):
         """Test for user status for malformed auth token"""
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -387,20 +374,19 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             response = client.get(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 headers=dict(Authorization="Bearer" + "malformed"),
             )
             data = response.json
             assert data is None
 
     @staticmethod
-    def test_valid_logout(client, server_config):
+    def test_valid_logout(client):
         """Test for logout before token expires"""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="user",
                 firstname="firstname",
                 lastname="lastName",
@@ -410,31 +396,30 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # user login
-            resp_login = login_user(client, server_config, "user", "12345")
+            resp_login = login_user(client, "user", "12345")
             data_login = resp_login.json
             assert data_login["auth_token"]
             # valid token logout
             response = client.post(
-                f"{server_config.rest_uri}/logout",
+                f"{server.config.rest_uri}/logout",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             assert response.status_code == HTTPStatus.OK
             # Check if the token has been successfully removed from the database
             assert (
-                not Database.db_session.query(AuthToken)
+                not server.db_session.query(AuthToken)
                 .filter_by(token=data_login["auth_token"])
                 .first()
             )
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_invalid_logout(client, server_config):
+    def test_invalid_logout(client):
         """Testing logout after the token expires"""
         with client:
             # user registration
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -444,14 +429,14 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # user login
-            resp_login = login_user(client, server_config, "username", "12345")
+            resp_login = login_user(client, "username", "12345")
             data_login = resp_login.json
             assert resp_login.status_code == HTTPStatus.OK
             assert data_login["auth_token"]
 
             # log out with the current token
             logout_response = client.post(
-                f"{server_config.rest_uri}/logout",
+                f"{server.config.rest_uri}/logout",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             assert logout_response.status_code == HTTPStatus.OK
@@ -459,18 +444,17 @@ class TestUserAuthentication:
             # Logout using invalid token
             # Expect 200 on response, since the invalid token can not be used anymore
             response = client.post(
-                f"{server_config.rest_uri}/logout",
+                f"{server.config.rest_uri}/logout",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_delete_user(client, server_config):
+    def test_delete_user(client):
         """Test for user status for malformed auth token"""
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -480,22 +464,21 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # user login
-            resp_login = login_user(client, server_config, "username", "12345")
+            resp_login = login_user(client, "username", "12345")
             data_login = resp_login.json
             assert data_login["auth_token"]
 
             response = client.delete(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_non_existent_user_delete(client, server_config):
+    def test_non_existent_user_delete(client):
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -505,23 +488,22 @@ class TestUserAuthentication:
             assert resp_register.status_code == HTTPStatus.CREATED
 
             # user login
-            resp_login = login_user(client, server_config, "username", "12345")
+            resp_login = login_user(client, "username", "12345")
             data_login = resp_login.json
             assert data_login["auth_token"]
 
             response = client.delete(
-                f"{server_config.rest_uri}/user/username1",
+                f"{server.config.rest_uri}/user/username1",
                 headers=dict(Authorization="Bearer " + data_login["auth_token"]),
             )
             assert response.status_code == HTTPStatus.FORBIDDEN
             assert response.json["message"] == "Not authorized to access user username1"
 
     @staticmethod
-    def test_admin_access(client, server_config, pbench_admin_token):
+    def test_admin_access(client, pbench_admin_token):
         with client:
             resp_register = register_user(
                 client,
-                server_config,
                 username="username",
                 firstname="firstname",
                 lastname="lastName",
@@ -532,7 +514,7 @@ class TestUserAuthentication:
 
             # Update user with admin credentials
             response = client.put(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 json={"first_name": "newname"},
                 headers=dict(Authorization="Bearer " + pbench_admin_token),
             )
@@ -540,17 +522,17 @@ class TestUserAuthentication:
 
             # Delete user with admin credentials
             response = client.delete(
-                f"{server_config.rest_uri}/user/username",
+                f"{server.config.rest_uri}/user/username",
                 headers=dict(Authorization="Bearer " + pbench_admin_token),
             )
             assert response.status_code == HTTPStatus.OK
 
     @staticmethod
-    def test_admin_delete(client, server_config, pbench_admin_token):
+    def test_admin_delete(client, pbench_admin_token):
         # Delete admin user with admin credentials
         # We should not be able to delete an admin user
         response = client.delete(
-            f"{server_config.rest_uri}/user/{admin_username}",
+            f"{server.config.rest_uri}/user/{admin_username}",
             headers=dict(Authorization="Bearer " + pbench_admin_token),
         )
         assert response.status_code == HTTPStatus.FORBIDDEN

--- a/lib/pbench/test/unit/server/test_user_management_cli.py
+++ b/lib/pbench/test/unit/server/test_user_management_cli.py
@@ -5,6 +5,13 @@ import pytest
 
 import pbench.cli.server.user_management as cli
 from pbench.server.database.models.users import User
+from pbench.server.globals import destroy_server_ctx
+
+
+@pytest.fixture
+def undo_server_ctx():
+    yield
+    destroy_server_ctx()
 
 
 def create_user():
@@ -57,14 +64,16 @@ class TestUserManagement:
     USER_CREATE_TIMESTAMP = datetime.datetime.now()
 
     @staticmethod
-    def test_help():
+    def test_help(server_config_obj):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(cli.user_create, ["--help"])
         assert result.exit_code == 0, result.stderr
         assert str(result.stdout).startswith("Usage:")
 
     @staticmethod
-    def test_valid_user_registration_with_password_input(server_config):
+    def test_valid_user_registration_with_password_input(
+        server_config_obj, undo_server_ctx
+    ):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -87,7 +96,7 @@ class TestUserManagement:
         )
 
     @staticmethod
-    def test_admin_user_creation(server_config):
+    def test_admin_user_creation(server_config_obj, undo_server_ctx):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -110,7 +119,7 @@ class TestUserManagement:
         assert result.stdout == "Admin user test_user registered\n"
 
     @staticmethod
-    def test_user_creation_with_invalid_role(server_config):
+    def test_user_creation_with_invalid_role(server_config_obj):
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             cli.user_create,
@@ -133,7 +142,7 @@ class TestUserManagement:
         assert result.stderr.find("Invalid value for '--role'") > -1
 
     @staticmethod
-    def test_valid_user_delete(monkeypatch, server_config):
+    def test_valid_user_delete(monkeypatch, server_config_obj, undo_server_ctx):
         monkeypatch.setattr(User, "delete", mock_valid_delete)
         runner = CliRunner(mix_stderr=False)
 
@@ -141,7 +150,7 @@ class TestUserManagement:
         assert result.exit_code == 0, result.stderr
 
     @staticmethod
-    def test_invalid_user_delete(server_config):
+    def test_invalid_user_delete(server_config_obj, undo_server_ctx):
         runner = CliRunner(mix_stderr=False)
         # Give username that doesn't exists to delete
         result = runner.invoke(cli.user_delete, args=["wrong_username"])
@@ -149,7 +158,7 @@ class TestUserManagement:
         assert result.stderr == "User wrong_username does not exist\n"
 
     @staticmethod
-    def test_valid_user_list(monkeypatch, server_config):
+    def test_valid_user_list(monkeypatch, server_config_obj, undo_server_ctx):
         monkeypatch.setattr(User, "query_all", mock_valid_list)
         runner = CliRunner(mix_stderr=False)
 
@@ -183,7 +192,9 @@ class TestUserManagement:
             (LAST_NAME_SWITCH, "newuser"),
         ],
     )
-    def test_valid_user_update(monkeypatch, server_config, switch, value):
+    def test_valid_user_update(
+        monkeypatch, switch, value, server_config_obj, undo_server_ctx
+    ):
         user = create_user()
 
         def mock_valid_update(**kwargs):
@@ -203,7 +214,7 @@ class TestUserManagement:
         assert result.stdout == "User test_user updated\n"
 
     @staticmethod
-    def test_invalid_role_update(server_config):
+    def test_invalid_role_update(server_config_obj):
         runner = CliRunner(mix_stderr=False)
 
         # Update with invalid role for the user
@@ -215,7 +226,7 @@ class TestUserManagement:
         assert result.stderr.find("Invalid value for '--role'") > -1
 
     @staticmethod
-    def test_invalid_user_update(server_config):
+    def test_invalid_user_update(server_config_obj, undo_server_ctx):
         runner = CliRunner(mix_stderr=False)
 
         # Update with non-existent username

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -18,6 +18,7 @@ from pbench.server.database.models.datasets import (
     OperationName,
     OperationState,
 )
+from pbench.server.globals import init_server_ctx, server
 from pbench.server.report import Report
 from pbench.server.s3backup import NoSuchKey, S3Config, Status
 from pbench.server.sync import Sync
@@ -31,8 +32,8 @@ _linkdest = "BACKED-UP"
 
 
 class LocalBackupObject:
-    def __init__(self, config):
-        self.backup_dir = config.BACKUP
+    def __init__(self):
+        self.backup_dir = server.config.BACKUP
 
 
 @dataclass
@@ -45,12 +46,12 @@ class Results:
     process_fail: int = 0
 
 
-def sanity_check(lb_obj, s3_obj, config, logger):
+def sanity_check(lb_obj, s3_obj):
     # make sure the local backup directory is present
-    backup = config.BACKUP
+    backup = server.config.BACKUP
 
     if not backup:
-        logger.error(
+        server.logger.error(
             "Unspecified backup directory, no pbench-backup-dir config in pbench-server section"
         )
         lb_obj = None
@@ -59,11 +60,11 @@ def sanity_check(lb_obj, s3_obj, config, logger):
             os.mkdir(backup)
         except FileExistsError:
             # directory already exists, verify it
-            backuppath = get_resolved_dir("BACKUP", backup, logger)
+            backuppath = get_resolved_dir("BACKUP", backup, server.logger)
             if not backuppath:
                 lb_obj = None
         except Exception as exc:
-            logger.error(
+            server.logger.error(
                 "os.mkdir: Unable to create backup destination directory: {} '{}'",
                 backup,
                 exc,
@@ -72,13 +73,15 @@ def sanity_check(lb_obj, s3_obj, config, logger):
 
     # make sure the S3 bucket is defined, exists and is accessible
     if s3_obj.bucket_name is None:
-        logger.warning("Bucket not defined in config file - S3 backup is disabled.")
+        server.logger.warning(
+            "Bucket not defined in config file - S3 backup is disabled."
+        )
         s3_obj = None
     else:
         try:
             s3_obj.head_bucket(s3_obj.bucket_name)
         except Exception:
-            logger.warning(
+            server.logger.warning(
                 "Bucket {} does not exist or is not accessible - S3 backup is disabled",
                 s3_obj.bucket_name,
             )
@@ -89,7 +92,6 @@ def sanity_check(lb_obj, s3_obj, config, logger):
 
 def backup_to_local(
     lb_obj,
-    logger,
     controller_path,
     controller,
     tb,
@@ -98,7 +100,7 @@ def backup_to_local(
     archive_md5,
     archive_md5_hex_value,
 ):
-    logger.debug("Start local backup of {}.", tar)
+    server.logger.debug("Start local backup of {}.", tar)
     if lb_obj is None:
         # Short-circuit operation when we don't have an lb object. This can
         # happen when the expected result of sanity check does not exist, or
@@ -111,7 +113,7 @@ def backup_to_local(
     backup_controller_path.mkdir(exist_ok=True)
 
     if not backup_controller_path.exists():
-        logger.error(
+        server.logger.error(
             "os.mkdir: Unable to create backup destination directory: {}",
             backup_controller_path,
         )
@@ -127,7 +129,9 @@ def backup_to_local(
             pass
         else:
             # backup md5 file does not exist or it is not a regular file
-            logger.error("{} does not exist or it is not a regular file", backup_md5)
+            server.logger.error(
+                "{} does not exist or it is not a regular file", backup_md5
+            )
             return Status.FAIL
 
         # read backup md5 file
@@ -136,16 +140,18 @@ def backup_to_local(
                 backup_md5_hex_value = f.readline().split(" ")[0]
         except Exception:
             # Could not read file
-            logger.exception("Could not read file {}", backup_md5)
+            server.logger.exception("Could not read file {}", backup_md5)
             return Status.FAIL
         else:
             if archive_md5_hex_value == backup_md5_hex_value:
                 # declare success
-                logger.info("Already locally backed-up: {}/{}", controller, resultname)
+                server.logger.info(
+                    "Already locally backed-up: {}/{}", controller, resultname
+                )
                 return Status.SUCCESS
             else:
                 # md5 file of archive and backup does not match
-                logger.error(
+                server.logger.error(
                     "{}/{} already exists in backup but md5 sums of archive and backup disagree",
                     controller,
                     resultname,
@@ -160,7 +166,7 @@ def backup_to_local(
         except Exception:
             # couldn't copy md5 file
             md5_done = False
-            logger.exception(
+            server.logger.exception(
                 "shutil.copy: Unable to copy {} from archive to backup: {}",
                 archive_md5,
                 backup_controller_path,
@@ -175,7 +181,7 @@ def backup_to_local(
             except Exception:
                 # couldn't copy tarball
                 tar_done = False
-                logger.exception(
+                server.logger.exception(
                     "shutil.copy: Unable to copy {} from archive to backup: {}",
                     tar,
                     backup_controller_path,
@@ -187,13 +193,15 @@ def backup_to_local(
                     try:
                         bmd5_file.remove(bmd5_file)
                     except Exception:
-                        logger.exception("Unable to remove: {}", bmd5_file)
+                        server.logger.exception("Unable to remove: {}", bmd5_file)
             else:
                 tar_done = True
 
-        logger.debug("End local backup of {}.", tar)
+        server.logger.debug("End local backup of {}.", tar)
         if md5_done and tar_done:
-            logger.info("Local backup of {}/{} successful", controller, resultname)
+            server.logger.info(
+                "Local backup of {}/{} successful", controller, resultname
+            )
             return Status.SUCCESS
         else:
             return Status.FAIL
@@ -201,7 +209,6 @@ def backup_to_local(
 
 def backup_to_s3(
     s3_obj,
-    logger,
     controller_path,
     controller,
     tb,
@@ -215,7 +222,7 @@ def backup_to_s3(
         # exist, or for other errors where we still want to backup locally.
         return Status.FAIL
 
-    logger.debug("Start S3 backup of {}.", tar)
+    server.logger.debug("Start S3 backup of {}.", tar)
     s3_resultname = os.path.join(controller, resultname)
 
     # Check if the result already present in s3 or not
@@ -224,7 +231,7 @@ def backup_to_s3(
     except NoSuchKey:
         s3_md5 = None
     except Exception as e:
-        logger.error("Exception raised by get_tarball_header(): {}", e)
+        server.logger.error("Exception raised by get_tarball_header(): {}", e)
         return Status.FAIL
     else:
         s3_md5 = s3_obj.s3_md5(tbh)
@@ -233,13 +240,13 @@ def backup_to_s3(
         # compare md5 which we already have so no need to recalculate
         if archive_md5_hex_value == s3_md5:
             # declare success
-            logger.info(
+            server.logger.info(
                 "The tarball {} is already present in S3 bucket with same md5",
                 s3_resultname,
             )
             _status = Status.SUCCESS
         else:
-            logger.error(
+            server.logger.error(
                 "The tarball {} is already present in S3 bucket, but with different MD5",
                 s3_resultname,
             )
@@ -247,7 +254,7 @@ def backup_to_s3(
         return _status
 
     size = s3_obj.getsize(str(tar))
-    logger.debug("tarball: {}, size = {}", tar, size)
+    server.logger.debug("tarball: {}, size = {}", tar, size)
     with open(tar, "rb") as f:
         sts = s3_obj.put_tarball(
             Name=tar,
@@ -257,13 +264,13 @@ def backup_to_s3(
             Bucket=s3_obj.bucket_name,
             Key=s3_resultname,
         )
-    logger.debug("End S3 backup of {}.", tar)
+    server.logger.debug("End S3 backup of {}.", tar)
 
     return sts
 
 
-def backup_data(lb_obj, s3_obj, config, logger):
-    sync = Sync(logger, OperationName.BACKUP)
+def backup_data(lb_obj, s3_obj):
+    sync = Sync(OperationName.BACKUP)
     datasets = sync.next()
     ntotal = nbackup_success = nbackup_fail = ns3_success = ns3_fail = process_fail = 0
 
@@ -277,9 +284,9 @@ def backup_data(lb_obj, s3_obj, config, logger):
             tar = None
             error = f"Tarball link, '{tb}', does not resolve to a real file"
             sync.error(dataset, error)
-            logger.error(error)
+            server.logger.error(error)
 
-        logger.debug("Start backup of {}.", tar)
+        server.logger.debug("Start backup of {}.", tar)
         # check tarball exists and it is a regular file
         if not (tar and tar.exists() and tar.is_file()):
             # tarball does not exist or it is not a regular file
@@ -304,7 +311,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
             error = f"can't read MD5 file {archive_md5}"
             sync.error(dataset, error)
             process_fail += 1
-            logger.exception(error)
+            server.logger.exception(error)
             continue
 
         # match md5sum of the tarball to its md5 file
@@ -315,14 +322,14 @@ def backup_data(lb_obj, s3_obj, config, logger):
             error = f"can't compute tarfile {tar} MD5"
             sync.error(dataset, error)
             process_fail += 1
-            logger.exception(error)
+            server.logger.exception(error)
             continue
 
         if archive_tar_hex_value != archive_md5_hex_value:
             error = f"Recorded MD5 {archive_md5_hex_value!r} does not match tarball MD5 {archive_tar_hex_value!r}"
             sync.error(dataset, error)
             process_fail += 1
-            logger.error(error)
+            server.logger.error(error)
             continue
 
         resultname = tar.name
@@ -333,7 +340,6 @@ def backup_data(lb_obj, s3_obj, config, logger):
         # operations and count the number of successes and failures.
         local_backup_result = backup_to_local(
             lb_obj,
-            logger,
             controller_path,
             controller,
             tb,
@@ -356,7 +362,6 @@ def backup_data(lb_obj, s3_obj, config, logger):
         # and count the number of successes and failures.
         s3_backup_result = backup_to_s3(
             s3_obj,
-            logger,
             controller_path,
             controller,
             tb,
@@ -379,7 +384,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
         ):
             # Record that the BACKUP operation is complete
             usage = shutil.disk_usage(tar.parent)
-            logger.info(
+            server.logger.info(
                 "{} backup: {}% full, {} bytes remaining",
                 tar.name,
                 float(usage.used) / float(usage.total) * 100.0,
@@ -392,7 +397,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
                 message=f"unable to backup: local {local_backup_result}, S3 {s3_backup_result}",
             )
 
-        logger.debug("End backup of {}.", tar)
+        server.logger.debug("End backup of {}.", tar)
 
     return Results(
         ntotal=ntotal,
@@ -422,19 +427,21 @@ def main(cfg_name):
 
     logger = get_pbench_logger(_NAME_, config)
 
+    init_server_ctx(config, logger)
+
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, logger)
+    init_db()
 
     # Add a BACKUP and QDIR field to the config object
     config.BACKUP = config.get("pbench-server", "pbench-backup-dir")
 
     # call the LocalBackupObject class
-    lb_obj = LocalBackupObject(config)
+    lb_obj = LocalBackupObject()
 
     # call the S3Config class
-    s3_obj = S3Config(config, logger)
+    s3_obj = S3Config()
 
-    lb_obj, s3_obj = sanity_check(lb_obj, s3_obj, config, logger)
+    lb_obj, s3_obj = sanity_check(lb_obj, s3_obj)
 
     if lb_obj is None and s3_obj is None:
         return 3
@@ -442,7 +449,7 @@ def main(cfg_name):
     logger.info("start-{}", config.TS)
 
     # Initiate the backup
-    counts = backup_data(lb_obj, s3_obj, config, logger)
+    counts = backup_data(lb_obj, s3_obj)
 
     result_string = (
         f"Total processed: {counts.ntotal},"

--- a/server/bin/pbench-cull-unpacked-tarballs
+++ b/server/bin/pbench-cull-unpacked-tarballs
@@ -33,6 +33,7 @@ from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 import pbench.server
 from pbench.server.database import init_db
+from pbench.server.globals import init_server_ctx, server
 from pbench.server.indexer import _STD_DATETIME_FMT
 from pbench.server.report import Report
 
@@ -98,7 +99,7 @@ def fetch_username(tb_incoming_dir):
     return user
 
 
-def remove_symlinks(tgt_p, tb_incoming_dir, logger, dry_run):
+def remove_symlinks(tgt_p, tb_incoming_dir, dry_run):
     """remove_symlinks - Given a target directory tree, remove all symbolic
     links which point to the given incoming tar ball directory.
 
@@ -125,11 +126,13 @@ def remove_symlinks(tgt_p, tb_incoming_dir, logger, dry_run):
                     try:
                         os.unlink(full_p)
                     except OSError as exc:
-                        logger.error("Failed to remove symlink '{}': {}", full_p, exc)
+                        server.logger.error(
+                            "Failed to remove symlink '{}': {}", full_p, exc
+                        )
                         errors += 1
                         status = "fail"
                     else:
-                        logger.debug("Removed symlink '{}'", full_p)
+                        server.logger.debug("Removed symlink '{}'", full_p)
                         status = "succ"
                     act.set_status(status)
                 # Dry-run, or actual, errors or no errors, we always record
@@ -144,7 +147,7 @@ def remove_symlinks(tgt_p, tb_incoming_dir, logger, dry_run):
     return errors, actions_taken
 
 
-def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dry_run):
+def remove_unpacked(tb_incoming_dir, controller_name, results, users, dry_run):
     """remove_unpacked - Remove the unpacked tar ball directory from the
     INCOMING tree and all symbolic links to that directory from the RESULTS
     and USERS trees.
@@ -165,17 +168,19 @@ def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dr
     """
     start = pbench.server._time()
     if not dry_run:
-        logger.info("Began removing unpacked tar ball directory, '{}'", tb_incoming_dir)
+        server.logger.info(
+            "Began removing unpacked tar ball directory, '{}'", tb_incoming_dir
+        )
 
     # Walk the results hierarchy for the tar ball's controller to find all
     # symbolic links to the INCOMING directory location.  Once we find a
     # symbolic link (which will be returned in the list of sub-directories)
     errors, actions_taken = remove_symlinks(
-        Path(results, controller_name), tb_incoming_dir, logger, dry_run
+        Path(results, controller_name), tb_incoming_dir, dry_run
     )
     if errors > 0:
         # NOTE: dry-runs never produce errors, so no check is needed.
-        logger.error(
+        server.logger.error(
             "Aborting removal of unpacked tar ball directory, '{}'", tb_incoming_dir
         )
         return ActionSet(actions_taken, errors, start, pbench.server._time())
@@ -186,13 +191,12 @@ def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dr
         errors, _actions_taken = remove_symlinks(
             Path(users, user_name, controller_name),
             tb_incoming_dir,
-            logger,
             dry_run,
         )
         actions_taken.extend(_actions_taken)
         if errors > 0:
             # NOTE: dry-runs never produce errors, so no check is needed.
-            logger.error(
+            server.logger.error(
                 "Aborting removal of unpacked tar ball directory, '{}'", tb_incoming_dir
             )
             return ActionSet(actions_taken, errors, start, pbench.server._time())
@@ -211,7 +215,7 @@ def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dr
         if not dry_run:
             os.rename(tb_incoming_dir, del_path)
     except OSError as exc:
-        logger.error(
+        server.logger.error(
             "Failed to rename incoming directory, '{}', to '{}': '{}'",
             tb_incoming_dir,
             del_path,
@@ -227,7 +231,7 @@ def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dr
             if not dry_run:
                 shutil.rmtree(del_path)
         except OSError as exc:
-            logger.error(
+            server.logger.error(
                 "Failed to remove incoming directory tree, '{}': '{}'",
                 del_path,
                 exc,
@@ -241,7 +245,7 @@ def remove_unpacked(tb_incoming_dir, controller_name, results, users, logger, dr
     act_set = ActionSet(actions_taken, errors, start, end)
     if errors == 0:
         duration = 0.0 if end < start else end - start
-        logger.info(
+        server.logger.info(
             "After {:0.2f} seconds, finished removal of unpacked tar ball"
             " directory, '{}'",
             duration,
@@ -322,8 +326,10 @@ def main(options):
 
     logger = get_pbench_logger(_NAME_, config)
 
+    init_server_ctx(config, logger)
+
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, logger)
+    init_db()
 
     archivepath = config.ARCHIVE
 
@@ -376,7 +382,6 @@ def main(options):
             controller_name,
             resultspath,
             userspath,
-            logger,
             options.dry_run,
         )
         unpacked_dir_name = Path(tb_incoming_dir).name

--- a/server/bin/pbench-index
+++ b/server/bin/pbench-index
@@ -17,6 +17,7 @@ from pbench.common.exceptions import BadConfig, ConfigFileError, JsonFileError
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.database import init_db
+from pbench.server.globals import init_server_ctx
 from pbench.server.indexer import IdxContext
 from pbench.server.indexing_tarballs import Index, SigTermException
 
@@ -106,10 +107,11 @@ def main(options, name):
         # independently.
         config = PbenchServerConfig.create(options.cfg_name)
         logger = get_pbench_logger(name, config)
-        init_db(config, logger)
+        init_server_ctx(config, logger)
+        init_db()
 
         # Now we can initialize the index context
-        idxctx = IdxContext(options, name, config, logger, _dbg=_DEBUG)
+        idxctx = IdxContext(options, name, _dbg=_DEBUG)
     except (ConfigFileError, ConfigParserError) as e:
         print(f"{name}: {e}", file=sys.stderr)
         return error_code["CFG_ERROR"].value
@@ -128,7 +130,7 @@ def main(options, name):
         idxctx.templates.dump_templates()
         return 0
 
-    idxctx.logger.debug("{}.{}: starting", name, idxctx.TS)
+    logger.debug("{}.{}: starting", name, idxctx.TS)
 
     index_obj = Index(name, options, idxctx)
     status, tarballs = index_obj.collect_tb()

--- a/server/bin/pbench-reindex
+++ b/server/bin/pbench-reindex
@@ -22,6 +22,8 @@ import os
 import re
 import sys
 
+from pbenhc.server.globals import init_server_ctx
+
 from pbench import BadConfig
 from pbench.common.logger import get_pbench_logger
 import pbench.server
@@ -173,8 +175,10 @@ def main(options):
 
     logger = get_pbench_logger(_NAME_, config)
 
+    init_server_ctx(config, logger)
+
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, logger)
+    init_db()
 
     archive_p = config.ARCHIVE
 

--- a/server/bin/pbench-unpack-tarballs
+++ b/server/bin/pbench-unpack-tarballs
@@ -9,6 +9,7 @@ from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.database import init_db
+from pbench.server.globals import init_server_ctx
 from pbench.server.unpack_tarballs import UnpackTarballs
 
 _NAME_ = "pbench-unpack-tarballs"
@@ -51,11 +52,13 @@ def main(cfg_name):
 
     logger = get_pbench_logger(prog, config)
 
+    init_server_ctx(config, logger)
+
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, logger)
+    init_db()
 
     # Initiate the unpacking
-    unpack_obj = UnpackTarballs(config, logger)
+    unpack_obj = UnpackTarballs()
     result = unpack_obj.unpack_tarballs(lowerbound, upperbound)
 
     result_string = (

--- a/server/bin/pbench-verify-backup-tarballs
+++ b/server/bin/pbench-verify-backup-tarballs
@@ -52,6 +52,7 @@ from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
 from pbench.server import get_resolved_dir, PbenchServerConfig, timestamp
 from pbench.server.database import init_db
+from pbench.server.globals import init_server_ctx, server
 from pbench.server.report import Report
 from pbench.server.s3backup import Entry, S3Config
 
@@ -64,7 +65,7 @@ class Status(Enum):
 
 
 class BackupObject:
-    def __init__(self, name, dirname, tmpdir, logger):
+    def __init__(self, name, dirname, tmpdir):
         self.name = name
         self.description = self.name
         if dirname is None:
@@ -79,7 +80,6 @@ class BackupObject:
             self.dirname = dirname
             self.s3_config_obj = None
         self.tmpdir = tmpdir
-        self.logger = logger
         self.content_list = None
         self.missing_list = None
         self.error_list = None
@@ -104,11 +104,11 @@ class BackupObject:
                     self.missing_list.append(tar)
                 else:
                     self.error_list.append(tar)
-                    self.logger.exception("ERROR reading file {}", md5_file)
+                    server.logger.exception("ERROR reading file {}", md5_file)
                 continue
             except Exception:
                 self.error_list.append(tar)
-                self.logger.exception("ERROR reading file {}", md5_file)
+                server.logger.exception("ERROR reading file {}", md5_file)
                 continue
             else:
                 self.content_list.append(
@@ -134,14 +134,14 @@ class BackupObject:
                 except KeyError:
                     # that was the last page
                     done = True
-                self.logger.debug(
+                server.logger.debug(
                     "list_objects: got {} objects{}",
                     len(resp["Contents"]),
                     " - continuing..." if not done else "",
                 )
 
         except Exception:
-            self.logger.exception("ERROR fetching list of objects from S3")
+            server.logger.exception("ERROR fetching list of objects from S3")
             return Status.FAIL
         else:
             return Status.SUCCESS
@@ -191,11 +191,11 @@ class BackupObject:
             except Exception:
                 # Could not open/read the file
                 msg = f"Failure trying to read from the file {fail_f}"
-                self.logger.exception(msg)
+                server.logger.exception(msg)
                 report.write(f"ERROR - {msg}\n")
 
 
-def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
+def compare_entry_lists(list_one_obj, list_two_obj, report):
     # Compare the two lists and report the differences.
     sorted_list_one_content = sorted(list_one_obj.content_list, key=lambda k: k.name)
     sorted_list_two_content = sorted(list_two_obj.content_list, key=lambda k: k.name)
@@ -212,7 +212,7 @@ def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
                 f"MD5 values don't match for: {sorted_list_one_content[i].name}\n"
             )
             report.write(report_text)
-            logger.debug(report_text)
+            server.logger.debug(report_text)
             i += 1
             j += 1
         elif sorted_list_one_content[i].name < sorted_list_two_content[j].name:
@@ -222,7 +222,7 @@ def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
                 f"{list_two_obj.description}\n"
             )
             report.write(report_text)
-            logger.debug(report_text)
+            server.logger.debug(report_text)
             i += 1
         else:
             assert (
@@ -234,7 +234,7 @@ def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
                 f"{list_one_obj.description}\n"
             )
             report.write(report_text)
-            logger.debug(report_text)
+            server.logger.debug(report_text)
             j += 1
     assert (i == len_list_one_content) or (j == len_list_two_content), "Logic error!"
 
@@ -245,7 +245,7 @@ def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
                 f" but not in {list_one_obj.description}\n"
             )
             report.write(report_text)
-            logger.debug(report_text)
+            server.logger.debug(report_text)
     elif i < len_list_one_content and j == len_list_two_content:
         for entry in sorted_list_one_content[i:len_list_one_content]:
             report_text = (
@@ -253,22 +253,24 @@ def compare_entry_lists(list_one_obj, list_two_obj, report, logger):
                 f"but not in {list_two_obj.description}\n"
             )
             report.write(report_text)
-            logger.debug(report_text)
+            server.logger.debug(report_text)
     else:
         assert (i == len_list_one_content) and (
             j == len_list_two_content
         ), "Logic error!"
 
 
-def sanity_check(s3_obj, logger):
+def sanity_check(s3_obj):
     # make sure the S3 bucket exists
     if s3_obj.bucket_name is None:
-        logger.warning("Bucket not defined in config file - S3 backup is disabled.")
+        server.logger.warning(
+            "Bucket not defined in config file - S3 backup is disabled."
+        )
         return None
     try:
         s3_obj.head_bucket(Bucket=s3_obj.bucket_name)
     except Exception as exc:
-        logger.error(
+        server.logger.error(
             "Bucket: {} does not exist or you have no access, {}",
             s3_obj.bucket_name,
             exc,
@@ -287,16 +289,19 @@ def main():
         )
         return 2
 
+    init_server_ctx()
     try:
         config = PbenchServerConfig.create(cfg_name)
     except BadConfig as e:
         print(f"{_NAME_}: {e}", file=sys.stderr)
         return 1
 
-    logger = get_pbench_logger(_NAME_, config)
+    logger = logger = get_pbench_logger(_NAME_, config)
+
+    init_server_ctx(config, logger)
 
     # We're going to need the DB to track dataset state, so setup DB access.
-    init_db(config, logger)
+    init_db()
 
     # add a BACKUP field to the config object
     config.BACKUP = backup = config.get("pbench-server", "pbench-backup-dir")
@@ -308,13 +313,13 @@ def main():
         )
         return 1
 
-    backuppath = get_resolved_dir("BACKUP", backup, logger)
+    backuppath = get_resolved_dir("BACKUP", backup, server.logger)
     if not backuppath:
         return 1
 
     # instantiate the s3config class
-    s3_config_obj = S3Config(config, logger)
-    s3_config_obj = sanity_check(s3_config_obj, logger)
+    s3_config_obj = S3Config(config)
+    s3_config_obj = sanity_check(s3_config_obj)
 
     logger.info("start-{}", config.TS)
     start = timestamp()
@@ -325,9 +330,9 @@ def main():
     # N.B. tmpdir is the pathname of the temp directory.
     with tempfile.TemporaryDirectory() as tmpdir:
 
-        archive_obj = BackupObject("ARCHIVE", config.ARCHIVE, tmpdir, logger)
-        local_backup_obj = BackupObject("BACKUP", config.BACKUP, tmpdir, logger)
-        s3_backup_obj = BackupObject("S3", s3_config_obj, tmpdir, logger)
+        archive_obj = BackupObject("ARCHIVE", config.ARCHIVE, tmpdir)
+        local_backup_obj = BackupObject("BACKUP", config.BACKUP, tmpdir)
+        s3_backup_obj = BackupObject("S3", s3_config_obj, tmpdir)
 
         with tempfile.NamedTemporaryFile(mode="w+t", dir=tmpdir) as reportfp:
             reportfp.write(
@@ -411,7 +416,7 @@ def main():
             msg = "Comparing ARCHIVE with BACKUP"
             reportfp.write(f"\n{msg}\n{'-' * len(msg)}\n")
             logger.debug("{}: start", msg)
-            compare_entry_lists(archive_obj, local_backup_obj, reportfp, logger)
+            compare_entry_lists(archive_obj, local_backup_obj, reportfp)
             logger.debug("{}: end", msg)
 
             if s3_config_obj is not None:
@@ -419,7 +424,7 @@ def main():
                 msg = "Comparing ARCHIVE with S3"
                 reportfp.write(f"\n{msg}\n{'-' * len(msg)}\n")
                 logger.debug("{}: start", msg)
-                compare_entry_lists(archive_obj, s3_backup_obj, reportfp, logger)
+                compare_entry_lists(archive_obj, s3_backup_obj, reportfp)
                 logger.debug("{}: end", msg)
 
             if s3_config_obj is None:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -21,3 +21,4 @@ python-dateutil
 requests
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6
+werkzeug>=2.2


### PR DESCRIPTION
Refactor code to leverage context variables.  Please find a detailed description of this work in the separate section below.

The goal is to submit these commits separately.

Two other commits are included before hand:

 * `Correct references to `ApiMethod` and `OperationCode` in comments`
 * `Stop using pbench logger in agent tests`

----

    Leverage context variables for config and logger

    We add a new module, `pbench.server.globals`, which provides a
    `ContextVar` called `server`.  The top-level interfaces for the server
    (`shell`, `tree-manager`, `server/bin/*` commands, etc.) are responsible
    for setting up the server context.

    The server context consists of three pieces:

     * `config` - A PbenchServerConfig instance
     * `logger` - A reference to the logger instance in use
     * `db_session` - [Optional] the current database session in use

    The majority of these changes are removing the `logger` fields from
    objects, using `server.logger` instead.  A somewhat smaller set, though
    still fairly large, are changes to remove embedded configuration object
    references in objects.  And lastly, we promote the database "session" up
    to use the same mechanism instead of via a class variable.

    The biggest reason to make this change is that by nature and design,
    loggers are singletons.  Within the context of a python interpreter
    instance, each logger has a name, and is fetchable in any context by
    using `logging.getLogger('<name>')`.  As you can see from these changes,
    by removing the need to pass a logger around, we reduce a substantial
    amount of code "mechanism."  By embracing the nature of singleton
    loggers we avoid the need to ensure loggers are available in all
    contexts referenced through object instances.

    Arguably the second biggest reason is to leverage the nature of context
    variables so as to facilitate removal of code mechanism for other
    singletons, the configuration in use and the database session in use.

    A third reason is that it also helps prepare for future concurrency
    mechanims ("async", which is not really asynchronous, and / or threads).

    The motivating reason for these changes is to ensure we have a handle on
    what loggers are in use for changes to how those loggers behave (adding
    / removing different handlers, in particular).

    Since most of the code for the server leverages Flask which already uses
    context variables (see `current_app` and the `g` object), we could have
    just used those existing mechanisms.  We chose to create our own so that
    we can consider contexts where we don't have, or don't want, Flask
    involved (yes, we are aware that Flask has support for CLIs).

    For the server unit tests, we now use a session-scoped fixture to create
    a logger using "brace" formatting.

----

Depends on #3114.