### PR TITLE
Hide access to internal conf object

### DIFF
--- a/lib/pbench/__init__.py
+++ b/lib/pbench/__init__.py
@@ -20,23 +20,23 @@ class PbenchConfig:
         # Enumerate the list of files
         config_files = configtools.file_list(cfg_name)
         config_files.reverse()
-        self.conf = ConfigParser()
-        self.files = self.conf.read(config_files)
+        self._conf = ConfigParser()
+        self.files = self._conf.read(config_files)
 
         try:
-            self.logger_type = self.conf.get("logging", "logger_type")
+            self.logger_type = self._conf.get("logging", "logger_type")
         except (NoOptionError, NoSectionError):
             self.logger_type = "devlog"
         else:
             if self.logger_type == "hostport":
                 try:
-                    self.logger_host = self.conf.get("logging", "logger_host")
-                    self.logger_port = self.conf.get("logging", "logger_port")
+                    self.logger_host = self._conf.get("logging", "logger_host")
+                    self.logger_port = self._conf.get("logging", "logger_port")
                 except (NoOptionError) as exc:
                     raise BadConfig(str(exc))
 
         try:
-            self.log_dir = self.conf.get("logging", "log_dir")
+            self.log_dir = self._conf.get("logging", "log_dir")
         except (NoOptionError, NoSectionError):
             # Allow for compatibility with previous configuration files.  Any
             # sub-class of this base class can change the log directory as
@@ -52,14 +52,14 @@ class PbenchConfig:
         self.log_using_caller_directory = False
 
         try:
-            self.default_logging_level = self.conf.get("logging", "logging_level")
+            self.default_logging_level = self._conf.get("logging", "logging_level")
         except (NoOptionError, NoSectionError):
             self.default_logging_level = "INFO"
 
         try:
             # We don't document the "log_format" parameter since it is really
             # only present to facilitate easier unit testing.
-            self.log_fmt = self.conf.get("logging", "log_format")
+            self.log_fmt = self._conf.get("logging", "log_format")
         except (NoOptionError, NoSectionError):
             self.log_fmt = None
 
@@ -69,4 +69,7 @@ class PbenchConfig:
         self.TZ = "UTC"
 
     def get(self, *args, **kwargs):
-        return self.conf.get(*args, **kwargs)
+        return self._conf.get(*args, **kwargs)
+
+    def getint(self, *args, **kwargs):
+        return self._conf.getint(*args, **kwargs)

--- a/lib/pbench/agent/__init__.py
+++ b/lib/pbench/agent/__init__.py
@@ -21,24 +21,24 @@ class PbenchAgentConfig(PbenchConfig):
 
         try:
             # Provide a few convenience attributes.
