### PR TITLE
Remove unused `agent` and `results` config dicts

### DIFF
--- a/lib/pbench/agent/__init__.py
+++ b/lib/pbench/agent/__init__.py
@@ -20,10 +20,7 @@ class PbenchAgentConfig(PbenchConfig):
         super().__init__(cfg_name)
 
         try:
-            # Provide a few convenience attributes.
-            self.agent = self._conf["pbench-agent"]
-            self.results = self._conf["results"]
-            # Now fetch some default common pbench settings that are required.
+            # Fetch some default common pbench settings that are required.
             self.pbench_run = Path(
                 self.get(
                     "pbench-agent", "pbench_run", fallback=DEFAULT_PBENCH_AGENT_RUN_DIR


### PR DESCRIPTION
Suggested commit message:

    Remove unused `agent` and `results` config dicts

    The convenience variables of `agent` and `results` are not used by any
    code working with a `PbenchAgentConfig` object.  We drop their use and
    update unit tests to verify using alternate methods.

----

Depends on PR #3224 landing first.