### PR TITLE
Modify the CI pipeline to publish successful branch build Agent containers

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -107,6 +107,11 @@ _DEFAULT_DISTROS = \
 	fedora-36 fedora-35
 #	rhel-9 rhel-8 rhel-7
 
+# This Makefile produces containers named "pbench-agent-<name>-<distro>"; this
+# is the list of possible fill-in's for <name>.  Note that the ./push script
+# also has its own copy of this list, and the two should be kept in sync.
+_CONTAINER_NAMES = base tools tool-meister tool-data-sink workloads all
+
 # By default we build the Tool Data Sink and Tool Meister images as well.
 everything: all-tags $(_DEFAULT_DISTROS:%=%-all-tagged)
 
@@ -297,10 +302,23 @@ centos-7-base.Dockerfile: _PKGMGR = yum
 # Special push target for the CI which pushes a full set of the various container
 # images for the distribution to the specified registry with the specified tag.
 $(_DEFAULT_DISTROS:%=%-push-ci): %-push-ci:
-	for image in base tools tool-meister tool-data-sink workloads all; do \
+	for image in ${_CONTAINER_NAMES}; do \
 	  buildah push \
 	    localhost/pbench-agent-$${image}-${*}:${_LOCAL_GIT_HASH} \
 	    ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} ; \
+	done
+
+# Special "push" target which pushes a full set of the various container images
+# for each of the default distributions to the specified registry with the
+# specified tag (e.g., for use by the CI).  Unlike the ./push script, it pushes
+# _only_ the requested tag and no tags based on the version or hash.
+publish:
+	for distro in ${_DEFAULT_DISTROS}; do \
+	  for image in ${_CONTAINER_NAMES}; do \
+	    buildah push \
+	      localhost/pbench-agent-$${image}-$${distro}:${_LOCAL_GIT_HASH} \
+	      ${IMAGE_REPO}/pbench-agent-$${image}-$${distro}:${IMAGE_TAG} ; \
+	  done ; \
 	done
 
 define _PUSH_RULE

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -98,6 +98,10 @@ relation to what has been published already.  The push targets are:
 
  * `push-beta` - pushes each image by its `beta` tag
 
+There is also a special "push" target `publish` which pushes all the
+containers for each of the default distributions, but it pushes only the one
+tag defined by `IMAGE_TAG` and not the RPM version or Git hash tags.
+
 **_NOTE WELL_**: Each separate tag for each image needs to be pushed to the
 non-local container image repository.  This does NOT result in multiple image
 copies over the wire using up network bandwidth, as `buildah push` is smart

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -80,7 +80,7 @@ pipeline {
             }
         }
         stage('For branches, build Agent containers for all distros and push to external registry') {
-            when { not changeRequest() }
+            when { not { changeRequest() } }
             environment {
                 PB_PUBLIC_REG_CRED=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
                 PB_PUBLIC_REGISTRY=credentials('24a93506-ecd6-403a-b4f0-386f9cc943e9')
@@ -88,7 +88,7 @@ pipeline {
             steps {
                 sh 'buildah login -u="${PB_PUBLIC_REG_CRED_USR}" -p="${PB_PUBLIC_REG_CRED_PSW}" ${PB_PUBLIC_REGISTRY}'
                 sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean everything'
-                sh 'make -C agent/containers/images IMAGE_REPO=${PB_PUBLIC_REGISTRY}/${PB_ORG_NAME} push-alpha'
+                sh 'make -C agent/containers/images IMAGE_REPO=${PB_PUBLIC_REGISTRY}/${PB_ORG_NAME} IMAGE_TAG=${PB_IMAGE_TAG} publish'
             }
         }
     }

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -79,6 +79,18 @@ pipeline {
                 sh 'jenkins/run-server-func-tests --cleanup'
             }
         }
+        stage('For branches, build Agent containers for all distros and push to external registry') {
+            when { not changeRequest() }
+            environment {
+                PB_PUBLIC_REG_CRED=credentials('87ad2797-02eb-464f-989f-8ab78d63cdf3')
+                PB_PUBLIC_REGISTRY=credentials('24a93506-ecd6-403a-b4f0-386f9cc943e9')
+            }
+            steps {
+                sh 'buildah login -u="${PB_PUBLIC_REG_CRED_USR}" -p="${PB_PUBLIC_REG_CRED_PSW}" ${PB_PUBLIC_REGISTRY}'
+                sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean everything'
+                sh 'make -C agent/containers/images IMAGE_REPO=${PB_PUBLIC_REGISTRY}/${PB_ORG_NAME} push-alpha'
+            }
+        }
     }
     post {
         success {


### PR DESCRIPTION
This PR adds a stage at the end of the CI pipeline which runs only for branch (e.g., `main`) builds which, after all the other stages complete successfully, builds all the Agent containers for all of our favorite distros and pushes them to the external/public repo with a tag which matches the branch name (e.g., "main").

In order to accomplish this, we also add a new target, `publish`, to the Agent container `Makefile` (and update the `README.md` accordingly).

NOTE:  the new stage will run only _after_ this branch is merged, so we won't really know whether it works until after we approve it.  🙂 