### PR TITLE
Make `access` parameter to `copy_result_tb` optional

### DIFF
--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
+from typing import Optional
 import urllib.parse
 
 import requests
@@ -311,7 +312,7 @@ class CopyResultTb:
         self.upload_url = f"{server_rest_url}/upload/{tbname}"
         self.logger = logger
 
-    def copy_result_tb(self, token: str, access: str) -> None:
+    def copy_result_tb(self, token: str, access: Optional[str] = None) -> None:
         """Copies the tar ball from the agent to the configured server using upload
         API.
 
@@ -320,14 +321,15 @@ class CopyResultTb:
                 authorized to make the PUT request on behalf of a
                 specific user.
             access: keyword that identifies whether a dataset needs
-                to be published public or private.
+                to be published public or private.  Optional:  if omitted
+                the result will be the server default.
 
         Raises:
             RuntimeError     if a connection to the server fails
             FileUploadError  if the tar ball failed to upload properly
 
         """
-        params = {"access": access}
+        params = {"access": access} if access else {}
         headers = {
             "Content-MD5": self.tarball_md5,
             "Authorization": f"Bearer {token}",


### PR DESCRIPTION
This is in response to [a request](https://github.com/distributed-system-analysis/pbench/pull/3119#discussion_r1050298738) made in #3119.  (This change was originally part of #3157, but it got booted.)

#3119 added the `--access` option to `pbench-results-push` and `pbench-results-move`.  Click performs the parameter validation and provides the CLI code with a default value if the user doesn't specify one.  Thus, the CLI code always provides a value for the `access` parameter when it calls what will become the "Agent library code" (i.e., `copy_result_tb()`), so the choices made in #3119 make reasonable sense.

However, once we establish a clean split between the Agent CLI and the underlying "library" code, it will become feasible for other projects to make use of the Agent via the API instead of via the CLI.  At that point, we don't necessarily want to require a value for the `access` parameter, instead allowing it to default in some way.

This PR implements that change, making the `access` parameter optional.  If it is unspecified, then no `"access"` value will be provided in the REST request to the Server, and the Server's default (`"private"`) will be used.

This PR also includes a rework of the `CopyResultTb` class unit tests.  Hopefully, this will make the coverage more complete, and the tests will be better isolated (e.g. from the file system).