### PR TITLE
For CVE-2022-40897 bump `setuptools` to `65.5.1`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 46.1.3",
+    "setuptools >= 65.5.1",
     "wheel >= 0.34.2",
 ]
 build-backend="setuptools.build_meta"


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2022-40897.