### PR TITLE
Separate satellite prefix from controller

### DIFF
--- a/server/lib/pbench/process_tb.py
+++ b/server/lib/pbench/process_tb.py
@@ -96,6 +96,9 @@ class ProcessTb:
             tbdir = tb.parent
             controller = tbdir.name
 
+            if "::" in controller:
+                satellite_prefix, controller = controller.split("::")
+
             try:
                 ProcessTb._results_push(controller, tb, self.token)
             except Exception as e:


### PR DESCRIPTION
PBENCH-464

This PR deals with removing satellite-prefix from controllers of the tarballs that are sent through  a  satellite server.