### PR TITLE
Set up Alembic test infrastructure

### DIFF
--- a/jenkins/ci.Dockerfile.j2
+++ b/jenkins/ci.Dockerfile.j2
@@ -77,6 +77,10 @@ RUN \
         `# Required for creating peer-containers on the host` \
         `#` \
         podman-remote \
+        `#` \
+        `# Required for Alembic migration test` \
+        `#` \
+        nc \
         && \
     `#` \
     `# Save space in the container image.` \

--- a/jenkins/podman
+++ b/jenkins/podman
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# A simple wrapper for the podman command which handles invocation inside a container
+
+if [ -n "${CONTAINER_HOST}" ]; then
+    # Since CONTAINER_HOST is defined, we perform the requested invocation using
+    # `podman-remote`, which will run it where CONTAINER_HOST points.  This
+    # allows invocations of containers from inside other containers, which won't
+    # work, otherwise.
+    PODMAN="podman-remote"
+else
+    # Since CONTAINER_HOST is not defined, just use `podman` as normal.
+    PODMAN="podman"
+fi
+
+${PODMAN} "${@}"

--- a/jenkins/run-alembic-migrations-check
+++ b/jenkins/run-alembic-migrations-check
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+echo "Starting PostgreSQL container" >&2
 jenkins/podman run --name postgresql-alembic \
     --detach \
     --rm \
@@ -23,10 +24,14 @@ jenkins/podman run --name postgresql-alembic \
     --env 'POSTGRESQL_DATABASE=pbench' \
     images.paas.redhat.com/pbench/postgresql-13:latest container-entrypoint run-postgresql
 
-trap "jenkins/podman stop postgresql-alembic" INT ABRT QUIT EXIT
+trap "echo 'Stopping PostgreSQL container' >&2 ; jenkins/podman stop postgresql-alembic" INT ABRT QUIT EXIT
 
-until nc -z localhost 5432; do
+# If the timeout is reached, the `timeout` command will exit with an error (124)
+# which will cause the script to exit immediately and trigger the `trap` above.
+timeout 60s bash -c 'until nc -z localhost 5432; do
+    echo "Waiting for PostgreSQL" >&2
     sleep 1
-done
+done'
 
+echo "Starting tox" >&2
 EXTRA_PODMAN_SWITCHES="${EXTRA_PODMAN_SWITCHES} --network host" jenkins/run tox -e alembic-check

--- a/jenkins/run-alembic-migrations-check
+++ b/jenkins/run-alembic-migrations-check
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-podman run --name postgresql-alembic \
+jenkins/podman run --name postgresql-alembic \
     --detach \
     --rm \
     --network host \
@@ -23,7 +23,7 @@ podman run --name postgresql-alembic \
     --env 'POSTGRESQL_DATABASE=pbench' \
     images.paas.redhat.com/pbench/postgresql-13:latest container-entrypoint run-postgresql
 
-trap "podman stop postgresql-alembic" INT ABRT QUIT EXIT
+trap "jenkins/podman stop postgresql-alembic" INT ABRT QUIT EXIT
 
 until nc -z localhost 5432; do
     sleep 1


### PR DESCRIPTION
This PR sets up the infrastructure required to run the Alembic migration test like any other test under `tox`.

The principal change is to provide a helper script, `jenkins/podman` which wraps the `podman` command to allow it to be invoked from inside a container run by `jenkins/run`.

The `jenkins/run-alembic-migrations-check` script is modified to use `jenkins/podman` instead of invoking `podman` directly.  This allows the script to be used either directly or under `jenkins/run`.  Since the script relies on the `nc` command, the CI container build is modified to include that command.

The second commit on this branch is a set of tweaks to `jenkins/run-alembic-migrations-check` including some diagnostic output and a timeout on the wait loop.

Once this infrastructure is in place, we can repackage the Alembic migration test and invoke it as a "linter".

(Note, this branch is currently based on the branch for #3200, so disregard the first commit.  I'm expecting that PR to land first, although I'm not aware of any actual dependency between the two.)