### PR TITLE
Create a separate tox env for Agent Python 3.6

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -35,7 +35,7 @@ pipeline {
         stage('Agent Python3.6 Check') {
             steps {
                 echo 'Verify agent side works with Python 3.6'
-                sh 'jenkins/run tox -e py36 -- agent'
+                sh 'jenkins/run tox -e agent-py36 -- agent'
             }
         }
         stage('Linting, Unit Tests, RPM builds') {

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ distshare = {toxworkdir}/distshare
 envlist = py39
 
 [testenv]
-description = Lints code and runs all agent and server unit/functional tests
+description = Runs all agent, client, and server unit/functional tests
 install_command = pip install --cache-dir={toxworkdir}/cache --progress-bar off --prefix={envdir} {opts} {packages}
 passenv =
     PY_COLORS
@@ -33,3 +33,10 @@ commands =
     bash -c "{toxinidir}/exec-tests {envdir} {posargs}"
 whitelist_externals =
     bash
+
+[testenv:agent-py36]
+description = Runs all agent unit tests under Python 3.6
+basepython = python3.6
+deps =
+    -r{toxinidir}/agent/requirements.txt
+    -r{toxinidir}/agent/test-requirements.txt


### PR DESCRIPTION
The requirements for the agent, client, and server are different enough that any new version requirement for the client or server code will cause the `py36` environment to fail installation.  This isolates the use of Python 3.6 so that only the agent requirements are installed.