### PR TITLE
Check missing content-md5 header value in /upload

### DIFF
--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -172,14 +172,14 @@ class Upload(ApiBase):
 
             try:
                 md5sum = request.headers["Content-MD5"]
-                if not md5sum:
-                    raise CleanupTime(
-                        HTTPStatus.BAD_REQUEST,
-                        "Missing required 'Content-MD5' header value",
-                    )
             except KeyError:
                 raise CleanupTime(
                     HTTPStatus.BAD_REQUEST, "Missing required 'Content-MD5' header"
+                )
+            if not md5sum:
+                raise CleanupTime(
+                    HTTPStatus.BAD_REQUEST,
+                    "Missing required 'Content-MD5' header value",
                 )
             try:
                 length_string = request.headers["Content-Length"]

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -170,12 +170,17 @@ class Upload(ApiBase):
                     f"File extension not supported, must be {Dataset.TARBALL_SUFFIX}",
                 )
 
-            md5sum = request.headers.get("Content-MD5")
-            if not md5sum:
+            try:
+                md5sum = request.headers["Content-MD5"]
+                if not md5sum:
+                    raise CleanupTime(
+                        HTTPStatus.BAD_REQUEST,
+                        "Missing required 'Content-MD5' header value",
+                    )
+            except KeyError:
                 raise CleanupTime(
                     HTTPStatus.BAD_REQUEST, "Missing required 'Content-MD5' header"
                 )
-
             try:
                 length_string = request.headers["Content-Length"]
                 content_length = int(length_string)

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -136,6 +136,23 @@ class TestUpload:
         self.verify_logs(caplog)
         assert not self.cachemanager_created
 
+    def test_missing_md5sum_header_value(
+        self, client, caplog, server_config, setup_ctrl, pbench_token
+    ):
+        expected_message = "Missing required 'Content-MD5' header value"
+        response = client.put(
+            self.gen_uri(server_config),
+            headers={
+                "Authorization": "Bearer " + pbench_token,
+                "controller": self.controller,
+                "Content-MD5": "",
+            },
+        )
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json.get("message") == expected_message
+        self.verify_logs(caplog)
+        assert not self.cachemanager_created
+
     def test_missing_filename_extension(
         self, client, caplog, server_config, setup_ctrl, pbench_token
     ):


### PR DESCRIPTION
PBENCH-495

While uploading some tarballs I had a bash script to automate adding the `content-md5` header to the `upload` API call and my bash script had a bug where it was not reading the content-md5 correctly and an empty value was getting added as the header value. It took some time to realize the bug in my script because the server kept responding that I am missing the `content-md5` header, which was not correct. 

We already have an issue [github issue](https://github.com/distributed-system-analysis/pbench/issues/2311) and Jira regarding this so addressing that here.

