### PR TITLE
Implement metadata for PUT

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -374,6 +374,8 @@ class PbenchServerClient:
         access = kwargs.get("access", "private")
         if access == "public":
             query_parameters["access"] = access
+        if "metadata" in kwargs:
+            query_parameters["metadata"] = kwargs.get("metadata")
         if "controller" in kwargs:
             controller = kwargs["controller"]
         else:

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1509,7 +1509,7 @@ class ApiBase(Resource):
     def _set_dataset_metadata(
         self, dataset: Dataset, metadata: dict[str, JSONVALUE]
     ) -> dict[str, str]:
-        """Set metadata on a specific Dataset and failure information.
+        """Set metadata on a specific Dataset and return a summary of failures.
 
         This supports strict Metadata key/value items associated with the
         Dataset as well as selected columns from the Dataset model.
@@ -1527,7 +1527,7 @@ class ApiBase(Resource):
             native_key = Metadata.get_native_key(k)
             user_id = None
             if native_key == Metadata.USER:
-                user_id = Auth.get_user_id()
+                user_id = Auth.get_current_user_id()
             try:
                 Metadata.setvalue(key=k, value=v, dataset=dataset, user_id=user_id)
             except MetadataError as e:

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1506,6 +1506,34 @@ class ApiBase(Resource):
 
         return metadata
 
+    def _set_dataset_metadata(
+        self, dataset: Dataset, metadata: dict[str, JSONVALUE]
+    ) -> dict[str, str]:
+        """Set metadata on a specific Dataset and failure information.
+
+        This supports strict Metadata key/value items associated with the
+        Dataset as well as selected columns from the Dataset model.
+
+        Args:
+            dataset: Dataset object
+            metadata: dict of key/value pairs
+
+        Returns:
+            A dict associating an error string with each failing metadata key.
+            An empty dict is "success".
+        """
+        fail: dict[str, str] = {}
+        for k, v in metadata.items():
+            native_key = Metadata.get_native_key(k)
+            user_id = None
+            if native_key == Metadata.USER:
+                user_id = Auth.get_user_id()
+            try:
+                Metadata.setvalue(key=k, value=v, dataset=dataset, user_id=user_id)
+            except MetadataError as e:
+                fail[k] = str(e)
+        return fail
+
     def _dispatch(
         self,
         method: ApiMethod,

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -128,9 +128,14 @@ class Upload(ApiBase):
         identified rather than authorizing against an existing resource.
 
         Args:
-            filename: A filename matching the metadata of the uploaded tarball
-            access: The desired access policy (default is "private")
-            metadata: Metadata key/value pairs to set on dataset
+            params: API parameters
+                URI parameters
+                    filename: A filename matching the metadata of the uploaded tarball
+                Query parameters
+                    access: The desired access policy (default is "private")
+                    metadata: Metadata key/value pairs to set on dataset
+            request: The original Request object containing query parameters
+            context: API context dictionary
         """
 
         # Used to record what steps have been completed during the upload, and

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -40,6 +40,7 @@ from pbench.server.database.models.datasets import (
     DatasetNotFound,
     Metadata,
     OperationName,
+    MetadataBadValue,
     OperationState,
 )
 from pbench.server.sync import Sync
@@ -77,7 +78,15 @@ class Upload(ApiBase):
                 ApiMethod.PUT,
                 OperationCode.CREATE,
                 uri_schema=Schema(Parameter("filename", ParamType.STRING)),
-                query_schema=Schema(Parameter("access", ParamType.ACCESS)),
+                query_schema=Schema(
+                    Parameter("access", ParamType.ACCESS),
+                    Parameter(
+                        "metadata",
+                        ParamType.LIST,
+                        element_type=ParamType.STRING,
+                        string_list=",",
+                    ),
+                ),
                 audit_type=AuditType.NONE,
                 audit_name="upload",
                 authorization=ApiAuthorizationType.NONE,
@@ -119,7 +128,9 @@ class Upload(ApiBase):
         identified rather than authorizing against an existing resource.
 
         Args:
-            filename:   A filename matching the metadata of the uploaded tarball
+            filename: A filename matching the metadata of the uploaded tarball
+            access: The desired access policy (default is "private")
+            metadata: Metadata key/value pairs to set on dataset
         """
 
         # Used to record what steps have been completed during the upload, and
@@ -130,6 +141,34 @@ class Upload(ApiBase):
         access = (
             args.query["access"] if "access" in args.query else Dataset.PRIVATE_ACCESS
         )
+
+        # We allow the client to set metadata on the new dataset. We won't do
+        # anything about this until upload is successful, but we process and
+        # validate it here so we can fail early.
+        metadata = {}
+        if "metadata" in args.query:
+            errors = []
+            for kw in args.query["metadata"]:
+                # an individual value for the "key" parameter is a simple key:value
+                # pair.
+                k, v = kw.split(":", maxsplit=1)
+                k = k.lower()
+                if not Metadata.is_key_path(k, Metadata.USER_UPDATEABLE_METADATA):
+                    errors.append(f"Key {k} is invalid or isn't settable")
+                    continue
+                try:
+                    Metadata.validate(dataset=None, key=k, value=v)
+                except MetadataBadValue as e:
+                    errors.append(str(e))
+                metadata[k] = v
+            if errors:
+                raise APIAbort(
+                    HTTPStatus.BAD_REQUEST,
+                    "at least one specified metadata key is invalid",
+                    errors=errors,
+                )
+
+        attributes = {"access": access, "metadata": metadata}
         filename = args.uri["filename"]
 
         current_app.logger.info("Uploading {} with {} access", filename, access)
@@ -268,6 +307,7 @@ class Upload(ApiBase):
                 user_name=username,
                 dataset=dataset,
                 status=AuditStatus.BEGIN,
+                attributes=attributes,
             )
             recovery.add(dataset.delete)
 
