### PR TITLE
Rework use of `get_pbench_logger` in unit tests

### DIFF
--- a/exec-tests
+++ b/exec-tests
@@ -45,7 +45,7 @@ _ECHO=${DEBUG_EXEC_UNITTESTS:+echo}
 parallel=${PBENCH_UNITTEST_PARALLEL:-auto}
 if [[ "${parallel}" == "serial" ]]; then
     para_jobs_arg="-j 1"
-    pytest_jobs_arg="-n 1"
+    pytest_jobs_arg=""
 elif [[ "${parallel}" == "auto" ]]; then
     para_jobs_arg=""
     pytest_jobs_arg="-n auto"
@@ -165,8 +165,9 @@ if [[ "${subtst:-python}" == "python" ]]; then
         --cov=${_pbench_sources} \
         --cov-report ${_cov_report} \
         -rs \
+        --pyargs \
         ${posargs} \
-        --pyargs ${_pytest_majors}
+        ${_pytest_majors}
     rc=${?}
     if [[ ${rc} -ne 0 ]]; then
         printf -- "\n%s pytest command failed with '%s'\n\n" "${major_list// /,}" "${rc}"
@@ -233,7 +234,7 @@ if [[ "${major}" == "all" || "${major}" == "server" ]]; then
         shift
         posargs="${@}"
         # We use SQLALCHEMY_SILENCE_UBER_WARNING here ... (see above).
-        SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s -rs ${posargs} --pyargs pbench.test.functional.server
+        SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} pytest --tb=native -v -s -rs --pyargs ${posargs} pbench.test.functional.server
         rc=${?}
     fi
 fi

--- a/lib/pbench/common/logger.py
+++ b/lib/pbench/common/logger.py
@@ -144,7 +144,9 @@ def get_pbench_logger(caller, config):
             logging_level = config.default_logging_level
         pbench_logger.setLevel(logging_level)
 
-        if config.logger_type == "file":
+        if config.logger_type == "null":
+            handler = logging.NullHandler()
+        elif config.logger_type == "file":
             log_dir = Path(config.log_dir)
             if config.log_using_caller_directory:
                 log_dir = log_dir / caller

--- a/lib/pbench/test/unit/agent/conftest.py
+++ b/lib/pbench/test/unit/agent/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 import shutil
 from typing import Dict
@@ -65,3 +66,11 @@ def setup(tmp_path_factory, agent_setup, monkeypatch) -> Dict[str, Path]:
         "_PBENCH_AGENT_CONFIG", str(agent_setup["cfg_dir"] / "pbench-agent.cfg")
     )
     return agent_setup
+
+
+@pytest.fixture(scope="session")
+def agent_logger():
+    """Construct a single Pbench Logger object for the entire session."""
+    logger = logging.getLogger("unit-tests-agent")
+    logger.setLevel(logging.DEBUG)
+    return logger

--- a/lib/pbench/test/unit/agent/task/test_make_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_make_result_tb.py
@@ -10,20 +10,18 @@ import pytest
 from pbench.agent import PbenchAgentConfig
 from pbench.agent.results import MakeResultTb
 from pbench.common import MetadataLog
-from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
 from pbench.test.unit.agent.task.common import MockDatetime
 
 
 class TestMakeResultTb:
     @pytest.fixture(autouse=True)
-    def config_and_logger(self):
+    def config(self):
         with tempfile.TemporaryDirectory() as target_dir, tempfile.TemporaryDirectory() as run_dir:
-            # Setup the configuration and logger
+            # Setup the configuration
             self.controller = "controller-42.example.com"
             self.target_dir = Path(target_dir)
             self.config = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
-            self.logger = get_pbench_logger("pbench", self.config)
 
             script, config, date = "bm", "config-00", "1970.01.01T00.00.42"
             self.name = f"{script}_{config}_{date}"
@@ -47,42 +45,32 @@ class TestMakeResultTb:
             yield
 
             # Teardown the setup
-            (
-                self.controller,
-                self.name,
-                self.result_dir,
-                self.target_dir,
-                self.config,
-                self.logger,
-            ) = (
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            )
+            self.controller = None
+            self.name = None
+            self.result_dir = None
+            self.target_dir = None
+            self.config = None
 
     @pytest.mark.parametrize("result_dir", ("bad/bad/result/dir", ""))
