### PR TITLE
Add expirations on containers pushed to remote registries

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -48,11 +48,15 @@ TEST =
 _TEST_SUFFIX = $(if $(TEST),-$(TEST),)
 _PBENCH_REPO_NAME = pbench-${_LOCAL_MAJORMINOR}${_TEST_SUFFIX}
 
-# By default we use the pbench Quay.io organization for the image
-# repository.  You can override this default using an environment
-# variable as appropriate.
-IMAGE_REPO ?= docker://quay.io/pbench
+# By default we use the pbench Quay.io organization for the image repository.
+# You can override this default using an environment variable as appropriate.
+# Export the Quay API access key bearer token as an environment variable for
+# recipe command invocations.
+IMAGE_REPO ?= quay.io/pbench
 IMAGE_TAG ?= latest
+IMAGE_REG = $(word 1, $(subst /, ,${IMAGE_REPO}))
+IMAGE_ORG = $(word 2, $(subst /, ,${IMAGE_REPO}))
+export PB_IMAGE_BEARER_TOKEN
 
 # Convenience reference to the repo template in the pbench tree.
 # Not intended to be overridden with an environment variable.
@@ -300,12 +304,15 @@ centos-7-base.Dockerfile: _PKGMGR = yum
 #-
 
 # Special push target for the CI which pushes a full set of the various container
-# images for the distribution to the specified registry with the specified tag.
+# images for the distribution to the specified registry with the specified tag
+# and expiration date.
 $(_DEFAULT_DISTROS:%=%-push-ci): %-push-ci:
 	for image in ${_CONTAINER_NAMES}; do \
 	  buildah push \
 	    localhost/pbench-agent-$${image}-${*}:${_LOCAL_GIT_HASH} \
-	    ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} ; \
+	    ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} && \
+	  ${_PBENCH_TOP}/jenkins/set-expiration $$(date --date "3 weeks" +%s) \
+	    ${IMAGE_REG} ${IMAGE_ORG}/pbench-agent-$${image}-${*} ${IMAGE_TAG} ; \
 	done
 
 # Special "push" target which pushes a full set of the various container images

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -308,11 +308,11 @@ centos-7-base.Dockerfile: _PKGMGR = yum
 # and expiration date.
 $(_DEFAULT_DISTROS:%=%-push-ci): %-push-ci:
 	for image in ${_CONTAINER_NAMES}; do \
-	  buildah push \
-	    localhost/pbench-agent-$${image}-${*}:${_LOCAL_GIT_HASH} \
-	    ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} && \
-	  ${_PBENCH_TOP}/jenkins/set-expiration $$(date --date "3 weeks" +%s) \
-	    ${IMAGE_REG} ${IMAGE_ORG}/pbench-agent-$${image}-${*} ${IMAGE_TAG} ; \
+	    buildah push \
+	        localhost/pbench-agent-$${image}-${*}:${_LOCAL_GIT_HASH} \
+	        ${IMAGE_REPO}/pbench-agent-$${image}-${*}:${IMAGE_TAG} && \
+	    ${_PBENCH_TOP}/jenkins/set-expiration $$(date --date "3 weeks" +%s) \
+	        ${IMAGE_REG} ${IMAGE_ORG}/pbench-agent-$${image}-${*} ${IMAGE_TAG} ; \
 	done
 
 # Special "push" target which pushes a full set of the various container images
@@ -321,11 +321,11 @@ $(_DEFAULT_DISTROS:%=%-push-ci): %-push-ci:
 # _only_ the requested tag and no tags based on the version or hash.
 publish:
 	for distro in ${_DEFAULT_DISTROS}; do \
