### PR TITLE
Add a pipeline stage to clear out container images

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -108,5 +108,8 @@ pipeline {
                 zoomCoverageChart: false])
             sh 'rm -f cov/report.xml'
         }
+        always {
+            sh 'podman image ls --filter reference="*pbench-agent*" --filter reference="*pbench-server*" --format "{{.Id}}" --filter containers=false | sort -u | xargs podman image rm -f'
+        }
     }
 }


### PR DESCRIPTION
We are suffering an unsightly (but out of sight) build-up of container images which eventually fills the local storage and causes builds to fail.  This PR adds a pipeline stage which runs at the end of every build to remove any `*pbench-server*` and `*pbench-agent*` container images which don't have running containers associated with them.  This should remove any images built in the current run as well as similar images which weren't removed (for whatever reason) by previous runs, but it should leave behind images _used_ by the build (such as the container image used by `jenkins/run`, the images used to run the RPM builds, the images used as base images for building other images, and the images run in conjunction with the canned Pbench server).