### PR TITLE
Remove the need for local logger in `auth` module

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -6,7 +6,7 @@ or any number of pbench agent users.
 
 import os
 
-from flask import current_app, Flask
+from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
 
@@ -55,9 +55,8 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
 
     base_uri = config.rest_uri
 
-    # Init the the authentication module
+    # Init the authentication module
     token_auth = Auth()
-    Auth.set_logger(current_app.logger)
     Auth.set_oidc_client(server_config=config)
 
     app.logger.info("Registering service endpoints with base URI {}", base_uri)

--- a/lib/pbench/test/unit/server/auth/conftest.py
+++ b/lib/pbench/test/unit/server/auth/conftest.py
@@ -14,7 +14,7 @@ def mock_get_oidc_public_key(oidc_client):
 
 
 @pytest.fixture
-def keycloak_oidc(server_config, make_logger, monkeypatch):
+def keycloak_oidc(server_config, monkeypatch):
     monkeypatch.setattr(
         OpenIDClient, "set_well_known_endpoints", mock_set_oidc_auth_endpoints
     )
@@ -23,7 +23,6 @@ def keycloak_oidc(server_config, make_logger, monkeypatch):
         server_url=server_config.get("authentication", "server_url"),
         realm_name="public_test_realm",
         client_id="test_client",
-        logger=make_logger,
     )
     return oidc
 

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -1,5 +1,6 @@
 import datetime
 
+from flask import Flask
 import jwt
 from jwt.exceptions import (
     ExpiredSignatureError,
@@ -134,12 +135,14 @@ class TestUserTokenManagement:
         monkeypatch.setattr(
             OpenIDClient, "token_introspect_online", fake_online_token_introspection
         )
-        Auth.set_logger(logger=make_logger)
-        token_payload = Auth.verify_third_party_token(
-            auth_token="",
-            algorithms=["HS256"],
-            oidc_client=keycloak_oidc,
-        )
+        app = Flask("test-verify-third-party-token")
+        app.logger = make_logger
+        with app.app_context():
+            token_payload = Auth.verify_third_party_token(
+                auth_token="",
+                algorithms=["HS256"],
+                oidc_client=keycloak_oidc,
+            )
         assert token_payload == InternalUser(
             id="12345",
             username="username",

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -130,7 +130,6 @@ def server_config(on_disk_server_config) -> PbenchServerConfig:
 @pytest.fixture()
 def set_oidc_well_known_endpoints(monkeypatch):
     def fake_well_known(oidc_client):
-
         oidc_client.USERINFO_ENDPOINT = "https://oidc_userinfo_endpoint.example.com"
         oidc_client.TOKENINFO_ENDPOINT = "https://oidc_token_introspection.example.com"
         oidc_client.JWKS_URI = "https://oidc_jwks_endpoint.example.com"

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -88,9 +88,8 @@ class TestApiBase:
         app.testing = True
         app.logger = make_logger
 
-        token_auth = Auth()
-        token_auth.set_logger(app.logger)
-        Auth.set_oidc_client(server_config=server_config)
+        with app.app_context():
+            Auth.set_oidc_client(server_config=server_config)
 
         # Mimic our normal use of ApiBase with our sub-classed instances.
         api = Api(app)


### PR DESCRIPTION
Use the logger from `current_app` when necessary.

Also, remove use of a logger in `Auth.get_secret_key()` and rename since it is only used in this module.

----

Covers first 5 commits in PR #3114:

 1. https://github.com/distributed-system-analysis/pbench/pull/3114/commits/87a15ec549fffa0ca9f4ed05bcb4f14ef252b199
 2. https://github.com/distributed-system-analysis/pbench/pull/3114/commits/1fbc229b4c524f44fc4cec65437e637e5229a6c0
 3. https://github.com/distributed-system-analysis/pbench/pull/3114/commits/5440984e393236c9eed1b48f52a26b0e8a23f995
 4. https://github.com/distributed-system-analysis/pbench/pull/3114/commits/518ee268265ce7f1a16757f1b0f23b9d86e71fad
 5. https://github.com/distributed-system-analysis/pbench/pull/3114/commits/652a9658fbd3790f6fd7a4fd5593222b6fbdeb8c