-    def test_bad_result_dir(self, result_dir, caplog):
-        caplog.set_level(logging.ERROR, logger=self.logger.name)
+    def test_bad_result_dir(self, result_dir, caplog, agent_logger):
+        caplog.set_level(logging.ERROR, logger=agent_logger.name)
         with pytest.raises(FileNotFoundError):
             mrt = MakeResultTb(
-                result_dir, self.target_dir, self.controller, self.config, self.logger
+                result_dir, self.target_dir, self.controller, self.config, agent_logger
             )
             mrt.make_result_tb()
 
     @pytest.mark.parametrize("target_dir", ("bad/bad/target/dir", ""))
-    def test_bad_target_dir(self, target_dir, caplog):
-        caplog.set_level(logging.ERROR, logger=self.logger.name)
+    def test_bad_target_dir(self, target_dir, caplog, agent_logger):
+        caplog.set_level(logging.ERROR, logger=agent_logger.name)
         with pytest.raises(FileNotFoundError):
             mrt = MakeResultTb(
-                self.result_dir, target_dir, self.controller, self.config, self.logger
+                self.result_dir, target_dir, self.controller, self.config, agent_logger
             )
             mrt.make_result_tb()
 
-    def test_already_copied(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=self.logger.name)
+    def test_already_copied(self, caplog, agent_logger):
+        caplog.set_level(logging.DEBUG, logger=agent_logger.name)
         full_result_dir = self.result_dir.resolve(strict=True)
         with open(f"{full_result_dir}.copied", "x"):
             with pytest.raises(MakeResultTb.AlreadyCopied):
@@ -91,12 +79,12 @@ class TestMakeResultTb:
                     self.target_dir,
                     self.controller,
                     self.config,
-                    self.logger,
+                    agent_logger,
                 )
                 mrt.make_result_tb()
 
-    def test_running(self, caplog):
-        caplog.set_level(logging.DEBUG, logger=self.logger.name)
+    def test_running(self, caplog, agent_logger):
+        caplog.set_level(logging.DEBUG, logger=agent_logger.name)
         full_result_dir = self.result_dir.resolve(strict=True)
         with open(f"{full_result_dir}/.running", "x"):
             with pytest.raises(MakeResultTb.BenchmarkRunning):
@@ -105,15 +93,15 @@ class TestMakeResultTb:
                     self.target_dir,
                     self.controller,
                     self.config,
-                    self.logger,
+                    agent_logger,
                 )
                 mrt.make_result_tb()
 
-    def test_make_tb(self, monkeypatch):
+    def test_make_tb(self, monkeypatch, agent_logger):
         monkeypatch.setattr(datetime, "datetime", MockDatetime)
         expected_tb = self.target_dir / f"{self.name}.tar.xz"
         mrt = MakeResultTb(
-            self.result_dir, self.target_dir, self.controller, self.config, self.logger
+            self.result_dir, self.target_dir, self.controller, self.config, agent_logger
         )
         tarball, tarball_len, tarball_md5 = mrt.make_result_tb()
         assert tarball.samefile(expected_tb), f"{tarball} {expected_tb}"

--- a/lib/pbench/test/unit/agent/test_tool_data_sink.py
+++ b/lib/pbench/test/unit/agent/test_tool_data_sink.py
@@ -145,6 +145,7 @@ class TestDataSinkWsgiServer:
 
     def test_log_methods(self, caplog):
         logger = logging.getLogger("test_log_methods")
+        caplog.set_level(logging.DEBUG, "test_log_methods")
         wsgi_server = DataSinkWsgiServer(
             host="host.example.com", port="42", logger=logger
         )
