### PR TITLE
Return `409 (CONFLICT)` on duplicate upload

### DIFF
--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -266,7 +266,7 @@ class Upload(ApiBase):
                     )
                 else:
                     response = jsonify(dict(message="Dataset already exists"))
-                    response.status_code = HTTPStatus.OK
+                    response.status_code = HTTPStatus.CONFLICT
                     return response
             except CleanupTime:
                 raise  # Propagate a CleanupTime exception to the outer block

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -406,7 +406,7 @@ class TestUpload:
                 headers=self.gen_headers(pbench_token, md5),
             )
 
-        assert response.status_code == HTTPStatus.OK, repr(response)
+        assert response.status_code == HTTPStatus.CONFLICT, repr(response)
         assert response.json.get("message") == "Dataset already exists"
 
         # We didn't get far enough to create a CacheManager


### PR DESCRIPTION
We want to respond with an error message with the reason we did NOT read the `PUT` payload body.