### PR TITLE
First pass unit tests for `shell.py`

### DIFF
--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -71,7 +71,7 @@ class TestShell:
         shell.find_the_unicorn(make_logger)
         assert os.environ["PATH"].endswith(
             "/bin:ONE:TWO"
-        ), f"Expected PATH to end with '/bin:ONE:TWO', foudn PATH == '{os.environ['PATH']}'"
+        ), f"Expected PATH to end with '/bin:ONE:TWO', found PATH == '{os.environ['PATH']}'"
 
     @staticmethod
     def test_generate_crontab_if_necessary_no_action(monkeypatch, make_logger):

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -17,10 +17,11 @@ from pbench.server.auth import OpenIDClient
 
 @pytest.fixture
 def mock_get_server_config(monkeypatch, on_disk_server_config):
+    cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
+    config = PbenchServerConfig(str(cfg_file))
+    del config.conf["authentication"]["server_url"]
+
     def get_server_config() -> PbenchServerConfig:
-        cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
-        config = PbenchServerConfig(str(cfg_file))
-        del config.conf["authentication"]["server_url"]
         return config
 
     monkeypatch.setattr(shell, "get_server_config", get_server_config)

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -77,8 +77,10 @@ class TestShell:
     def test_generate_crontab_if_necessary_no_action(monkeypatch, make_logger):
         """Test site.generate_crontab_if_necessary with no action taken"""
 