@@ -395,11 +435,11 @@ class Upload(ApiBase):
             # won't be committed to the database until the "advance" operation
             # at the end.
             try:
-                metadata = tarball.metadata
+                metalog = tarball.metadata
                 dataset.created = UtcTimeHelper.from_string(
-                    metadata["pbench"]["date"]
+                    metalog["pbench"]["date"]
                 ).utc_time
-                Metadata.create(dataset=dataset, key=Metadata.METALOG, value=metadata)
+                Metadata.create(dataset=dataset, key=Metadata.METALOG, value=metalog)
             except Exception as exc:
                 raise CleanupTime(
                     HTTPStatus.BAD_REQUEST,
@@ -430,6 +470,9 @@ class Upload(ApiBase):
                     key=Metadata.DELETION,
                     value=UtcTimeHelper(deletion).to_iso_string(),
                 )
+                f = self._set_dataset_metadata(dataset, metadata)
+                if f:
+                    attributes["failures"] = f
             except Exception as e:
                 raise CleanupTime(
                     HTTPStatus.INTERNAL_SERVER_ERROR, f"Unable to set metadata: {e!s}"
@@ -443,7 +486,9 @@ class Upload(ApiBase):
                     state=OperationState.OK,
                     enabled=[OperationName.BACKUP, OperationName.UNPACK],
                 )
