### PR TITLE
Dump the `journalctl` log if the Server doesn't start

### DIFF
--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -49,11 +49,12 @@ while [[ "${status_code}" == "502" || "${status_code}" == "503" ]]; do
 done
 if [[ "${status_code}" != "200" ]]; then
     curl ${SERVER_API_ENDPOINTS}
-    exit 1
+    exit_status=2
+else
+    EXTRA_PODMAN_SWITCHES="${EXTRA_PODMAN_SWITCHES} --network host" jenkins/run tox -e py39 -- server functional ${SERVER_URL}
+    exit_status=${?}
 fi
 
-EXTRA_PODMAN_SWITCHES="${EXTRA_PODMAN_SWITCHES} --network host" jenkins/run tox -e py39 -- server functional ${SERVER_URL}
-exit_status=${?}
 if [[ ${exit_status} -ne 0 ]]; then
     printf -- "\nFunctional tests exited with code %s\n" ${exit_status}
     printf -- "+++ journalctl dump +++\n"


### PR DESCRIPTION
Currently, `jenkins/run-server-func-tests` only dumps the `journalctl` log if the functional tests fail.  However, if the Pbench Server fails to start (based on the return from the `curl` command), then the script exits without producing the log, which makes diagnosing Server start-up problems awkward.

This PR adjusts the exit handling so that, instead of exiting when the `curl` command fails, the script only runs the functional tests if it succeeds; either way, the exit status (from either the `curl` command or the functional tests) is evaluated, and the dump is produced on a failure in either case.