### PR TITLE
Apply corrections for when tests are skipped

### DIFF
--- a/exec-tests
+++ b/exec-tests
@@ -164,6 +164,7 @@ if [[ "${subtst:-python}" == "python" ]]; then
         --basetemp="${_toxenvdir}/tmp" \
         --cov=${_pbench_sources} \
         --cov-report ${_cov_report} \
+        -rs \
         ${posargs} \
         --pyargs ${_pytest_majors}
     rc=${?}
@@ -232,7 +233,7 @@ if [[ "${major}" == "all" || "${major}" == "server" ]]; then
         shift
         posargs="${@}"
         # We use SQLALCHEMY_SILENCE_UBER_WARNING here ... (see above).
-        SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s ${posargs} --pyargs pbench.test.functional.server
+        SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s -rs ${posargs} --pyargs pbench.test.functional.server
         rc=${?}
     fi
 fi

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1056,6 +1056,9 @@ class ApiSchemaSet:
     def __contains__(self, item):
         return item in self.schemas
 
+    def __len__(self):
+        return len(self.schemas)
+
     def get_param_by_type(
         self, method: ApiMethod, dtype: ParamType, params: Optional[ApiParams]
     ) -> Optional[ParamSet]:

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -17,8 +17,7 @@ from pbench.server.database.models.template import Template
 
 
 class MissingDatasetNameParameter(SchemaError):
-    """
-    The subclass schema is missing the required "name" parameter required
+    """The subclass schema is missing the required "name" parameter required
     to locate a Dataset.
 
     NOTE: This is a development error, not a client error, and will be raised
@@ -36,8 +35,7 @@ class MissingDatasetNameParameter(SchemaError):
 
 
 class IndexMapBase(ElasticBase):
-    """
-    A base class for query apis that depends on Metadata for getting the
+    """A base class for query apis that depends on Metadata for getting the
     indices.
 
     This class extends the ElasticBase class and implements a common
@@ -106,8 +104,7 @@ class IndexMapBase(ElasticBase):
             )
 
     def preprocess(self, params: ApiParams, context: ApiContext) -> NoReturn:
-        """
-        Identify the Dataset on which we're operating, and return it in the
+        """Identify the Dataset on which we're operating, and return it in the
         context for the Elasticsearch assembly and postprocessing.
 
         Note that the class constructor validated that the API is authorized
@@ -121,9 +118,8 @@ class IndexMapBase(ElasticBase):
         context["dataset"] = dataset
 
     def get_index(self, dataset: Dataset, root_index_name: AnyStr) -> AnyStr:
-        """
-        Retrieve the list of ES indices from the metadata table based on a given
-        root_index_name.
+        """Retrieve the list of ES indices from the metadata table based on a
+        given root_index_name.
         """
         try:
             index_map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
@@ -159,12 +155,12 @@ class IndexMapBase(ElasticBase):
 
     @staticmethod
     def get_mappings(document: JSON) -> JSON:
-        """
-        Utility function to return ES mappings by querying the Template
+        """Utility function to return ES mappings by querying the Template
         database against a given index.
 
         Args:
-            document: One of the values of ES_INTERNAL_INDEX_NAMES (JSON)
+            document : One of the values of ES_INTERNAL_INDEX_NAMES (JSON)
+
         Returns:
             JSON containing whitelisted keys of the index and corresponding
             values.

--- a/lib/pbench/test/unit/server/query_apis/commons.py
+++ b/lib/pbench/test/unit/server/query_apis/commons.py
@@ -16,8 +16,7 @@ from pbench.test.unit.server.headertypes import HeaderTypes
 
 
 class Commons:
-    """
-    Unit testing for all the elasticsearch resources class.
+    """Unit testing for all the elasticsearch resources class.
 
     In a web service context, we access class functions mostly via the
     Flask test client rather than trying to directly invoke the class
@@ -63,11 +62,10 @@ class Commons:
             assert False, "api_method is neither ApiMethod.GET nor ApiMethod.POST"
 
     def build_index(self, server_config, dates):
-        """
-        Build the index list for query
+        """Build the index list for query.
 
         Args:
-            dates (iterable): list of date strings
+            dates (iterable) : list of date strings
         """
         idx = server_config.get("Indexing", "index_prefix") + ".v6.run-data."
         index = "".join([f"{idx}{d}," for d in dates])
@@ -75,9 +73,8 @@ class Commons:
         return f"/{index}"
 
     def build_index_from_metadata(self) -> str:
