### PR TITLE
Remove the need to pass logger to APIs

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -7,7 +7,7 @@ Dashboard or any number of pbench agent users.
 import os
 import sys
 
-from flask import Flask
+from flask import current_app, Flask
 from flask_cors import CORS
 from flask_restful import Api
 
@@ -49,57 +49,56 @@ def register_endpoints(api, app, config):
     to make the APIs active."""
 
     base_uri = config.rest_uri
-    logger = app.logger
 
     # Init the the authentication module
     token_auth = Auth()
-    Auth.set_logger(logger)
+    Auth.set_logger(current_app.logger)
     Auth.set_oidc_client(server_config=config)
 
-    logger.info("Registering service endpoints with base URI {}", base_uri)
+    app.logger.info("Registering service endpoints with base URI {}", base_uri)
 
     api.add_resource(
         DatasetsContents,
         f"{base_uri}/datasets/contents/<string:dataset>/",
         f"{base_uri}/datasets/contents/<string:dataset>/<path:target>",
         endpoint="datasets_contents",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsDateRange,
         f"{base_uri}/datasets/daterange",
         endpoint="datasets_daterange",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsDelete,
         f"{base_uri}/datasets/delete/<string:dataset>",
         endpoint="datasets_delete",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsDetail,
         f"{base_uri}/datasets/detail/<string:dataset>",
         endpoint="datasets_detail",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsList,
         f"{base_uri}/datasets/list",
         endpoint="datasets_list",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsMappings,
         f"{base_uri}/datasets/mappings/<string:dataset_view>",
         endpoint="datasets_mappings",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsMetadata,
         f"{base_uri}/datasets/metadata/<string:dataset>",
         endpoint="datasets_metadata",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsInventory,
@@ -107,61 +106,61 @@ def register_endpoints(api, app, config):
         f"{base_uri}/datasets/inventory/<string:dataset>/",
         f"{base_uri}/datasets/inventory/<string:dataset>/<path:target>",
         endpoint="datasets_inventory",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         SampleNamespace,
         f"{base_uri}/datasets/namespace/<string:dataset>/<string:dataset_view>",
         endpoint="datasets_namespace",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         SampleValues,
         f"{base_uri}/datasets/values/<string:dataset>/<string:dataset_view>",
         endpoint="datasets_values",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsPublish,
         f"{base_uri}/datasets/publish/<string:dataset>",
         endpoint="datasets_publish",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsSearch,
         f"{base_uri}/datasets/search",
         endpoint="datasets_search",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         EndpointConfig,
         f"{base_uri}/endpoints",
         endpoint="endpoints",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         Login,
         f"{base_uri}/login",
         endpoint="login",
-        resource_class_args=(config, logger, token_auth),
+        resource_class_args=(config, token_auth),
     )
     api.add_resource(
         Logout,
         f"{base_uri}/logout",
         endpoint="logout",
-        resource_class_args=(config, logger, token_auth),
+        resource_class_args=(config, token_auth),
     )
     api.add_resource(
         RegisterUser,
         f"{base_uri}/register",
         endpoint="register",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         ServerAudit,
         f"{base_uri}/server/audit",
         endpoint="server_audit",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         ServerConfiguration,
@@ -169,19 +168,19 @@ def register_endpoints(api, app, config):
         f"{base_uri}/server/configuration/",
         f"{base_uri}/server/configuration/<string:key>",
         endpoint="server_configuration",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
     api.add_resource(
         UserAPI,
         f"{base_uri}/user/<string:target_username>",
         endpoint="user",
-        resource_class_args=(logger, token_auth),
+        resource_class_args=(token_auth,),
     )
     api.add_resource(
         Upload,
         f"{base_uri}/upload/<string:filename>",
         endpoint="upload",
-        resource_class_args=(config, logger),
+        resource_class_args=(config,),
     )
 
 
@@ -213,7 +212,8 @@ def create_app(server_config):
 
     api = Api(app)
 
-    register_endpoints(api, app, server_config)
+    with app.app_context():
+        register_endpoints(api, app, server_config)
 
     try:
         init_db(configuration=server_config, logger=app.logger)

--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -1,5 +1,3 @@
-from logging import Logger
-
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 from sqlalchemy import func
@@ -25,10 +23,9 @@ class DatasetsDateRange(ApiBase):
     API class to retrieve the available date range of accessible datasets.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,8 +1,7 @@
 from http import HTTPStatus
-from logging import Logger
 from urllib.request import Request
 
-from flask import send_file
+from flask import current_app, send_file
 from flask.wrappers import Response
 
 from pbench.server import OperationCode, PbenchServerConfig
@@ -26,10 +25,9 @@ class DatasetsInventory(ApiBase):
     API class to retrieve inventory files from a dataset
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -62,7 +60,7 @@ class DatasetsInventory(ApiBase):
         dataset = params.uri["dataset"]
         target = params.uri.get("target")
 
-        cache_m = CacheManager(self.config, self.logger)
+        cache_m = CacheManager(self.config, current_app.logger)
         try:
             tarball = cache_m.find_dataset(dataset.resource_id)
         except TarballNotFound as e:

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, List, Tuple
 from urllib.parse import urlencode, urlparse
 
+from flask import current_app
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 from sqlalchemy.orm import Query
@@ -33,10 +34,9 @@ def urlencode_json(json: JSON) -> str:
 class DatasetsList(ApiBase):
     """API class to list datasets based on database metadata."""
 
-    def __init__(self, config: PbenchServerConfig, logger: logging.Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -143,8 +143,8 @@ class DatasetsList(ApiBase):
 
         # Useful for debugging, but verbose: this displays the fully expanded
         # SQL `SELECT` statement.
-        if self.logger.isEnabledFor(logging.DEBUG):
-            self.logger.debug(
+        if current_app.logger.isEnabledFor(logging.DEBUG):
+            current_app.logger.debug(
                 "QUERY {}",
                 query.statement.compile(compile_kwargs={"literal_binds": True}),
             )
@@ -166,7 +166,7 @@ class DatasetsList(ApiBase):
             try:
                 d["metadata"] = self._get_dataset_metadata(dataset, keys)
             except MetadataError as e:
-                self.logger.warning(
+                current_app.logger.warning(
                     "Error getting metadata {} for dataset {}: {}", keys, dataset, e
                 )
             response.append(d)

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from logging import Logger
 from typing import Any
 
 from flask.json import jsonify
@@ -33,10 +32,9 @@ class DatasetsMetadata(ApiBase):
     API class to retrieve and mutate Dataset metadata.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.PUT,
                 OperationCode.UPDATE,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_contents.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
-from logging import Logger
+
+from flask import current_app
 
 from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -24,10 +25,9 @@ class DatasetsContents(IndexMapBase):
 
     MAX_SIZE = 10000
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -56,7 +56,7 @@ class DatasetsContents(IndexMapBase):
 
         dataset = context["dataset"]
 
-        self.logger.info(
+        current_app.logger.info(
             "Discover dataset {} Contents, directory {}",
             dataset.name,
             target,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_detail.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from logging import Logger
 
 from flask import jsonify
 
@@ -29,10 +28,9 @@ class DatasetsDetail(IndexMapBase):
     Get detailed data from the run document for a dataset by name.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -1,5 +1,3 @@
-from logging import Logger
-
 from flask import jsonify
 from flask.wrappers import Request, Response
 
@@ -67,10 +65,9 @@ class DatasetsMappings(ApiBase):
     }
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/namespace_and_rows.py
@@ -1,5 +1,6 @@
 from http import HTTPStatus
-from logging import Logger
+
+from flask import current_app
 
 from pbench.server import JSON, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -26,10 +27,9 @@ class SampleNamespace(IndexMapBase):
     selecting for certain fields or certain values within those fields.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,
@@ -67,7 +67,7 @@ class SampleNamespace(IndexMapBase):
 
         document_index = document["index"]
 
-        self.logger.info(
+        current_app.logger.info(
             "Return {} namespace for dataset {}, prefix {}",
             document_index,
             dataset,
@@ -181,10 +181,9 @@ class SampleValues(IndexMapBase):
     DOCUMENT_SIZE = 10000  # Number of documents to return in one page
     SCROLL_EXPIRY = "1m"  # Scroll id expires in 1 minute
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.POST,
                 OperationCode.READ,
@@ -250,7 +249,7 @@ class SampleValues(IndexMapBase):
 
         document_index = document["index"]
 
-        self.logger.info(
+        current_app.logger.info(
             "Return {} rows {} for dataset {}, prefix {}",
             document_index,
             "next page " if scroll_id else "",
@@ -343,7 +342,7 @@ class SampleValues(IndexMapBase):
         try:
             count = int(es_json["hits"]["total"]["value"])
             if count == 0:
-                self.logger.info("No data returned by Elasticsearch")
+                current_app.logger.info("No data returned by Elasticsearch")
                 return {}
 
             results = [hit["_source"] for hit in es_json["hits"]["hits"]]

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -1,5 +1,6 @@
-from logging import Logger
 from typing import Iterator
+
+from flask import current_app
 
 from pbench.server import JSONOBJECT, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -29,10 +30,9 @@ class DatasetsDelete(ElasticBulkBase):
     backup.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.POST,
                 OperationCode.DELETE,
@@ -69,7 +69,7 @@ class DatasetsDelete(ElasticBulkBase):
         """
 
         dataset.advance(States.DELETING)
