### PR TITLE
Allow changing dataset ownership API

### DIFF
--- a/dashboard/src/actions/overviewActions.js
+++ b/dashboard/src/actions/overviewActions.js
@@ -215,7 +215,7 @@ export const publishDataset =
       const savedRuns = getState().overview.savedRuns;
 
       const response = await API.post(
-        `${endpoints?.api?.datasets_publish}/${dataset.resource_id}?access=${updateValue}`
+        `${endpoints?.api?.datasets_update}/${dataset.resource_id}?access=${updateValue}`
       );
       if (response.status === 200) {
         const dataIndex = savedRuns.findIndex(

--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -47,7 +47,7 @@ class API(Enum):
     DATASETS_MAPPINGS = "datasets_mappings"
     DATASETS_METADATA = "datasets_metadata"
     DATASETS_NAMESPACE = "datasets_namespace"
-    DATASETS_PUBLISH = "datasets_publish"
+    DATASETS_UPDATE = "datasets_update"
     DATASETS_SEARCH = "datasets_search"
     DATASETS_VALUES = "datasets_values"
     ENDPOINTS = "endpoints"

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -32,8 +32,8 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleValues,
 )
 from pbench.server.api.resources.query_apis.datasets_delete import DatasetsDelete
-from pbench.server.api.resources.query_apis.datasets_publish import DatasetsPublish
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
+from pbench.server.api.resources.query_apis.datasets_update import DatasetsUpdate
 from pbench.server.api.resources.server_audit import ServerAudit
 from pbench.server.api.resources.server_configuration import ServerConfiguration
 from pbench.server.api.resources.upload_api import Upload
@@ -126,9 +126,9 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
         resource_class_args=(config,),
     )
     api.add_resource(
-        DatasetsPublish,
-        f"{base_uri}/datasets/publish/<string:dataset>",
-        endpoint="datasets_publish",
+        DatasetsUpdate,
+        f"{base_uri}/datasets/<string:dataset>",
+        endpoint="datasets_update",
         resource_class_args=(config,),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -25,9 +25,11 @@ from pbench.server.api.resources import (
     ApiMethod,
     ApiParams,
     ApiSchema,
+    MissingParameters,
     ParamType,
     SchemaError,
     UnauthorizedAccess,
+    UnauthorizedAdminAccess,
 )
 from pbench.server.auth.auth import Auth
 from pbench.server.database.models.audit import AuditReason, AuditStatus
@@ -573,10 +575,9 @@ class ElasticBulkBase(ApiBase):
             raise MissingBulkSchemaParameters(
                 api_name, "dataset parameter is not defined or not required"
             )
-        if self.schemas[ApiMethod.POST].authorization != ApiAuthorizationType.DATASET:
-            raise MissingBulkSchemaParameters(
-                api_name, "schema authorization is not by dataset"
-            )
+        assert (
+            self.schemas[ApiMethod.POST].authorization == ApiAuthorizationType.DATASET
+        ), f"API {self.__class__.__name__} authorization type must be DATASET"
 
     def generate_actions(
         self,
@@ -751,6 +752,10 @@ class ElasticBulkBase(ApiBase):
                     raise_on_error=False,
                 )
                 report = self._analyze_bulk(results)
+            except UnauthorizedAdminAccess as e:
+                raise APIAbort(e.http_status, str(e))
+            except MissingParameters as e:
+                raise APIAbort(e.http_status, str(e))
             except Exception as e:
                 raise APIInternalError("Unexpected backend error") from e
         elif self.require_map:

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -35,7 +35,7 @@ class TestDatasetsContents(Commons):
         """
         # remove the last two components of the pbench_endpoint
         incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-2])
-        response = client.get(f"{server_config.rest_uri}{incorrect_endpoint}")
+        response = client.get(f"{server_config.rest_uri}{incorrect_endpoint}/")
         assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_with_incorrect_index_document(self, client, server_config, pbench_token):

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
@@ -9,9 +9,9 @@ from pbench.server.database.models.datasets import Dataset
 from pbench.test.unit.server.headertypes import HeaderTypes
 
 
-class TestDatasetsPublish:
+class TestDatasetsUpdate:
     """
-    Unit testing for DatasetsPublish class.
+    Unit testing for DatasetsUpdate class.
 
     In a web service context, we access class functions mostly via the
     Flask test client rather than trying to directly invoke the class
@@ -92,48 +92,6 @@ class TestDatasetsPublish:
 
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
-    @pytest.mark.parametrize(
-        "owner",
-        ("drb", "test"),
-    )
-    def test_query(
-        self,
-        attach_dataset,
-        build_auth_header,
-        client,
-        get_document_map,
-        monkeypatch,
-        owner,
-        server_config,
-    ):
-        """
-        Check behavior of the publish API with various combinations of dataset
-        owner (managed by the "owner" parametrization here) and authenticated
-        user (managed by the build_auth_header fixture).
-        """
-        self.fake_elastic(monkeypatch, get_document_map, False)
-
-        is_admin = build_auth_header["header_param"] == HeaderTypes.VALID_ADMIN
-        if not HeaderTypes.is_valid(build_auth_header["header_param"]):
-            expected_status = HTTPStatus.UNAUTHORIZED
-        elif owner != "drb" and not is_admin:
-            expected_status = HTTPStatus.FORBIDDEN
-        else:
-            expected_status = HTTPStatus.OK
-
-        ds = Dataset.query(name=owner)
-
-        response = client.post(
-            f"{server_config.rest_uri}/datasets/publish/{ds.resource_id}",
-            headers=build_auth_header["header"],
-            query_string=self.PAYLOAD,
-        )
-        assert response.status_code == expected_status
-        if expected_status == HTTPStatus.OK:
-            assert response.json == {"ok": 31, "failure": 0}
-            dataset = Dataset.query(name=owner)
-            assert dataset.access == Dataset.PUBLIC_ACCESS
-
     def test_partial(
         self,
         attach_dataset,
@@ -144,13 +102,13 @@ class TestDatasetsPublish:
         server_config,
     ):
         """
-        Check the publish API when some document updates fail. We expect an
+        Check the datasets_update API when some document updates fail. We expect an
         internal error with a report of success and failure counts.
         """
         self.fake_elastic(monkeypatch, get_document_map, True)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish/random_md5_string1",
+            f"{server_config.rest_uri}/datasets/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_token}"},
             query_string=self.PAYLOAD,
         )
