### PR TITLE
Filter datasets by metadata

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1287,7 +1287,9 @@ class ApiBase(Resource):
         #    authenticated client.
         # 4) An authenticated client cannot mutate data owned by a different
         #    user, nor READ private data owned by another user.
-        if role == OperationCode.READ and (access == Dataset.PUBLIC_ACCESS or access is None):
+        if role == OperationCode.READ and (
+            access == Dataset.PUBLIC_ACCESS or access is None
+        ):
             # We are reading public data: this is always allowed.
             pass
         else:

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -1689,14 +1689,6 @@ class ApiBase(Resource):
 
         try:
             response = execute(params, request, {"auditing": auditing})
-            if auditing["finalize"]:
-                Audit.create(
-                    root=auditing["audit"],
-                    status=auditing["status"],
-                    reason=auditing["reason"],
-                    attributes=auditing["attributes"],
-                )
-            return response
         except APIInternalError as e:
             current_app.logger.exception("{} {}", api_name, e.details)
             abort(e.http_status, message=str(e))
@@ -1731,6 +1723,14 @@ class ApiBase(Resource):
                     attributes=attr,
                 )
             abort(x.http_status, message=x.message)
+        if auditing["finalize"]:
+            Audit.create(
+                root=auditing["audit"],
+                status=auditing["status"],
+                reason=auditing["reason"],
+                attributes=auditing["attributes"],
+            )
+        return response
 
     def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
         """Perform the requested GET operation, and handle any exceptions.

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -239,7 +239,11 @@ class DatasetsList(ApiBase):
                 else:
                     try:
                         c = getattr(Dataset, second)
-                        if c.type.python_type is str:
+                        try:
+                            is_str = c.type.python_type is str
+                        except NotImplementedError:
+                            is_str = False
+                        if is_str:
                             column = c
                         else:
                             column = cast(getattr(Dataset, second), String)

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -130,7 +130,7 @@ class DatasetsList(ApiBase):
     def filter_query(filters: list[str], query: Query) -> Query:
         """Provide Metadata filtering for datasets.
 
-        Add SQLAlchemy filters to fulfill the intend of a series of filter
+        Add SQLAlchemy filters to fulfill the intent of a series of filter
         expressions that want to match exactly or in part against a series of
         metadata keys.
 
@@ -174,7 +174,7 @@ class DatasetsList(ApiBase):
 
             "?filter=a.b:c,^b.c:d,^c.d:e"
         and
-            "?filter=a.b:c&filter=&b.c:d&filter:^c.d:e"
+            "?filter=a.b:c&filter=^b.c:d&filter:^c.d:e"
 
         result in identical filtering.
 

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -86,5 +86,8 @@ class Database:
             logger: A Python logger object
         """
         if logger.isEnabledFor(DEBUG):
-            q_str = query.statement.compile(compile_kwargs={"literal_binds": True})
-            logger.debug("QUERY {}", q_str)
+            try:
+                q_str = query.statement.compile(compile_kwargs={"literal_binds": True})
+                logger.debug("QUERY {}", q_str)
+            except Exception as e:
+                logger.debug("Can't compile query {}: {}", query, e)

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -736,9 +736,10 @@ class Metadata(Database.Base):
         return key.lower().split(".")[0]
 
     @staticmethod
-    def is_key_path(key: str, valid: List[str]) -> bool:
+    def is_key_path(key: str, valid: List[str], metalog_key_ok: bool = False) -> bool:
         """Determine whether 'key' is a valid Metadata key path using the list
-        specified in 'valid'.
+        specified in 'valid'. If the "native" key (first element of a dotted
+        path) is in the list, then it's valid.
 
         If the "native" key (first element of a dotted path) is in the list,
         then it's valid.
@@ -754,8 +755,10 @@ class Metadata(Database.Base):
         server version will return None rather than failing in validation.)
 
         Args:
-            key: metadata key path
-            valid: list of acceptable key paths
+            key : metadata key path
+            valid : list of acceptable key paths
+            metalog_key_ok : skip the key charset validation (used only for
+                a query, specifically to support weird metadata.log keys)
 
         Returns:
             True if the path is valid, or False
@@ -772,7 +775,7 @@ class Metadata(Database.Base):
         if path[0] not in valid:
             return False
         # Check that all open namespace keys are valid symbols
