### PR TITLE
Allow Tox to run a single unit test

### DIFF
--- a/exec-tests
+++ b/exec-tests
@@ -140,16 +140,22 @@ _cov_report="${_cov_report_kind}:${_cov_report_name}"
 rc=0
 
 if [[ "${subtst:-python}" == "python" ]]; then
-    _pytest_majors="pbench.test.unit.common"
-    for _major in ${major_list}; do
-        _pytest_majors="${_pytest_majors} pbench.test.unit.${_major}"
-        if [[ "${_major}" == "agent" ]]; then
-            # TODO: real functional tests require a deployed instance. Current
-            # agent "functional" tests are mocked Click tests rather than true
-            # "functional" tests.
-            _pytest_majors="${_pytest_majors} pbench.test.functional.agent"
-        fi
+    no_tests_specified=1
+    for word in ${posargs}; do
+        if [[ ${word} != -* ]]; then no_tests_specified=0; fi
     done
+    if [[ ${no_tests_specified} -eq 1 ]]; then
+        _pytest_majors="pbench.test.unit.common"
+        for _major in ${major_list}; do
+            _pytest_majors="${_pytest_majors} pbench.test.unit.${_major}"
+            if [[ "${_major}" == "agent" ]]; then
+                # TODO: real functional tests require a deployed instance. Current
+                # agent "functional" tests are mocked Click tests rather than true
+                # "functional" tests.
+                _pytest_majors="${_pytest_majors} pbench.test.functional.agent"
+            fi
+        done
+    fi
 
     printf -- "\n\n\nRunning %s python3-based unit tests via pytest\n\n" "${major_list// /,}"
     _pbench_sources=$(python3 -c 'import inspect, pathlib, pbench; print(pathlib.Path(inspect.getsourcefile(pbench)).parent)')


### PR DESCRIPTION
Currently, one can control what unit tests get run under Tox via a command like the following:
```
tox -- agent python pbench.test.unit.agent.task.test_copy_result_tb
```
Ostensibly, this should run only the tests in the `test_copy_result_tb` module.  Sadly, it does not only that but it also runs 50 or even 500 other tests from `pbench.test.unit.common`, `pbench.test.unit.agent` and `pbench.test.functional.agent`.

This change allows `exec-tests` to skip appending the extra paths to the test list.

However, I have a question for reviewers (i.e., @portante).  The last argument to `tox`/`exec-tests` is named "posargs" and the code comment claims that it is for "positional arguments".  However, the value is inserted after the PyTest `--pyargs` switch, which makes me think that the only acceptable arguments are Python packages.  Is that indeed the case?  We're not supposed to be able to use this mechanism for `pytest` switches?  If so, I can make this change _a lot_ simpler....

(BTW, this change will be even easier to review if you let GitHub hide whitespace changes under the "gear" pull-down at the top of the diff's page.)