### PR TITLE
Drop controller from PUT agent side

### DIFF
--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -1,9 +1,8 @@
 +++ Running test-24 pbench-results-push --help
-Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
+Usage: pbench-results-push [OPTIONS] RESULT_TB_NAME
 
   Push a result tar ball to the configured Pbench server.
 
-  CONTROLLER is the name of the controlling node.
   RESULT_TB_NAME is the path to the result tar ball.
 
 Options:

--- a/agent/util-scripts/gold/pbench-results-push/test-36.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-36.txt
@@ -1,8 +1,8 @@
 +++ Running test-36 pbench-results-push 
-Usage: pbench-results-push [OPTIONS] CONTROLLER RESULT_TB_NAME
+Usage: pbench-results-push [OPTIONS] RESULT_TB_NAME
 Try 'pbench-results-push --help' for help.
 
-Error: Missing argument 'CONTROLLER'.
+Error: Missing argument 'RESULT_TB_NAME'.
 --- Finished test-36 pbench-results-push (status=2)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -286,7 +286,6 @@ class CopyResultTb:
 
     def __init__(
         self,
-        controller: str,
         tarball: str,
         tarball_len: int,
         tarball_md5: str,
@@ -296,12 +295,8 @@ class CopyResultTb:
         """Constructor for object representing tar ball to be copied remotely.
 
         Raises
-            ValueError          if the given controller is not a valid hostname
             FileNotFoundError   if the given tar ball does not exist
         """
-        if validate_hostname(controller) != 0:
-            raise ValueError(f"Controller {controller!r} is not a valid host name")
-        self.controller = controller
         self.tarball = Path(tarball)
         if not self.tarball.exists():
             raise FileNotFoundError(f"Tar ball '{self.tarball}' does not exist")
@@ -333,7 +328,6 @@ class CopyResultTb:
         headers = {
             "Content-MD5": self.tarball_md5,
             "Authorization": f"Bearer {token}",
-            "controller": self.controller,
         }
         with self.tarball.open("rb") as f:
             try:

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -129,7 +129,8 @@ class MakeResultTb:
             )
         return msg
 
-    def verify_metadata(self, pbench_run_name):
+    def verify_metadata(self, pbench_run_name: str):
+        """Verifies and Updates Metadata in metadata.log file"""
         mdlog_name = self.result_dir / "metadata.log"
         mdlog = MetadataLog()
         try:
@@ -200,10 +201,7 @@ class MakeResultTb:
                                or verifying the created tar ball
         """
         pbench_run_name = self.result_dir.name
-        try:
-            self.verify_metadata(pbench_run_name)
-        except Exception:
-            raise
+        self.verify_metadata(pbench_run_name)
 
         tarball = self.target_dir / f"{pbench_run_name}.tar.xz"
         e_file = self.target_dir / f"{pbench_run_name}.tar.err"

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -97,7 +97,6 @@ class MoveResults(BaseCommand):
 
                 try:
                     crt = CopyResultTb(
-                        self.context.controller,
                         result_tb_name,
                         result_tb_len,
                         result_tb_md5,

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -17,7 +17,6 @@ class ResultsPush(BaseCommand):
     def execute(self) -> int:
         tarball_len, tarball_md5 = md5sum(self.context.result_tb_name)
         crt = CopyResultTb(
-            self.context.controller,
             self.context.result_tb_name,
             tarball_len,
             tarball_md5,
@@ -32,7 +31,6 @@ class ResultsPush(BaseCommand):
 @click.command(name="pbench-results-push")
 @common_options
 @results_common_options
-@click.argument("controller")
 @click.argument(
     "result_tb_name",
     type=click.Path(
@@ -47,7 +45,6 @@ class ResultsPush(BaseCommand):
 @pass_cli_context
 def main(
     context: CliContext,
-    controller: str,
     result_tb_name: str,
     token: str,
     access: str,
@@ -55,14 +52,12 @@ def main(
     """Push a result tar ball to the configured Pbench server.
 
     \b
