### PR TITLE
Add metadata query parameter on PUT

### DIFF
--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -13,8 +13,8 @@ Options:
   --delete / --no-delete         Remove local data after successful copy
                                  [default: delete]
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
-                                 Option may need to be specified multiple times
-                                 for multiple values. Format: key:value
+                                 Option may need to be specified multiple
+                                 times for multiple values. Format: key:value
   --show-server TEXT             Display information about the pbench server
                                  where the result(s) will be moved (Not
                                  implemented)

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -13,7 +13,7 @@ Options:
   --delete / --no-delete         Remove local data after successful copy
                                  [default: delete]
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
-                                 Option needs to be specified multiple times
+                                 Option may need to be specified multiple times
                                  for multiple values. Format: key:value
   --show-server TEXT             Display information about the pbench server
                                  where the result(s) will be moved (Not

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -12,6 +12,7 @@ Options:
   --controller TEXT              Override the default controller name
   --delete / --no-delete         Remove local data after successful copy
                                  [default: delete]
+  -m, --metadata TEXT            metadata to add information for server
   --show-server TEXT             Display information about the pbench server
                                  where the result(s) will be moved (Not
                                  implemented)

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -12,7 +12,9 @@ Options:
   --controller TEXT              Override the default controller name
   --delete / --no-delete         Remove local data after successful copy
                                  [default: delete]
-  -m, --metadata TEXT            metadata to add information for server
+  -m, --metadata TEXT            list of metadata keys to be sent on PUT.
+                                 Option needs to be specified multiple times
+                                 for multiple values. Format: key:value
   --show-server TEXT             Display information about the pbench server
                                  where the result(s) will be moved (Not
                                  implemented)

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -11,6 +11,7 @@ Options:
   -C, --config PATH              Path to a pbench-agent configuration file
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]
+  -m, --metadata TEXT            metadata to add information for server
   --token TEXT                   pbench server authentication token
                                  [required]
   --help                         Show this message and exit.

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -12,7 +12,7 @@ Options:
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
-                                 Option needs to be specified multiple times
+                                 Option may need to be specified multiple times
                                  for multiple values. Format: key:value
   --token TEXT                   pbench server authentication token
                                  [required]

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -12,8 +12,8 @@ Options:
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
-                                 Option may need to be specified multiple times
-                                 for multiple values. Format: key:value
+                                 Option may need to be specified multiple
+                                 times for multiple values. Format: key:value
   --token TEXT                   pbench server authentication token
                                  [required]
   --help                         Show this message and exit.

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -11,7 +11,9 @@ Options:
   -C, --config PATH              Path to a pbench-agent configuration file
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]
-  -m, --metadata TEXT            metadata to add information for server
+  -m, --metadata TEXT            list of metadata keys to be sent on PUT.
+                                 Option needs to be specified multiple times
+                                 for multiple values. Format: key:value
   --token TEXT                   pbench server authentication token
                                  [required]
   --help                         Show this message and exit.

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -324,8 +324,8 @@ class CopyResultTb:
             access: keyword that identifies whether a dataset needs
                 to be published public or private.  Optional:  if omitted
                 the result will be the server default.
-            metadata: multiple or single additional metadata keys
-                that are required to be sent on PUT.
+            metadata: list of metadata keys to be sent on PUT. (Optional)
+                Format: key:value
 
         Raises:
             RuntimeError     if a connection to the server fails

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 import shutil
 import subprocess
-from typing import Optional
+from typing import List, Optional
 import urllib.parse
 
 import requests
@@ -311,7 +311,9 @@ class CopyResultTb:
         self.upload_url = f"{server_rest_url}/upload/{tbname}"
         self.logger = logger
 
-    def copy_result_tb(self, token: str, access: Optional[str] = None) -> None:
+    def copy_result_tb(
+        self, token: str, access: Optional[str] = None, metadata: Optional[List] = None
+    ) -> None:
         """Copies the tar ball from the agent to the configured server using upload
         API.
 
@@ -322,6 +324,8 @@ class CopyResultTb:
             access: keyword that identifies whether a dataset needs
                 to be published public or private.  Optional:  if omitted
                 the result will be the server default.
+            metadata: multiple or single additional metadata keys
+                that are required to be sent on PUT.
 
         Raises:
             RuntimeError     if a connection to the server fails
@@ -329,6 +333,9 @@ class CopyResultTb:
 
         """
         params = {"access": access} if access else {}
