### PR TITLE
Fix operation synchronization

### DIFF
--- a/lib/pbench/server/api/resources/datasets_daterange.py
+++ b/lib/pbench/server/api/resources/datasets_daterange.py
@@ -57,7 +57,7 @@ class DatasetsDateRange(ApiBase):
 
         # Build a SQLAlchemy Query object expressing all of our constraints
         query = Database.db_session.query(
-            func.min(Dataset.created), func.max(Dataset.created)
+            func.min(Dataset.uploaded), func.max(Dataset.uploaded)
         )
         query = self._build_sql_query(owner, access, query)
 

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -132,11 +132,11 @@ class DatasetsList(ApiBase):
         # Build a SQLAlchemy Query object expressing all of our constraints
         query = Database.db_session.query(Dataset)
         if "start" in json and "end" in json:
-            query = query.filter(Dataset.created.between(json["start"], json["end"]))
+            query = query.filter(Dataset.uploaded.between(json["start"], json["end"]))
         elif "start" in json:
-            query = query.filter(Dataset.created >= json["start"])
+            query = query.filter(Dataset.uploaded >= json["start"])
         elif "end" in json:
-            query = query.filter(Dataset.created <= json["end"])
+            query = query.filter(Dataset.uploaded <= json["end"])
         if "name" in json:
             query = query.filter(Dataset.name.contains(json["name"]))
         query = self._build_sql_query(json.get("owner"), json.get("access"), query)

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -15,7 +15,12 @@ from pbench.server.api.resources import (
 from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
 from pbench.server.cache_manager import CacheManager
 from pbench.server.database.models.audit import AuditType
-from pbench.server.database.models.datasets import Dataset, States
+from pbench.server.database.models.datasets import (
+    Dataset,
+    OperationName,
+    OperationState,
+)
+from pbench.server.sync import Sync
 
 
 class DatasetsDelete(ElasticBulkBase):
@@ -67,9 +72,9 @@ class DatasetsDelete(ElasticBulkBase):
         Returns:
             A generator for Elasticsearch bulk delete actions
         """
-
-        dataset.advance(States.DELETING)
         current_app.logger.info("Starting delete operation for dataset {}", dataset)
+        sync = Sync(logger=current_app.logger, component=OperationName.DELETE)
+        sync.update(dataset=dataset, did=OperationState.WORKING)
 
         # Generate a series of bulk delete documents, which will be passed to
         # the Elasticsearch bulk helper.

--- a/lib/pbench/server/api/resources/query_apis/datasets_delete.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_delete.py
@@ -74,7 +74,7 @@ class DatasetsDelete(ElasticBulkBase):
         """
         current_app.logger.info("Starting delete operation for dataset {}", dataset)
         sync = Sync(logger=current_app.logger, component=OperationName.DELETE)
-        sync.update(dataset=dataset, did=OperationState.WORKING)
+        sync.update(dataset=dataset, state=OperationState.WORKING)
 
         # Generate a series of bulk delete documents, which will be passed to
         # the Elasticsearch bulk helper.

--- a/lib/pbench/server/api/resources/query_apis/datasets_update.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_update.py
@@ -77,8 +77,8 @@ class DatasetsUpdate(ElasticBulkBase):
             A generator for Elasticsearch bulk update actions
         """
 
-        sync = Sync(logger=current_app.logger, component=OperationName.DELETE)
-        sync.update(dataset=dataset, did=OperationState.WORKING)
+        sync = Sync(logger=current_app.logger, component=OperationName.UPDATE)
+        sync.update(dataset=dataset, state=OperationState.WORKING)
         context["sync"] = sync
 
         access = params.query.get("access")
@@ -142,4 +142,4 @@ class DatasetsUpdate(ElasticBulkBase):
                 attributes["owner"] = owner
                 dataset.owner_id = owner
             dataset.update()
-        context["sync"].update(dataset=dataset, did=state, message=message)
+        context["sync"].update(dataset=dataset, state=state, message=message)

--- a/lib/pbench/server/api/resources/query_apis/datasets_update.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets_update.py
@@ -1,5 +1,7 @@
 from typing import Any, Iterator
 
+from flask import current_app
+
 from pbench.server import JSONOBJECT, OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
     ApiAuthorizationType,
@@ -15,7 +17,12 @@ from pbench.server.api.resources import (
 from pbench.server.api.resources.query_apis import ApiContext, ElasticBulkBase
 import pbench.server.auth.auth as Auth
 from pbench.server.database.models.audit import AuditType
-from pbench.server.database.models.datasets import Dataset
+from pbench.server.database.models.datasets import (
+    Dataset,
+    OperationName,
+    OperationState,
+)
+from pbench.server.sync import Sync
 
 
 class DatasetsUpdate(ElasticBulkBase):
@@ -70,6 +77,10 @@ class DatasetsUpdate(ElasticBulkBase):
             A generator for Elasticsearch bulk update actions
         """
 
+        sync = Sync(logger=current_app.logger, component=OperationName.DELETE)
+        sync.update(dataset=dataset, did=OperationState.WORKING)
+        context["sync"] = sync
+
         access = params.query.get("access")
         owner = params.query.get("owner")
         es_doc = {}
@@ -117,7 +128,11 @@ class DatasetsUpdate(ElasticBulkBase):
         """
         auditing: dict[str, Any] = context["auditing"]
         attributes = auditing["attributes"]
+        state = OperationState.FAILED
+        message = "Unable to update some indexed documents"
         if summary["failure"] == 0:
+            state = OperationState.OK
+            message = None
             access = context.get("access")
             if access:
                 attributes["access"] = access
@@ -127,3 +142,4 @@ class DatasetsUpdate(ElasticBulkBase):
                 attributes["owner"] = owner
                 dataset.owner_id = owner
             dataset.update()
+        context["sync"].update(dataset=dataset, did=state, message=message)

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -440,7 +440,7 @@ class Upload(ApiBase):
             try:
                 Sync(current_app.logger, OperationName.UPLOAD).update(
                     dataset=dataset,
-                    did=OperationState.OK,
+                    state=OperationState.OK,
                     enabled=[OperationName.BACKUP, OperationName.UNPACK],
                 )
                 Audit.create(root=audit, status=AuditStatus.SUCCESS)

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -39,9 +39,10 @@ from pbench.server.database.models.datasets import (
     DatasetDuplicate,
     DatasetNotFound,
     Metadata,
-    States,
+    OperationName,
+    OperationState,
 )
-from pbench.server.sync import Operation, Sync
+from pbench.server.sync import Sync
 from pbench.server.utils import UtcTimeHelper
 
 
@@ -437,11 +438,10 @@ class Upload(ApiBase):
             # Finally, update the dataset state and commit the `created` date
             # and state change.
             try:
-                dataset.advance(States.UPLOADED)
-                Sync(current_app.logger, "upload").update(
+                Sync(current_app.logger, OperationName.UPLOAD).update(
                     dataset=dataset,
-                    enabled=[Operation.BACKUP, Operation.UNPACK],
-                    status="ok",
+                    did=OperationState.OK,
+                    enabled=[OperationName.BACKUP, OperationName.UNPACK],
                 )
                 Audit.create(root=audit, status=AuditStatus.SUCCESS)
             except Exception as exc:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -468,6 +468,7 @@ class OperationName(enum.Enum):
     REINDEX = enum.auto()
     TOOLINDEX = enum.auto()
     UNPACK = enum.auto()
+    UPDATE = enum.auto()
     UPLOAD = enum.auto()
 
 
@@ -596,10 +597,6 @@ class Metadata(Database.Base):
     #
     # {"server.reindex": True}
     REINDEX = "server.reindex"
-
-    # OPERATION tag to tell the Pbench Server cron tools which operation needs
-    # to be performed next, replacing the old STATE symlink subdirectories.
-    OPERATION = "server.operation"
 
     # TARBALL_PATH access path of the dataset tarball. (E.g., we could use this
     # to record an S3 object store key.) NOT YET USED.

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -341,7 +341,7 @@ class Dataset(Database.Base):
         Returns:
             The stripped "stem" of the dataset
         """
-        p = Path(str(path))
+        p = Path(path)
         if __class__.is_tarball(p):
             return p.name[: -len(Dataset.TARBALL_SUFFIX)]
         else:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -62,7 +62,7 @@ class DatasetDuplicate(DatasetError):
 
 
 class DatasetNotFound(DatasetError):
-    """Attempt to attach to a Dataset that doesn't exist."""
+    """Attempt to locate a Dataset that doesn't exist."""
 
     def __init__(self, **kwargs):
         self.kwargs = [f"{key}={value}" for key, value in kwargs.items()]
@@ -87,32 +87,6 @@ class DatasetBadParameterType(DatasetError):
 
     def __str__(self) -> str:
         return f'Value "{self.bad_value}" ({type(self.bad_value)}) is not a {self.expected_type}'
-
-
-class DatasetTransitionError(DatasetError):
-    """A base class for errors reporting disallowed dataset state transitions.
-
-    It is never raised directly, but may be used in "except" clauses.
-    """
-
-
-class DatasetBadStateTransition(DatasetTransitionError):
-    """An attempt was made to advance a dataset to a new state that's not
-    reachable from the current state.
-
-    The error text will identify the dataset by name, and both the current and
-    requested new states.
-    """
-
-    def __init__(self, dataset: "Dataset", requested_state: "States"):
-        self.dataset = dataset
-        self.requested_state = requested_state
-
-    def __str__(self) -> str:
-        return (
-            f"Dataset {self.dataset} desired state {self.requested_state}"
-            f" is not allowed from current state {self.dataset.state}"
-        )
 
 
 class MetadataError(DatasetError):
@@ -274,39 +248,6 @@ class MetadataDuplicateKey(MetadataError):
         return f"{self.dataset} already has metadata key {self.key}"
 
 
-class States(enum.Enum):
-    """Track the progress of a dataset (tarball) through the various stages and
-    operation of the Pbench server.
-    """
-
-    UPLOADING = ("Uploading", True)
-    UPLOADED = ("Uploaded", False)
-    INDEXING = ("Indexing", True)
-    INDEXED = ("Indexed", False)
-    DELETING = ("Deleting", True)
-    DELETED = ("Deleted", False)
-
-    def __init__(self, friendly: str, mutating: bool):
-        """Extended ENUM constructor.
-
-        We extend an ENUM adding a value to record whether each state is a
-        "busy" state where some component is mutating the dataset in some way,
-        and adding a mixed case "friendly" name for the state. "Mutating"
-        states are expected to be transient as the component should complete
-        the mutation, and should usually have "-ing" endings.
-
-        Args:
-            name (string) : Friendly name for the state
-            mutating (boolean) : True if a component is mutating dataset
-        """
-        self.friendly = friendly
-        self.mutating = mutating
-
-    def __str__(self) -> str:
-        """Return the state's friendly name."""
-        return self.friendly
-
-
 class Dataset(Database.Base):
     """Identify a Pbench dataset (tarball plus metadata).
 
@@ -324,33 +265,9 @@ class Dataset(Database.Base):
 
     __tablename__ = "datasets"
 
-    # This dict defines the allowed dataset state transitions through its
-    # lifecycle. We have a set of "-ING" action states while the dataset is
-    # being mutated, and a set of "-ED" states designating the last successful
-    # mutation, from UPLOAD through INDEX and eventually DELETE.
-    #
-    # All "-ING" action states allow self-transitions, which provides for a
-    # failed action to be retried later.
-    #
-    # DELETED is a "marker" state, for completeness. When we complete a dataset
-    # delete, we remove the SQL row entirely rather than transitioning from
-    # DELETING to DELETE. A failed delete will leave the dataset in DELETING
-    # state, which allows retry. If we actually set DELETED state, retaining
-    # the SQL row, we would allow "re-activation" via a PUT operation, so we
-    # allow the theoretical transition to UPLOADING.
-    transitions = {
-        States.UPLOADING: [States.UPLOADED, States.UPLOADING, States.DELETING],
-        States.UPLOADED: [States.INDEXING, States.DELETING],
-        States.INDEXING: [States.INDEXED, States.INDEXING, States.DELETING],
-        States.INDEXED: [States.INDEXING, States.DELETING],
-        States.DELETING: [States.DELETED, States.DELETING],
-        States.DELETED: [States.UPLOADING],
-    }
-
     # "Virtual" metadata key paths to access Dataset column data
     ACCESS = "dataset.access"
     OWNER = "dataset.owner"
-    CREATED = "dataset.created"
     UPLOADED = "dataset.uploaded"
 
     # Acceptable values of the "access" column
@@ -359,6 +276,9 @@ class Dataset(Database.Base):
     PUBLIC_ACCESS = "public"
     PRIVATE_ACCESS = "private"
     ACCESS_KEYWORDS = [PUBLIC_ACCESS, PRIVATE_ACCESS]
+
+    # Access policy for Dataset (public or private)
+    access = Column(String(255), unique=False, nullable=False, default="private")
 
     # Generated unique ID for Dataset row
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -369,9 +289,6 @@ class Dataset(Database.Base):
     # OIDC UUID of the owning user
     owner_id = Column(String(255), nullable=False)
 
-    # Access policy for Dataset (public or private)
-    access = Column(String(255), unique=False, nullable=False, default="private")
-
     # This is the MD5 hash of the dataset tarball, which we use as the unique
     # dataset resource ID throughout the Pbench server.
     resource_id = Column(String(255), unique=True, nullable=False)
@@ -379,21 +296,11 @@ class Dataset(Database.Base):
     # Time of Dataset record creation
     uploaded = Column(TZDateTime, nullable=False, default=TZDateTime.current_time)
 
-    # Time of the data collection run (from metadata.log `date`). This is the
-    # time the data was generated as opposed to the date it was imported into
-    # the server ("uploaded").
-    created = Column(TZDateTime, nullable=True, unique=False)
-
-    # Current state of the Dataset
-    state = Column(Enum(States), unique=False, nullable=False, default=States.UPLOADING)
-
-    # Timestamp when Dataset state was last changed
-    transition = Column(TZDateTime, nullable=False, default=TZDateTime.current_time)
-
-    # NOTE: this relationship defines a `dataset` property in `Metadata`
-    # that refers to the parent `Dataset` object.
     metadatas = relationship(
         "Metadata", back_populates="dataset", cascade="all, delete-orphan"
+    )
+    operations = relationship(
+        "Operation", back_populates="dataset", cascade="all, delete-orphan"
     )
 
     TARBALL_SUFFIX = ".tar.xz"
@@ -434,33 +341,11 @@ class Dataset(Database.Base):
         Returns:
             The stripped "stem" of the dataset
         """
-        p = Path(path)
+        p = Path(str(path))
         if __class__.is_tarball(p):
             return p.name[: -len(Dataset.TARBALL_SUFFIX)]
         else:
             raise DatasetBadName(p)
-
-    @validates("state")
-    def validate_state(self, key: str, value: Any) -> States:
-        """Validate dataset state.
-
-        Validate that the value provided for the Dataset state is a member
-        of the States ENUM before it's applied by the SQLAlchemy constructor.
-
-        Args:
-            key : state
-            value : state ENUM member
-
-        Raises:
-            DatasetBadParameter : the value given doesn't resolve to a
-                States ENUM.
-
-        Returns:
-            state
-        """
-        if type(value) is not States:
-            raise DatasetBadParameterType(value, States)
-        return value
 
     @validates("access")
     def validate_access(self, key: str, value: str) -> str:
@@ -480,65 +365,6 @@ class Dataset(Database.Base):
         if access in Dataset.ACCESS_KEYWORDS:
             return access
         raise DatasetBadParameterType(value, "access keyword")
-
-    @staticmethod
-    def create(**kwargs) -> "Dataset":
-        """A simple factory method to construct a new Dataset object and
-        add it to the database.
-
-        Args:
-            kwargs (dict) :
-                access : The dataset access policy
-                name : The dataset name (file path stem).
-                owner_id : The owner id of the dataset.
-                resource_id : The tarball MD5
-                state : The initial state of the new dataset.
-
-        Returns:
-            A new Dataset object initialized with the keyword parameters.
-        """
-        try:
-            dataset = Dataset(**kwargs)
-            dataset.add()
-        except Exception:
-            Dataset.logger.exception("Failed create: {}", kwargs.get("name"))
-            raise
-        return dataset
-
-    @staticmethod
-    def attach(resource_id: str, state: Optional[States] = None) -> "Dataset":
-        """Attempt to find the dataset with the specified dataset resource ID.
-
-        If state is specified, attach will attempt to advance the dataset to
-        that state.
-
-        NOTE: Unless you need to advance the state of the dataset, use
-        Dataset.query instead.
-
-        Args:
-            resource_id : The dataset resource ID.
-            state : The desired state to advance the dataset.
-
-        Raises:
-            DatasetSqlError : problem interacting with Database
-            DatasetNotFound : the specified dataset doesn't exist
-            DatasetBadParameterType : The state parameter isn't a States ENUM
-            DatasetTerminalStateViolation : dataset is in terminal state and
-                can't be advanced
-            DatasetBadStateTransition : dataset cannot be advanced to the
-                specified state
-
-        Returns:
-            A Dataset object in the desired state (if specified)
-        """
-        dataset = Dataset.query(resource_id=resource_id)
-
-        if dataset is None:
-            Dataset.logger.warning("Dataset {} not found", resource_id)
-            raise DatasetNotFound(resource_id=resource_id)
-        elif state:
-            dataset.advance(state)
-        return dataset
 
     @staticmethod
     def query(**kwargs) -> "Dataset":
@@ -571,15 +397,21 @@ class Dataset(Database.Base):
             metadata_log = Metadata.get(self, Metadata.METALOG).value
         except MetadataNotFound:
             metadata_log = None
+        operations = (
+            Database.db_session.query(Operation)
+            .filter(Operation.dataset_ref == self.id)
+            .all()
+        )
         return {
             "access": self.access,
-            "created": self.created.isoformat() if self.created else None,
             "name": self.name,
             "owner_id": self.owner_id,
-            "state": str(self.state),
-            "transition": self.transition.isoformat(),
             "uploaded": self.uploaded.isoformat(),
-            Metadata.METALOG: metadata_log,
+            "metalog": metadata_log,
+            "operations": {
+                o.name.name: {"state": o.state.name, "message": o.message}
+                for o in operations
+            },
         }
 
     def __str__(self) -> str:
@@ -589,37 +421,6 @@ class Dataset(Database.Base):
             string: Representation of the dataset
         """
         return f"({self.owner_id})|{self.name}"
-
-    def advance(self, new_state: States):
-        """Transition the Dataset object to the next valid state.
-
-        Modify the state of the Dataset object, if the new_state is
-        a valid transition from the dataset's current state.
-
-        Args:
-            new_state (State ENUM) : New desired state for the dataset
-
-        Raises:
-            DatasetBadParameterType : The state parameter isn't a States ENUM
-            DatasetBadStateTransition : The dataset does not support transition
-                from the current state to the desired state.
-        """
-        if type(new_state) is not States:
-            raise DatasetBadParameterType(new_state, States)
-        elif new_state not in self.transitions[self.state]:
-            self.logger.error(
-                "{}, Current state {} can't advance to {}", self, self.state, new_state
-            )
-            raise DatasetBadStateTransition(self, new_state)
-
-        # TODO: this would be a good place to generate an audit log
-        self.logger.debug(
-            "{}, Current state {}, advancing to {}", self, self.state, new_state
-        )
-
-        self.state = new_state
-        self.transition = datetime.datetime.utcnow()
-        self.update()
 
     def add(self):
         """Add the Dataset object to the database."""
@@ -654,6 +455,54 @@ class Dataset(Database.Base):
         except Exception:
             Database.db_session.rollback()
             raise
+
+
+class OperationName(enum.Enum):
+    """Track and orchestrate the progress of a dataset (tarball) through the
+    various stages of the Pbench server.
+    """
+
+    BACKUP = enum.auto()
+    DELETE = enum.auto()
+    INDEX = enum.auto()
+    REINDEX = enum.auto()
+    TOOLINDEX = enum.auto()
+    UNPACK = enum.auto()
+    UPLOAD = enum.auto()
+
+
+class OperationState(enum.Enum):
+    """Record the status of an Operation as its enabled and retired"""
+
+    READY = enum.auto()
+    WORKING = enum.auto()
+    OK = enum.auto()
+    FAILED = enum.auto()
+
+
+class Operation(Database.Base):
+    """Orchestrate and track the operational flow of datasets through the
+    server.
+
+    This table is managed by the Sync class, but defined here with the parent
+    Dataset class since they're linked.
+
+    Columns:
+        id          Generated unique ID of table row
+        dataset_ref Dataset row ID (foreign key)
+        name        Operation name (OperationName enum)
+        status      Status of operation (OperationStatus enum)
+        message     Message explaining operation status
+    """
+
+    __tablename__ = "dataset_operations"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(Enum(OperationName), index=True)
+    state = Column(Enum(OperationState))
+    message = Column(String(255))
+    dataset_ref = Column(Integer, ForeignKey("datasets.id"))
+    dataset = relationship("Dataset", back_populates="operations")
 
 
 class Metadata(Database.Base):
@@ -802,7 +651,7 @@ class Metadata(Database.Base):
     value = Column(JSON, unique=False, nullable=True)
     dataset_ref = Column(Integer, ForeignKey("datasets.id"), nullable=False)
 
-    dataset = relationship("Dataset", back_populates="metadatas", single_parent=True)
+    dataset = relationship("Dataset", back_populates="metadatas")
     user_id = Column(String(255), nullable=True)
 
     @validates("key")

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -584,7 +584,7 @@ class Index:
                                 print(tb, file=fp)
                             self.sync.update(
                                 dataset=dataset,
-                                did=OperationState.OK,
+                                state=OperationState.OK,
                                 enabled=self.enabled,
                             )
                         elif tb_res is error_code["OP_ERROR"]:

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -209,7 +209,7 @@ class Sync:
                     self.component.name,
                     ds_name,
                     retry,
-                    str(e)
+                    str(e),
                 )
                 last_error = e
             time.sleep(self.DELAY)

--- a/lib/pbench/server/unpack_tarballs.py
+++ b/lib/pbench/server/unpack_tarballs.py
@@ -97,7 +97,7 @@ class UnpackTarballs:
 
             if min_size <= s < max_size:
                 self.logger.info(
-                    "will unpack {} ({} >= {} < {})",
+                    "will unpack {} ({} <= {} < {})",
                     Dataset.stem(p),
                     min_size,
                     s,
@@ -113,7 +113,7 @@ class UnpackTarballs:
                 self.unpack(tarball)
                 self.sync.update(
                     dataset=tarball.dataset,
-                    did=OperationState.OK,
+                    state=OperationState.OK,
                     enabled=[OperationName.INDEX],
                 )
             except Exception as e:

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -55,7 +55,7 @@ class TestPut:
             print(f"Uploaded {t.name}")
 
         datasets = server_client.get_list(
-            metadata=["dataset.access", "server.tarball-path", "server.operations"]
+            metadata=["dataset.access", "server.tarball-path", "dataset.operations"]
         )
         found = frozenset({d.name for d in datasets})
         expected = frozenset(tarballs.keys())
@@ -66,7 +66,7 @@ class TestPut:
                     continue
                 t = tarballs[dataset.name]
                 assert dataset.name in dataset.metadata["server.tarball-path"]
-                assert dataset.metadata["server.operations"]["UPLOAD"]["state"] == "OK"
+                assert dataset.metadata["dataset.operations"]["UPLOAD"]["state"] == "OK"
                 assert t.access == dataset.metadata["dataset.access"]
         except HTTPError as exc:
             pytest.fail(

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -55,7 +55,7 @@ class TestPut:
             print(f"Uploaded {t.name}")
 
         datasets = server_client.get_list(
-            metadata=["dataset.access", "server.tarball-path", "server.status"]
+            metadata=["dataset.access", "server.tarball-path", "server.operations"]
         )
         found = frozenset({d.name for d in datasets})
         expected = frozenset(tarballs.keys())
@@ -66,7 +66,7 @@ class TestPut:
                     continue
                 t = tarballs[dataset.name]
                 assert dataset.name in dataset.metadata["server.tarball-path"]
-                assert dataset.metadata["server.status"]["upload"] == "ok"
+                assert dataset.metadata["server.operations"]["UPLOAD"]["state"] == "OK"
                 assert t.access == dataset.metadata["dataset.access"]
         except HTTPError as exc:
             pytest.fail(
@@ -120,19 +120,17 @@ class TestPut:
             for dataset in datasets:
                 print(f"\t... on {dataset.metadata['server.tarball-path']}")
                 metadata = server_client.get_metadata(
-                    dataset.resource_id, ["dataset.state", "server.status"]
+                    dataset.resource_id, ["dataset.operations"]
                 )
-                state = metadata["dataset.state"]
-                status = metadata["server.status"]
-                stats = set(status.keys()) if status else set()
-                if state == "Indexed" and {"unpack", "index"} <= stats:
-                    # Don't wait for backup, and don't fail if we haven't as
-                    # it's completely independent from unpack/index; but if we
-                    # have backed up, check that the status was successful.
-                    if "backup" in stats:
-                        assert status["backup"] == "ok"
-                    assert status["unpack"] == "ok"
-                    assert status["index"] == "ok"
+                operations = metadata["dataset.operations"]
+                if "INDEX" in operations and operations["INDEX"]["state"] == "OK":
+                    assert operations["UPLOAD"]["state"] == "OK"
+                    assert operations["UNPACK"]["state"] == "OK"
+                    assert operations["INDEX"]["state"] == "OK"
+
+                    # Backup is asynchronous: it's OK if it hasn't completed
+                    # yet, but must be at least in READY state.
+                    assert operations["BACKUP"]["state"] in ("OK", "READY")
                     indexed.append(dataset)
                 else:
                     print(f"\t\tstate={state!r} status={status!r}")

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -133,8 +133,14 @@ class TestPut:
                     assert operations["BACKUP"]["state"] in ("OK", "READY")
                     indexed.append(dataset)
                 else:
-                    done = ','.join(name for name, op in operations.items() if op["state"] == "OK")
-                    status = ','.join(f"{name}={op['state']}" for name, op in operations.items() if op["state"] != "OK")
+                    done = ",".join(
+                        name for name, op in operations.items() if op["state"] == "OK"
+                    )
+                    status = ",".join(
+                        f"{name}={op['state']}"
+                        for name, op in operations.items()
+                        if op["state"] != "OK"
+                    )
                     print(f"\t\tfinished {done!r}, awaiting {status!r}")
                     not_indexed.append(dataset)
         except HTTPError as exc:

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -133,7 +133,9 @@ class TestPut:
                     assert operations["BACKUP"]["state"] in ("OK", "READY")
                     indexed.append(dataset)
                 else:
-                    print(f"\t\tstate={state!r} status={status!r}")
+                    done = ','.join(name for name, op in operations.items() if op["state"] == "OK")
+                    status = ','.join(f"{name}={op['state']}" for name, op in operations.items() if op["state"] != "OK")
+                    print(f"\t\tfinished {done!r}, awaiting {status!r}")
                     not_indexed.append(dataset)
         except HTTPError as exc:
             pytest.fail(

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -26,7 +26,7 @@ import pbench.server.auth.auth as Auth
 from pbench.server.database import init_db
 from pbench.server.database.database import Database
 from pbench.server.database.models.active_tokens import ActiveTokens
-from pbench.server.database.models.datasets import Dataset, Metadata, States
+from pbench.server.database.models.datasets import Dataset, Metadata
 from pbench.server.database.models.template import Template
 from pbench.server.database.models.users import User
 from pbench.test import on_disk_config
@@ -327,10 +327,10 @@ def attach_dataset(create_drb_user, create_user):
 
     The resulting datasets are:
 
-        Owner   Access  Date        Name
-        ------- ------- ----------- ---------
-        drb     private 2020-02-15  drb
-        test    private 2002-05-16  test
+        Owner   Access  Uploaded    Name
+        ------- ------- ----------  ----
+        drb     private 2022-01-01  drb
+        test    private 1970-01-01  test
 
     Args:
         create_drb_user: create a "drb" user
@@ -344,17 +344,13 @@ def attach_dataset(create_drb_user, create_user):
     with freeze_time("1970-01-01 00:42:00"):
         Dataset(
             owner_id=str(create_drb_user.id),
-            created=datetime.datetime(2020, 2, 15),
             uploaded=datetime.datetime(2022, 1, 1),
-            state=States.INDEXED,
             name="drb",
             access="private",
             resource_id="random_md5_string1",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2002, 5, 16),
-            state=States.INDEXED,
             name="test",
             access="private",
             resource_id="random_md5_string2",
@@ -375,16 +371,16 @@ def more_datasets(
 
     In combination with attach_dataset, the resulting datasets are:
 
-        Owner   Access  Date        Name
-        ------- ------- ----------- ---------
-        drb     private 2020-02-15  drb
-        test    private 2002-05-16  test
-        drb     public  2020-02-15  fio_1
-        test    public  2002-05-16  fio_2
-        test    private 2022-12-08  uperf_1
-        test    private 2022-12-09  uperf_2
-        test    private 2022-12-10  uperf_3
-        test    private 2022-12-11  uperf_4
+        Owner   Access  Uploaded    Name
+        ------- ------- ----------  ----
+        drb     private 2022-01-01  drb
+        test    private 1970-01-01  test
+        drb     public  1978-06-26  fio_1
+        test    public  2022-01-01  fio_2
+        test    private 1978-06-26  uperf_1
+        test    private 1978-06-26  uperf_2
+        test    private 1978-06-26  uperf_3
+        test    private 1978-06-26  uperf_4
 
     Args:
         client: Provide a Flask API client
@@ -392,54 +388,42 @@ def more_datasets(
         create_drb_user: Create the "drb" user
         create_admin_user: Create the "test_admin" user
         attach_dataset: Provide some datasets
-        create_user: Create another user
+        create_user: Create the "test" user
     """
     with freeze_time("1978-06-26 08:00:00"):
         Dataset(
             owner_id=str(create_drb_user.id),
-            created=datetime.datetime(2020, 2, 15),
-            uploaded=datetime.datetime(2022, 1, 1),
-            state=States.INDEXED,
             name="fio_1",
             access="public",
             resource_id="random_md5_string3",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2002, 5, 16),
-            state=States.INDEXED,
+            uploaded=datetime.datetime(2022, 1, 1),
             name="fio_2",
             access="public",
             resource_id="random_md5_string4",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2022, 12, 8),
