### PR TITLE
Remove hyphen from openid-connect section of the endpoints api

### DIFF
--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -181,14 +181,14 @@ class EndpointConfig(Resource):
             secret = self.server_config.get("openid-connect", "secret")
             client = self.server_config.get("openid-connect", "client")
             realm = self.server_config.get("openid-connect", "realm")
-            issuer = self.server_config.get("openid-connect", "server_url")
+            server = self.server_config.get("openid-connect", "server_url")
         except (NoOptionError, NoSectionError):
             pass
         else:
-            endpoints["openid-connect"] = {
+            endpoints["openid"] = {
                 "client": client,
                 "realm": realm,
-                "issuer": issuer,
+                "server": server,
                 "secret": secret,
             }
 

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -178,9 +178,9 @@ class EndpointConfig(Resource):
         }
 
         try:
-            secret = self.server_config.get("openid-connect", "secret")
             client = self.server_config.get("openid-connect", "client")
             realm = self.server_config.get("openid-connect", "realm")
+            secret = self.server_config.get("openid-connect", "secret")
             server = self.server_config.get("openid-connect", "server_url")
         except (NoOptionError, NoSectionError):
             pass
@@ -188,8 +188,8 @@ class EndpointConfig(Resource):
             endpoints["openid"] = {
                 "client": client,
                 "realm": realm,
-                "server": server,
                 "secret": secret,
+                "server": server,
             }
 
         try:

--- a/lib/pbench/test/functional/server/test_connect.py
+++ b/lib/pbench/test/functional/server/test_connect.py
@@ -28,6 +28,6 @@ class TestConnect:
             assert e in endpoints["uri"].keys()
 
         # verify all the required openid-connect fields are present
-        if "openid-connect" in endpoints:
-            expected = {"issuer", "client", "realm", "secret"}
-            assert set(endpoints["openid-connect"]) >= expected
+        if "openid" in endpoints:
+            expected = {"server", "client", "realm", "secret"}
+            assert set(endpoints["openid"]) >= expected

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -140,7 +140,7 @@ class TestEndpointConfig:
 
         try:
             oidc_client = server_config.get("openid-connect", "client")
-            oidc_issuer = server_config.get("openid-connect", "server_url")
+            oidc_server = server_config.get("openid-connect", "server_url")
             oidc_realm = server_config.get("openid-connect", "realm")
             oidc_secret = server_config.get("openid-connect", "secret")
         except (NoOptionError, NoSectionError):
@@ -148,7 +148,7 @@ class TestEndpointConfig:
         else:
             expected_results["openid-connect"] = {
                 "client": oidc_client,
-                "issuer": oidc_issuer,
+                "server": oidc_server,
                 "realm": oidc_realm,
                 "secret": oidc_secret,
             }

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -140,17 +140,17 @@ class TestEndpointConfig:
 
         try:
             oidc_client = server_config.get("openid-connect", "client")
-            oidc_server = server_config.get("openid-connect", "server_url")
             oidc_realm = server_config.get("openid-connect", "realm")
             oidc_secret = server_config.get("openid-connect", "secret")
+            oidc_server = server_config.get("openid-connect", "server_url")
         except (NoOptionError, NoSectionError):
             pass
         else:
             expected_results["openid-connect"] = {
                 "client": oidc_client,
-                "server": oidc_server,
                 "realm": oidc_realm,
                 "secret": oidc_secret,
+                "server": oidc_server,
             }
 
         response = client.get(f"{server_config.rest_uri}/endpoints", headers=my_headers)


### PR DESCRIPTION
Addresses issue #3240 
Originally asked [here](https://github.com/distributed-system-analysis/pbench/pull/3233#discussion_r1101403449) 

Commit message:

Remove hyphen from openid-connect section of the endpoints API

- Getting rid of the excess quotes and brackets would make this easier to read
- It also makes easier to reference in Dashboard javascript code when there is 
no hyphen involved (`endpoints.openid` instead of `endpoints['openid-connect']`)