### PR TITLE
Make sure dashboard routing stays within the app

### DIFF
--- a/dashboard/src/utils/routeConstants.js
+++ b/dashboard/src/utils/routeConstants.js
@@ -1,4 +1,4 @@
-export const HOME = "dashboard";
+export const HOME = "dashboard/";
 
 export const AUTH = "auth";
 export const AUTH_LOGIN = "login";


### PR DESCRIPTION
PBENCH-1050

In some cases, routing was dropping the trailing `/` and we were losing the default "/dashboard" base directory on loads. While the mechanism still isn't entirely clear and I suspect there are cleaner ways to solve this in the longer term, Varshini, Webb, and I discovered that simply adding a trailing slash to the dashboard's `HOME` variable resolves the problem.

Closes #3128 