-            state=States.INDEXED,
             name="uperf_1",
             access="private",
             resource_id="random_md5_string5",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2022, 12, 9),
-            state=States.INDEXED,
             name="uperf_2",
             access="private",
             resource_id="random_md5_string6",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2022, 12, 10),
-            state=States.INDEXED,
             name="uperf_3",
             access="private",
             resource_id="random_md5_string7",
         ).add()
         Dataset(
             owner_id=str(create_user.id),
-            created=datetime.datetime(2020, 12, 11),
-            state=States.INDEXED,
             name="uperf_4",
             access="private",
             resource_id="random_md5_string8",

--- a/lib/pbench/test/unit/server/database/test_datasets_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_db.py
@@ -1,33 +1,12 @@
-from datetime import datetime
-
 from freezegun.api import freeze_time
 import pytest
 
-from pbench.server.database.models.datasets import (
-    Dataset,
-    DatasetBadParameterType,
-    DatasetBadStateTransition,
-    DatasetNotFound,
-    States,
-)
+from pbench.server.database.models.datasets import Dataset, DatasetNotFound
 from pbench.server.database.models.users import User
 from pbench.test.unit.server import DRB_USER_ID
 
 
 class TestDatasets:
-    def test_state_enum(self):
-        """Test the States ENUM properties"""
-        assert len(States.__members__) == 6
-        for n, s in States.__members__.items():
-            assert str(s) == s.friendly
-            assert s.mutating == (
-                "ing" in s.friendly
-            ), f"Enum {n} name and state don't match"
-
-            # We have no "terminal" states: every state must be a key in the
-            # transitions table!
-            assert s in Dataset.transitions
-
     def test_construct(self, db_session, create_user):
         """Test dataset contructor"""
         user = create_user
@@ -36,27 +15,16 @@ class TestDatasets:
             ds.add()
         assert ds.owner_id == str(user.id)
         assert ds.name == "fio"
-        assert ds.state == States.UPLOADING
         assert ds.resource_id == "f00b0ad"
-
-        # The "uploaded" and "transition" timestamps will be set automatically
-        # to the current time, and should initially be identical. The
-        # "created" timestamp cannot be set until a tarball has been fully
-        # uploaded and we unpack and process the metadata.log file; the
-        # constructor leaves this empty to avoid confusion.
-        assert ds.created is None
-        assert ds.uploaded <= ds.transition
         assert ds.id is not None
         assert f"({user.id})|fio" == str(ds)
         assert ds.as_dict() == {
             "access": "private",
-            "created": None,
             "name": "fio",
             "owner_id": str(user.id),
-            "state": "Uploading",
-            "transition": "1970-01-01T00:00:00+00:00",
             "uploaded": "1970-01-01T00:00:00+00:00",
             "metalog": None,
+            "operations": {},
         }
 
     def test_dataset_survives_user(self, db_session, create_user):
@@ -78,11 +46,8 @@ class TestDatasets:
         ds1 = Dataset.query(name="drb")
         assert ds1.as_dict() == {
             "access": "private",
-            "created": "2020-02-15T00:00:00+00:00",
             "name": "drb",
             "owner_id": DRB_USER_ID,
-            "state": "Indexed",
-            "transition": "1970-01-01T00:42:00+00:00",
             "uploaded": "2022-01-01T00:00:00+00:00",
             "metalog": {
                 "pbench": {
@@ -93,128 +58,25 @@ class TestDatasets:
                 },
                 "run": {"controller": "node1.example.com"},
             },
+            "operations": {},
         }
-
-    def test_construct_bad_state(self, db_session, create_user):
-        """Test with a non-States state value"""
-        with pytest.raises(DatasetBadParameterType):
-            Dataset(
-                owner_id=str(create_user.id),
-                name="fio",
-                resource_id="d00d",
-                state="notStates",
-            )
-
-    def test_attach_exists(self, db_session, create_user):
-        """Test that we can attach to a dataset"""
-        ds1 = Dataset(
-            owner_id=str(create_user.id),
-            name="fio",
-            resource_id="bib",
-            state=States.INDEXING,
-        )
-        ds1.add()
-
-        ds2 = Dataset.attach(resource_id=ds1.resource_id, state=States.INDEXED)
-        assert ds2.owner_id == ds1.owner_id
-        assert ds2.name == ds1.name
-        assert ds2.state == States.INDEXED
-        assert ds2.resource_id is ds1.resource_id
-        assert ds2.id is ds1.id
-
-    def test_attach_none(self, db_session):
-        """Test expected failure when we try to attach to a dataset that
-        does not exist.
-        """
-        with pytest.raises(DatasetNotFound):
-            Dataset.attach(resource_id="xyzzy", state=States.UPLOADING)
 
     def test_query_name(self, db_session, create_user):
         """Test that we can find a dataset by name alone"""
-        ds1 = Dataset(
-            owner_id=str(create_user.id),
-            resource_id="deed1e",
-            name="fio",
-            state=States.INDEXING,
-        )
+        ds1 = Dataset(owner_id=str(create_user.id), resource_id="deed1e", name="fio")
         ds1.add()
 
         ds2 = Dataset.query(name="fio")
         assert ds2.name == "fio"
         assert ds2.owner_id == ds1.owner_id
         assert ds2.name == ds1.name
-        assert ds2.state == ds1.state
         assert ds2.resource_id == ds1.resource_id
         assert ds2.id == ds1.id
-
-    def test_advanced_good(self, db_session, create_user):
-        """Test advancing the state of a dataset"""
-        with freeze_time("2525-05-25T15:15"):
-            ds = Dataset(
-                owner_id=str(create_user.id), name="fio", resource_id="beefeed"
-            )
-            ds.created = datetime(2020, 1, 25, 23, 14)
-            ds.add()
-        with freeze_time("2525-08-25T15:25"):
-            ds.advance(States.UPLOADED)
-        assert ds.state == States.UPLOADED
-        assert ds.uploaded <= ds.transition
-        assert ds.as_dict() == {
-            "access": "private",
-            "created": "2020-01-25T23:14:00+00:00",
-            "name": "fio",
-            "owner_id": str(create_user.id),
-            "state": "Uploaded",
-            "transition": "2525-08-25T15:25:00+00:00",
-            "uploaded": "2525-05-25T15:15:00+00:00",
-            "metalog": None,
-        }
-
-    def test_advanced_bad_state(self, db_session, create_user):
-        """Test with a non-States state value"""
-        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="feebeed")
-        ds.add()
-        with pytest.raises(DatasetBadParameterType):
-            ds.advance("notStates")
-
-    def test_advanced_illegal(self, db_session, create_user):
-        """Test that we can't advance to a state that's not a
-        successor to the initial state.
-        """
-        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="debead")
-        ds.add()
-        with pytest.raises(DatasetBadStateTransition):
-            ds.advance(States.DELETED)
-
-    def test_lifecycle(self, db_session, create_user):
-        """Advance a dataset through the entire lifecycle using the state
-        transition dict.
-        """
-        ds = Dataset(owner_id=str(create_user.id), name="fio", resource_id="beaddee")
-        ds.add()
-        assert ds.state == States.UPLOADING
-        beenthere = [ds.state]
-        while ds.state in Dataset.transitions:
-            advances = Dataset.transitions[ds.state]
-            for n in advances:
-                if n not in beenthere:
-                    next = n
-                    break
-            else:
-                break  # avoid infinite reindex loop!
-            beenthere.append(next)
-            ds.advance(next)
-            assert ds.state == next
-        lifecycle = ",".join([s.name for s in beenthere])
-        assert lifecycle == "UPLOADING,UPLOADED,INDEXING,INDEXED,DELETING,DELETED"
 
     def test_delete(self, db_session, create_user):
         """Test that we can delete a dataset"""
         ds1 = Dataset(
-            owner_id=str(create_user.id),
-            name="foobar",
-            resource_id="f00dea7",
-            state=States.INDEXING,
+            owner_id=str(create_user.id), name="foobar", resource_id="f00dea7"
         )
         ds1.add()
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_update.py
@@ -155,7 +155,7 @@ class TestDatasetsUpdate:
         # Verify the report and status
         assert response.status_code == HTTPStatus.CONFLICT
         assert response.json == {
-            "message": "Dataset update requires 'Indexed' dataset but state is 'Indexed'"
+            "message": "Operation unavailable: dataset random_md5_string1 is not indexed."
         }
 
     def test_exception(

--- a/lib/pbench/test/unit/server/test_datasets_daterange.py
+++ b/lib/pbench/test/unit/server/test_datasets_daterange.py
@@ -63,16 +63,16 @@ class TestDatasetsDateRange:
         )
         for name in sorted(name_list):
             dataset = Dataset.query(name=name)