@@ -237,6 +238,7 @@ class TestDataSinkWsgiServer:
         does nothing when "serve_forever" is called.
         """
         logger = logging.getLogger("test_run")
+        caplog.set_level(logging.DEBUG, "test_run")
         wsgi_server = DataSinkWsgiServer(
             host="host.example.com", port="42", logger=logger
         )
@@ -383,7 +385,8 @@ class TestDataSinkWsgiServer:
             F="exception.example.com",
         )
         caplog_idx = 0
-        logger = logging.getLogger("test_run")
+        logger = logging.getLogger("test_stop_and_wait")
+        caplog.set_level(logging.DEBUG, "test_stop_and_wait")
         for scenario in ["A", "B", "C", "D", "E", "F"]:
             wsgi_server = DataSinkWsgiServer(
                 host=hostnames[scenario], port="42", logger=logger

--- a/lib/pbench/test/unit/server/auth/conftest.py
+++ b/lib/pbench/test/unit/server/auth/conftest.py
@@ -1,7 +1,6 @@
 import jwt
 import pytest
 
-from pbench.common.logger import get_pbench_logger
 from pbench.server.auth import OpenIDClient
 
 
@@ -15,8 +14,7 @@ def mock_get_oidc_public_key(oidc_client):
 
 
 @pytest.fixture
-def keycloak_oidc(server_config, monkeypatch):
-    logger = get_pbench_logger("TEST", server_config)
+def keycloak_oidc(server_config, make_logger, monkeypatch):
     monkeypatch.setattr(
         OpenIDClient, "set_well_known_endpoints", mock_set_oidc_auth_endpoints
     )
@@ -25,7 +23,7 @@ def keycloak_oidc(server_config, monkeypatch):
         server_url=server_config.get("authentication", "server_url"),
         realm_name="public_test_realm",
         client_id="test_client",
-        logger=logger,
+        logger=make_logger,
     )
     return oidc
 

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -9,7 +9,6 @@ from jwt.exceptions import (
 )
 import pytest
 
-from pbench.common.logger import get_pbench_logger
 from pbench.server.auth import OpenIDClient
 from pbench.server.auth.auth import Auth, InternalUser
 
@@ -103,7 +102,12 @@ class TestUserTokenManagement:
         assert str(e.value) == "Invalid token"
 
     def test_online_third_party_verification(
-        self, server_config, monkeypatch, keycloak_oidc, keycloak_mock_token
+        self,
+        server_config,
+        make_logger,
+        monkeypatch,
+        keycloak_oidc,
+        keycloak_mock_token,
     ):
         def offline_token_introspection_exception(token: str, key: str, audience: str):
             raise Exception("some exception")
@@ -130,7 +134,7 @@ class TestUserTokenManagement:
         monkeypatch.setattr(
             OpenIDClient, "token_introspect_online", fake_online_token_introspection
         )
-        Auth.set_logger(logger=get_pbench_logger("test-api-server", server_config))
+        Auth.set_logger(logger=make_logger)
         token_payload = Auth.verify_third_party_token(
             auth_token="",
             algorithms=["HS256"],

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -44,7 +44,7 @@ host = elasticsearch.example.com
 port = 7080
 
 [logging]
-logger_type = file
+logger_type = null
 # We run with DEBUG level logging during the server unit tests to help
 # verify we are not emitting too many logs.
 logging_level = DEBUG

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -21,7 +21,7 @@ from requests import Response
 from pbench.common import MetadataLog
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
-from pbench.server.api import create_app, get_server_config
+from pbench.server.api import create_app
 from pbench.server.auth.auth import Auth, OpenIDClient
 from pbench.server.database.database import Database
 from pbench.server.database.models.datasets import Dataset, Metadata, States
@@ -109,8 +109,8 @@ def on_disk_server_config(tmp_path_factory) -> Dict[str, Path]:
     return on_disk_config(tmp_path_factory, "server", do_setup)
 
 
-@pytest.fixture()
-def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
+@pytest.fixture(scope="session")
+def server_config(on_disk_server_config) -> PbenchServerConfig:
     """
     Mock a pbench-server.cfg configuration as defined above.
 
@@ -122,9 +122,7 @@ def server_config(on_disk_server_config, monkeypatch) -> PbenchServerConfig:
         a PbenchServerConfig object the test case can use
     """
     cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
-    monkeypatch.setenv("_PBENCH_SERVER_CONFIG", str(cfg_file))
-
-    server_config = get_server_config()
+    server_config = PbenchServerConfig(str(cfg_file))
     return server_config
 
 
@@ -172,7 +170,7 @@ def client(
     return app_client
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def make_logger(server_config):
     """
     Construct a Pbench Logger object

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -4,7 +4,6 @@ from flask import Flask
 from flask.wrappers import Request, Response
 from flask_restful import Api
 