+        called = {"run": False}
+
         def run(args, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
-            assert False, "Mocked run should not have been called."
+            called["run"] = True
 
         monkeypatch.setenv("PATH", "one:two")
         # An existing crontab does nothing.
@@ -91,6 +93,9 @@ class TestShell:
 
         assert ret_val == 0
         assert os.environ["PATH"] == "one:two", f"PATH='{os.environ['PATH']}'"
+        assert not called[
+            "run"
+        ], "generate_crontab_if_necessary() took action unexpectedly"
 
     @staticmethod
     def test_generate_crontab_if_necessary_created(monkeypatch, make_logger):

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -1,0 +1,384 @@
+"""Test the Gunicorn driver module, `shell`, to ensure it is usable."""
+from configparser import NoOptionError, NoSectionError
+import logging
+import os
+from pathlib import Path
+import subprocess
+from typing import Optional
+
+from flask import Flask
+import pytest
+
+import pbench.cli.server.shell as shell
+from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
+from pbench.server import PbenchServerConfig
+from pbench.server.auth import OpenIDClient
+
+
+@pytest.fixture
+def mock_get_server_config(monkeypatch, on_disk_server_config):
+    def get_server_config() -> PbenchServerConfig:
+        cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
+        config = PbenchServerConfig(str(cfg_file))
+        del config.conf["authentication"]["server_url"]
+        return config
+
+    monkeypatch.setattr(shell, "get_server_config", get_server_config)
+
+
+def exists_false(theself: Path) -> bool:
+    """Mock Path.exists() returning False."""
+    return False
+
+
+def exists_true(theself: Path) -> bool:
+    """Mock Path.exists() returning False."""
+    return True
+
+
+class TestShell:
+    @staticmethod
+    def test_app_normal(monkeypatch, mock_get_server_config):
+        """Test site.app() success case"""
+
+        def mocked_create_app(config: PbenchServerConfig):
+            return Flask("fake")
+
+        monkeypatch.setattr(shell, "create_app", mocked_create_app)
+
+        app = shell.app()
+
+        assert app.name == "fake"
+
+    @staticmethod
+    def test_find_the_unicorn(monkeypatch, make_logger):
+        """Test site.find_the_unicorn success and failure cases"""
+        # Only need to set this once since the second test will change it.
+        monkeypatch.setenv("PATH", "ONE:TWO")
+        monkeypatch.setattr(Path, "exists", exists_false)
+
+        # Should be successful.
+        shell.find_the_unicorn(make_logger)
+
+        assert os.environ["PATH"] == "ONE:TWO", f"PATH='{os.environ['PATH']}'"
+
+        monkeypatch.setattr(Path, "exists", exists_true)
+
+        # Should fail.
+        shell.find_the_unicorn(make_logger)
+
+        assert os.environ["PATH"].endswith(
+            "/bin:ONE:TWO"
+        ), f"PATH='{os.environ['PATH']}'"
+
+    @staticmethod
+    def test_generate_crontab_if_necessary_no_action(monkeypatch, make_logger):
+        """Test site.generate_crontab_if_necessary with no action taken"""
+        monkeypatch.setenv("PATH", "one:two")
+        # An existing crontab does nothing.
+        monkeypatch.setattr(Path, "exists", exists_true)
+
+        ret_val = shell.generate_crontab_if_necessary(
+            "/tmp", Path("bindir"), "cwd", make_logger
+        )
+
+        assert ret_val == 0
+        assert os.environ["PATH"] == "one:two", f"PATH='{os.environ['PATH']}'"
+
+    @staticmethod
+    def test_generate_crontab_if_necessary_created(monkeypatch, make_logger):
+        """Test site.generate_crontab_if_necessary creating the crontab"""
+
+        commands = []
+
+        def run_success(args, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
+            commands.append(args)
+            return subprocess.CompletedProcess(args, 0)
+
+        monkeypatch.setenv("PATH", "a:b")
+        # We don't have an existing crontab
+        monkeypatch.setattr(Path, "exists", exists_false)
+        monkeypatch.setattr(subprocess, "run", run_success)
+
+        ret_val = shell.generate_crontab_if_necessary(
+            "/tmp", Path("bindir"), "cwd", make_logger
+        )
+
+        assert ret_val == 0
+        assert os.environ["PATH"] == "bindir:a:b", f"PATH='{os.environ['PATH']}'"
+        assert commands == [
+            ["pbench-create-crontab", "/tmp"],
+            ["crontab", "/tmp/crontab"],
+        ]
+
+    @staticmethod
+    def test_generate_crontab_if_necessary_create_failed(monkeypatch, make_logger):
+        monkeypatch.setenv("PATH", "a:b")
+
+        unlink_record = []
+
+        def unlink(*args, **kwargs):
+            unlink_record.append("unlink")
+
+        monkeypatch.setattr(Path, "unlink", unlink)
+
+        commands = []
+
+        def run(args, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
+            commands.append(args)
+            return subprocess.CompletedProcess(args, 1)
+
+        # We don't have an existing crontab
+        monkeypatch.setattr(Path, "exists", exists_false)
+        monkeypatch.setattr(subprocess, "run", run)
+
+        ret_val = shell.generate_crontab_if_necessary(
+            "/tmp", Path("bindir"), "cwd", make_logger
+        )
+
+        assert ret_val == 1
+        assert os.environ["PATH"] == "bindir:a:b", f"PATH='{os.environ['PATH']}'"
+        assert commands == [["pbench-create-crontab", "/tmp"]]
+        assert unlink_record == ["unlink"]
+
+    @staticmethod
+    def test_generate_crontab_if_necessary_crontab_failed(monkeypatch, make_logger):
+        monkeypatch.setenv("PATH", "a:b")
+
+        unlink_record = []
+
+        def unlink(*args, **kwargs):
+            unlink_record.append("unlink")
+
+        monkeypatch.setattr(Path, "unlink", unlink)
+
+        commands = []
+
+        def run(args, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
+            commands.append(args)
+            ret_val = 1 if args[0] == "crontab" else 0
+            return subprocess.CompletedProcess(args, ret_val)
+
+        # We don't have an existing crontab
+        monkeypatch.setattr(Path, "exists", exists_false)
+        monkeypatch.setattr(subprocess, "run", run)
+
+        ret_val = shell.generate_crontab_if_necessary(
+            "/tmp", Path("bindir"), "cwd", make_logger
+        )
+
+        assert ret_val == 1
+        assert os.environ["PATH"] == "bindir:a:b", f"PATH='{os.environ['PATH']}'"
+        assert commands == [
+            ["pbench-create-crontab", "/tmp"],
+            ["crontab", "/tmp/crontab"],
+        ]
+        assert unlink_record == ["unlink"]
+
+    @staticmethod
+    @pytest.mark.parametrize("user_site", [False, True])
+    @pytest.mark.parametrize("oidc_conf", [False, True])
+    def test_main(
+        monkeypatch, make_logger, mock_get_server_config, user_site, oidc_conf
+    ):
+        find_called = [False]
+
+        def find_the_unicorn(logger: logging.Logger):
+            find_called[0] = True
+
+        def wait_for_oidc_server(
+            server_config: PbenchServerConfig, logger: logging.Logger
+        ) -> str:
+            if oidc_conf:
+                return "https://oidc.example.com"
+            else:
+                raise OpenIDClient.NotConfigured()
+
+        commands = []
+
+        def run(args, cwd: Optional[str] = None) -> subprocess.CompletedProcess:
+            commands.append(args)
+            ret_val = 42 if args[0] == "gunicorn" else 0
+            return subprocess.CompletedProcess(args, ret_val)
+
+        monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", user_site)
+        monkeypatch.setattr(shell, "find_the_unicorn", find_the_unicorn)
+        monkeypatch.setattr(
+            shell.OpenIDClient, "wait_for_oidc_server", wait_for_oidc_server
+        )
+        monkeypatch.setattr(subprocess, "run", run)
+
+        ret_val = shell.main()
+
+        assert ret_val == 42
+        assert not user_site or find_called[0]
+        assert len(commands) == 3, f"{commands!r}"
+        assert commands[0][0] == "pbench-create-crontab"
+        assert commands[1][0] == "crontab"
+        gunicorn_command = commands[2]
+        assert gunicorn_command[-1] == "pbench.cli.server.shell:app()", f"{commands!r}"
+        gunicorn_command = gunicorn_command[:-1]
+        if user_site:
+            assert (
+                gunicorn_command[-2:][0] == "--pythonpath"
+            ), f"commands[2] = {commands[2]!r}"
+            gunicorn_command = gunicorn_command[:-2]
+        expected_command = [
+            "gunicorn",
+            "--workers",
+            "3",
+            "--timeout",
+            "9000",
+            "--pid",
+            "/run/pbench-server/gunicorn.pid",
+            "--bind",
+            "0.0.0.0:8001",
+            "--log-syslog",
+            "--log-syslog-prefix",
+            "pbench-server",
+        ]
+        assert (
+            gunicorn_command == expected_command
+        ), f"expected_command = {expected_command!r}, commands[2] = {commands[2]!r}"
+
+    @staticmethod
+    def test_main_crontab_failed(monkeypatch, make_logger, mock_get_server_config):
+        def generate_crontab_if_necessary(*args, **kwargs) -> int:
+            return 43
+
+        monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", False)
+        monkeypatch.setattr(
+            shell, "generate_crontab_if_necessary", generate_crontab_if_necessary
+        )
+
+        ret_val = shell.main()
+
+        assert ret_val == 43
+
+    @staticmethod
+    @pytest.mark.parametrize("init_db_exc", ["section", "option"])
+    def test_main_initdb_failed(
+        monkeypatch, make_logger, mock_get_server_config, init_db_exc
+    ):
+        def init_db(*args, **kwargs) -> int:
+            if init_db_exc == "section":
+                exc = NoSectionError("missingsection")
+            elif init_db_exc == "option":
+                exc = NoOptionError("section", "missingoption")
+            else:
+                raise Exception(f"Bad test parameter, {init_db_exc}")
+            raise exc
+
+        monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", False)
+        monkeypatch.setattr(shell, "init_db", init_db)
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+
+    @staticmethod
+    def test_main_wait_for_oidc_server_exc(
+        monkeypatch, make_logger, mock_get_server_config
+    ):
+        def wait_for_oidc_server(
+            server_config: PbenchServerConfig, logger: logging.Logger
+        ) -> str:
+            raise Exception("oidc exception")
+
+        monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", False)
+        monkeypatch.setattr(
+            shell.OpenIDClient, "wait_for_oidc_server", wait_for_oidc_server
+        )
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+
+    @staticmethod
+    def test_main_wait_for_database_exc(
+        monkeypatch, make_logger, mock_get_server_config
+    ):
+        def wait_for_database(
+            server_config: PbenchServerConfig, logger: logging.Logger
+        ) -> str:
+            raise ConnectionRefusedError("database exception")
+
+        monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", False)
+        monkeypatch.setattr(shell.Database, "wait_for_database", wait_for_database)
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+
+    @staticmethod
+    @pytest.mark.parametrize("section", ["database", "pbench-server"])
+    def test_main_server_config_no_section(
+        monkeypatch, on_disk_server_config, make_logger, section
+    ):
+        def get_server_config() -> PbenchServerConfig:
+            cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
+            config = PbenchServerConfig(str(cfg_file))
+            del config.conf[section]
+            return config
+
+        monkeypatch.setattr(shell, "get_server_config", get_server_config)
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "option",
+        [
+            "bind_host",
+            "bind_port",
+            "uri",
+            "wait_timeout",
+            "workers",
+            "worker_timeout",
+            "crontab-dir",
+        ],
+    )
+    def test_main_server_config_no_option(
+        monkeypatch, on_disk_server_config, make_logger, option
+    ):
+        def get_server_config() -> PbenchServerConfig:
+            cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
+            config = PbenchServerConfig(str(cfg_file))
+            section = (
+                "database"
+                if option in frozenset(("uri", "wait_timeout"))
+                else "DEFAULT"
+                if option == "crontab-dir"
+                else "pbench-server"
+            )
+            make_logger.error(config.conf[section][option])
+            del config.conf[section][option]
+            return config
+
+        monkeypatch.setattr(shell, "get_server_config", get_server_config)
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+
+    @staticmethod
+    @pytest.mark.parametrize("gsc_exc", ["nofile", "bad"])
+    def test_main_get_server_config_exc(capsys, monkeypatch, make_logger, gsc_exc):
+        def get_server_config() -> PbenchServerConfig:
+            if gsc_exc == "nofile":
+                exc = ConfigFileNotSpecified("nofile found")
+            elif gsc_exc == "bad":
+                exc = BadConfig("bad to the bone")
+            else:
+                raise Exception(f"Bad test parameter, {gsc_exc}")
+            raise exc
+
+        monkeypatch.setattr(shell, "get_server_config", get_server_config)
+
+        ret_val = shell.main()
+
+        assert ret_val == 1
+        out, err = capsys.readouterr()
+        assert err.startswith(gsc_exc), f"out={out!r}, err={err!r}"


### PR DESCRIPTION
A mistake was made in PR #3170 which went unnoticed until the functional tests were run (see https://github.com/distributed-system-analysis/pbench/pull/3170/commits/f4299ab55257839f14e49e5099cbb08e3a9925ad#diff-2db83614a5b08b212f0017da6957f4fb794106d2d4473c99f2ac6ec258d5d90bR9).

This PR adds a set of unit tests for `pbench.cli.server.shell` so that any changes to that module can be verified quickly before waiting for the CI job to run functional tests.

Two commits are provided here, the first removes the use of `sys.exit()` from the `main()` method of `shell.py`, since the auto-generated command wrapper for it already takes does that.  This makes writing unit tests a bit easier since we wont have to catch `SystemExit`.