-            to_time = max(dataset.created, to_time)
-            from_time = min(dataset.created, from_time)
+            to_time = max(dataset.uploaded, to_time)
+            from_time = min(dataset.uploaded, from_time)
         return {"from": from_time.isoformat(), "to": to_time.isoformat()}
 
     @pytest.mark.parametrize(
         "login,query,results",
         [
             ("drb", {"owner": "drb"}, ["drb", "fio_1"]),
-            ("drb", {"access": "public"}, ["drb", "fio_2"]),
-            ("test_admin", {"owner": "drb"}, ["drb"]),
+            ("drb", {"access": "public"}, ["fio_1", "fio_2"]),
+            ("test_admin", {"owner": "drb"}, ["drb", "fio_1"]),
             ("drb", {}, ["drb", "fio_1", "fio_2"]),
             (
                 "test",

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -122,7 +122,9 @@ class TestDatasetsList:
                     "name": dataset.name,
                     "resource_id": dataset.resource_id,
                     "metadata": {
-                        "dataset.created": datetime.datetime.isoformat(dataset.created)
+                        "dataset.uploaded": datetime.datetime.isoformat(
+                            dataset.uploaded
+                        )
                     },
                 }
             )
@@ -160,9 +162,17 @@ class TestDatasetsList:
                     "uperf_4",
                 ],
             ),