-        """
-        Retrieve the list of ES indices from the dataset index
-        map metadata based on a given root index name.
+        """Retrieve the list of ES indices from the dataset index map metadata
+        based on a given root index name.
 
         Returns:
             An Elasticsearch query URL string listing the set of
@@ -90,8 +87,8 @@ class Commons:
         return "/" + ",".join(index_keys)
 
     def date_range(self, start: AnyStr, end: AnyStr) -> list:
-        """
-        Builds list of range of dates between start and end
+        """Builds list of range of dates between start and end.
+
         It expects the date to look like YYYY-MM
         """
         date_range = []
@@ -105,8 +102,7 @@ class Commons:
         return date_range
 
     def get_expected_status(self, payload: JSON, header: HeaderTypes) -> int:
-        """
-        Decode the various test cases we use, which are a combination of the
+        """Decode the various test cases we use, which are a combination of the
         test case parametrization (for "user" parameter value) and the
         parametrization of the `build_auth_header` fixture (for the API
         authentication header);
@@ -155,8 +151,7 @@ class Commons:
     def test_malformed_authorization_header(
         self, client, server_config, malformed_token, attach_dataset
     ):
-        """
-        Test behavior when the Authorization header is present but is not a
+        """Test behavior when the Authorization header is present but is not a
         proper Bearer schema.
 
         TODO: This actually tests behavior with no client authentication, as
@@ -179,9 +174,7 @@ class Commons:
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     def test_bad_user_name(self, client, server_config, pbench_token):
-        """
-        Test behavior when authenticated user specifies a non-existent user.
-        """
+        """Test behavior when authenticated user specifies a non-existent user."""
         # The pbench_token fixture logs in as user "drb"
         # Trying to access the data belong to the user "pp"
         user = self.cls_obj.schemas.get_param_by_type(
@@ -205,8 +198,7 @@ class Commons:
     def test_accessing_user_data_with_invalid_token(
         self, client, server_config, pbench_token_invalid, user
     ):
-        """
-        Test behavior when expired authentication token is provided.
+        """Test behavior when expired authentication token is provided.
 
         TODO: This actually tests behavior with no client authentication, as
         Flask-HTTPTokenAuth hides the validation failure because our query
@@ -234,9 +226,7 @@ class Commons:
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 
     def test_missing_json_object(self):
-        """
-        Test behavior when no JSON payload is given
-        """
+        """Test behavior when no JSON payload is given."""
         with pytest.raises(SchemaError) as exc:
             self.cls_obj.schemas.validate(
                 self.api_method, ApiParams(uri=None, query=None, body={})
@@ -244,9 +234,7 @@ class Commons:
         assert str(exc.value).startswith("Missing required parameters: ")
 
     def test_malformed_payload(self, client, server_config, pbench_token):
-        """
-        Test behavior when payload is not valid JSON
-        """
+        """Test behavior when payload is not valid JSON."""
         if self.api_method != ApiMethod.POST:
             pytest.skip("skipping " + self.test_malformed_payload.__name__)
         response = self.make_request_call(
@@ -265,8 +253,7 @@ class Commons:
         )
 
     def test_missing_keys(self, client, server_config, pbench_token):
-        """
-        Test behavior when JSON payload does not contain all required keys.
+        """Test behavior when JSON payload does not contain all required keys.
 
         Note that Pbench will silently ignore any additional keys that are
         specified but not required.
@@ -321,9 +308,7 @@ class Commons:
             missing_key_helper({"notakey": None})
 
     def test_bad_dates(self, client, server_config, pbench_token):
-        """
-        Test behavior when a bad date string is given
-        """
+        """Test behavior when a bad date string is given."""
         if self.api_method != ApiMethod.POST:
             pytest.skip("skipping " + self.test_bad_dates.__name__)
 
@@ -357,10 +342,11 @@ class Commons:
         find_template,
         build_auth_header,
     ):
-        """
-        Check proper handling of a query resulting in no Elasticsearch matches.
-        PyTest will run this test multiple times with different values of the build_auth_header
-        fixture.
+        """Check proper handling of a query resulting in no Elasticsearch
+        matches.
+
+        PyTest will run this test multiple times with different values of the
+        build_auth_header fixture.
         """
         if not self.empty_es_response_payload or not self.elastic_endpoint:
             pytest.skip("skipping " + self.test_empty_query.__name__)
@@ -413,8 +399,8 @@ class Commons:
         pbench_token,
         provide_metadata,
     ):