-	  for image in ${_CONTAINER_NAMES}; do \
-	    buildah push \
-	      localhost/pbench-agent-$${image}-$${distro}:${_LOCAL_GIT_HASH} \
-	      ${IMAGE_REPO}/pbench-agent-$${image}-$${distro}:${IMAGE_TAG} ; \
-	  done ; \
+	    for image in ${_CONTAINER_NAMES}; do \
+	        buildah push \
+	            localhost/pbench-agent-$${image}-$${distro}:${_LOCAL_GIT_HASH} \
+	            ${IMAGE_REPO}/pbench-agent-$${image}-$${distro}:${IMAGE_TAG} ; \
+	    done ; \
 	done
 
 define _PUSH_RULE

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -10,6 +10,7 @@ pipeline {
         // Configuration for remote container registries
         PB_CI_REGISTRY=credentials('c3e2d737-0e56-4c1e-a945-d86bc644384c')
         PB_CI_REG_CRED=credentials('12b404ca-3036-4960-9929-979148b9e49a')
+        PB_IMAGE_BEARER_TOKEN=credentials('169468a1-dd32-47db-98cb-6a38d3b6e0fb')
         PB_ORG_NAME="pbench"
         PB_CONTAINER_REG="${PB_CI_REGISTRY}/${PB_ORG_NAME}"
         // If we are executing for a PR, as opposed to executing for a branch
@@ -42,11 +43,17 @@ pipeline {
                 KEYCLOAK_CLIENT_SECRET=credentials('5cf0304d-8a00-48a4-ade5-9f59cb37ba68')
                 PB_SERVER_IMAGE_TAG="${PB_IMAGE_TAG}"
                 RPM_PATH="${WORKSPACE_TMP}/rpmbuild/RPMS/noarch/pbench-server-*.rpm"
+                EXPIRATION="""${sh(returnStdout: true, script: 'date --date "3 weeks" "+%s"').trim()}"""
             }
             steps {
                 sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'
                 sh 'bash -ex ./server/pbenchinacan/container-build.sh'
                 sh 'buildah push ${PB_CONTAINER_REG}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
+                sh './jenkins/set-expiration \
+                      ${EXPIRATION} \
+                      ${PB_CI_REGISTRY} \
+                      ${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME} \
+                      ${PB_IMAGE_TAG}'
             }
         }
         stage('Build the Pbench Agent Containers') {
@@ -56,8 +63,14 @@ pipeline {
             steps {
                 sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'
                 sh '/usr/bin/python3 -m pip install --user jinja2-cli'
-                sh 'make -C agent/containers/images CI_RPM_ROOT=${WORKSPACE_TMP} clean ${PB_AGENT_DISTRO}-everything'
-                sh 'make -C agent/containers/images IMAGE_REPO=${PB_CONTAINER_REG} IMAGE_TAG=${PB_IMAGE_TAG} ${PB_AGENT_DISTRO}-push-ci'
+                sh 'make -C agent/containers/images \
+                        CI_RPM_ROOT=${WORKSPACE_TMP} clean \
+                        ${PB_AGENT_DISTRO}-everything'
+                sh 'make -C agent/containers/images \
+                        IMAGE_REPO=${PB_CONTAINER_REG} \
+                        IMAGE_TAG=${PB_IMAGE_TAG} \
+                        PB_IMAGE_BEARER_TOKEN=${PB_IMAGE_BEARER_TOKEN} \
+                        ${PB_AGENT_DISTRO}-push-ci'
             }
         }
         stage('Deploy server and run functional tests') {
@@ -103,7 +116,13 @@ pipeline {
             sh 'rm -f cov/report.xml'
         }
         always {
-            sh 'podman image ls --filter reference="*pbench-agent*" --filter reference="*pbench-server*" --format "{{.Id}}" --filter containers=false | sort -u | xargs podman image rm -f'
+            sh 'podman image ls \
+                    --filter reference="*pbench-agent*" \
+                    --filter reference="*pbench-server*" \
+                    --format "{{.Id}}" --filter containers=false \
+                    | sort -u \
+                    | xargs podman image rm -f \
+                    || true'
         }
     }
 }

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -50,10 +50,10 @@ pipeline {
                 sh 'bash -ex ./server/pbenchinacan/container-build.sh'
                 sh 'buildah push ${PB_CONTAINER_REG}/${PB_SERVER_IMAGE_NAME}:${PB_IMAGE_TAG}'
                 sh './jenkins/set-expiration \
-                      ${EXPIRATION} \
-                      ${PB_CI_REGISTRY} \
-                      ${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME} \
-                      ${PB_IMAGE_TAG}'
+                        ${EXPIRATION} \
+                        ${PB_CI_REGISTRY} \
+                        ${PB_ORG_NAME}/${PB_SERVER_IMAGE_NAME} \
+                        ${PB_IMAGE_TAG}'
             }
         }
         stage('Build the Pbench Agent Containers') {

--- a/jenkins/set-expiration
+++ b/jenkins/set-expiration
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# This script sets the expiration date on a container image tag in a remote
+# repository (using the Quay RESTful interface).
+#
+# jenkins/set-expiration <expiration> <image_reg> <image_name> <image_tag>
+#
+# Command line arguments:
+#   expiration:  date in seconds since the UNIX epoch
+#   image_reg:  Image registry (e.g., "quay.io")
+#   image_name:  Image name (e.g., "pbench/pbench-server")
+#   image_tag:  Image tag
+#
+# Environment variables:
+#   PB_IMAGE_BEARER_TOKEN:  API key (bearer authorization token)
+#
+# Example invocation:
+#
+#   PB_IMAGE_BEARER_TOKEN=<token-string...> \
+#     jenkins/set-expiration \
+#       $(date --date "3 weeks" +%s) \
+#       quay.io pbench/pbench-server my_tag
+#
+
+if [[ $# -ne 4 ]] ; then
+  echo "Incorrect number of arguments (expected 4, got $#)" >&2
+  exit 2
+elif [[ -z ${PB_IMAGE_BEARER_TOKEN} ]]; then
+  echo "Missing bearer token (PB_IMAGE_BEARER_TOKEN not defined)" >&2
+  exit 2
+fi
+
+expiration="{\"expiration\": ${1}}"
+image_reg=${2}
+image_name=${3}
+image_tag=${4}
+content_length=$(( $(wc -c <<< "${expiration}") - 1 ))  # Don't count newline
+
+curl -fs -X PUT -d "${expiration}" \
+  -w "Set expiration response: %{response_code}\n" \
+  -H "Authorization: Bearer ${PB_IMAGE_BEARER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -H "Content-Length: ${content_length}" \
+  https://${image_reg}/api/v1/repository/${image_name}/tag/${image_tag}

--- a/jenkins/set-expiration
+++ b/jenkins/set-expiration
@@ -23,11 +23,11 @@
 #
 
 if [[ $# -ne 4 ]] ; then
-  echo "Incorrect number of arguments (expected 4, got $#)" >&2
-  exit 2
+    echo "Incorrect number of arguments (expected 4, got $#)" >&2
+    exit 2
 elif [[ -z ${PB_IMAGE_BEARER_TOKEN} ]]; then
-  echo "Missing bearer token (PB_IMAGE_BEARER_TOKEN not defined)" >&2
-  exit 2
+    echo "Missing bearer token (PB_IMAGE_BEARER_TOKEN not defined)" >&2
+    exit 2
 fi
 
 expiration="{\"expiration\": ${1}}"
@@ -37,8 +37,8 @@ image_tag=${4}
 content_length=$(( $(wc -c <<< "${expiration}") - 1 ))  # Don't count newline
 
 curl -fs -X PUT -d "${expiration}" \
-  -w "Set expiration response: %{response_code}\n" \
-  -H "Authorization: Bearer ${PB_IMAGE_BEARER_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -H "Content-Length: ${content_length}" \
-  https://${image_reg}/api/v1/repository/${image_name}/tag/${image_tag}
+    -w "Set expiration response: %{response_code}\n" \
+    -H "Authorization: Bearer ${PB_IMAGE_BEARER_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -H "Content-Length: ${content_length}" \
+    https://${image_reg}/api/v1/repository/${image_name}/tag/${image_tag}


### PR DESCRIPTION
This PR modifies the places where the CI pushes containers to the remote registry to also set an automatic expiration date on the pushed containers.  In this way, containers pushed by PR builds will eventually be removed without requiring manual clean-up of the remote registry.  This change only affects Agent and Server containers; it doesn't affect the persistent containers such as the CI's own container and the containers used to build RPMs; it also doesn't affect branch builds which are "published" by the CI, and it doesn't affect containers which are "released".  It only affects containers which are built by the CI for functional testing.

Details:
- Add a script which is basically just a wrapper around a `curl` command which hits a Quay RESTful interface to set the expiration date for the container that we just pushed.  This implicitly assumes that the remote registry is running an implementation of Quay (which each of our remote registries currently does).
- Removed the "transport" specifier from the default value for `IMAGE_REPO` in the Agent container makefile.  This is the default transport, so we don't really need to specify it here, and we never specify the transport when we override this value.  Presuming that the transport is not present allows the value to be trivially parsed.
- The containers for the Pbench Agent and the Pbench Server are pushed from separate parts of our infrastructure -- the Agent is pushed via commands in `agent/containers/images/Makefile` while the Server is pushed directly from the Jenkins pipeline.  This change adds an invocation of the new script after each of the `push` operations.
- The expiration is currently hard-coded at three weeks from when the container is pushed.  We can consider parameterizing this if we care.
- Access to the repository is granted via a bearer token, which is stored in the Jenkins environment as another "credential" secret.

----
Suggested commit log:
```
Add expirations on containers pushed to remote registries

Modify the CI to automatically set expiration dates on the containers
which it pushes to the remote registry for testing.
```