-            ("drb", {"start": "2000-01-01", "end": "2005-12-31"}, ["fio_2"]),
-            ("drb", {"start": "2005-01-01"}, ["drb", "fio_1"]),
-            ("drb", {"end": "2020-09-01"}, ["drb", "fio_1", "fio_2"]),
+            (
+                "drb",
+                {"start": "1978-06-25", "end": "2022-01-02"},
+                ["drb", "fio_1", "fio_2"],
+            ),
+            ("drb", {"start": "2005-01-01"}, ["drb", "fio_2"]),
+            (
+                "test",
+                {"end": "1980-01-01"},
+                ["test", "fio_1", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
+            ),
             ("drb", {"end": "1970-09-01"}, []),
         ],
     )
@@ -177,7 +187,7 @@ class TestDatasetsList:
                 automatically supplemented with a metadata request term)
             results: A list of the dataset names we expect to be returned
         """
-        query.update({"metadata": ["dataset.created"]})
+        query.update({"metadata": ["dataset.uploaded"]})
         result = query_as(query, login, HTTPStatus.OK)
         assert result.json == self.get_results(results, query, server_config)
 
@@ -204,7 +214,7 @@ class TestDatasetsList:
                 automatically supplemented with a metadata request term)
             results: A list of the dataset names we expect to be returned
         """