-        return bool(re.fullmatch(Metadata._valid_key_charset, k))
+        return metalog_key_ok or bool(re.fullmatch(Metadata._valid_key_charset, k))
 
     @staticmethod
     def getvalue(

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -385,8 +385,7 @@ class Dataset(Database.Base):
         try:
             dataset = Database.db_session.query(Dataset).filter_by(**kwargs).first()
         except SQLAlchemyError as e:
-            Dataset.logger.warning("Error querying {}: {}", kwargs, str(e))
-            raise DatasetSqlError("querying", **kwargs)
+            raise DatasetSqlError("querying", **kwargs) from e
 
         if dataset is None:
             raise DatasetNotFound(**kwargs)
@@ -444,10 +443,10 @@ class Dataset(Database.Base):
             Database.db_session.rollback()
             self.logger.warning("Duplicate dataset {}: {}", self.name, e)
             raise DatasetDuplicate(self.name) from None
-        except Exception:
+        except Exception as e:
             Database.db_session.rollback()
-            self.logger.exception("Can't add {} to DB", str(self))
-            raise DatasetSqlError("adding", name=self.name)
+            self.logger.error("Can't add {} to DB: {}", str(self), str(e))
+            raise DatasetSqlError("adding", name=self.name) from e
 
     def update(self):
         """Update the database row with the modified version of the Dataset
@@ -455,19 +454,20 @@ class Dataset(Database.Base):
         """
         try:
             Database.db_session.commit()
-        except Exception:
+        except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't update {} in DB", str(self))
-            raise DatasetSqlError("updating", name=self.name)
+            self.logger.error("Can't update {} in DB: {}", str(self), str(e))
+            raise DatasetSqlError("updating", name=self.name) from e
 
     def delete(self):
         """Delete the Dataset from the database."""
         try:
             Database.db_session.delete(self)
             Database.db_session.commit()
-        except Exception:
+        except Exception as e:
             Database.db_session.rollback()
-            raise
+            self.logger.error("Can't delete {} in DB: {}", str(self), str(e))
+            raise DatasetSqlError("updating", name=self.name) from e
 
 
 class OperationName(enum.Enum):
@@ -712,16 +712,9 @@ class Metadata(Database.Base):
         if type(dataset) is not Dataset:
             raise DatasetBadParameterType(dataset, Dataset)
 
-        try:
-            meta = Metadata(**kwargs)
-            meta.add(dataset)
-        except Exception:
-            Metadata.logger.exception(
-                "Failed create: {}>>{}", kwargs.get("dataset"), kwargs.get("key")
-            )
-            return None
-        else:
-            return meta
+        meta = Metadata(**kwargs)
+        meta.add(dataset)
+        return meta
 
     @staticmethod
     def get_native_key(key: str) -> str:
@@ -1018,7 +1011,7 @@ class Metadata(Database.Base):
         try:
             meta = __class__._query(dataset, key, user_id).first()
         except SQLAlchemyError as e:
-            Metadata.logger.exception("Can't get {}>>{} from DB", dataset, key)
+            Metadata.logger.error("Can't get {}>>{} from DB: {}", dataset, key, str(e))
             raise MetadataSqlError("getting", dataset, key) from e
         else:
             if meta is None:
@@ -1040,7 +1033,9 @@ class Metadata(Database.Base):
             __class__._query(dataset, key, user_id).delete()
             Database.db_session.commit()
         except SQLAlchemyError as e:
-            Metadata.logger.exception("Can't remove {}>>{} from DB", dataset, key)
+            Metadata.logger.error(
+                "Can't remove {}>>{} from DB: {}", dataset, key, str(e)
+            )
             raise MetadataSqlError("deleting", dataset, key) from e
 
     def __str__(self) -> str:
@@ -1064,7 +1059,7 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.exception("Can't add {}>>{} to DB", dataset, self.key)
+            self.logger.error("Can't add {}>>{} to DB: {}", dataset, self.key, str(e))
             dataset.metadatas.remove(self)
             raise MetadataSqlError("adding", dataset, self.key) from e
 
@@ -1074,7 +1069,7 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.exception("Can't update {} in DB", self)
+            self.logger.error("Can't update {} in DB: {}", self, str(e))
             raise MetadataSqlError("updating", self.dataset, self.key) from e
 
     def delete(self):
@@ -1084,7 +1079,7 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.exception("Can't delete {} from DB", self)
+            self.logger.error("Can't delete {} from DB: {}", self, str(e))
             raise MetadataSqlError("deleting", self.dataset, self.key) from e
 
 

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -365,7 +365,10 @@ class TestList:
 
 
 class TestDelete:
-    @pytest.mark.dependency(depends=["list_none", "list_all", "index"], scope="session")
+    @pytest.mark.dependency(
+        depends=["list_none", "list_all", "list_and", "list_or", "index"],
+        scope="session",
+    )
     def test_delete_all(self, server_client: PbenchServerClient, login_user):
         """Verify we can delete each previously uploaded dataset.
 

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -296,7 +296,7 @@ class TestList:
         """
         fio_names = {Dataset.stem(t) for t in TARBALL_DIR.glob("*fio*.tar.xz")}
         linpack_names = {Dataset.stem(t) for t in TARBALL_DIR.glob("*linpack*.tar.xz")}
-        expected = fio_names + linpack_names
+        expected = fio_names | linpack_names
         datasets = server_client.get_list(
             metadata=["dataset.metalog.pbench.name"],
             owner="tester",

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -334,7 +334,7 @@ class TestList:
             filter=[
                 "dataset.metalog.pbench.date:~2018",
                 "dataset.access:public",
-            ]
+            ],
         )
 
         for dataset in datasets:
@@ -358,14 +358,16 @@ class TestList:
                 "dataset.access:public",
                 "^dataset.metalog.pbench.date:~2018",
                 "^dataset.metalog.pbench.date:~2019",
-            ]
+            ],
         )
 
         for dataset in datasets:
             date = dataset.metadata["dataset.metalog.pbench.date"]
             access = dataset.metadata["dataset.access"]
             assert access == "public", f"Dataset {dataset.name} access is {access}"
-            assert "2018" in date or "2019" in date, f"Dataset {dataset.name} date is {date}"
+            assert (
+                "2018" in date or "2019" in date
+            ), f"Dataset {dataset.name} date is {date}"
 
 
 class TestDelete:

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -24,17 +24,10 @@ class Tarball:
 
 
 class TestPut:
-    """These tests depend on the order of their definition to execute properly.
+    """Test success and failure cases of PUT dataset upload"""
 
-    That is, `test_index_all` assumes that all the tar balls in the
-    `TARBALL_DIR` were uploaded successfully by `test_upload_all`, and that it
-    is run before `test_delete` (otherwise it won't find any data sets to
-    verify were indexed). In turn, `test_delete` expects to be run after
-    `test_upload_all` in order to find the data sets to be deleted.
-    """
-
-    @staticmethod
-    def test_upload_all(server_client: PbenchServerClient, login_user):
+    @pytest.mark.dependency(name="upload", scope="session")
+    def test_upload_all(self, server_client: PbenchServerClient, login_user):
         """Upload each of the pregenerated tarballs, and perform some basic
         sanity checks on the resulting server state.
         """
@@ -58,8 +51,8 @@ class TestPut:
             response = server_client.upload(t, access=a, metadata=metadata)
             assert (
                 response.status_code == HTTPStatus.CREATED
-            ), f"upload returned unexpected status {response.status_code}, {response.text}"
-            print(f"Uploaded {t.name}")
+            ), f"upload returned unexpected status {response.status_code}, {response.text} ({t})"
+            print(f"\t... uploaded {t.name}")
 
         datasets = server_client.get_list(
             metadata=["dataset.access", "server.tarball-path", "dataset.operations"]
@@ -81,8 +74,8 @@ class TestPut:
                 f" code = {exc.response.status_code}, text = {exc.response.text!r}"
             )
 
-    @staticmethod
-    def test_upload_again(server_client: PbenchServerClient, login_user):
+    @pytest.mark.dependency(depends=["upload"], scope="session")
+    def test_upload_again(self, server_client: PbenchServerClient, login_user):
         """Try to upload a dataset we've already uploaded. This should succeed
         but with an OK (200) response instead of CREATED (201)
         """
@@ -187,13 +180,10 @@ class TestPut:
             )
         return not_indexed, indexed
 