-        self.logger.info("Starting delete operation for dataset {}", dataset)
+        current_app.logger.info("Starting delete operation for dataset {}", dataset)
 
         # Generate a series of bulk delete documents, which will be passed to
         # the Elasticsearch bulk helper.
@@ -99,6 +99,6 @@ class DatasetsDelete(ElasticBulkBase):
         # Only on total success we update the Dataset's registered access
         # column; a "partial success" will remain in the previous state.
         if summary["failure"] == 0:
-            cache_m = CacheManager(self.config, self.logger)
+            cache_m = CacheManager(self.config, current_app.logger)
             cache_m.delete(dataset.resource_id)
             dataset.delete()

--- a/lib/pbench/server/api/resources/query_apis/datasets_publish.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_publish.py
@@ -1,5 +1,6 @@
-from logging import Logger
 from typing import Any, Iterator
+
+from flask import current_app
 
 from pbench.server import JSONOBJECT, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -25,10 +26,9 @@ class DatasetsPublish(ElasticBulkBase):
     Called as `POST /api/v1/datasets/publish/{resource_id}?access=public`
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.POST,
                 OperationCode.UPDATE,
@@ -70,7 +70,7 @@ class DatasetsPublish(ElasticBulkBase):
         access = params.query["access"]
         context["access"] = access
 