-        query.update({"metadata": ["dataset.created"], "limit": 5})
+        query.update({"metadata": ["dataset.uploaded"], "limit": 5})
         result = query_as(query, login, HTTPStatus.OK)
         assert result.json == self.get_results(results, query, server_config)
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -112,11 +112,8 @@ class TestDatasetsMetadataGet:
             "server.deletion": "2022-12-26",
             "dataset": {
                 "access": "private",
-                "created": "2020-02-15T00:00:00+00:00",
                 "name": "drb",
                 "owner_id": "3",
-                "state": "Indexed",
-                "transition": "1970-01-01T00:42:00+00:00",
                 "uploaded": "2022-01-01T00:00:00+00:00",
                 "metalog": {
                     "pbench": {
@@ -127,6 +124,7 @@ class TestDatasetsMetadataGet:
                     },
                     "run": {"controller": "node1.example.com"},
                 },
+                "operations": {},
             },
         }
 

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -21,7 +21,8 @@ from pbench.server.database.models.datasets import (
     Dataset,
     Metadata,
     MetadataBadKey,
-    States,
+    OperationName,
+    OperationState,
 )
 from pbench.server.indexing_tarballs import (
     Index,
@@ -29,24 +30,14 @@ from pbench.server.indexing_tarballs import (
     SigTermException,
     TarballData,
 )
-from pbench.server.sync import Operation
 from pbench.server.templates import TemplateError
 
 
 class FakeDataset:
-    logger: Logger
-    new_state: Optional[States] = None
-    advance_error: Optional[Exception] = None
-
     def __init__(self, name: str, resource_id: str):
         self.name = name
         self.resource_id = resource_id
         self.owner_id = 1
-
-    def advance(self, state: States):
-        if __class__.advance_error:
-            raise __class__.advance_error
-        __class__.new_state = state
 
     def __repr__(self) -> str:
         return self.name
@@ -54,7 +45,6 @@ class FakeDataset:
     @classmethod
     def reset(cls):
         cls.new_state = None
-        cls.advance_error = None
 
 
 class FakeMetadata:
@@ -210,10 +200,10 @@ class FakePbenchTarBall:
 
 
 class FakeSync:
-    tarballs: Dict[Operation, List[Dataset]] = {}
+    tarballs: Dict[OperationName, List[Dataset]] = {}
     called: List[str] = []
-    did: Optional[Operation] = None
-    updated: Optional[List[Operation]] = None
+    did: Optional[OperationState] = None
+    updated: Optional[List[OperationName]] = None
     errors: JSONOBJECT = {}
 
     @classmethod
@@ -224,20 +214,20 @@ class FakeSync:
         cls.updated = None
         cls.errors = {}
 
-    def __init__(self, logger: Logger, component: str):
+    def __init__(self, logger: Logger, component: OperationName):
         self.logger = logger
         self.component = component
 
-    def next(self, operation: Operation) -> List[Dataset]:
-        __class__.called.append(f"next-{operation.name}")
-        assert operation in __class__.tarballs
-        return __class__.tarballs[operation]
+    def next(self) -> List[Dataset]:
+        __class__.called.append(f"next-{self.component.name}")
+        assert self.component in __class__.tarballs
+        return __class__.tarballs[self.component]
 
     def update(
         self,
         dataset: Dataset,
-        did: Optional[Operation],
-        enabled: Optional[List[Operation]],
+        did: Optional[OperationState],
+        enabled: Optional[list[OperationName]],
     ):
         __class__.did = did
         __class__.updated = enabled
@@ -406,14 +396,14 @@ class TestIndexingTarballs:
         assert FakeReport.reported
 
     def test_collect_tb_empty(self, mocks, index):
-        FakeSync.tarballs[Operation.INDEX] = []
+        FakeSync.tarballs[OperationName.INDEX] = []
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
         assert tb_list == (0, [])
 
     def test_collect_tb_missing_tb(self, mocks, index):
         mocks.setattr("pbench.server.indexing_tarballs.os.stat", __class__.mock_stat)
-        FakeSync.tarballs[Operation.INDEX] = [ds1, ds2]
+        FakeSync.tarballs[OperationName.INDEX] = [ds1, ds2]
         FakeMetadata.no_tarball = ["ds2"]
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
@@ -423,7 +413,7 @@ class TestIndexingTarballs:
     def test_collect_tb_fail(self, mocks, index):
         mocks.setattr("pbench.server.indexing_tarballs.os.stat", __class__.mock_stat)
         __class__.stat_failure = {"ds1": OSError("something wicked that way goes")}
-        FakeSync.tarballs[Operation.INDEX] = [ds1, ds2]
+        FakeSync.tarballs[OperationName.INDEX] = [ds1, ds2]
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
         assert tb_list == (0, [tarball_2])
@@ -432,7 +422,7 @@ class TestIndexingTarballs:
     def test_collect_tb_exception(self, mocks, index):
         mocks.setattr("pbench.server.indexing_tarballs.os.stat", __class__.mock_stat)
         __class__.stat_failure = {"ds1": Exception("the greater of two weevils")}
-        FakeSync.tarballs[Operation.INDEX] = [ds1, ds2]
+        FakeSync.tarballs[OperationName.INDEX] = [ds1, ds2]
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
         assert tb_list == (12, [])
@@ -440,7 +430,7 @@ class TestIndexingTarballs:
 
     def test_collect_tb(self, mocks, index):
         mocks.setattr("pbench.server.indexing_tarballs.os.stat", self.mock_stat)
-        FakeSync.tarballs[Operation.INDEX] = [ds1, ds2]
+        FakeSync.tarballs[OperationName.INDEX] = [ds1, ds2]
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
         assert tb_list == (0, [tarball_2, tarball_1])

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -202,7 +202,7 @@ class FakePbenchTarBall:
 class FakeSync:
     tarballs: Dict[OperationName, List[Dataset]] = {}
     called: List[str] = []
-    did: Optional[OperationState] = None
+    state: Optional[OperationState] = None
     updated: Optional[List[OperationName]] = None
     errors: JSONOBJECT = {}
 
@@ -210,7 +210,7 @@ class FakeSync:
     def reset(cls):
         cls.tarballs = {}
         cls.called = []
-        cls.did = None
+        cls.state = None
         cls.updated = None
         cls.errors = {}
 
@@ -226,10 +226,10 @@ class FakeSync:
     def update(
         self,
         dataset: Dataset,
-        did: Optional[OperationState],
+        state: Optional[OperationState],
         enabled: Optional[list[OperationName]],
     ):
-        __class__.did = did
+        __class__.state = state
         __class__.updated = enabled
 
     def error(self, dataset: Dataset, message: str):

--- a/lib/pbench/test/unit/server/test_requests.py
+++ b/lib/pbench/test/unit/server/test_requests.py
@@ -19,7 +19,6 @@ from pbench.server.database.models.datasets import (
     DatasetNotFound,
     Metadata,
     MetadataKeyError,
-    States,
 )
 
 
@@ -322,12 +321,14 @@ class TestUpload:
         assert dataset is not None
         assert dataset.resource_id == md5
         assert dataset.name == name
-        assert dataset.state == States.UPLOADED
-        assert dataset.created.isoformat() == "2002-05-16T00:00:00+00:00"
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
         assert Metadata.getvalue(dataset, "global") is None
         assert Metadata.getvalue(dataset, Metadata.DELETION) == "1972-01-02"
-        assert Metadata.getvalue(dataset, Metadata.OPERATION) == ["BACKUP", "UNPACK"]
+        assert Metadata.getvalue(dataset, "dataset.operations") == {
+            "BACKUP": {"state": "READY", "message": None},
+            "UNPACK": {"state": "READY", "message": None},
+            "UPLOAD": {"state": "OK", "message": None},
+        }
         assert self.cachemanager_created
         assert dataset.name in self.cachemanager_created
 

--- a/lib/pbench/test/unit/server/test_sync.py
+++ b/lib/pbench/test/unit/server/test_sync.py
@@ -52,8 +52,8 @@ class TestSync:
             "UPLOAD": {"state": "FAILED", "message": "this is an error"}
         }
 
