### PR TITLE
Fix repeated indexing

### DIFF
--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -73,7 +73,12 @@ class Sync:
             if self.logger.isEnabledFor(DEBUG):
                 q_str = query.statement.compile(compile_kwargs={"literal_binds": True})
                 self.logger.debug("QUERY {}", q_str)
-            return list(query.all())
+            datasets_l = []
+            for dataset in query.all():
+                op_val = Metadata.getvalue(dataset, Metadata.OPERATION)
+                if op_val and op_val[0] == operation.name:
+                    datasets_l.append(dataset)
+            return datasets_l
         except Exception as e:
             self.logger.exception("Failed to query for {}", operation)
             raise SyncSqlError("next") from e

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -76,7 +76,7 @@ class Sync:
             datasets_l = []
             for dataset in query.all():
                 op_val = Metadata.getvalue(dataset, Metadata.OPERATION)
-                if op_val and op_val[0] == operation.name:
+                if op_val and operation.name in op_val:
                     datasets_l.append(dataset)
             return datasets_l
         except Exception as e:

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -16,7 +16,6 @@ class Operation(Enum):
     BACKUP = auto()
     DELETE = auto()
     UNPACK = auto()
-    COPY_SOS = auto()
     INDEX = auto()
     INDEX_TOOL = auto()
     RE_INDEX = auto()

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -154,7 +154,7 @@ tasks = pbench-unpack-tarballs-small, pbench-unpack-tarballs-medium, pbench-unpa
 [pbench-backup]
 user = %(default-user)s
 mailfrom = %(user)s@localhost
-tasks = pbench-backup-tarballs
+tasks = pbench-backup-tarballs, pbench-verify-backup-tarballs
 
 ###########################################################################
 # crontab tasks

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -14,7 +14,7 @@ max-unpacked-age = 36500
 maximum-dataset-retention-days = 36500
 default-dataset-retention-days = 730
 # Override the roles this pbench server takes on -- omit pbench-prep.
-roles = pbench-maintenance, pbench-results, pbench-backup
+roles = pbench-results, pbench-backup
 
 [Indexing]
 index_prefix = container-pbench


### PR DESCRIPTION
Fixes issue #3198.

The root cause was that we have operation names for indexing which all had "INDEX" in the name: "INDEX", "INDEX_TOOL", and "RE_INDEX".

If any dataset had in its list of operations either "INDEX_TOOL" or "RE_INDEX", then any search for "INDEX" would also match those option names because a `contains()` operation was used in the query filter.  If all the operation names did not have any overlaps, that would work.

The fix was to filter locally by the exact operation name.  Since the total number of datasets on the system are rarely in the same operational state, it seems like a point solution that solves the problem efficiently without to many cascading changes.

----

Commits:

 * Ensure operation metadata query finds unique vals
 * Remove `COPY_SOS` op, add failing index test
   * The copy sos reports functionality was remove long ago.
   * We also add a failing unit test to demonstrate that a dataset with an "operation" of "INDEX_TOOL" is found when looking for "INDEX".
 * Remove `maintenance` role; add verify backup