-    CONTROLLER is the name of the controlling node.
     RESULT_TB_NAME is the path to the result tar ball.
     \f
     (This docstring will be printed as the help text for this command;
     the backslash-escaped letters are formatting directives; this
     parenthetical text will not appear in the help output.)
     """
-    context.controller = controller
     context.result_tb_name = result_tb_name
     context.token = token
     context.access = access

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -22,14 +22,6 @@ class TestCopyResults:
         self.config = None
 
     @staticmethod
-    def get_path_exists_mock(path: str, result: bool) -> Callable:
-        def mock_func(self: Path) -> bool:
-            assert self.name == path
-            return result
-
-        return mock_func
-
-    @staticmethod
     def get_path_open_mock(path: str, result: io.IOBase) -> Callable:
         def mock_func(self: Path, mode: str) -> io.IOBase:
             assert self.name == path
@@ -42,9 +34,7 @@ class TestCopyResults:
         bad_tarball_name = "nonexistent-tarball.tar.xz"
         expected_error_message = f"Tar ball '{bad_tarball_name}' does not exist"
 
-        monkeypatch.setattr(
-            Path, "exists", self.get_path_exists_mock(bad_tarball_name, False)
-        )
+        monkeypatch.setattr(Path, "exists", lambda self: False)
 
         with pytest.raises(FileNotFoundError) as excinfo:
             CopyResultTb(
@@ -78,7 +68,7 @@ class TestCopyResults:
             callback=request_callback,
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -106,7 +96,7 @@ class TestCopyResults:
             responses.PUT, upload_url, body=requests.exceptions.ConnectionError("uh-oh")
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -120,7 +110,8 @@ class TestCopyResults:
                 agent_logger,
             )
             crt.copy_result_tb("token")
-        assert str(excinfo.value).endswith(
+
+        assert str(excinfo.value).startswith(
             expected_error_message
         ), f"expected='...{expected_error_message}', found='{str(excinfo.value)}'"
 
@@ -132,7 +123,7 @@ class TestCopyResults:
 
         responses.add(responses.PUT, upload_url, body=RuntimeError("uh-oh"))
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -37,25 +37,6 @@ class TestCopyResults:
 
         return mock_func
 
-    def test_controller_invalid(self, agent_logger):
-        """Test error when the controller value is invalid"""
-        bad_controller_name = "#invalid!"
-        expected_error_message = (
-            f"Controller {bad_controller_name!r} is not a valid host name"
-        )
-        with pytest.raises(ValueError) as excinfo:
-            CopyResultTb(
-                bad_controller_name,
-                "tarball",
-                0,
-                "ignoremd5",
-                self.config,
-                agent_logger,
-            )
-        assert str(excinfo.value).endswith(
-            expected_error_message
-        ), f"expected='...{expected_error_message}', found='{str(excinfo.value)}'"
-
     def test_tarball_nonexistent(self, monkeypatch, agent_logger):
         """Test error when the tarball file does not exist"""
         bad_tarball_name = "nonexistent-tarball.tar.xz"
@@ -67,7 +48,6 @@ class TestCopyResults:
 
         with pytest.raises(FileNotFoundError) as excinfo:
             CopyResultTb(
-                "controller",
                 bad_tarball_name,
                 0,
                 "ignoremd5",
@@ -104,7 +84,6 @@ class TestCopyResults:
         )
 
         crt = CopyResultTb(
-            "controller",
             tb_name,
             len(tb_contents),
             "someMD5",
@@ -134,7 +113,6 @@ class TestCopyResults:
 
         with pytest.raises(RuntimeError) as excinfo:
             crt = CopyResultTb(
-                "controller",
                 tb_name,
                 len(tb_contents),
                 "someMD5",
@@ -161,7 +139,6 @@ class TestCopyResults:
 
         with pytest.raises(CopyResultTb.FileUploadError) as excinfo:
             crt = CopyResultTb(
-                "controller",
                 tb_name,
                 len(tb_contents),
                 "someMD5",

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -22,6 +22,14 @@ class TestCopyResults:
         self.config = None
 
     @staticmethod
+    def get_path_exists_mock(path: str, result: bool) -> Callable:
+        def mock_func(self: Path) -> bool:
+            assert self.name == path
+            return result
+
+        return mock_func
+
+    @staticmethod
     def get_path_open_mock(path: str, result: io.IOBase) -> Callable:
         def mock_func(self: Path, mode: str) -> io.IOBase:
             assert self.name == path
@@ -68,7 +76,7 @@ class TestCopyResults:
             callback=request_callback,
         )
 
-        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -96,7 +104,7 @@ class TestCopyResults:
             responses.PUT, upload_url, body=requests.exceptions.ConnectionError("uh-oh")
         )
 
-        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -123,7 +131,7 @@ class TestCopyResults:
 
         responses.add(responses.PUT, upload_url, body=RuntimeError("uh-oh"))
 
-        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -42,7 +42,9 @@ class TestCopyResults:
         bad_tarball_name = "nonexistent-tarball.tar.xz"
         expected_error_message = f"Tar ball '{bad_tarball_name}' does not exist"
 
-        monkeypatch.setattr(Path, "exists", lambda self: False)
+        monkeypatch.setattr(
+            Path, "exists", self.get_path_exists_mock(bad_tarball_name, False)
+        )
 
         with pytest.raises(FileNotFoundError) as excinfo:
             CopyResultTb(

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -12,7 +12,6 @@ from pbench.test.unit.agent.task.common import bad_tarball, tarball
 
 class TestResultsPush:
 
-    CTRL_TEXT = "controller.example.com"
     TOKN_SWITCH = "--token"
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
     ACCESS_SWITCH = "--access"

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -58,7 +58,6 @@ class TestResultsPush:
             args=[
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
-                TestResultsPush.CTRL_TEXT,
             ],
         )
         assert result.exit_code == 2
@@ -73,7 +72,6 @@ class TestResultsPush:
             args=[
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
-                TestResultsPush.CTRL_TEXT,
                 bad_tarball,
             ],
         )
@@ -95,7 +93,6 @@ class TestResultsPush:
             args=[
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
-                TestResultsPush.CTRL_TEXT,
                 tarball,
                 "extra-arg",
             ],
@@ -115,7 +112,6 @@ class TestResultsPush:
             args=[
                 TestResultsPush.TOKN_SWITCH,
                 TestResultsPush.TOKN_TEXT,
-                TestResultsPush.CTRL_TEXT,
                 TestResultsPush.ACCESS_SWITCH,
                 TestResultsPush.ACCESS_TEXT,
                 tarball,
@@ -131,7 +127,7 @@ class TestResultsPush:
 
         TestResultsPush.add_http_mock_response()
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 2, result.stderr
         assert "Missing option '--token'" in str(result.stderr)
 
@@ -144,7 +140,7 @@ class TestResultsPush:
         TestResultsPush.add_http_mock_response()
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 0, result.stderr
         assert result.stderr == "File uploaded successfully\n"
 
@@ -160,7 +156,6 @@ class TestResultsPush:
         result = runner.invoke(
             main,
             args=[
-                TestResultsPush.CTRL_TEXT,
                 tarball,
                 TestResultsPush.ACCESS_SWITCH,
                 TestResultsPush.ACCESS_WRONG_TEXT,
@@ -180,7 +175,7 @@ class TestResultsPush:
         TestResultsPush.add_connectionerr_mock_response()
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 1
         assert str(result.stderr).startswith("Cannot connect to")
 
@@ -193,7 +188,7 @@ class TestResultsPush:
         TestResultsPush.add_http_mock_response(HTTPStatus.NOT_FOUND)
         caplog.set_level(logging.DEBUG)
         runner = CliRunner(mix_stderr=False)
-        result = runner.invoke(main, args=[TestResultsPush.CTRL_TEXT, tarball])
+        result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 1
         assert (
             str(result.stderr).find("Not Found") > -1


### PR DESCRIPTION
Drop controller from PUT agent side

The server no longer relies on the controller
header to PUT, the agent should stop generating
and sending it.

Will be merged after #3193  #3194