-    def test_update_did(self, make_logger, more_datasets):
-        """Test that the sync update operation changes the component state as
+    def test_update_state(self, make_logger, more_datasets):
+        """Test that the sync update operation sets the component state as
         specified.
         """
         drb = Dataset.query(name="drb")
@@ -76,9 +76,9 @@ class TestSync:
             "BACKUP": {"state": "OK", "message": None},
         }
 
-    def test_update_did_not_enabled(self, make_logger, more_datasets):
-        """Test that the sync update operation behaves correctly when the
-        specified component operation wasn't enabled.
+    def test_update_state_new(self, make_logger, more_datasets):
+        """Test that the sync update operation updates component state when the
+        specified component wasn't present.
         """
         drb = Dataset.query(name="drb")
         sync = Sync(make_logger, OperationName.INDEX)
@@ -94,8 +94,8 @@ class TestSync:
             "BACKUP": {"state": "READY", "message": None},
         }
 
-    def test_update_did_status(self, make_logger, more_datasets):
-        """Test that sync update records operation status."""
+    def test_update_state_update(self, make_logger, more_datasets):
+        """Test that sync update records operation state."""
         drb = Dataset.query(name="drb")
         sync = Sync(make_logger, OperationName.BACKUP)
         sync.update(drb, None, [OperationName.UNPACK, OperationName.BACKUP])
@@ -124,10 +124,8 @@ class TestSync:
             "REINDEX": {"state": "READY", "message": None},
         }
 
-    def test_update_enable_status(self, make_logger, more_datasets):
-        """Test that sync update can enable new operations and set a status
-        message.
-        """
+    def test_update_enable_message(self, make_logger, more_datasets):
+        """Test that sync update can enable new operations and set a message."""
         drb = Dataset.query(name="drb")
         sync = Sync(make_logger, OperationName.DELETE)
         sync.update(drb, enabled=[OperationName.UNPACK])
@@ -144,9 +142,9 @@ class TestSync:
             "DELETE": {"state": "FAILED", "message": "bad"},
         }
 
-    def test_update_did_enable(self, make_logger, more_datasets):
-        """Verify sync update behavior with "did", "enabled" operation set,
-        with success status.
+    def test_update_state_enable(self, make_logger, more_datasets):
+        """Verify sync update behavior with both completed and enabled
+        operations
         """
         drb = Dataset.query(name="drb")
         sync = Sync(make_logger, OperationName.UNPACK)
@@ -165,8 +163,8 @@ class TestSync:
             "TOOLINDEX": {"state": "READY", "message": None},
         }
 
-    def test_update_did_enable_status(self, make_logger, more_datasets):
-        """Test sync update with all three options, to remove a completed
+    def test_update_state_enable_status(self, make_logger, more_datasets):
+        """Test sync update with all three options, to mark a completed
         operation, enable a new operation, and set a message.
         """
         drb = Dataset.query(name="drb")

--- a/lib/pbench/test/unit/server/test_sync.py
+++ b/lib/pbench/test/unit/server/test_sync.py
@@ -11,7 +11,7 @@ from pbench.server.sync import Sync, SyncSqlError
 
 class TestSync:
     @pytest.fixture
-    def fake_raise_session(self, monkeypatch):
+    def fake_raise_session(self, monkeypatch, attach_dataset):
         class FakeSession:
             def query(self, **kwargs):
                 raise Exception("nothing happened")

--- a/lib/pbench/test/unit/server/test_sync.py
+++ b/lib/pbench/test/unit/server/test_sync.py
@@ -1,18 +1,199 @@
 import pytest
 
-from pbench.server.database.models.datasets import Dataset, Metadata
-from pbench.server.sync import Operation, Sync, SyncSqlError
+from pbench.server.database.models.datasets import (
+    Dataset,
+    Metadata,
+    OperationName,
+    OperationState,
+)
+from pbench.server.sync import Sync, SyncSqlError
 
 
 class TestSync:
+    @pytest.fixture
+    def fake_raise_session(self, monkeypatch):
+        class FakeSession:
+            def query(self, **kwargs):
+                raise Exception("nothing happened")
+
+        monkeypatch.setattr("pbench.server.sync.Database.maker.begin", FakeSession())
+
     def test_construct(self, make_logger):
         """A few simple checks on the sync constructor, including the
         string conversion.
         """
-        sync = Sync(make_logger, "test")
+        sync = Sync(make_logger, OperationName.UPLOAD)
         assert sync.logger is make_logger
-        assert sync.component == "test"
-        assert str(sync) == "<Synchronizer for component 'test'>"
+        assert sync.component == OperationName.UPLOAD
+        assert str(sync) == "<Synchronizer for component 'UPLOAD'>"
+
+    def test_error(self, make_logger, more_datasets):
+        """Test that the sync error operation writes the expected data."""
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UPLOAD)
+        sync.update(drb, enabled=[OperationName.UPLOAD])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UPLOAD": {"state": "READY", "message": None}
+        }
+        sync.error(drb, "this is an error")
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UPLOAD": {"state": "FAILED", "message": "this is an error"}
+        }
+
+    def test_error_new(self, make_logger, more_datasets):
+        """Test that the sync error operation creates an operation row if one
+        didn't already exist."""
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UPLOAD)
+        sync.error(drb, "this is an error")
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UPLOAD": {"state": "FAILED", "message": "this is an error"}
+        }
+
+    def test_update_did(self, make_logger, more_datasets):
+        """Test that the sync update operation removes the specified "did"
+        operation from the pending operation set.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UPLOAD)
+        sync.update(drb, None, [OperationName.BACKUP, OperationName.UNPACK])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "READY", "message": None},
+        }
+        sync1 = Sync(make_logger, OperationName.BACKUP)
+        sync1.update(drb, OperationState.OK)
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "OK", "message": None},
+        }
+        sync2 = Sync(make_logger, OperationName.UNPACK)
+        sync2.update(drb, OperationState.FAILED, message="oops")
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "FAILED", "message": "oops"},
+            "BACKUP": {"state": "OK", "message": None},
+        }
+
+    def test_update_did_not_enabled(self, make_logger, more_datasets):
+        """Test that the sync update operation behaves correctly when the
+        specified "did" operation is not in the enabled operation set.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.INDEX)
+        sync.update(drb, None, [OperationName.UNPACK, OperationName.BACKUP])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "READY", "message": None},
+        }
+        sync.update(drb, did=OperationState.OK)
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "INDEX": {"state": "OK", "message": None},
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "READY", "message": None},
+        }
+
+    def test_update_did_status(self, make_logger, more_datasets):
+        """Test that sync update records operation status."""
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.BACKUP)
+        sync.update(drb, None, [OperationName.UNPACK, OperationName.BACKUP])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "READY", "message": None},
+        }
+        sync.update(drb, did=OperationState.FAILED, message="failed")
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None},
+            "BACKUP": {"state": "FAILED", "message": "failed"},
+        }
+
+    def test_update_enable(self, make_logger, more_datasets):
+        """Test that sync update correctly enables specified operations."""
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.INDEX)
+        sync.update(drb, enabled=[OperationName.REINDEX])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "REINDEX": {"state": "READY", "message": None}
+        }
+        sync.update(drb, enabled=[OperationName.BACKUP, OperationName.INDEX])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "BACKUP": {"state": "READY", "message": None},
+            "INDEX": {"state": "READY", "message": None},
+            "REINDEX": {"state": "READY", "message": None},
+        }
+
+    def test_update_enable_status(self, make_logger, more_datasets):
+        """Test that sync update can enable new operations and set a status
+        message.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.DELETE)
+        sync.update(drb, enabled=[OperationName.UNPACK])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "READY", "message": None}
+        }
+        sync.update(
+            drb, enabled=[OperationName.BACKUP, OperationName.INDEX], message="bad"
+        )
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "BACKUP": {"state": "READY", "message": None},
+            "INDEX": {"state": "READY", "message": None},
+            "UNPACK": {"state": "READY", "message": None},
+            "DELETE": {"state": "FAILED", "message": "bad"},
+        }
+
+    def test_update_did_enable(self, make_logger, more_datasets):
+        """Verify sync update behavior with "did", "enabled" operation set,
+        with success status.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UNPACK)
+        sync.update(drb, did=OperationState.WORKING)
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "WORKING", "message": None}
+        }
+        sync.update(
+            drb,
+            did=OperationState.OK,
+            enabled=[OperationName.BACKUP, OperationName.TOOLINDEX],
+        )
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "OK", "message": None},
+            "BACKUP": {"state": "READY", "message": None},
+            "TOOLINDEX": {"state": "READY", "message": None},
+        }
+
+    def test_update_did_enable_status(self, make_logger, more_datasets):
+        """Test sync update with all three options, to remove a completed
+        operation, enable a new operation, and set a message.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UNPACK)
+        sync.update(drb, did=OperationState.WORKING)
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "WORKING", "message": None}
+        }
+        sync.update(
+            drb, did=OperationState.OK, enabled=[OperationName.INDEX], message="plugh"
+        )
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "UNPACK": {"state": "OK", "message": "plugh"},
+            "INDEX": {"state": "READY", "message": None},
+        }
+
+    def test_tool_sequence(self, make_logger, more_datasets):
+        """Test sync update with INDEX and INDEX_TOOL does not find the data
+        again.
+        """
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.INDEX)
+        sync.update(drb, did=OperationState.OK, enabled=[OperationName.TOOLINDEX])
+        assert Metadata.getvalue(drb, "dataset.operations") == {
+            "INDEX": {"state": "OK", "message": None},
+            "TOOLINDEX": {"state": "READY", "message": None},
+        }
+        dataset_l = sync.next()
+        assert len(dataset_l) == 0, f"{dataset_l!r}"
 
     def test_next(self, make_logger, more_datasets):
         """Test that the sync next operation returns the datasets enabled for
