### PR TITLE
Fix PUT metadata partial success

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -26,7 +26,7 @@ from pbench.server.database.models.datasets import (
     DatasetNotFound,
     Metadata,
     MetadataBadKey,
-    MetadataNotFound,
+    MetadataError,
 )
 from pbench.server.database.models.server_config import ServerConfig
 from pbench.server.database.models.users import User
@@ -1482,7 +1482,7 @@ class ApiBase(Resource):
                     metadata[i] = Metadata.getvalue(
                         dataset=dataset, key=i, user_id=user_id
                     )
-                except MetadataNotFound:
+                except MetadataError:
                     metadata[i] = None
             else:
                 raise MetadataBadKey(i)
@@ -1658,13 +1658,11 @@ class ApiBase(Resource):
                         attributes=attr,
                     )
                 except Exception:
-                    self.logger.error(
-                        "Unexpected exception on audit: {}", json.dumps(auditing)
-                    )
+                    self.logger.error("Unexpected exception on audit: {}", auditing)
             abort(e.http_status, message=str(e))
         except Exception as e:
             self.logger.exception(
-                "Exception {} API error: {}: {!r}", api_name, e, json.dumps(auditing)
+                "Exception {} API error: {}: {!r}", api_name, e, auditing
             )
             if auditing["finalize"]:
                 attr = auditing.get("attributes", {})

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -210,7 +210,7 @@ class MetadataBadValue(MetadataError):
         )
 
 
-class MetadataKeyError(DatasetError):
+class MetadataKeyError(MetadataError):
     """
     A base class for metadata key errors in the context of Metadata errors
     that have no associated Dataset. It is never raised directly, but may

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -370,8 +370,8 @@ class TestMetadataNamespace:
         "value",
         [
             "Symbols like $ and _ and @",
-            "MY_DATA",
-            "123456",
+            "MY_DATA_IS_UGLY",
+            "1234567890",
             "La palabra año incluye unicode",
             "Shift to the left",
         ],
@@ -386,7 +386,7 @@ class TestMetadataNamespace:
 
     @pytest.mark.parametrize(
         "value",
-        ["", True, 1, "This is a really long name that exceeds the maximum length"],
+        ["", True, 1, "A" * 132],
     )
     def test_mutable_dataset_bad(self, attach_dataset, value):
         """


### PR DESCRIPTION
PBENCH-1049

During the course of making an unrelated change, I "broke" a metadata test case for the "partial success" case of `PUT /datasets/metadata`. The test was still expecting the previous 500/internal-server-error behavior even though this had been changed to a success with an advisory message.

The reason the test "succeeded" was that the product code attempted to report the issue with an error log message, which failed because it involved trying to serialize an `Audit` record via `json.dumps` which apparently is unhappy with the `Audit` (and probably all SQLAlchemy proxy) objects, and the failure caused the API call to terminate with ... an internal server error.

This PR fixes the test and some aspects of the implementation, including making all metadata exceptions extend `MetadataError` to provide an easy catch-all handle.