+        if metadata:
+            params["metadata"] = metadata
+
         headers = {
             "Content-MD5": self.tarball_md5,
             "Authorization": f"Bearer {token}",

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -31,9 +31,7 @@ class MoveResults(BaseCommand):
     def __init__(self, context: CliContext):
         super().__init__(context)
 
-    def execute(
-        self, metadata: List, single_threaded: bool, delete: bool = True
-    ) -> int:
+    def execute(self, single_threaded: bool, delete: bool = True) -> int:
         runs_copied = 0
         failures = 0
         no_of_tb = 0
@@ -107,7 +105,7 @@ class MoveResults(BaseCommand):
                         self.logger,
                     )
                     crt.copy_result_tb(
-                        self.context.token, self.context.access, metadata
+                        self.context.token, self.context.access, self.context.metadata
                     )
                 except Exception as exc:
                     if isinstance(exc, (CopyResultTb.FileUploadError, RuntimeError)):
@@ -241,12 +239,13 @@ def main(
 
     context.access = access
     context.token = token
+    context.metadata = metadata
 
     if show_server:
         click.echo("WARNING -- Option '--show-server' is not implemented", err=True)
 
     try:
-        rv = MoveResults(context).execute(metadata, xz_single_threaded, delete=delete)
+        rv = MoveResults(context).execute(xz_single_threaded, delete=delete)
     except Exception as exc:
         click.echo(exc, err=True)
         rv = 1

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import socket
 import tempfile
+from typing import List
 
 import click
 
@@ -30,7 +31,9 @@ class MoveResults(BaseCommand):
     def __init__(self, context: CliContext):
         super().__init__(context)
 
-    def execute(self, single_threaded: bool, delete: bool = True) -> int:
+    def execute(
+        self, metadata: List, single_threaded: bool, delete: bool = True
+    ) -> int:
         runs_copied = 0
         failures = 0
         no_of_tb = 0
@@ -103,7 +106,9 @@ class MoveResults(BaseCommand):
                         self.config,
                         self.logger,
                     )
-                    crt.copy_result_tb(self.context.token, self.context.access)
+                    crt.copy_result_tb(
+                        self.context.token, self.context.access, metadata
+                    )
                 except Exception as exc:
                     if isinstance(exc, (CopyResultTb.FileUploadError, RuntimeError)):
                         msg = "Error uploading file"
@@ -208,6 +213,7 @@ def main(
     access: str,
     token: str,
     delete: bool,
+    metadata: List,
     xz_single_threaded: bool,
     show_server: str,
 ):