@@ -21,130 +202,38 @@ class TestSync:
         drb = Dataset.query(name="drb")
         fio_1 = Dataset.query(name="fio_1")
         fio_2 = Dataset.query(name="fio_2")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK"])
-        Metadata.setvalue(fio_1, Metadata.OPERATION, ["UNPACK"])
-        Metadata.setvalue(fio_2, Metadata.OPERATION, ["BACKUP"])
-        list = sync.next(Operation.UNPACK)
+        sync = Sync(make_logger, OperationName.UNPACK)
+        sync.update(drb, None, [OperationName.UNPACK])
+        sync.update(fio_1, None, [OperationName.UNPACK])
+        sync.update(fio_2, None, [OperationName.BACKUP])
+        list = sync.next()
         assert ["drb", "fio_1"] == sorted(d.name for d in list)
 
-    def test_next_failure(self, monkeypatch, make_logger):
+    def test_next_failure(self, fake_raise_session, make_logger):
         """Test the behavior of the sync next behavior when a DB failure
         occurs.
         """
 
-        def fake_query(self, *entities, **kwargs):
-            raise Exception("nothing happened")
-
-        sync = Sync(make_logger, "test")
-        monkeypatch.setattr("pbench.server.sync.Database.db_session.query", fake_query)
+        sync = Sync(make_logger, OperationName.UNPACK)
         with pytest.raises(SyncSqlError):
-            sync.next(Operation.UNPACK)
+            sync.next()
 
-    def test_error(self, make_logger, more_datasets):
-        """Test that the sync error operation writes the expected metadata."""
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        sync.error(drb, "this is an error")
-        assert Metadata.getvalue(drb, "server.status.test") == "this is an error"
-
-    def test_update_did(self, make_logger, more_datasets):
-        """Test that the sync update operation removes the specified "did"
-        operation from the pending operation set.
+    def test_update_failure(self, fake_raise_session, make_logger):
+        """Test the behavior of the sync next behavior when a DB failure
+        occurs.
         """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK", "BACKUP"])
-        sync.update(drb, did=Operation.BACKUP)
-        assert Metadata.getvalue(drb, "server.status.test") == "ok"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == ["UNPACK"]
 
-    def test_update_did_not_enabled(self, make_logger, more_datasets):
-        """Test that the sync update operation behaves correctly when the
-        specified "did" operation is not in the enabled operation set.
+        drb = Dataset.query(name="drb")
+        sync = Sync(make_logger, OperationName.UNPACK)
+        with pytest.raises(SyncSqlError):
+            sync.update(drb, OperationState.OK)
+
+    def test_error_failure(self, fake_raise_session, make_logger):
+        """Test the behavior of the sync next behavior when a DB failure
+        occurs.
         """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK", "BACKUP"])
-        sync.update(drb, did=Operation.INDEX)
-        assert Metadata.getvalue(drb, "server.status.test") == "ok"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == ["BACKUP", "UNPACK"]
 
-    def test_update_did_status(self, make_logger, more_datasets):
-        """Test that sync update records operation status."""
         drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK", "BACKUP"])
-        sync.update(drb, did=Operation.BACKUP, status="failed")
-        assert Metadata.getvalue(drb, "server.status.test") == "failed"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == ["UNPACK"]
-
-    def test_update_enable(self, make_logger, more_datasets):
-        """Test that sync update correctly enables specified operations."""
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK"])
-        sync.update(drb, enabled=[Operation.BACKUP, Operation.INDEX])
-        assert Metadata.getvalue(drb, "server.status.test") is None
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == [
-            "BACKUP",
-            "INDEX",
-            "UNPACK",
-        ]
-
-    def test_update_enable_status(self, make_logger, more_datasets):
-        """Test that sync update can enable new operations and set a status
-        message.
-        """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK"])
-        sync.update(drb, enabled=[Operation.BACKUP, Operation.INDEX], status="bad")
-        assert Metadata.getvalue(drb, "server.status.test") == "bad"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == [
-            "BACKUP",
-            "INDEX",
-            "UNPACK",
-        ]
-
-    def test_update_did_enable(self, make_logger, more_datasets):
-        """Verify sync update behavior with "did", "enabled" operation set,
-        with the default success message.
-        """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["INDEX", "UNPACK"])
-        sync.update(
-            drb, did=Operation.UNPACK, enabled=[Operation.BACKUP, Operation.INDEX_TOOL]
-        )
-        assert Metadata.getvalue(drb, "server.status.test") == "ok"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == [
-            "BACKUP",
-            "INDEX",
-            "INDEX_TOOL",
-        ]
-
-    def test_update_did_enable_status(self, make_logger, more_datasets):
-        """Test sync update with all three options, to remove a completed
-        operation, enable a new operation, and set a message.
-        """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["UNPACK"])
-        sync.update(
-            drb, did=Operation.UNPACK, enabled=[Operation.INDEX], status="plugh"
-        )
-        assert Metadata.getvalue(drb, "server.status.test") == "plugh"
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == ["INDEX"]
-
-    def test_tool_sequence(self, make_logger, more_datasets):
-        """Test sync update with INDEX and INDEX_TOOL does not find the data
-        again.
-        """
-        drb = Dataset.query(name="drb")
-        sync = Sync(make_logger, "test")
-        Metadata.setvalue(drb, Metadata.OPERATION, ["INDEX"])
-        sync.update(drb, did=Operation.INDEX, enabled=[Operation.INDEX_TOOL])
-        assert Metadata.getvalue(drb, Metadata.OPERATION) == ["INDEX_TOOL"]
-        dataset_l = sync.next(Operation.INDEX)
-        assert len(dataset_l) == 0, f"{dataset_l!r}"
+        sync = Sync(make_logger, OperationName.UNPACK)
+        with pytest.raises(SyncSqlError):
+            sync.error(drb, "this won't work")

--- a/lib/pbench/test/unit/server/test_unpack_tarballs.py
+++ b/lib/pbench/test/unit/server/test_unpack_tarballs.py
@@ -110,12 +110,12 @@ class MockSync:
         return [x.dataset for x in datasets]
 
     def update(
-        self, dataset: Dataset, did: OperationState, enabled: list[OperationName]
+        self, dataset: Dataset, state: OperationState, enabled: list[OperationName]
     ):
         assert dataset.resource_id not in __class__.record
         __class__.record[dataset.resource_id] = {
             "component": self.component,
-            "did": did,
+            "state": state,
             "enabled": enabled,
         }
 
@@ -251,7 +251,7 @@ class TestUnpackTarballs:
         assert sorted(MockSync.record.keys()) == sorted(targets)
         for actions in MockSync.record.values():
             assert actions["component"] == OperationName.UNPACK
-            assert actions["did"] == OperationState.OK
+            assert actions["state"] == OperationState.OK
             assert actions["enabled"] == [OperationName.INDEX]
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/test_unpack_tarballs.py
+++ b/lib/pbench/test/unit/server/test_unpack_tarballs.py
@@ -85,6 +85,9 @@ class MockPath:
                 return StatResult(st_mode=0o554, st_size=t.size)
         raise FileNotFoundError(f"No such file or directory: '{self.path}'")
 
+    def __fspath__(self) -> str:
+        return self.path
+
     def __str__(self) -> str:
         return self.path
 

--- a/lib/pbench/test/unit/server/test_unpack_tarballs.py
+++ b/lib/pbench/test/unit/server/test_unpack_tarballs.py
@@ -8,9 +8,13 @@ import pytest
 
 from pbench.server import JSON, JSONOBJECT, PbenchServerConfig
 from pbench.server.cache_manager import TarballUnpackError
-from pbench.server.database.models.datasets import Dataset, Metadata
+from pbench.server.database.models.datasets import (
+    Dataset,
+    Metadata,
+    OperationName,
+    OperationState,
+)
 from pbench.server.database.models.users import User
-from pbench.server.sync import Operation
 from pbench.server.unpack_tarballs import UnpackTarballs
 
 
@@ -96,21 +100,35 @@ class MockPath:
 class MockSync:
 
     record: dict[str, JSONOBJECT] = {}
+    errors: dict[str, JSONOBJECT] = {}
 
-    def __init__(self, logger: Logger, component: str):
+    def __init__(self, logger: Logger, component: OperationName):
         self.component = component
         self.logger = logger
 
-    def next(self, operation: Operation) -> list[Dataset]:
+    def next(self) -> list[Dataset]:
         return [x.dataset for x in datasets]
 