-            self.agent = self.conf["pbench-agent"]
-            self.results = self.conf["results"]
+            self.agent = self._conf["pbench-agent"]
+            self.results = self._conf["results"]
             # Now fetch some default common pbench settings that are required.
             self.pbench_run = Path(
-                self.conf.get(
+                self.get(
                     "pbench-agent", "pbench_run", fallback=DEFAULT_PBENCH_AGENT_RUN_DIR
                 )
             )
             self.pbench_tmp = self.pbench_run / "tmp"
             self.pbench_log = Path(
-                self.conf.get(
+                self.get(
                     "pbench-agent",
                     "pbench_log",
                     fallback=str(self.pbench_run / "pbench.log"),
                 )
             )
             self.pbench_install_dir = Path(
-                self.conf.get(
+                self.get(
                     "pbench-agent",
                     "install-dir",
                     fallback=DEFAULT_PBENCH_AGENT_INSTALL_DIR,
@@ -69,28 +69,24 @@ class PbenchAgentConfig(PbenchConfig):
             self.log_dir = str(self.pbench_log.parent)
 
         try:
-            self.ssh_opts = self.conf.get(
-                "results", "ssh_opts", fallback=DEFAULT_SSH_OPTS
-            )
+            self.ssh_opts = self.get("results", "ssh_opts", fallback=DEFAULT_SSH_OPTS)
         except (NoOptionError, NoSectionError):
             self.ssh_opts = DEFAULT_SSH_OPTS
 
         try:
-            self.scp_opts = self.conf.get(
-                "results", "scp_opts", fallback=DEFAULT_SCP_OPTS
-            )
+            self.scp_opts = self.get("results", "scp_opts", fallback=DEFAULT_SCP_OPTS)
         except (NoOptionError, NoSectionError):
             self.scp_opts = DEFAULT_SCP_OPTS
 
         try:
-            self._unittests = self.conf.get("pbench-agent", "debug_unittest")
+            self._unittests = self.get("pbench-agent", "debug_unittest")
         except Exception:
             self._unittests = False
         else:
             self._unittests = bool(self._unittests)
 
         try:
-            self._debug = self.conf.get("pbench-agent", "debug")
+            self._debug = self.get("pbench-agent", "debug")
         except Exception:
             self._debug = False
         else:

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -180,15 +180,15 @@ class PbenchServerConfig(PbenchConfig):
 
     @property
     def PBENCH_ENV(self) -> str:
-        return self.conf.get("pbench-server", "environment", fallback="")
+        return self.get("pbench-server", "environment", fallback="")
 
     @property
     def COMMIT_ID(self) -> str:
-        return self.conf.get("pbench-server", "commit_id", fallback="(unknown)")
+        return self.get("pbench-server", "commit_id", fallback="(unknown)")
 
     @property
     def rest_uri(self) -> str:
-        return self.conf.get("pbench-server", "rest_uri")
+        return self.get("pbench-server", "rest_uri")
 
     @property
     def max_retention_period(self) -> int:
@@ -198,7 +198,7 @@ class PbenchServerConfig(PbenchConfig):
         Returns:
             An integer number of days representing the maximum retention period.
         """
-        return self.conf.getint(
+        return self.getint(
             "pbench-server",
             "maximum-dataset-retention-days",
             fallback=self.MAXIMUM_RETENTION_DAYS,
@@ -212,7 +212,7 @@ class PbenchServerConfig(PbenchConfig):
         Returns:
             An integer number of days representing the default retention period.
         """
-        return self.conf.getint(
+        return self.getint(
             "pbench-server",
             "default-dataset-retention-days",
             fallback=self.DEFAULT_RETENTION_DAYS,
@@ -227,7 +227,7 @@ class PbenchServerConfig(PbenchConfig):
             An integer number of bytes.
         """
         return filesize_bytes(
-            self.conf.get("pbench-server", "rest_max_content_length", fallback="1 gb")
+            self.get("pbench-server", "rest_max_content_length", fallback="1 gb")
         )
 
     def _get_valid_dir_option(self, env_name: str, section: str, option: str) -> Path:
@@ -247,7 +247,7 @@ class PbenchServerConfig(PbenchConfig):
             A Path directory object.
         """
         try:
-            dir_val = self.conf.get(section, option)
+            dir_val = self.get(section, option)
         except (NoOptionError, NoSectionError) as exc:
             raise BadConfig(str(exc))
         else:

--- a/lib/pbench/test/unit/agent/test_config.py
+++ b/lib/pbench/test/unit/agent/test_config.py
@@ -50,7 +50,7 @@ class MockPbenchConfig:
     """Mocked PbenchConfig class"""
 
     def __init__(self, cfg_name: str):
-        self.conf = MockedConfigParser()
+        self._conf = MockedConfigParser()
         self.logger_type = "file"
         self.log_dir = "/mock/log_dir"
         self.files = cfg_name

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -19,7 +19,7 @@ from pbench.server.auth import OpenIDClient
 def mock_get_server_config(monkeypatch, on_disk_server_config):
     cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
     config = PbenchServerConfig(str(cfg_file))
-    del config.conf["authentication"]["server_url"]
+    del config._conf["authentication"]["server_url"]
 
     def get_server_config() -> PbenchServerConfig:
         return config
@@ -330,7 +330,7 @@ class TestShell:
         def get_server_config() -> PbenchServerConfig:
             cfg_file = on_disk_server_config["cfg_dir"] / "pbench-server.cfg"
             config = PbenchServerConfig(str(cfg_file))
-            del config.conf[section]
+            del config._conf[section]
             return config
 
         monkeypatch.setattr(shell, "get_server_config", get_server_config)
@@ -365,8 +365,8 @@ class TestShell:
                 if option == "crontab-dir"
                 else "pbench-server"
             )
-            make_logger.error(config.conf[section][option])
-            del config.conf[section][option]
+            make_logger.error(config._conf[section][option])
+            del config._conf[section][option]
             return config
 
         monkeypatch.setattr(shell, "get_server_config", get_server_config)

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -428,7 +428,7 @@ def main(cfg_name):
     init_db(config, logger)
 
     # Add a BACKUP and QDIR field to the config object
-    config.BACKUP = config.conf.get("pbench-server", "pbench-backup-dir")
+    config.BACKUP = config.get("pbench-server", "pbench-backup-dir")
 
     # call the LocalBackupObject class
     lb_obj = LocalBackupObject(config)

--- a/server/bin/pbench-cull-unpacked-tarballs
+++ b/server/bin/pbench-cull-unpacked-tarballs
@@ -345,7 +345,7 @@ def main(options):
     # Fetch the configured maximum number of days a tar can remain "unpacked"
     # in the INCOMING tree.
     try:
-        max_unpacked_age = config.conf.get("pbench-server", "max-unpacked-age")
+        max_unpacked_age = config.get("pbench-server", "max-unpacked-age")
     except configparser.NoOptionError as e:
         logger.error(f"{e}")
         return 5

--- a/server/bin/pbench-verify-backup-tarballs
+++ b/server/bin/pbench-verify-backup-tarballs
@@ -299,7 +299,7 @@ def main():
     init_db(config, logger)
 
     # add a BACKUP field to the config object
-    config.BACKUP = backup = config.conf.get("pbench-server", "pbench-backup-dir")
+    config.BACKUP = backup = config.get("pbench-server", "pbench-backup-dir")
 
     if not backup:
         logger.error(


### PR DESCRIPTION
We hide all access to the internal `ConfigParser` object so that all access will be through the `PbenchConfig` object.