### PR TITLE
Rework how we name Server container images

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -46,12 +46,13 @@ pipeline {
             environment {
                 KEYCLOAK_CLIENT_SECRET=credentials('5cf0304d-8a00-48a4-ade5-9f59cb37ba68')
                 PB_SERVER_IMAGE_TAG="${PB_IMAGE_TAG}"
+                PB_SERVER_IMAGE_PREFIX="${PB_CI_REGISTRY}/${PB_ORG_NAME}"
                 RPM_PATH="${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm"
             }
             steps {
                 sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'
                 sh 'bash -ex ./server/pbenchinacan/container-build.sh'
-                sh 'buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG} ${PB_CI_REGISTRY}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
+                sh 'buildah push ${PB_SERVER_IMAGE_PREFIX}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
             }
         }
         stage('Build the Pbench Agent Containers') {

--- a/jenkins/runlocal
+++ b/jenkins/runlocal
@@ -1,18 +1,18 @@
 #!/bin/bash -e
 
 # Build the RPM and then build the containers, pushing only the CI image
-# to the registry, and then run the fuctional tests against the built
+# to the registry, and then run the functional tests against the built
 # container image.
 
 export PB_CONTAINER_REG=images.paas.redhat.com
-export PB_ORG_NAME=pbench
+export PB_SERVER_IMAGE_PREFIX=${PB_CONTAINER_REG}/pbench
 export PB_SERVER_IMAGE_NAME=pbench-server
 export PB_SERVER_IMAGE_TAG=${USER}
 export PB_DASHBOARD_DIR=$(pwd)/dashboard/build
 
 make -C server/rpm clean rpm
 
-# Typically, one logs in to a container registery with automated scripts using
+# Typically, one logs in to a container registry with automated scripts using
 # an "application" token.  When using quay.io based container registries, the
 # application token uses the user name `$app` and the token is provided as the
 # password.
@@ -24,6 +24,6 @@ make -C server/rpm clean rpm
 # $ buildah login -u='$app' -p="${__LOGIN_SECRET__}" ${PB_CONTAINER_REG}
 
 RPM_PATH=${HOME}/rpmbuild/RPMS/noarch/pbench-server-*.rpm bash -ex ./server/pbenchinacan/container-build.sh
-buildah push localhost/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG} ${PB_CONTAINER_REG}/${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}
+buildah push ${PB_SERVER_IMAGE_PREFIX}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}
 
 jenkins/run-server-func-tests

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -9,6 +9,7 @@
 
 BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
 PB_SERVER_IMAGE_NAME=${PB_SERVER_IMAGE_NAME:-"pbench-server"}
+PB_SERVER_IMAGE_PREFIX=${PB_SERVER_IMAGE_PREFIX:-"localhost"}
 PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
 RPM_PATH=${RPM_PATH:-/root/sandbox/rpmbuild/RPMS/noarch/pbench-server-*.rpm}
 KEYCLOAK_CLIENT_SECRET=${KEYCLOAK_CLIENT_SECRET:-"client-secret"}
@@ -99,4 +100,4 @@ buildah run $container cp /usr/share/nginx/html/404.html /usr/share/nginx/html/5
 buildah run $container chown --recursive pbench:pbench /srv/pbench
 
 # Create the container image
-buildah commit $container localhost/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}
+buildah commit $container ${PB_SERVER_IMAGE_PREFIX}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}


### PR DESCRIPTION
_NOTE:  This PR is an extension of #3214, and, until it is merged, the commit(s) from that branch will show up in this one._

This PR reworks some of how we refer to Pbench Server container images.  A container image name consists of three parts:  a registry name, a repository name, and an image tag; the repository is further subdivided in most of our registries to include an organization prefix and an image suffix.  Currently, when we push an image, we compose an image name from a registry, our organization, and the image suffix (plus a tag); however, when we build the image and store it locally, we use `localhost` instead of the remote registry and organization.  This dichotomy is not strictly necessary.

Instead, this PR changes our usage to always name an image using the remote (target) registry, the `pbench` organization, and the image suffix, *even when storing the image locally*.  This removes the dichotomy, and it allows a given image to have the same name regardless of where it is stored.  (This is not strange:  in a typical case, when one pulls an image from a remote registry, it appears in the local registry with the remote registry in its name; correspondingly, when building an image it is stored in the local registry, and it can be named using the remote registry, which allows it to be `push`'d using a single argument.)

This change introduces a new environment variable, `PB_SERVER_IMAGE_PREFIX`, which encompasses the registry and organization, used to name the Pbench Server image when it is built and which directs where it is pushed, by each of the Jenkins Pipeline and the `runlocal` script.  (Pulling/running images is unchanged -- it still uses the registry, organization, and image suffixes as components of the name.)