### PR TITLE
Address problems with our `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,21 +8,21 @@
 # exclude prevents those checks being run.
 exclude: (agent/bench-scripts/test-bin/fio-histo-log-pctiles\.py|web-server/v0\.3/demo\.py)
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         name: flake8 (python3)
         language_version: python3
   - repo: https://github.com/python/black.git
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
         name: black (python3)
         language_version: python3
         args: ["--check"]
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python3)

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,3 +1,3 @@
-black==22.3.0
-flake8==4.0.1
-isort==5.10.1
+black==22.12.0
+flake8==6.0.0
+isort==5.12.0


### PR DESCRIPTION
Suggested commit message to use:

----

    First, the reference to `gitlab.com` for `flake8` was incorrect.  It has
    been corrected to `github.com`.

    If one starts using a different python interpreter (for example, if you
    upgrade your linux distribution and that upgrade defaults to a new
    version) then your previous pre-commit setup will need to be re-
    installed.

    Because of the `gitlab.com` reference that was not possible.

    The second change is to bump the versions of all the pre-commit programs
    used, `black`, `flake8`, and `isort`, to their latest versions.  It is
    unfortunate but the existing versions we are using don't work with newer
    versions of the Python 3, in particular, Python 3.11, but they do work
    with Python 3.9 and later.