-        self.logger.info("Starting publish operation for dataset {}", dataset)
+        current_app.logger.info("Starting publish operation for dataset {}", dataset)
 
         # Generate a series of bulk update documents, which will be passed to
         # the Elasticsearch bulk helper.

--- a/lib/pbench/server/api/resources/server_audit.py
+++ b/lib/pbench/server/api/resources/server_audit.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from logging import Logger
 
 from flask.json import jsonify
 from flask.wrappers import Request, Response
@@ -31,10 +30,9 @@ class ServerAudit(ApiBase):
     API class to retrieve audit records.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.GET,
                 OperationCode.READ,

--- a/lib/pbench/server/api/resources/server_configuration.py
+++ b/lib/pbench/server/api/resources/server_configuration.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
-from logging import Logger
 
+from flask import current_app
 from flask.json import jsonify
 from flask.wrappers import Request, Response
 
@@ -31,10 +31,9 @@ class ServerConfiguration(ApiBase):
     API class to retrieve and mutate server configuration settings.
     """
 
-    def __init__(self, config: PbenchServerConfig, logger: Logger):
+    def __init__(self, config: PbenchServerConfig):
         super().__init__(
             config,
-            logger,
             ApiSchema(
                 ApiMethod.PUT,
                 OperationCode.UPDATE,
@@ -200,7 +199,7 @@ class ServerConfiguration(ApiBase):
             except ServerConfigBadValue as e:
                 failures.append(str(e))
             except Exception as e:
-                self.logger.warning("{}", e)
+                current_app.logger.warning("{}", e)
                 raise APIInternalError(f"Error setting server configuration {k}")
         if failures:
             raise APIAbort(HTTPStatus.BAD_REQUEST, message=", ".join(failures))

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -168,7 +168,9 @@ def client(
     app_client.config = app.config
     app_client.debug = True
     app_client.testing = True
-    return app_client
+
+    with app.app_context():
+        yield app_client
 
 
 @pytest.fixture(scope="session")

--- a/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
+++ b/lib/pbench/test/unit/server/query_apis/test_dataset_search.py
@@ -18,7 +18,7 @@ class TestDatasetSummary(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=DatasetsSearch(client.config, client.logger),
+            cls_obj=DatasetsSearch(client.config),
             pbench_endpoint="/datasets/search",
             elastic_endpoint="/_search?ignore_unavailable=true",
             payload={

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -21,7 +21,7 @@ class TestDatasetsContents(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=DatasetsContents(client.config, client.logger),
+            cls_obj=DatasetsContents(client.config),
             pbench_endpoint="/datasets/contents/random_md5_string1/1-default",
             elastic_endpoint="/_search",
             index_from_metadata="run-toc",

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -22,7 +22,7 @@ class TestDatasetsDetail(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=DatasetsDetail(client.config, client.logger),
+            cls_obj=DatasetsDetail(client.config),
             pbench_endpoint="/datasets/detail/random_md5_string1",
             elastic_endpoint="/_search?ignore_unavailable=true",
             index_from_metadata="run-data",

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -22,7 +22,7 @@ class TestSampleNamespace(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=SampleNamespace(client.config, client.logger),
+            cls_obj=SampleNamespace(client.config),
             pbench_endpoint="/datasets/namespace/random_md5_string1/iterations",
             elastic_endpoint="/_search",
             index_from_metadata="result-data-sample",
@@ -404,7 +404,7 @@ class TestSampleValues(Commons):
     @pytest.fixture(autouse=True)
     def _setup(self, client):
         super()._setup(
-            cls_obj=SampleValues(client.config, client.logger),
+            cls_obj=SampleValues(client.config),
             pbench_endpoint="/datasets/values/random_md5_string1/iterations",
             elastic_endpoint="/_search",
             payload={},

--- a/lib/pbench/test/unit/server/query_apis/test_query_builder.py
+++ b/lib/pbench/test/unit/server/query_apis/test_query_builder.py
@@ -16,9 +16,7 @@ USER_ID = "20"  # This is arbitrary, but can't match either fixture
 class TestQueryBuilder:
     @pytest.fixture()
     def elasticbase(self, client) -> ElasticBase:
-        return ElasticBase(
-            client.config, client.logger, ApiSchema(ApiMethod.POST, OperationCode.READ)
-        )
+        return ElasticBase(client.config, ApiSchema(ApiMethod.POST, OperationCode.READ))
 
     @pytest.fixture()
     def current_user_admin(self, monkeypatch):

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -17,20 +17,17 @@ from pbench.server.database.models.server_config import ServerConfig
 
 
 class OnlyGet(ApiBase):
-    def __init__(self, server_config, logger):
-        super().__init__(
-            server_config, logger, ApiSchema(ApiMethod.GET, OperationCode.READ)
-        )
+    def __init__(self, server_config):
+        super().__init__(server_config, ApiSchema(ApiMethod.GET, OperationCode.READ))
 
     def _get(self, args: ApiParams, request: Request, context: ApiContext) -> str:
         return "OK - Only GET"
 
 
 class Always(ApiBase):
-    def __init__(self, server_config, logger):
+    def __init__(self, server_config):
         super().__init__(
             server_config,
-            logger,
             ApiSchema(ApiMethod.GET, OperationCode.READ),
             always_enabled=True,
         )
@@ -40,10 +37,9 @@ class Always(ApiBase):
 
 
 class All(ApiBase):
-    def __init__(self, server_config, logger):
+    def __init__(self, server_config):
         super().__init__(
             server_config,
-            logger,
             ApiSchema(ApiMethod.GET, OperationCode.READ),
             ApiSchema(ApiMethod.HEAD, OperationCode.READ),
             ApiSchema(ApiMethod.POST, OperationCode.CREATE),
@@ -70,10 +66,9 @@ class All(ApiBase):
 
 
 class OptionsMethod(ApiBase):
-    def __init__(self, server_config, logger):
+    def __init__(self, server_config):
         super().__init__(
             server_config,
-            logger,
             ApiSchema(99, OperationCode.READ),
         )
 
@@ -103,25 +98,25 @@ class TestApiBase:
             OnlyGet,
             "/api/v1/onlyget",
             endpoint="onlyget",
-            resource_class_args=(server_config, app.logger),
+            resource_class_args=(server_config,),
         )
         api.add_resource(
             Always,
             "/api/v1/always",
             endpoint="always",
-            resource_class_args=(server_config, app.logger),
+            resource_class_args=(server_config,),
         )
         api.add_resource(
             All,
             "/api/v1/all",
             endpoint="all",
-            resource_class_args=(server_config, app.logger),
+            resource_class_args=(server_config,),
         )
         api.add_resource(
             OptionsMethod,
             "/api/v1/other",
             endpoint="other",
-            resource_class_args=(server_config, app.logger),
+            resource_class_args=(server_config,),
         )
 
         # Flask-provided test client

--- a/lib/pbench/test/unit/server/test_authorization.py
+++ b/lib/pbench/test/unit/server/test_authorization.py
@@ -28,9 +28,7 @@ class TestAuthorization:
 
     @pytest.fixture()
     def apibase(self, client) -> ApiBase:
-        return ApiBase(
-            client.config, client.logger, ApiSchema(ApiMethod.GET, OperationCode.READ)
-        )
+        return ApiBase(client.config, ApiSchema(ApiMethod.GET, OperationCode.READ))
 
     @pytest.fixture()
     def current_user_admin(self, monkeypatch):

--- a/lib/pbench/test/unit/server/test_server_configuration.py
+++ b/lib/pbench/test/unit/server/test_server_configuration.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-import logging
 
 import pytest
 import requests
@@ -91,7 +90,7 @@ class TestServerConfiguration:
         handling of a condition that ought to be impossible through Flask
         routing.
         """
-        put = ServerConfiguration(server_config, logging.getLogger("test"))
+        put = ServerConfiguration(server_config)
         with pytest.raises(APIAbort, match="Missing parameter 'key'"):
             put._put_key(ApiParams(uri={"plugh": "xyzzy", "foo": "bar"}), context=None)
 


### PR DESCRIPTION
The API handling code now retrieves a logger from `flask.current_app` only when needed.

This exposed a small problem with the test environment where the `Flask` app context was not setup properly for the unit tests.

----

Pulled from PR #3114 (see https://github.com/distributed-system-analysis/pbench/pull/3114/commits/913fb7142091d88b21a495c949e4379a8a6c8c3a).