### PR TITLE
Move `get_valid_dir_option` to module method

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -65,10 +65,10 @@ def tstos(ts: float = None) -> str:
     return dt.strftime("%Y-%m-%dT%H:%M:%S-%Z")
 
 
-def _get_valid_path(
+def get_resolved_dir(
     env_name: str, dir_val: str, logger: Optional[Logger]
 ) -> Optional[Path]:
-    """Get the fully resolved path from the given path.
+    """Get the resolved directory associated with the environment name.
 
     If a logger is given, will emit error logs when the directory is not
     found or the resolved name is not a directory.
@@ -80,7 +80,8 @@ def _get_valid_path(
             emitted
 
     Returns:
-        A Path directory object of the directory on disk, None otherwise.
+        A Path directory object, None if the directory value does not
+            resolve to a real directory.
     """
     try:
         dir_path = Path(dir_val).resolve(strict=True)
@@ -91,7 +92,7 @@ def _get_valid_path(
                 env_name,
                 dir_val,
             )
-        return None
+        dir_path = None
     else:
         if not dir_path.is_dir():
             if logger:
@@ -100,29 +101,7 @@ def _get_valid_path(
                     env_name,
                     dir_path,
                 )
-            return None
-    return dir_path
-
-
-def get_resolved_dir(
-    env_name: str, dir_val: str, logger: Optional[Logger]
-) -> Optional[Path]:
-    """Get the resolved directory associated with the environment name.
-
-    Args:
-        env_name : Legacy environment name to display in error messages
-        dir_val : A directory value to resolve to a real directory
-        logger : Logger to use when low-level error messages should be
-            emitted
-
-    Returns:
-        A Path directory object, None if the directory value does not
-            resolve to a real directory.
-    """
-    dir_path = _get_valid_path(env_name, dir_val, logger)
-    if not dir_path:
-        return None
-
+            dir_path = None
     return dir_path
 
 
@@ -314,7 +293,7 @@ class PbenchServerConfig(PbenchConfig):
         else:
             if not dir_val:
                 raise BadConfig(f"option {option} in section {section} is empty")
-        dir_path = _get_valid_path(env_name, dir_val, None)
+        dir_path = get_resolved_dir(env_name, dir_val, None)
         if not dir_path:
             raise BadConfig(f"Bad {env_name}={dir_val}")
         return dir_path

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -11,7 +11,7 @@ import tempfile
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
-from pbench.server import PbenchServerConfig
+from pbench.server import get_resolved_dir, PbenchServerConfig
 from pbench.server.database import init_db
 from pbench.server.database.models.datasets import Dataset, DatasetError, Metadata
 from pbench.server.report import Report
@@ -55,7 +55,7 @@ def sanity_check(lb_obj, s3_obj, config, logger):
             os.mkdir(backup)
         except FileExistsError:
             # directory already exists, verify it
-            backuppath = config.get_valid_dir_option("BACKUP", backup, logger)
+            backuppath = get_resolved_dir("BACKUP", backup, logger)
             if not backuppath:
                 lb_obj = None
         except Exception as exc:

--- a/server/bin/pbench-cull-unpacked-tarballs
+++ b/server/bin/pbench-cull-unpacked-tarballs
@@ -328,17 +328,17 @@ def main(options):
     archivepath = config.ARCHIVE
 
     incoming = config.INCOMING
-    incomingpath = config.get_valid_dir_option("INCOMING", incoming, logger)
+    incomingpath = pbench.server.get_resolved_dir("INCOMING", incoming, logger)
     if not incomingpath:
         return 3
 
     results = config.RESULTS
-    resultspath = config.get_valid_dir_option("RESULTS", results, logger)
+    resultspath = pbench.server.get_resolved_dir("RESULTS", results, logger)
     if not resultspath:
         return 3
 
     users = config.USERS
-    userspath = config.get_valid_dir_option("USERS", users, logger)
+    userspath = pbench.server.get_resolved_dir("USERS", users, logger)
     if not userspath:
         return 3
 

--- a/server/bin/pbench-verify-backup-tarballs
+++ b/server/bin/pbench-verify-backup-tarballs
@@ -50,7 +50,7 @@ import tempfile
 from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
-from pbench.server import PbenchServerConfig
+from pbench.server import get_resolved_dir, PbenchServerConfig
 from pbench.server.database import init_db
 from pbench.server.report import Report
 from pbench.server.s3backup import Entry, S3Config
@@ -308,7 +308,7 @@ def main():
         )
         return 1
 
-    backuppath = config.get_valid_dir_option("BACKUP", backup, logger)
+    backuppath = get_resolved_dir("BACKUP", backup, logger)
     if not backuppath:
         return 1
 


### PR DESCRIPTION
We move the `PbenchServerConfig.get_valid_dir_option()` method to a module method, renaming it to `get_resolved_dir()`.  We also move `_get_valid_path` to a module method.