### PR TITLE
Add pbench agent dependencies list 

### DIFF
--- a/docs/pbench-agent-package-dependencies-list.md
+++ b/docs/pbench-agent-package-dependencies-list.md
@@ -1,0 +1,39 @@
+### PBench Agent package dependencies
+
+|  Upstream | PyPI | Fedora  |
+| ------------ | ------------ | ------------ |
+|[bottle](https://bottlepy.org/docs/dev)| [bottle](https://pypi.org/project/bottle)  | [python3-bottle](https://src.fedoraproject.org/rpms/python-bottle) |
+|[cffi](http://cffi.readthedocs.org)| [cffi](https://pypi.org/project/cffi)  | [python3-cffi](https://src.fedoraproject.org/rpms/python-cffi) |
+|[click](https://palletsprojects.com/p/click)| [click](https://pypi.org/project/click)  |  [python3-click](https://src.fedoraproject.org/rpms/python-click) |
+|[ifaddr](https://github.com/pydron/ifaddr)| [ifaddr](https://pypi.org/project/ifaddr)  | [python3-ifaddr](https://src.fedoraproject.org/rpms/python-ifaddr)  |
+|[jinja2](https://palletsprojects.com/p/jinja)|  [jinja2](https://pypi.org/project/Jinja2/) | [python3-jinja2](https://src.fedoraproject.org/rpms/python-jinja2)  |
+|[python-daemon](https://pagure.io/python-daemon)| [python-daemon](https://pypi.org/project/python-daemon)  | [python3-daemon](https://src.fedoraproject.org/rpms/python-daemon)  |
+|[python-pidfile](https://github.com/mosquito/python-pidfile)| [python-pidfile](https://pypi.org/project/python-pidfile)  | [python3-pidfile](https://src.fedoraproject.org/rpms/python-pidfile)  |
+|[redis](https://github.com/redis/redis-py)|  [redis](https://pypi.org/project/redis/) | [python3-redis](https://src.fedoraproject.org/rpms/python-redis)  |
+|[requests](https://requests.readthedocs.io)| [requests](https://pypi.org/project/requests/) | [python3-requests](https://src.fedoraproject.org/rpms/python-requests) |
+|[sh](https://github.com/amoffat/sh)| [sh](https://pypi.org/project/sh/)  | [python3-sh](https://src.fedoraproject.org/rpms/python-sh)  |
+|[docutils](https://docutils.sourceforge.io/)| [docutils](https://pypi.org/project/docutils) | [python3-docutils](https://src.fedoraproject.org/rpms/python-docutils) |
+|[psutil](https://github.com/giampaolo/psutil)| [psutil](https://pypi.org/project/psutil)  | [python3-psutil](https://src.fedoraproject.org/rpms/python-psutil)  |
+|[python-daemon](https://pagure.io/python-daemon)| [python-daemon](https://pypi.org/project/python-daemon)  | [python3-daemon](https://src.fedoraproject.org/rpms/python-daemon) |
+|[perl](https://www.perl.org)| -  |  [perl](https://src.fedoraproject.org/rpms/perl) |
+|[perl-Data-UUID](https://metacpan.org/release/Data-UUID)| -  | [perl-Data-UUID](https://src.fedoraproject.org/rpms/perl-Data-UUID) |
+|[perl-JSON](https://metacpan.org/release/JSON)| -  | [perl-JSON](https://src.fedoraproject.org/rpms/perl-JSON)  |
+|[perl-JSON-XS](https://metacpan.org/release/JSON-XS)| -  | [perl-JSON-XS](https://src.fedoraproject.org/rpms/perl-JSON-XS)  |
+|[perl-Time-HiRes](https://metacpan.org/release/Time-HiRes)| -  | [perl-Time-HiRes](https://src.fedoraproject.org/rpms/perl-Time-HiRes)  |
+|[bc](http://www.gnu.org/software/bc)| -  |  [bc](https://src.fedoraproject.org/rpms/bc) |
+|[bzip2](http://www.bzip.org)| - |[bzip2](https://src.fedoraproject.org/rpms/bzip2)|
+|[hostname](http://packages.qa.debian.org/h/hostname.html)| -  | [hostname](https://src.fedoraproject.org/rpms/hostname) |
+|[iproute](https://mirrors.edge.kernel.org/pub/linux/utils/net/iproute2)| -  | [iproute](https://src.fedoraproject.org/rpms/iproute) |
+|[iputils](https://github.com/iputils/iputils)| -  | [iputils](https://src.fedoraproject.org/rpms/iputils) |
+|[net-tools](http://sourceforge.net/projects/net-tools)| -  | [net-tools](https://src.fedoraproject.org/rpms/net-tools) |
+|openssh-clients|  - | openssh-clients |
+|openssh-server| -  | openssh-server |
+|[procps-ng](https://sourceforge.net/projects/procps-ng)| -  | [procps-ng](https://src.fedoraproject.org/rpms/procps-ng)  |
+|[psmisc](https://gitlab.com/psmisc/psmisc)| -  | [psmisc](https://src.fedoraproject.org/rpms/psmisc)  |
+|[rpmdevtools](https://pagure.io/rpmdevtools)| -  | [rpmdevtools](https://src.fedoraproject.org/rpms/rpmdevtools) |
+|[rsync](https://rsync.samba.org)| -  |  [rsync](https://src.fedoraproject.org/rpms/rsync) |
+|[screen](http://www.gnu.org/software/screen)| -  | [screen](https://src.fedoraproject.org/rpms/screen)  |
+|[sos](https://github.com/sosreport/sos)| -  | [sos](https://src.fedoraproject.org/rpms/sos)  |
+|[tar](https://www.gnu.org/software/tar)| -  |  [tar](https://src.fedoraproject.org/rpms/tar) |
+|[xz](https://tukaani.org/xz/)| -  | [xz](https://src.fedoraproject.org/rpms/xz)  |
+


### PR DESCRIPTION
These are the package dependencies for pbench-agent.
This list will help for installing and/or packaging pbench-agent from sources.
Also, this list has an upstream link for packages if the package is not packaged
into any distro users can use this upstream project link to know more.

[Preview](https://github.com/vishalvvr/pbench/blob/PBENCH-221/docs/pbench-agent-package-dependencies-list.md)

PBENCH-221