### PR TITLE
Use symbolic constants for user IDs when creating users in tests. 

### DIFF
--- a/lib/pbench/test/unit/server/__init__.py
+++ b/lib/pbench/test/unit/server/__init__.py
@@ -1,3 +1,7 @@
 import pytest
 
 pytest.register_assert_rewrite("pbench.test.unit.server.query_apis.commons")
+
+ADMIN_USER_ID = "6"
+DRB_USER_ID = "3"
+TEST_USER_ID = "20"

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -29,6 +29,7 @@ from pbench.server.database.models.datasets import Dataset, Metadata, States
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
 from pbench.test import on_disk_config
+from pbench.test.unit.server import ADMIN_USER_ID, DRB_USER_ID, TEST_USER_ID
 from pbench.test.unit.server.headertypes import HeaderTypes
 
 server_cfg_tmpl = """[DEFAULT]
@@ -256,6 +257,7 @@ def create_user(client, fake_email_validator) -> User:
     """
     user = User(
         email="test@example.com",
+        id=TEST_USER_ID,
         password=generic_password,
         username="test",
         first_name="Test",
@@ -275,7 +277,7 @@ def create_admin_user(client, fake_email_validator) -> User:
     """
     user = User(
         email=admin_email,
-        id=6,
+        id=ADMIN_USER_ID,
         password=generic_password,
         username=admin_username,
         first_name="Admin",
@@ -296,7 +298,7 @@ def create_drb_user(client, fake_email_validator):
     """
     drb = User(
         email="drb@example.com",
-        id=3,
+        id=DRB_USER_ID,
         password=generic_password,
         username="drb",
         first_name="Authorized",

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -11,6 +11,7 @@ from pbench.server.database.models.datasets import (
     States,
 )
 from pbench.server.database.models.users import User
+from pbench.test.unit.server import DRB_USER_ID
 
 
 class TestDatasets:
@@ -46,12 +47,12 @@ class TestDatasets:
         assert ds.created is None
         assert ds.uploaded <= ds.transition
         assert ds.id is not None
-        assert "(1)|fio" == str(ds)
+        assert f"({user.id})|fio" == str(ds)
         assert ds.as_dict() == {
             "access": "private",
             "created": None,
             "name": "fio",
-            "owner_id": "1",
+            "owner_id": str(user.id),
             "state": "Uploading",
             "transition": "1970-01-01T00:00:00+00:00",
             "uploaded": "1970-01-01T00:00:00+00:00",
@@ -79,7 +80,7 @@ class TestDatasets:
             "access": "private",
             "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
-            "owner_id": "3",
+            "owner_id": DRB_USER_ID,
             "state": "Indexed",
             "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
@@ -162,7 +163,7 @@ class TestDatasets:
             "access": "private",
             "created": "2020-01-25T23:14:00+00:00",
             "name": "fio",
-            "owner_id": "1",
+            "owner_id": str(create_user.id),
             "state": "Uploaded",
             "transition": "2525-08-25T15:25:00+00:00",
             "uploaded": "2525-05-25T15:15:00+00:00",

--- a/lib/pbench/test/unit/server/query_apis/test_query_builder.py
+++ b/lib/pbench/test/unit/server/query_apis/test_query_builder.py
@@ -5,10 +5,7 @@ import pytest
 from pbench.server import JSON, OperationCode
 from pbench.server.api.resources import ApiMethod, ApiSchema
 from pbench.server.api.resources.query_apis import ElasticBase
-
-ADMIN_ID = "6"  # This needs to match the current_user_admin fixture
-SELF_ID = "3"  # This needs to match the current_user_drb fixture
-USER_ID = "20"  # This is arbitrary, but can't match either fixture
+from pbench.test.unit.server import ADMIN_USER_ID, DRB_USER_ID, TEST_USER_ID
 
 
 class TestQueryBuilder:
@@ -43,12 +40,12 @@ class TestQueryBuilder:
             (None, None),
             (None, "public"),
             (None, "private"),
-            (USER_ID, None),
-            (USER_ID, "private"),
-            (USER_ID, "public"),
-            (ADMIN_ID, None),
-            (ADMIN_ID, "private"),
-            (ADMIN_ID, "public"),
+            (TEST_USER_ID, None),
+            (TEST_USER_ID, "private"),
+            (TEST_USER_ID, "public"),
+            (ADMIN_USER_ID, None),
+            (ADMIN_USER_ID, "private"),
+            (ADMIN_USER_ID, "public"),
         ],
     )
     def test_admin(self, elasticbase, server_config, current_user_admin, user, access):
@@ -66,24 +63,24 @@ class TestQueryBuilder:
         "ask,expect",
         [
             ({"access": "public"}, {"access": "public"}),
-            ({"access": "private"}, {"user": SELF_ID, "access": "private"}),
-            ({"user": SELF_ID}, {"user": SELF_ID}),
-            ({"user": USER_ID}, {"user": USER_ID, "access": "public"}),
+            ({"access": "private"}, {"user": DRB_USER_ID, "access": "private"}),
+            ({"user": DRB_USER_ID}, {"user": DRB_USER_ID}),
+            ({"user": TEST_USER_ID}, {"user": TEST_USER_ID, "access": "public"}),
             (
-                {"user": USER_ID, "access": "private"},
-                {"user": USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "private"},
+                {"user": TEST_USER_ID, "access": "public"},
             ),
             (
-                {"user": SELF_ID, "access": "private"},
-                {"user": SELF_ID, "access": "private"},
+                {"user": DRB_USER_ID, "access": "private"},
+                {"user": DRB_USER_ID, "access": "private"},
             ),
             (
-                {"user": SELF_ID, "access": "public"},
-                {"user": SELF_ID, "access": "public"},
+                {"user": DRB_USER_ID, "access": "public"},
+                {"user": DRB_USER_ID, "access": "public"},
             ),
             (
-                {"user": USER_ID, "access": "public"},
-                {"user": USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "public"},
             ),
         ],
     )
@@ -107,14 +104,14 @@ class TestQueryBuilder:
             ({}, {"access": "public"}),
             ({"access": "public"}, {"access": "public"}),
             ({"access": "private"}, {"access": "public"}),
-            ({"user": USER_ID}, {"user": USER_ID, "access": "public"}),
+            ({"user": TEST_USER_ID}, {"user": TEST_USER_ID, "access": "public"}),
             (
-                {"user": USER_ID, "access": "public"},
-                {"user": USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "public"},
             ),
             (
-                {"user": USER_ID, "access": "private"},
-                {"user": USER_ID, "access": "public"},
+                {"user": TEST_USER_ID, "access": "private"},
+                {"user": TEST_USER_ID, "access": "public"},
             ),
         ],
     )


### PR DESCRIPTION
_[This PR is a follow-on to PR #3221.]_

The first commit replaces some literals with references to symbolic constants, and makes explicit the ID for the "other user" when it is created.

The second commit is a sequence of hopefully inconsequential changes to satisfy the Python linter.