-        """
-        Check that an exception in calling Elasticsearch is reported correctly.
+        """Check that an exception in calling Elasticsearch is reported
+        correctly.
         """
         if not self.elastic_endpoint:
             pytest.skip("skipping " + self.test_http_exception.__name__)
@@ -448,8 +434,7 @@ class Commons:
         provide_metadata,
         errors,
     ):
-        """
-        Check that an Elasticsearch error is reported correctly through the
+        """Check that an Elasticsearch error is reported correctly through the
         response.raise_for_status() and Pbench handlers.
         """
         if not self.elastic_endpoint:

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -26,6 +26,7 @@ class TestSampleNamespace(Commons):
             pbench_endpoint="/datasets/namespace/random_md5_string1/iterations",
             elastic_endpoint="/_search",
             index_from_metadata="result-data-sample",
+            empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
     def test_with_no_index_document(
@@ -408,6 +409,7 @@ class TestSampleValues(Commons):
             elastic_endpoint="/_search",
             payload={},
             index_from_metadata="result-data-sample",
+            empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
         )
 
     @pytest.mark.parametrize("filters", ({"sample.name": "sample1"}, {}, None))

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -11,9 +11,9 @@ from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.test.unit.server.query_apis.commons import Commons
 
 
-class TestSamplesNamespace(Commons):
-    """
-    Unit testing for SamplesNamespace class.
+class TestSampleNamespace(Commons):
+    """Unit testing for SampleNamespace class.
+
     In a web service context, we access class functions mostly via the
     Flask test client rather than trying to directly invoke the class
     constructor and `get` service.
@@ -31,9 +31,7 @@ class TestSamplesNamespace(Commons):
     def test_with_no_index_document(
         self, client, server_config, pbench_token, attach_dataset
     ):
-        """
-        Check the Namespace API when no index name is provided
-        """
+        """Check the Namespace API when no index name is provided."""
         # remove the last component of the pbench_endpoint
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-1])
         response = client.get(f"{server_config.rest_uri}{incorrect_endpoint}")
@@ -42,10 +40,10 @@ class TestSamplesNamespace(Commons):
     def test_with_incorrect_index_document(
         self, client, server_config, pbench_token, attach_dataset
     ):
-        """
-        Check the Namespace API when an incorrect index name is provided.
-        currently we only support iterations (result-data-samples) and
-        timeseries (result-data) documents
+        """Check the Namespace API when an incorrect index name is provided.
+
+        Currently we only support iterations (result-data-samples) and
+        timeseries (result-data) documents.
         """
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-1]) + "/test"
         response = client.get(
@@ -111,10 +109,11 @@ class TestSamplesNamespace(Commons):
         find_template,
         provide_metadata,
     ):
-        """
-        Check the construction of Elasticsearch query URI and filtering of the
-        response body. Note that the mock set up by the attach_dataset fixture
-        matches the dataset name to the dataset's owner.
+        """Check the construction of Elasticsearch query URI and filtering of
+        the response body.
+
+        Note that the mock set up by the attach_dataset fixture matches the
+        dataset name to the dataset's owner.
         """
         response_payload = {
             "took": 14,
@@ -392,8 +391,8 @@ class TestSamplesNamespace(Commons):
 
 
 class TestSampleValues(Commons):
-    """
-    Unit testing for IterationSamplesRowse class.
+    """Unit testing for SampleValues class.
+
     In a web service context, we access class functions mostly via the
     Flask test client rather than trying to directly invoke the class
     constructor and `post` service.


### PR DESCRIPTION
The `Commons` class provides a set of shared tests as a "base" class, of sorts, for various other tests classes to use to help validate behaviors.

However, it wasn't clear what tests were supposed to be skipped or not.

**_It is this author's opinion that we should drop test skipping in the future._**

In the mean time, we have applied some comments, reworked existing skip conditions, added other conditions, and removed unused skips in an attempt to verify what is skipped is expected.

This actually resulted in an _increase_ in the number of skipped tests due to the fact that one of the tests was not actually executing when a parameter was missing.

----

This PR is divided into 5 commits which are intended to be merged as separate commits.

The first commit is a set of changes to doc strings that were made by reviewing all doc strings in the modules which were under investigation for test skipping.

The second commit resulted from reviewing the doc strings of the conversion routines, which let to a review of the exceptions being raised.

The third commit resulted from confusion on the use of `self.schema` when `ApiBase` already provides `self.schemas`.

The fourth commit is a simple change to add an explicit report on what tests were skipped.  Unfortunately, it does not report using the sub-class name, but it does provide the line numbers for the `pytest.skip` statement used, which helps us understand the skipping behavior.