@@ -165,11 +123,11 @@ class TestDatasetsPublish:
         self, client, get_document_map, monkeypatch, pbench_token, server_config
     ):
         """
-        Check the publish API if the dataset doesn't exist.
+        Check the datasets_update API if the dataset doesn't exist.
         """
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish/badwolf",
+            f"{server_config.rest_uri}/datasets/badwolf",
             headers={"authorization": f"Bearer {pbench_token}"},
             query_string=self.PAYLOAD,
         )
@@ -179,17 +137,17 @@ class TestDatasetsPublish:
         assert response.json["message"] == "Dataset 'badwolf' not found"
 
     def test_no_index(
-        self, client, monkeypatch, attach_dataset, pbench_token, server_config
+        self, attach_dataset, client, monkeypatch, pbench_token, server_config
     ):
         """
-        Check the publish API if the dataset has no INDEX_MAP. It should
+        Check the datasets_update API if the dataset has no INDEX_MAP. It should
         fail with a CONFLICT error.
         """
         self.fake_elastic(monkeypatch, {}, True)
 
         ds = Dataset.query(name="drb")
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish/{ds.resource_id}",
+            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
             headers={"authorization": f"Bearer {pbench_token}"},
             query_string=self.PAYLOAD,
         )
@@ -203,15 +161,15 @@ class TestDatasetsPublish:
     def test_exception(
         self,
         attach_dataset,
+        capinternal,
         client,
         monkeypatch,
         get_document_map,
         pbench_token,
         server_config,
-        capinternal,
     ):
         """
-        Check the publish API response if the bulk helper throws an exception.
+        Check the datasets_update API response if the bulk helper throws an exception.
 
         (It shouldn't do this as we've set raise_on_exception=False, but we
         check the code path anyway.)
@@ -228,10 +186,94 @@ class TestDatasetsPublish:
         monkeypatch.setattr("elasticsearch.helpers.streaming_bulk", fake_bulk)
 
         response = client.post(
-            f"{server_config.rest_uri}/datasets/publish/random_md5_string1",
+            f"{server_config.rest_uri}/datasets/random_md5_string1",
             headers={"authorization": f"Bearer {pbench_token}"},
             query_string=self.PAYLOAD,
         )
 
         # Verify the failure
         capinternal("Unexpected backend error", response)
+
+    @pytest.mark.parametrize("ds_name", ("drb", "test"))
+    @pytest.mark.parametrize("owner", ("drb", "test", None))
+    @pytest.mark.parametrize("access", ("public", "private", None))
+    def test_query_owner_publish(
+        self,
+        access,
+        attach_dataset,
+        build_auth_header,
+        client,
+        create_drb_user,
+        create_user,
+        ds_name,
+        get_document_map,
+        monkeypatch,
+        owner,
+        server_config,
+    ):
+        """
+        Check behavior of the datasets_update API with various combinations of dataset
+        access and owner (managed by the "owner" parametrization here) and
+        authenticated user (managed by the build_auth_header fixture).
+        """
+        self.fake_elastic(monkeypatch, get_document_map, False)
+        query_json = {}
+        if access:
+            query_json["access"] = access
+        if owner:
+            query_json["owner"] = owner
+            assert_id = (
+                str(create_drb_user.id) if owner == "drb" else str(create_user.id)
+            )
+
+        is_admin = build_auth_header["header_param"] == HeaderTypes.VALID_ADMIN
+        if not HeaderTypes.is_valid(build_auth_header["header_param"]):
+            expected_status = HTTPStatus.UNAUTHORIZED
+        elif not is_admin and (owner or ds_name == "test"):
+            expected_status = HTTPStatus.FORBIDDEN
+        elif not query_json:
+            expected_status = HTTPStatus.BAD_REQUEST
+        else:
+            expected_status = HTTPStatus.OK
+
+        ds = Dataset.query(name=ds_name)
+        response = client.post(
+            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
+            headers=build_auth_header["header"],
+            query_string=query_json,
+        )
+
+        assert response.status_code == expected_status
+        if expected_status == HTTPStatus.OK:
+            assert response.json == {"ok": 31, "failure": 0}
+            dataset = Dataset.query(name=ds_name)
+            if access:
+                assert dataset.access == access
+            if owner:
+                assert dataset.owner_id == assert_id
+
+    def test_invalid_owner_params(
+        self,
+        client,
+        get_document_map,
+        monkeypatch,
+        pbench_admin_token,
+        server_config,
+    ):
+        """
+        Check the datasets_update API response if the "owner" attribute is invalid.
+        """
+
+        ds = Dataset.query(name="drb")
+        response = client.post(
+            f"{server_config.rest_uri}/datasets/{ds.resource_id}",
+            headers={"authorization": f"Bearer {pbench_admin_token}"},
+            query_string={"owner": str("invalid_owner")},
+        )
+
+        # Verify the report and status
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        assert (
+            response.json["message"]
+            == "Value 'invalid_owner' (str) cannot be parsed as a username"
+        )

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -258,13 +258,12 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
 
         return query_api
 
-    @pytest.mark.parametrize("uri", ("/datasets/metadata/", "/datasets/metadata"))
-    def test_put_missing_uri_param(self, client, server_config, pbench_token, uri):
+    def test_put_missing_uri_param(self, client, server_config, pbench_token):
         """
         Test behavior when no dataset name is given on the URI. (NOTE that
         Flask automatically handles this with a NOT_FOUND response.)
         """
-        response = client.put(f"{server_config.rest_uri}{uri}")
+        response = client.put(f"{server_config.rest_uri}/datasets/metadata/")
         assert response.status_code == HTTPStatus.NOT_FOUND
 
     def test_put_missing_key(self, client, server_config, pbench_token):

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -60,8 +60,8 @@ class TestEndpointConfig:
                 "datasets_mappings": f"{uri}/datasets/mappings",
                 "datasets_metadata": f"{uri}/datasets/metadata",
                 "datasets_namespace": f"{uri}/datasets/namespace",
-                "datasets_publish": f"{uri}/datasets/publish",
                 "datasets_search": f"{uri}/datasets/search",
+                "datasets_update": f"{uri}/datasets",
                 "datasets_values": f"{uri}/datasets/values",
                 "endpoints": f"{uri}/endpoints",
                 "login": f"{uri}/login",
@@ -115,11 +115,11 @@ class TestEndpointConfig:
                         "dataset_view": {"type": "string"},
                     },
                 },
-                "datasets_publish": {
-                    "template": f"{uri}/datasets/publish/{{dataset}}",
+                "datasets_search": {"template": f"{uri}/datasets/search", "params": {}},
+                "datasets_update": {
+                    "template": f"{uri}/datasets/{{dataset}}",
                     "params": {"dataset": {"type": "string"}},
                 },
-                "datasets_search": {"template": f"{uri}/datasets/search", "params": {}},
                 "datasets_values": {
                     "template": f"{uri}/datasets/values/{{dataset}}/{{dataset_view}}",
                     "params": {


### PR DESCRIPTION
PBENCH-817

Implemented a mechanism to change the owner of

- An "anonymous" upload of the dataset through the put-shim server, which can be "adopted" by a registered user
- An "orphaned" dataset can be picked up by a different user.

API - `POST  /datasets/change_owner/{dataset}?owner=user` 

And this API requires `ADMIN` access to perform the `change_owner` operation