### PR TITLE
Clarify code which installs the Flask application context teardown handler

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -202,6 +202,10 @@ def get_server_config() -> PbenchServerConfig:
 def create_app(server_config):
     """Create Flask app with defined resource endpoints."""
 
+    def shutdown_session(exception=None):
+        """Called from app context teardown hook to end the database session"""
+        Database.db_session.remove()
+
     app = Flask(__name__.split(".")[0])
     CORS(app, resources={r"/api/*": {"origins": "*"}})
 
@@ -221,8 +225,6 @@ def create_app(server_config):
         app.logger.exception("Exception while initializing sqlalchemy database")
         sys.exit(1)
 
-    @app.teardown_appcontext
-    def shutdown_session(exception=None):
-        Database.db_session.remove()
+    app.teardown_appcontext(shutdown_session)
 
     return app


### PR DESCRIPTION
This is a follow-on to PR #3170, where, as a reviewer, [I was ~tricked~confused](https://github.com/distributed-system-analysis/pbench/pull/3170#discussion_r1086910380) by the use of a function decorator for an inner function.  This change replaces that usage with a simple declaration and call.