### PR TITLE
Silence warnings display by python unit tests

### DIFF
--- a/exec-tests
+++ b/exec-tests
@@ -153,7 +153,12 @@ if [[ "${subtst:-python}" == "python" ]]; then
 
     printf -- "\n\n\nRunning %s python3-based unit tests via pytest\n\n" "${major_list// /,}"
     _pbench_sources=$(python3 -c 'import inspect, pathlib, pbench; print(pathlib.Path(inspect.getsourcefile(pbench)).parent)')
-    PYTHONUNBUFFERED=True _PBENCH_COV_DIR="${_toxenvdir}/cov" ${_ECHO} _time pytest \
+    # We use SQLALCHEMY_SILENCE_UBER_WARNING here to silence very prolific
+    # warnings posted by SQLAlchemy 1.4.x about features / behaviors being
+    # used which are not compatible with SQLAlchemy 2.x. Since we are not
+    # going to switch to 2.x any time soon, we use the big hammer approach
+    # to avoid the noise.
+    SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True _PBENCH_COV_DIR="${_toxenvdir}/cov" ${_ECHO} _time pytest \
         --tb=native \
         ${pytest_jobs_arg} \
         --basetemp="${_toxenvdir}/tmp" \
@@ -226,7 +231,8 @@ if [[ "${major}" == "all" || "${major}" == "server" ]]; then
         server_arg=${1}
         shift
         posargs="${@}"
-        PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s ${posargs} --pyargs pbench.test.functional.server
+        # We use SQLALCHEMY_SILENCE_UBER_WARNING here ... (see above).
+        SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s ${posargs} --pyargs pbench.test.functional.server
         rc=${?}
     fi
 fi

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -1,8 +1,7 @@
 import sys
 
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 
 from pbench.server import NoOptionError, NoSectionError
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,8 @@
 addopts = -s
 log_cli=False
 log_level=DEBUG
+filterwarnings=
+  # Issue #557 in `pytest-cov` (currently v4.x) has not moved for a while now,
+  # but once a resolution has been adopted we can drop this "ignore".
+  # Ref: https://github.com/pytest-dev/pytest-cov/issues/557
+  ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning


### PR DESCRIPTION
There were two categories of warnings being displayed, those related to the xdist plugin, and those related to SQLAlchemy 2.0 migration.

The xdist plugin warnings are due to a bug in pytest-cov, see https://github.com/pytest-dev/pytest-cov/issues/557.  We just ignore them entirely for now, as that issue seems to be quiet.

The SQLAlchemy 2.0 migration warnings have 2 sub-categories.  The first being that `declarative_base` has moved modules, and that warning is removed by using the proper import.

However, once that `declarative_base` warning is removed, one encounters:

    .../pbench/server/database/models/datasets.py:875:
        RemovedIn20Warning: "Metadata" object is being merged into a
        Session along the backref cascade path for relationship
        "Dataset.metadatas"; in SQLAlchemy 2.0, this reverse cascade
        will not take place.  Set cascade_backrefs to False in either
        the relationship() or backref() function for the 2.0 behavior;
        or to set globally for the whole Session, set the future=True
        flag (Background on SQLAlchemy 2.0 at:
        https://sqlalche.me/e/b8d9)
            meta = Metadata(**kwargs)

Since we are no going to migrate to SQLAlchemy 2.0 any time soon, it seemed appropriate to just use the big hammer and turn the warnings off entirely.