-                Audit.create(root=audit, status=AuditStatus.SUCCESS)
+                Audit.create(
+                    root=audit, status=AuditStatus.SUCCESS, attributes=attributes
+                )
             except Exception as exc:
                 raise CleanupTime(
                     HTTPStatus.INTERNAL_SERVER_ERROR,

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -39,8 +39,8 @@ from pbench.server.database.models.datasets import (
     DatasetDuplicate,
     DatasetNotFound,
     Metadata,
-    OperationName,
     MetadataBadValue,
+    OperationName,
     OperationState,
 )
 from pbench.server.sync import Sync
@@ -128,7 +128,7 @@ class Upload(ApiBase):
         identified rather than authorizing against an existing resource.
 
         Args:
-            params: API parameters
+            args: API parameters
                 URI parameters
                     filename: A filename matching the metadata of the uploaded tarball
                 Query parameters

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -161,15 +161,28 @@ class MetadataBadValue(MetadataError):
     actual and expected value type.
     """
 
-    def __init__(self, dataset: "Dataset", key: str, value: str, expected: str):
+    def __init__(
+        self, dataset: Optional["Dataset"], key: str, value: str, expected: str
+    ):
+        """Construct an exception to report a failure in metadata key validation.
+
+        This is used during creation of a new dataset where we don't yet have a
+        full Dataset object, so we report it as "new".
+
+        Args:
+            dataset: Identify the associated dataset, or None before creation
+            key: Metadata key name
+            value: Metadata key value
+            expected: The expected metadata value type
+        """
         super().__init__(dataset, key)
         self.value = value
         self.expected = expected
 
     def __str__(self) -> str:
         return (
-            f"Metadata key {self.key!r} value {self.value!r} for dataset "
-            f"{self.dataset} must be a {self.expected}"
+            f"Metadata key {self.key!r} value {self.value!r} for dataset"
+            f"{' ' + str(self.dataset) if self.dataset else ''} must be a {self.expected}"
         )
 
 
@@ -813,7 +826,7 @@ class Metadata(Database.Base):
         return value
 
     @staticmethod
-    def validate(dataset: Dataset, key: str, value: Any) -> Any:
+    def validate(dataset: Optional[Dataset], key: str, value: Any) -> Any:
         """Validate a metadata value.
 
         This method supports hierarchical dotted paths like "global.seen" and
@@ -857,9 +870,14 @@ class Metadata(Database.Base):
                 raise MetadataBadValue(dataset, key, value, "date/time") from p
 
             max_retention = ServerConfig.get(key=OPTION_DATASET_LIFETIME)
-            maximum = dataset.uploaded + datetime.timedelta(
-                days=int(max_retention.value)
+
+            # If 'dataset' was omitted, then assume the current UTC timestamp.
+            base_time = (
+                dataset.uploaded
+                if dataset
+                else datetime.datetime.now(datetime.timezone.utc)
             )
+            maximum = base_time + datetime.timedelta(days=int(max_retention.value))
             if target > maximum:
                 raise MetadataBadValue(
                     dataset, key, value, f"date/time before {maximum:%Y-%m-%d}"

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -167,7 +167,7 @@ class MetadataBadValue(MetadataError):
         """Construct an exception to report a failure in metadata key validation.
 
         This is used during creation of a new dataset where we don't yet have a
-        full Dataset object, so we report it as "new".
+        Dataset object, so the caller can omit the dataset.
 
         Args:
             dataset: Identify the associated dataset, or None before creation

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -349,10 +349,11 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
             "drb",
             HTTPStatus.BAD_REQUEST,
         )
-        assert (
-            put.json["message"]
-            == "Metadata key 'dataset.name' value 1 for dataset (3)|drb must be a UTF-8 string of 1 to 1024 characters"
-        )
+        json = put.json
+        assert json["message"] == "at least one specified metadata key is invalid"
+        assert json["errors"] == [
+            "Metadata key 'dataset.name' value 1 for dataset (3)|drb must be a UTF-8 string of 1 to 1024 characters"
+        ]
 
         # verify that the values didn't change
         get = query_get_as(
@@ -385,10 +386,11 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
             "drb",
             HTTPStatus.BAD_REQUEST,
         )
-        assert (
-            put.json["message"]
-            == "Metadata key 'server.deletion' value '1800-25-55' for dataset (3)|drb must be a date/time"
-        )
+        json = put.json
+        assert json["message"] == "at least one specified metadata key is invalid"
+        assert json["errors"] == [
+            "Metadata key 'server.deletion' value '1800-25-55' for dataset (3)|drb must be a date/time"
+        ]
 
         # verify that the values didn't change
         get = query_get_as(

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import socket
 from typing import Any
 
+from freezegun import freeze_time
 import pytest
 
 from pbench.server import OperationCode, PbenchServerConfig
@@ -187,6 +188,32 @@ class TestUpload:
         self.verify_logs(caplog)
         assert not self.cachemanager_created
 
+    def test_bad_metadata_upload(
+        self, client, caplog, server_config, setup_ctrl, pbench_token
+    ):
+        with freeze_time("1970-01-01 00:42:00"):
+            response = client.put(
+                self.gen_uri(server_config),
+                headers={
+                    "Authorization": "Bearer " + pbench_token,
+                    "controller": self.controller,
+                    "Content-MD5": "ANYMD5",
+                    "Content-Length": "STRING",
+                },
+                query_string={
+                    "metadata": "foobar.badpath:data,server.deletion:3000-12-25T23:59:59+00:00"
+                },
+            )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        json = response.json
+        assert "errors" in json and "message" in json
+        assert json["message"] == "at least one specified metadata key is invalid"
+        assert json["errors"] == [
+            "Key foobar.badpath is invalid or isn't settable",
+            "Metadata key 'server.deletion' value '3000-12-25T23:59:59+00:00' for dataset must be a date/time before 1979-12-30",
+        ]
+        assert not self.cachemanager_created
+
     def test_mismatched_md5sum_header(
         self, client, caplog, server_config, setup_ctrl, pbench_drb_token
     ):
@@ -312,6 +339,7 @@ class TestUpload:
                 self.gen_uri(server_config, datafile.name),
                 data=data_fp,
                 headers=self.gen_headers(pbench_drb_token, md5),
+                query_string={"metadata": "global.pbench.test:data"},
             )
 
         assert response.status_code == HTTPStatus.CREATED, repr(response)
@@ -322,7 +350,7 @@ class TestUpload:
         assert dataset.resource_id == md5
         assert dataset.name == name
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
-        assert Metadata.getvalue(dataset, "global") is None
+        assert Metadata.getvalue(dataset, "global") == {"pbench": {"test": "data"}}
         assert Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-02"
         assert Metadata.getvalue(dataset, "dataset.operations") == {
             "BACKUP": {"state": "READY", "message": None},
@@ -345,7 +373,10 @@ class TestUpload:
         assert audit[0].user_id == "3"
         assert audit[0].user_name == "drb"
         assert audit[0].reason is None
-        assert audit[0].attributes is None
+        assert audit[0].attributes == {
+            "access": "private",
+            "metadata": {"global.pbench.test": "data"},
+        }
         assert audit[1].id == 2
         assert audit[1].root_id == 1
         assert audit[1].operation == OperationCode.CREATE
@@ -357,7 +388,10 @@ class TestUpload:
         assert audit[1].user_id == "3"
         assert audit[1].user_name == "drb"
         assert audit[1].reason is None
-        assert audit[1].attributes is None
+        assert audit[1].attributes == {
+            "access": "private",
+            "metadata": {"global.pbench.test": "data"},
+        }
 
     def test_upload_duplicate(
         self,
@@ -446,7 +480,7 @@ class TestUpload:
         assert audit[0].user_id == "3"
         assert audit[0].user_name == "drb"
         assert audit[0].reason is None
-        assert audit[0].attributes is None
+        assert audit[0].attributes == {"access": "private", "metadata": {}}
         assert audit[1].id == 2
         assert audit[1].root_id == 1
         assert audit[1].operation == OperationCode.CREATE

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -189,13 +189,13 @@ class TestUpload:
         assert not self.cachemanager_created
 
     def test_bad_metadata_upload(
-        self, client, caplog, server_config, setup_ctrl, pbench_token
+        self, client, caplog, server_config, setup_ctrl, pbench_drb_token
     ):
         with freeze_time("1970-01-01 00:42:00"):
             response = client.put(
                 self.gen_uri(server_config),
                 headers={
-                    "Authorization": "Bearer " + pbench_token,
+                    "Authorization": "Bearer " + pbench_drb_token,
                     "controller": self.controller,
                     "Content-MD5": "ANYMD5",
                     "Content-Length": "STRING",


### PR DESCRIPTION
PBENCH-1059

Allow the Agent (or other client) to define metadata keys when initially uploading a dataset to the Pbench Server by specifying the `?metadata` query parameter on the `PUT`.