### PR TITLE
Capture `DecodeError` generated by func tests

### DIFF
--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -125,6 +125,8 @@ def verify_auth(auth_token: str) -> Optional[Union[User, InternalUser]]:
         an internally generated one, and an `InternalUser` object when the
         token is validated using the OpenID Connect client.
     """
+    if not auth_token:
+        return None
     user = None
     try:
         if oidc_client is not None:
@@ -164,7 +166,7 @@ def verify_auth_internal(auth_token: str) -> Optional[User]:
                 "verify_exp": True,
             },
         )
-    except jwt.InvalidSignatureError:
+    except (jwt.InvalidSignatureError, jwt.DecodeError):
         pass
     except jwt.ExpiredSignatureError:
         try:


### PR DESCRIPTION
And only try to verify auth tokens if we actually have one.

----

Stack trace when `verify_auth()` receives an empty authorization token:

```
2023-02-10T20:01:47.536580 ERROR 115 140622575369088 pbench.server.api auth verify_auth 135 -- Unexpected exception occurred while verifying the auth token '': Not enough segments
Traceback (most recent call last):
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 250, in _load
    signing_input, crypto_segment = jwt.rsplit(b".", 1)
ValueError: not enough values to unpack (expected 2, got 1)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/pbench-server/lib/pbench/server/auth/auth.py", line 133, in verify_auth
    user = verify_auth_internal(auth_token)
  File "/opt/pbench-server/lib/pbench/server/auth/auth.py", line 157, in verify_auth_internal
    payload = jwt.decode(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jwt.py", line 168, in decode
    decoded = self.decode_complete(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jwt.py", line 120, in decode_complete
    decoded = api_jws.decode_complete(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 191, in decode_complete
    payload, signing_input, header, signature = self._load(jwt)
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 253, in _load
    raise DecodeError("Not enough segments") from err
jwt.exceptions.DecodeError: Not enough segments
```

----

Stack trace when `verify_auth()` receives a bad authorization token:

```
2023-02-10T20:01:47.805466 ERROR 120 140622575369088 pbench.server.api auth verify_auth 135 -- Unexpected exception occurred while verifying the auth token 'of bad tokens': Not enough segments
Traceback (most recent call last):
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 250, in _load
    signing_input, crypto_segment = jwt.rsplit(b".", 1)
ValueError: not enough values to unpack (expected 2, got 1)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/pbench-server/lib/pbench/server/auth/auth.py", line 133, in verify_auth
    user = verify_auth_internal(auth_token)
  File "/opt/pbench-server/lib/pbench/server/auth/auth.py", line 157, in verify_auth_internal
    payload = jwt.decode(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jwt.py", line 168, in decode
    decoded = self.decode_complete(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jwt.py", line 120, in decode_complete
    decoded = api_jws.decode_complete(
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 191, in decode_complete
    payload, signing_input, header, signature = self._load(jwt)
  File "/home/pbench/.local/lib/python3.9/site-packages/jwt/api_jws.py", line 253, in _load
    raise DecodeError("Not enough segments") from err
jwt.exceptions.DecodeError: Not enough segments
```