### PR TITLE
Remove "apache" section; print to `stderr`

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -20,7 +20,7 @@ def app():
     try:
         server_config = get_server_config()
     except (ConfigFileNotSpecified, BadConfig) as e:
-        print(e)
+        print(e, file=sys.stderr)
         sys.exit(1)
     return create_app(server_config)
 
@@ -84,7 +84,7 @@ def main():
     try:
         server_config = get_server_config()
     except (ConfigFileNotSpecified, BadConfig) as e:
-        print(e)
+        print(e, file=sys.stderr)
         sys.exit(1)
     logger = get_pbench_logger(PROG, server_config)
     if site.ENABLE_USER_SITE:

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -126,15 +126,6 @@ lowerbound = 820
 # uri = driver://user:password@hostname/dbname
 wait_timeout = 120
 
-# We need to install some stuff in the apache document root so we
-# either get it directly or look in the config file.
-#
-# N.B. Different distros use different config files.  The following
-# works on Fedora, RHEL, CentOS.
-[apache]
-documentroot = /var/www/html
-configfile = /etc/httpd/conf/httpd.conf
-
 # [pbench-backup-tarballs]
 # logging_level = DEBUG
 


### PR DESCRIPTION
We are now using Nginx and never really used the "apache" section of the pbench server configuration.

We modify the pbench server API shell to print errors to `stderr`.