-    def update(self, dataset: Dataset, did: Operation, enabled: list[Operation]):
+    def update(
+        self, dataset: Dataset, did: OperationState, enabled: list[OperationName]
+    ):
         assert dataset.resource_id not in __class__.record
-        __class__.record[dataset.resource_id] = {"did": did, "enabled": enabled}
+        __class__.record[dataset.resource_id] = {
+            "component": self.component,
+            "did": did,
+            "enabled": enabled,
+        }
+
+    def error(self, dataset: Dataset, message: str):
+        __class__.errors[dataset.resource_id] = {
+            "component": self.component,
+            "message": message,
+        }
 
     @classmethod
     def _reset(cls):
         cls.record = {}
+        cls.errors = {}
 
 
 class FakePbenchTemplates:
@@ -232,8 +250,9 @@ class TestUnpackTarballs:
         assert sorted(MockCacheManager.unpacked) == sorted(targets)
         assert sorted(MockSync.record.keys()) == sorted(targets)
         for actions in MockSync.record.values():
-            assert actions["did"] == Operation.UNPACK
-            assert actions["enabled"] == [Operation.INDEX]
+            assert actions["component"] == OperationName.UNPACK
+            assert actions["did"] == OperationState.OK
+            assert actions["enabled"] == [OperationName.INDEX]
 
     @pytest.mark.parametrize(
         "fail", [["md5.1"], ["md5.1", "md5.2"], ["md5.1", "md5.2", "md5.3"]]
@@ -270,15 +289,19 @@ class TestUnpackTarballs:
         result = obj.unpack_tarballs(0.0, float("inf"))
         assert result.success == len(datasets) - len(fail)
         assert result.total == len(datasets)
-        ids = sorted(
-            [
-                t.dataset.resource_id
-                for t in datasets
-                if t.dataset.resource_id not in fail
-            ]
-        )
-        assert sorted(MockCacheManager.unpacked) == ids
-        assert sorted(MockSync.record.keys()) == ids
+        success_ids = []
+        fail_ids = []
+        for t in datasets:
+            id = t.dataset.resource_id
+            if id in fail:
+                fail_ids.append(id)
+            else:
+                success_ids.append(id)
+        success_ids.sort()
+        fail_ids.sort()
+        assert sorted(MockCacheManager.unpacked) == success_ids
+        assert sorted(MockSync.record.keys()) == success_ids
+        assert sorted(MockSync.errors.keys()) == fail_ids
 
     def test_unpack_report(self, make_logger, mocks):
         obj = UnpackTarballs(MockConfig, make_logger)

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -384,7 +384,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
                 float(usage.used) / float(usage.total) * 100.0,
                 usage.free,
             )
-            sync.update(dataset=dataset, did=OperationState.OK)
+            sync.update(dataset=dataset, state=OperationState.OK)
         else:
             sync.error(
                 dataset=dataset,

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -275,8 +275,9 @@ def backup_data(lb_obj, s3_obj, config, logger):
             tar = Path(tb).resolve(strict=True)
         except FileNotFoundError:
             tar = None
-            sync.error(dataset, f"tarball link {tb} isn't a real file")
-            logger.error("Tarball link, '{}', does not resolve to a real location", tb)
+            error = f"Tarball link, '{tb}', does not resolve to a real file"
+            sync.error(dataset, error)
+            logger.error(error)
 
         logger.debug("Start backup of {}.", tar)
         # check tarball exists and it is a regular file

--- a/server/bin/pbench-backup-tarballs
+++ b/server/bin/pbench-backup-tarballs
@@ -13,10 +13,14 @@ from pbench.common.logger import get_pbench_logger
 from pbench.common.utils import md5sum
 from pbench.server import get_resolved_dir, PbenchServerConfig, timestamp
 from pbench.server.database import init_db
-from pbench.server.database.models.datasets import Dataset, DatasetError, Metadata
+from pbench.server.database.models.datasets import (
+    Metadata,
+    OperationName,
+    OperationState,
+)
 from pbench.server.report import Report
 from pbench.server.s3backup import NoSuchKey, S3Config, Status
-from pbench.server.sync import Operation, Sync
+from pbench.server.sync import Sync
 
 _NAME_ = "pbench-backup-tarballs"
 
@@ -259,8 +263,8 @@ def backup_to_s3(
 
 
 def backup_data(lb_obj, s3_obj, config, logger):
-    sync = Sync(logger, "backup")
-    datasets = sync.next(Operation.BACKUP)
+    sync = Sync(logger, OperationName.BACKUP)
+    datasets = sync.next()
     ntotal = nbackup_success = nbackup_fail = ns3_success = ns3_fail = process_fail = 0
 
     for dataset in datasets:
@@ -271,6 +275,7 @@ def backup_data(lb_obj, s3_obj, config, logger):
             tar = Path(tb).resolve(strict=True)
         except FileNotFoundError:
             tar = None
+            sync.error(dataset, f"tarball link {tb} isn't a real file")
             logger.error("Tarball link, '{}', does not resolve to a real location", tb)
 
         logger.debug("Start backup of {}.", tar)
@@ -322,15 +327,6 @@ def backup_data(lb_obj, s3_obj, config, logger):
         resultname = tar.name
         controller_path = tar.parent
         controller = controller_path.name
-        try:
-            dataset = Dataset.attach(resource_id=archive_md5_hex_value)
-        except DatasetError as e:
-            logger.error(
-                "Unable to find dataset with resource ID {!r}: {}",
-                archive_md5_hex_value,
-                str(e),
-            )
-            continue
 
         # This will handle all the local backup related
         # operations and count the number of successes and failures.
@@ -388,11 +384,12 @@ def backup_data(lb_obj, s3_obj, config, logger):
                 float(usage.used) / float(usage.total) * 100.0,
                 usage.free,
             )
-            sync.update(dataset=dataset, did=Operation.BACKUP)
+            sync.update(dataset=dataset, did=OperationState.OK)
         else:
-            # Do nothing when the backup fails, allowing us to retry on a
-            # future pass.
-            pass
+            sync.error(
+                dataset=dataset,
+                message=f"unable to backup: local {local_backup_result}, S3 {s3_backup_result}",
+            )
 
         logger.debug("End backup of {}.", tar)
 


### PR DESCRIPTION
PBENCH-993

This is fairly large, but yet much smaller than it started out. This solves two problems in Pbench Server task scheduling:

1. The default SQLAlchemy transaction model is to start a transaction on any SELECT and end it on any UPDATE or INSERT; this means there's no potential for atomic update. This impacts the management of all internal context, but serious problems have been observed with the "operation" and "state" of the datasets.
2. I began the dataset with the concept of a "state", as the dataset progresses through upload, backup, unpack, index, and delete. I quickly discovered that this wasn't ideal, but had trouble backing off completely from the concept. When I added the DB-based "operation" to replace the old filesystem links, the relationship between "operation" and "state" became even messier.

The primary change here is to divorce the `Sync` class entirely from general metadata. (I originally set out to make `Metadata` management atomic, and the fan-out was enormous: I'll tackle that again later, but while important in the long run, getting `Sync` working is immediately critical.)

There is a new `Operation` DB object associated with a `Dataset`, and this is entirely managed within the `Sync` class. For visibility, `Dataset.as_json` will collect associated rows just as it does for `dataset.metalog`, but this doesn't require any special transactional management. (It's a snapshot.)

I've completely *removed* the `Dataset.state` column (and its associated "last transition" timestamp). "State" is tracked and observed by the various `Operation` rows created and managed by `Sync`. This corresponds to the previous `dataset.status` sub-object managed by the old `Sync`: each named operation (`OperationName` enum) that's been associated to a dataset will have a row with `state` and `message` columns. The `state` can be advanced through `READY`, `WORKING`, `OK`, and `FAILED`, and a message can be associated with each row (on error via `Sync.error` or as part of transition via `Sync.update`).

While I was modifying the Dataset schema, I also removed the `created` column; it's really redundant with `dataset.metalog.pbench.date`, and we'll need to understand that for "non-Pbench-standard" tarballs we might not be able to get this anyway. This wasn't quite as "easy" as I'd thought, because it meant that I had to refactor date-range operations to work on `uploaded` (perhaps they should have been that way originally).

* `Sync.__init__`: Construct a sync object for a particular named operation.
* `Sync.next`: Return a list of datasets which have `Operation` rows for the sync component that are in `READY` state.
* `Sync.update`: Change the state of the sync component's `Operation`, optionally add a message to that `Operation`, and set a list of named operations for that dataset to `READY`.
* `Sync.error`: Change the state of the sync component's `Operation` to `FAILED` and record an explanatory message for the failure.

To avoid rippling massive SQLAlchemy transaction model changes across all our code, I've added a second session factory in `Database` with the most strict integrity level, `SERIALIZABLE`. (In fact, I *think* that `"REPEATABLE READ"` would be enough, and slightly more efficient, but sqlite3 doesn't support that and I don't think I want to trust the weaker model it does support.)

*Only* the `Sync` class in `sync.py` currently uses that alternate session factory. To avoid conflicts and confusions with autoflush and autocommit and other SQLAlchemy "help", I'm creating new sessions on-the-fly for each call and retiring them after commit/rollback. Note that the idiom `with Database.maker.begin() as session:` constructs a new session with fresh state, allows a sequence of session operations, and then implicitly tears down the session after it commits on success or rolls back on an exception.

To avoid multiple `SELECT` statements within our transaction, `Sync.update` fetches all relevant rows in a single `SELECT`, and then organizes them for selective updates. This ensures we have no `SELECT` following the update of any proxy object, which confuses SQLAlchemy in normal configuration.

`Sync.update` and `Sync.error` will loop up to 10 times on commit failure to re-try with fresh data. Note that I've observed the retry logic in dozens of functional test runs; and while I wonder vaguely whether I should be concerned with the constant 10, I rarely see more than one or two retries since I added a small delay to minimize thrashing.