-from pbench.common.logger import get_pbench_logger
 from pbench.server import JSONOBJECT, OperationCode
 from pbench.server.api.resources import (
     ApiBase,
@@ -86,13 +85,13 @@ class TestApiBase:
     """Verify internal methods of the API base class."""
 
     def test_method_validation(
-        self, server_config, monkeypatch, set_oidc_well_known_endpoints
+        self, server_config, make_logger, monkeypatch, set_oidc_well_known_endpoints
     ):
         # Create the temporary flask application.
         app = Flask("test-api-server")
         app.debug = True
         app.testing = True
-        app.logger = get_pbench_logger("test-api-server", server_config)
+        app.logger = make_logger
 
         token_auth = Auth()
         token_auth.set_logger(app.logger)

--- a/lib/pbench/test/unit/server/test_unpack_tarballs.py
+++ b/lib/pbench/test/unit/server/test_unpack_tarballs.py
@@ -6,21 +6,12 @@ from typing import Optional, Union
 
 import pytest
 
-from pbench.common.logger import get_pbench_logger
 from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
 from pbench.server.cache_manager import TarballUnpackError
 from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.server.database.models.users import User
 from pbench.server.sync import Operation
 from pbench.server.unpack_tarballs import UnpackTarballs
-
-
-@pytest.fixture()
-def make_logger(server_config):
-    """
-    Construct a Pbench Logger object
-    """
-    return get_pbench_logger("TEST", server_config)
 
 
 @dataclass(frozen=True)

--- a/lib/pbench/test/unit/server/test_user_management_cli.py
+++ b/lib/pbench/test/unit/server/test_user_management_cli.py
@@ -32,6 +32,15 @@ def mock_valid_query(**kwargs):
     return create_user()
 
 
+@pytest.fixture(autouse=True)
+def server_config_env(on_disk_server_config, monkeypatch):
+    """Provide a pbench server configuration environment variable for all user
+    management CLI tests.
+    """
+    cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
+    monkeypatch.setenv("_PBENCH_SERVER_CONFIG", str(cfg_file))
+
+
 class TestUserManagement:
     USER_SWITCH = "--username"
     PSWD_SWITCH = "--password"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts = -s
 log_cli=False
-log_level=DEBUG
+log_level=INFO
 filterwarnings=
   # Issue #557 in `pytest-cov` (currently v4.x) has not moved for a while now,
   # but once a resolution has been adopted we can drop this "ignore".


### PR DESCRIPTION
This work contains some cleanup and some streamlining of the logging behaviors with respect to the python unit tests.

The main goal is to reduce the explicit use of `get_pbench_logger()` in the unit tests to ensure we don't have unexpected logging behaviors in our tests suite.  The secondary goal is to make it easy to identify and control the loggers used for unit tests.

This PR is broken into 5 separate commits (which I'd like to keep separate if we can in case these changes cause problems down the road when issues arise debugging the unit tests), the first being:

----

    Don't use xdist plugin for serial pytests

    If we use the `-n 1` pytest argument we still run using the `xdist`
    plugin, but it just uses one process.  Since the `xdist` plugin changes
    the test environment a bit, don't use it when trying to run tests one at
    a time.

    We also ensure that the optional positional arguments provided by the
    caller come after all of the default pytest arguments.

----

The second commit corrects the use of the `get_pbench_logger()` with agent unit tests.

The third commit introduces the use of the `NullHandler` for the unit test environment whenever `get_pbench_logger()` is used, which eliminates a fair amount of file system logging during the unit tests.

The fourth commit modifies the unit test environment so that it only captures WARNING level or above logs by default (but we had to correct agent side tests that relied on DEBUG level logging explicitly).

The fifth, and final commit of the series, and the title of the PR, reworks the use of `get_pbench_logger()` in the server unit tests:

----

    Rework use of `get_pbench_logger` in unit tests

    The unit tests use a fixed server configuration file which is generated
    once per testing session (for all tests discovered).

    Only one test suite, `test_user_management_cli`, requires the use of the
    `_PBENCH_SERVER_CONFIG` environment variable for testing since that
    module is actually testing a CLI interface.

    We take advantage of this to make the `server_config` fixture scoped for
    the "session", moving the use of `monkeypatch` to set the environment
    variable to a fixture for `test_user_management_cli` suite.

    With this change, we can use the one `server_config` fixture (removing
    the other ones), and then also promote the `make_logger` fixture to be
    "session" scoped as well.  This means we only create a "TEST" logger
    once for all tests for the session and then use it were needed.

    As a result we can remove the use of `get_pbench_logger` from all the
    other test suite files.