-    @staticmethod
-    def test_index_all(server_client: PbenchServerClient, login_user):
+    @pytest.mark.dependency(name="index", depends=["upload"], scope="session")
+    def test_index_all(self, server_client: PbenchServerClient, login_user):
         """Wait for datasets to reach the "Indexed" state, and ensure that the
         state and metadata look good.
-
-        Requires that test_upload_all has been run successfully, and that
-        test_delete has NOT been run yet.
         """
         tarball_names = frozenset(t.name for t in TARBALL_DIR.glob("*.tar.xz"))
 
@@ -259,7 +249,7 @@ class TestPut:
                 if os.path.basename(tp) not in tarball_names:
                     continue
                 count += 1
-                print(f"    Indexed {tp}")
+                print(f"\t... indexed {tp}")
             now = datetime.utcnow()
             if not not_indexed or now >= timeout:
                 break
@@ -274,8 +264,113 @@ class TestPut:
             len(tarball_names) == count
         ), f"Didn't find all expected datasets, found {count} of {len(tarball_names)}"
 
-    @staticmethod
-    def test_delete_all(server_client: PbenchServerClient, login_user):
+
+class TestList:
+    @pytest.mark.dependency(name="list_none", depends=["upload"], scope="session")
+    def test_list_anonymous(self, server_client: PbenchServerClient):
+        """List all datasets without a login.
+
+        We should see only published datasets. We don't care whether there are
+        pre-existing datasets in this case: we'll simply confirm that every one
+        we see is public. We do care that we don't get an empty list, since we
+        uploaded datasets with access public."""
+        datasets = server_client.get_list(metadata=["dataset.access"])
+        count = 0
+
+        for dataset in datasets:
+            assert dataset.metadata["dataset.access"] == "public"
+            count += 1
+
+        assert count > 1
+
+    @pytest.mark.dependency(name="list_all", depends=["upload"], scope="session")
+    def test_list_filter_or(self, server_client: PbenchServerClient, login_user):
+        """Check a simple OR filter list.
+
+        Authorized as our "tester" user, we can see all the datasets we've
+        uploaded. Try a filtered list choosing datasets run with the "fio"
+        script OR the "linpack" script. Only those datasets should appear: we
+        check the list against a glob of our upload source directory."""
+        fio_names = {Dataset.stem(t) for t in TARBALL_DIR.glob("*fio*.tar.xz")}
+        linpack_names = {Dataset.stem(t) for t in TARBALL_DIR.glob("*linpack*.tar.xz")}
+        datasets = server_client.get_list(
+            metadata=["dataset.metalog.pbench.name"],
+            owner="tester",
+            filter=[
+                "^dataset.metalog.pbench.script:fio",
+                "^dataset.metalog.pbench.script:linpack",
+            ],
+        )
+
+        for dataset in datasets:
+            name = dataset.metadata["dataset.metalog.pbench.name"]
+            if name in fio_names:
+                fio_names.remove(name)
+            elif name in linpack_names:
+                linpack_names.remove(name)
+            else:
+                pytest.fail(
+                    f"Dataset {name} should not have been returned by the filtered query"
+                )
+
+        assert len(fio_names) == 0
+        assert len(linpack_names) == 0
+
+    @pytest.mark.dependency(name="list_all", depends=["upload"], scope="session")
+    def test_list_filter_and(self, server_client: PbenchServerClient, login_user):
+        """Check a simple AND filter list.
+
+        Authorized as our "tester" user, we can see all the datasets we've
+        uploaded. Try a filtered list choosing datasets which are public AND
+        were created in 2018.
+
+        NOTE: the original "owner", "access", "start", "end", and "name"
+        filters are supported and implicitly linked as AND; their matching is
+        also more "friendly" in some cases, e.g., being case-insensitive. In
+        this case we're using "dataset.access"."""
+        datasets = server_client.get_list(
+            metadata=["dataset.metalog.pbench.date", "dataset.access"],
+            owner="tester",
+            filter=[
+                "dataset.metalog.pbench.date:~2018",
+                "dataset.access:public",
+            ]
+        )
+
+        for dataset in datasets:
+            date = dataset.metadata["dataset.metalog.pbench.date"]
+            access = dataset.metadata["dataset.access"]
+            assert access == "public", f"Dataset {dataset.name} access is {access}"
+            assert "2018" in date, f"Dataset {dataset.name} date is {date}"
+
+    @pytest.mark.dependency(name="list_all", depends=["upload"], scope="session")
+    def test_list_filter_and_or(self, server_client: PbenchServerClient, login_user):
+        """Check a simple AND-OR filter list.
+
+        Authorized as our "tester" user, we can see all the datasets we've
+        uploaded. Try a filtered list choosing datasets which are public AND
+        created in either 2018 or 2019.
+        """
+        datasets = server_client.get_list(
+            metadata=["dataset.metalog.pbench.date", "dataset.access"],
+            owner="tester",
+            filter=[
+                "dataset.access:public",
+                "^dataset.metalog.pbench.date:~2018",
+                "^dataset.metalog.pbench.date:~2019",
+            ]
+        )
+
+        for dataset in datasets:
+            date = dataset.metadata["dataset.metalog.pbench.date"]
+            access = dataset.metadata["dataset.access"]
+            assert access == "public", f"Dataset {dataset.name} access is {access}"
+            assert "2018" in date or "2019" in date, f"Dataset {dataset.name} date is {date}"
+
+
+class TestDelete:
+    @pytest.mark.dependency(depends=["list_none", "list_all", "index"], scope="session")
+    def test_delete_all(self, server_client: PbenchServerClient, login_user):
         """Verify we can delete each previously uploaded dataset.
 
         Requires that test_upload_all has been run successfully.
@@ -299,4 +394,4 @@ class TestPut:
             assert (
                 response.ok
             ), f"delete failed with {response.status_code}, {response.text}"
-            print(f"Deleted {t.name}")
+            print(f"\t ... deleted {t.name}")

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -324,10 +324,9 @@ def attach_dataset(create_drb_user, create_user):
 
     The resulting datasets are:
 
-        Owner   Access  Uploaded    Name
-        ------- ------- ----------  ----
-        drb     private 2022-01-01  drb
-        test    private 1970-01-01  test
+        Name     Owner Access   Uploaded
+        drb          3 private  2022-01-01:00:00
+        test        20 private  1970-01-01:00:42
 
     Args:
         create_drb_user: create a "drb" user
@@ -368,16 +367,15 @@ def more_datasets(
 
     In combination with attach_dataset, the resulting datasets are:
 
-        Owner   Access  Uploaded    Name
-        ------- ------- ----------  ----
-        drb     private 2022-01-01  drb
-        test    private 1970-01-01  test
-        drb     public  1978-06-26  fio_1
-        test    public  2022-01-01  fio_2
-        test    private 1978-06-26  uperf_1
-        test    private 1978-06-26  uperf_2
-        test    private 1978-06-26  uperf_3
-        test    private 1978-06-26  uperf_4
+        Name     Owner Access   Uploaded
+        drb          3 private  2022-01-01:00:00
+        test        20 private  1970-01-01:00:42
+        fio_1        3 public   1978-06-26:08:00
+        fio_2       20 public   2022-01-01:00:00
+        uperf_1     20 private  1978-06-26:08:00
+        uperf_2     20 private  1978-06-26:08:00
+        uperf_3     20 private  1978-06-26:08:00
+        uperf_4     20 private  1978-06-26:08:00
 
     Args:
         client: Provide a Flask API client

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -341,7 +341,12 @@ class TestDatasetsList:
             ),
         ],
     )
-    def test_filter_query(self, monkeypatch, filters, expected):
+    def test_filter_query(self, monkeypatch, db_session, filters, expected):
+        """Test generation of Metadata value filters
+
+        Use the filter_query method directly to verify SQL generation from sets
+        of metadata filter expressions.
+        """
         monkeypatch.setattr(
             "pbench.server.api.resources.datasets_list.Auth.get_current_user_id",
             lambda: DRB_USER_ID,
@@ -363,7 +368,12 @@ class TestDatasetsList:
             == prefix + expected
         )
 
-    def test_user_no_auth(self, monkeypatch):
+    def test_user_no_auth(self, monkeypatch, db_session):
+        """Test errors in generation of Metadata value filters
+
+        Use the filter_query method directly to verify error paths in SQL
+        filter generation from sets of metadata filter expressions.
+        """
         monkeypatch.setattr(
             "pbench.server.api.resources.datasets_list.Auth.get_current_user_id",
             lambda: None,

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -177,9 +177,9 @@ class TestDatasetsList:
             ),
             ("drb", {"end": "1970-09-01"}, []),
             ("drb", {"filter": "dataset.access:public"}, ["fio_1", "fio_2"]),
-            ("drb", {"filter": "dataset.name:~fio"}, ["fio_1", "fio_2"]),
+            ("drb", {"filter": "dataset.name:fio_1"}, ["fio_1"]),
             ("drb", {"filter": "^dataset.name:~fio,^dataset.name:uperf_1"}, ["fio_1", "fio_2", "uperf_1"]),
-            ("drb", {"filter": "^dataset.name:~fio,^dataset.name:uperf_1,dataset.owner_id:3"}, ["fio_2", "uperf_1"]),
+            ("drb", {"filter": "^dataset.name:~fio,^dataset.name:uperf_1,dataset.owner_id:3"}, ["fio_1"]),
         ],
     )
     def test_dataset_list(self, query_as, login, query, results, server_config):
@@ -205,7 +205,7 @@ class TestDatasetsList:
             (
                 "test",
                 {},
-                ["test", "fio_1", "fio_2", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
+                ["test", "fio_1", "fio_2", "uperf_1", "uperf_2"],
             ),
         ],
     )

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -133,6 +133,8 @@ class TestDatasetsList:
     @pytest.mark.parametrize(
         "login,query,results",
         [
+            (None, {}, ["fio_1", "fio_2"]),
+            (None, {"access": "public"}, ["fio_1", "fio_2"]),
             ("drb", {"name": "fio"}, ["fio_1", "fio_2"]),
             ("drb", {"name": "fio", "limit": 1}, ["fio_1", "fio_2"]),
             ("drb", {"name": "fio", "limit": 1, "offset": 2}, ["fio_1", "fio_2"]),
@@ -174,6 +176,10 @@ class TestDatasetsList:
                 ["test", "fio_1", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
             ),
             ("drb", {"end": "1970-09-01"}, []),
+            ("drb", {"filter": "dataset.access:public"}, ["fio_1", "fio_2"]),
+            ("drb", {"filter": "dataset.name:~fio"}, ["fio_1", "fio_2"]),
+            ("drb", {"filter": "^dataset.name:~fio,^dataset.name:uperf_1"}, ["fio_1", "fio_2", "uperf_1"]),
+            ("drb", {"filter": "^dataset.name:~fio,^dataset.name:uperf_1,dataset.owner_id:3"}, ["fio_2", "uperf_1"]),
         ],
     )
     def test_dataset_list(self, query_as, login, query, results, server_config):

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -7,6 +7,7 @@ pytest-cov>=2.7.1
 pytest-freezegun
 pytest-helpers-namespace==2019.1.8
 pytest-mock
+pytest-dependency  # functional tests
 pytest-xdist
 requests_mock
 responses


### PR DESCRIPTION
PBENCH-825

Create the new query parameter `?filter` on `/datasets/list` to allow the query to filter on the basis of arbitrary `Metadata` key values. This code experimentally allows a combination of _AND_ and _OR_ as well as exact string and "contains" matches, using symbols in the filter value.

E.g., to find all "fio" runs from 2018, you could do the following. `:fio` is an exact value match on "fio" while `:~2018` requires that the string "2018" appear within the value:

 `?filter=dataset.metalog.pbench.script:fio,dataset.metalog.date:~2018`

(We have the `start` and `end` keywords, which provide more exact timestamp matches, but you get the idea.)

Or, to find all datasets that have been favorited by the current user _or_ marked "seen" by the owner (should someone want to to this), the `^` character provides _or_ linkage to consecutively designated values:

 `?filter=^user.dashboard.favorite:true,^global.dashboard.seen:false`

Or to find datasets that the authorized user has favorited, with a dataset _name_ containing either "webb" or "dave":

 `?filter=user.dashboard.favorite:true,^dataset.name:~dave,^dataset.name:~webb`

__NOTE__

This also introduces functional tests for filtered `/datasets/list`, which rely on the `pytest-dependencies` package to ensure we run in the proper sequence. (The one thing I _don't_ like here is that, because I need to push `delete` after `list`, and eventually after other tests, it won't happen if those tests fail. We may want to consider re-writing the delete test as a `pytest` cleanup action so it happens at the end even if intermediate tests fail... but I leave that as an exercise for some reader...)