@@ -240,7 +246,7 @@ def main(
         click.echo("WARNING -- Option '--show-server' is not implemented", err=True)
 
     try:
-        rv = MoveResults(context).execute(xz_single_threaded, delete=delete)
+        rv = MoveResults(context).execute(metadata, xz_single_threaded, delete=delete)
     except Exception as exc:
         click.echo(exc, err=True)
         rv = 1

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -15,7 +15,7 @@ class ResultsPush(BaseCommand):
     def __init__(self, context: CliContext):
         super().__init__(context)
 
-    def execute(self, metadata: List) -> int:
+    def execute(self) -> int:
         tarball_len, tarball_md5 = md5sum(self.context.result_tb_name)
         crt = CopyResultTb(
             self.context.result_tb_name,
@@ -24,7 +24,9 @@ class ResultsPush(BaseCommand):
             self.config,
             self.logger,
         )
-        crt.copy_result_tb(self.context.token, self.context.access, metadata)
+        crt.copy_result_tb(
+            self.context.token, self.context.access, self.context.metadata
+        )
         return 0
 
 
@@ -63,9 +65,10 @@ def main(
     context.result_tb_name = result_tb_name
     context.token = token
     context.access = access
+    context.metadata = metadata
 
     try:
-        rv = ResultsPush(context).execute(metadata)
+        rv = ResultsPush(context).execute()
     except Exception as exc:
         click.echo(exc, err=True)
         rv = 1

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import List
 
 import click
 
@@ -14,7 +15,7 @@ class ResultsPush(BaseCommand):
     def __init__(self, context: CliContext):
         super().__init__(context)
 
-    def execute(self) -> int:
+    def execute(self, metadata: List) -> int:
         tarball_len, tarball_md5 = md5sum(self.context.result_tb_name)
         crt = CopyResultTb(
             self.context.result_tb_name,
@@ -23,7 +24,7 @@ class ResultsPush(BaseCommand):
             self.config,
             self.logger,
         )
-        crt.copy_result_tb(self.context.token, self.context.access)
+        crt.copy_result_tb(self.context.token, self.context.access, metadata)
         return 0
 
 
@@ -48,6 +49,7 @@ def main(
     result_tb_name: str,
     token: str,
     access: str,
+    metadata: List,
 ):
     """Push a result tar ball to the configured Pbench server.
 
@@ -63,7 +65,7 @@ def main(
     context.access = access
 
     try:
-        rv = ResultsPush(context).execute()
+        rv = ResultsPush(context).execute(metadata)
     except Exception as exc:
         click.echo(exc, err=True)
         rv = 1

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -23,7 +23,7 @@ def results_common_options(f):
             multiple=True,
             help=(
                 "list of metadata keys to be sent on PUT."
-                " Option needs to be specified multiple times for multiple values."
+                " Option may need to be specified multiple times for multiple values."
                 " Format: key:value"
             ),
         ),

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -21,7 +21,11 @@ def results_common_options(f):
             required=False,
             default=[],
             multiple=True,
-            help="metadata to add information for server",
+            help=(
+                "list of metadata keys to be sent on PUT."
+                "Option needs to be specified multiple times for multiple values"
+                "Format: key:value"
+            ),
         ),
         click.option(
             "--token",

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -16,6 +16,14 @@ def results_common_options(f):
             help="pbench tarball access permission",
         ),
         click.option(
+            "-m",
+            "--metadata",
+            required=False,
+            default=[],
+            multiple=True,
+            help="metadata to add information for server",
+        ),
+        click.option(
             "--token",
             required=True,
             envvar="PBENCH_ACCESS_TOKEN",

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -23,8 +23,8 @@ def results_common_options(f):
             multiple=True,
             help=(
                 "list of metadata keys to be sent on PUT."
-                "Option needs to be specified multiple times for multiple values"
-                "Format: key:value"
+                " Option needs to be specified multiple times for multiple values."
+                " Format: key:value"
             ),
         ),
         click.option(

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -87,6 +87,47 @@ class TestCopyResults:
         # If we got this far without an exception, then the test passes.
 
     @responses.activate
+    @pytest.mark.parametrize(
+        "metadata", (["pbench.test:TEST", "pbench.sat:FOO"], (), None)
+    )
+    def test_with_metadata(self, metadata, monkeypatch, agent_logger):
+        tb_name = "test_tarball.tar.xz"
+        tb_contents = "I'm a result!"
+        access = "private"
+
+        def request_callback(request: requests.Request):
+            if metadata:
+                assert "metadata" in request.params
+                assert request.params["metadata"] == metadata
+            else:
+                assert "metadata" not in request.params
+            return HTTPStatus.OK, {}, ""
+
+        responses.add_callback(
+            responses.PUT,
+            f"{self.config.get('results', 'server_rest_url')}/upload/{tb_name}",
+            callback=request_callback,
+        )
+
+        monkeypatch.setattr(Path, "exists", lambda self: True)
+        monkeypatch.setattr(
+            Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
+        )
+
+        crt = CopyResultTb(
+            tb_name,
+            len(tb_contents),
+            "someMD5",
+            self.config,
+            agent_logger,
+        )
+        if metadata is None:
+            crt.copy_result_tb("token")
+        else:
+            crt.copy_result_tb("token", access, metadata)
+        # If we got this far without an exception, then the test passes.
+
+    @responses.activate
     def test_connection_error(self, monkeypatch, agent_logger):
         tb_name = "test_tarball.tar.xz"
         tb_contents = "I'm a result!"

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -22,14 +22,6 @@ class TestCopyResults:
         self.config = None
 
     @staticmethod
-    def get_path_exists_mock(path: str, result: bool) -> Callable:
-        def mock_func(self: Path) -> bool:
-            assert self.name == path
-            return result
-
-        return mock_func
-
-    @staticmethod
     def get_path_open_mock(path: str, result: io.IOBase) -> Callable:
         def mock_func(self: Path, mode: str) -> io.IOBase:
             assert self.name == path
@@ -42,9 +34,7 @@ class TestCopyResults:
         bad_tarball_name = "nonexistent-tarball.tar.xz"
         expected_error_message = f"Tar ball '{bad_tarball_name}' does not exist"
 
-        monkeypatch.setattr(
-            Path, "exists", self.get_path_exists_mock(bad_tarball_name, False)
-        )
+        monkeypatch.setattr(Path, "exists", lambda self: False)
 
         with pytest.raises(FileNotFoundError) as excinfo:
             CopyResultTb(
@@ -78,7 +68,7 @@ class TestCopyResults:
             callback=request_callback,
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -106,7 +96,7 @@ class TestCopyResults:
             responses.PUT, upload_url, body=requests.exceptions.ConnectionError("uh-oh")
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )
@@ -133,7 +123,7 @@ class TestCopyResults:
 
         responses.add(responses.PUT, upload_url, body=RuntimeError("uh-oh"))
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+        monkeypatch.setattr(Path, "exists", lambda self: True)
         monkeypatch.setattr(
             Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
         )

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -48,6 +48,9 @@ class TestMoveResults:
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
     ACCESS_TEXT = "private"
     SWSR_TEXT = None
+    META_SWITCH = "--metadata"
+    META_TEXT_FOO = "pbench.sat:FOO"
+    META_TEXT_TEST = "pbench.test:TEST"
     URL = "http://pbench.example.com/api/v1"
     ENDPOINT = "/login"
 
@@ -79,6 +82,68 @@ class TestMoveResults:
                 TestMoveResults.SWSR_TEXT,
                 TestMoveResults.ACCESS_SWITCH,
                 TestMoveResults.ACCESS_TEXT,
+            ],
+        )
+        assert (
+            result.exit_code == 0
+        ), f"Expected success exit code of 0: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        assert (
+            not result.stderr
+        ), f"Unexpected stderr: '{result.stderr}', stdout: '{result.stdout}'"
+        assert result.stdout.startswith(
+            "Status: total "
+        ), f"Unexpected stdout: '{result.stdout}', stderr: '{result.stderr}'"
+
+    @staticmethod
+    @responses.activate
+    def test_metadata_args():
+        """Test metadata with irregular option/value pair"""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestMoveResults.CTRL_SWITCH,
+                TestMoveResults.CTRL_TEXT,
+                TestMoveResults.TOKN_SWITCH,
+                TestMoveResults.TOKN_TEXT,
+                TestMoveResults.DELY_SWITCH,
+                TestMoveResults.XZST_SWITCH,
+                TestMoveResults.SWSR_SWITCH,
+                TestMoveResults.SWSR_TEXT,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
+                TestMoveResults.META_SWITCH,
+                TestMoveResults.META_TEXT_TEST,
+                TestMoveResults.META_TEXT_FOO,
+            ],
+        )
+        assert (
+            result.exit_code == 2
+        ), f"Expected success exit code of 0: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        assert result.stderr, f"Usage: '{result.stderr}', stdout: '{result.stdout}'"
+
+    @staticmethod
+    @responses.activate
+    def test_multiple_metadata_args():
+        """Test metadata with multiple values"""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestMoveResults.CTRL_SWITCH,
+                TestMoveResults.CTRL_TEXT,
+                TestMoveResults.TOKN_SWITCH,
+                TestMoveResults.TOKN_TEXT,
+                TestMoveResults.DELY_SWITCH,
+                TestMoveResults.XZST_SWITCH,
+                TestMoveResults.SWSR_SWITCH,
+                TestMoveResults.SWSR_TEXT,
+                TestMoveResults.ACCESS_SWITCH,
+                TestMoveResults.ACCESS_TEXT,
+                TestMoveResults.META_SWITCH,
+                TestMoveResults.META_TEXT_TEST,
+                TestMoveResults.META_SWITCH,
+                TestMoveResults.META_TEXT_FOO,
             ],
         )
         assert (

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -119,8 +119,9 @@ class TestMoveResults:
         )
         assert (
             result.exit_code == 2
-        ), f"Expected success exit code of 0: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        ), f"Expected exit code of 2: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
         assert result.stderr, f"Usage: '{result.stderr}', stdout: '{result.stdout}'"
+        assert "Error: Got unexpected extra argument (pbench.sat:FOO)" in result.stderr
 
     @staticmethod
     @responses.activate

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -120,7 +120,6 @@ class TestMoveResults:
         assert (
             result.exit_code == 2
         ), f"Expected exit code of 2: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
-        assert result.stderr, f"Usage: '{result.stderr}', stdout: '{result.stdout}'"
         assert "Error: Got unexpected extra argument (pbench.sat:FOO)" in result.stderr
 
     @staticmethod

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -17,6 +17,9 @@ class TestResultsPush:
     ACCESS_SWITCH = "--access"
     ACCESS_TEXT = "public"
     ACCESS_WRONG_TEXT = "public/private"
+    META_SWITCH = "--metadata"
+    META_TEXT_FOO = "pbench.sat:FOO"
+    META_TEXT_TEST = "pbench.test:TEST"
     URL = "http://pbench.example.com/api/v1"
 
     @staticmethod
@@ -85,6 +88,35 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
+    def test_meta_args():
+        """Test operation when irregular arguments and options are specified"""
+
+        TestResultsPush.add_http_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.TOKN_SWITCH,
+                TestResultsPush.TOKN_TEXT,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+                TestResultsPush.META_SWITCH,
+                TestResultsPush.META_TEXT_TEST,
+                TestResultsPush.META_TEXT_FOO,
+                tarball,
+            ],
+        )
+        assert result.exit_code == 2
+        assert (
+            result.stderr.find(
+                "Invalid value for 'RESULT_TB_NAME': "
+                "File 'pbench.sat:FOO' does not exist."
+            )
+            > -1
+        )
+
+    @staticmethod
+    @responses.activate
     def test_extra_arg():
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
@@ -101,7 +133,7 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_args():
+    def test_multiple_meta_args():
         """Test normal operation when all arguments and options are specified"""
 
         TestResultsPush.add_http_mock_response()
@@ -113,6 +145,10 @@ class TestResultsPush:
                 TestResultsPush.TOKN_TEXT,
                 TestResultsPush.ACCESS_SWITCH,
                 TestResultsPush.ACCESS_TEXT,
+                TestResultsPush.META_SWITCH,
+                TestResultsPush.META_TEXT_TEST,
+                TestResultsPush.META_SWITCH,
+                TestResultsPush.META_TEXT_FOO,
                 tarball,
             ],
         )

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -108,11 +108,8 @@ class TestResultsPush:
         )
         assert result.exit_code == 2
         assert (
-            result.stderr.find(
-                "Invalid value for 'RESULT_TB_NAME': "
-                "File 'pbench.sat:FOO' does not exist."
-            )
-            > -1
+            "Invalid value for 'RESULT_TB_NAME': "
+            "File 'pbench.sat:FOO' does not exist." in result.stderr
         )
 
     @staticmethod
@@ -130,6 +127,28 @@ class TestResultsPush:
         )
         assert result.exit_code == 2
         assert result.stderr.find("unexpected extra argument") > -1
+
+    @staticmethod
+    @responses.activate
+    def test_multiple_meta_args_single_option():
+        """Test normal operation when all arguments and options are specified"""
+
+        TestResultsPush.add_http_mock_response()
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestResultsPush.TOKN_SWITCH,
+                TestResultsPush.TOKN_TEXT,
+                TestResultsPush.ACCESS_SWITCH,
+                TestResultsPush.ACCESS_TEXT,
+                TestResultsPush.META_SWITCH,
+                TestResultsPush.META_TEXT_TEST + "," + TestResultsPush.META_TEXT_FOO,
+                tarball,
+            ],
+        )
+        assert result.exit_code == 0, result.stderr
+        assert result.stderr == "File uploaded successfully\n"
 
     @staticmethod
     @responses.activate


### PR DESCRIPTION
This PR will allow the Agent (or other client) to define metadata keys when initially uploading a dataset to the Pbench Server by specifying the ?metadata query parameter on the PUT.

This PR is based on #3187 and should be merged after that.