### PR TITLE
Use `LIBDIR` (`lib-dir`) config, don't derive it

### DIFF
--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -4094,7 +4094,7 @@ class IdxContext:
 
         self.es = get_es(self.config, self.logger)
         self.templates = PbenchTemplates(
-            self.config.BINDIR,
+            self.config.LIBDIR,
             self.idx_prefix,
             self.logger,
             _known_tool_handlers,

--- a/lib/pbench/server/report.py
+++ b/lib/pbench/server/report.py
@@ -89,7 +89,7 @@ class Report:
             self.templates = templates
         else:
             self.templates = PbenchTemplates(
-                self.config.BINDIR, self.idx_prefix, self.logger
+                self.config.LIBDIR, self.idx_prefix, self.logger
             )
 
     def init_report_template(self):

--- a/lib/pbench/server/templates.py
+++ b/lib/pbench/server/templates.py
@@ -558,7 +558,7 @@ class PbenchTemplates:
 
     def __init__(
         self,
-        basepath: str,
+        lib_dir: Path,
         idx_prefix: str,
         logger: Logger,
         known_tool_handlers: JSONOBJECT = None,
@@ -575,19 +575,17 @@ class PbenchTemplates:
         template documents are derived from common skeleton mappings.
 
         Args:
-            basepath:               The base Pbench server installation
-                                    directory
-            idx_prefix:             The server's Elasticsearch index prefix
-            logger:                 A Python Logger
-            known_tool_handlers:    Describes the set of tools that will have
-                                    templates generated from a common tool-data
-                                    skeleton.
-            _dbg:                   Debug level for output (historical: not
-                                    used)
+            lib_dir:              The Pbench server library directory
+            idx_prefix:           The server's Elasticsearch index prefix
+            logger:               A Python Logger
+            known_tool_handlers:  Describes the set of tools that will have
+                                  templates generated from a common tool-data
+                                  skeleton.
+            _dbg:                 Debug level for output (historical: not
+                                  used)
         """
-        base_dir = Path(basepath).parent / "lib"
-        mapping_dir = base_dir / "mappings"
-        setting_dir = base_dir / "settings"
+        mapping_dir = lib_dir / "mappings"
+        setting_dir = lib_dir / "settings"
 
         self.templates: Dict[str, TemplateFile] = {}
         self.idx_prefix: str = idx_prefix

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -86,7 +86,14 @@ class FakePbenchTemplates:
     templates_updated = False
     failure: Optional[Exception] = None
 
-    def __init__(self, basepath, idx_prefix, logger, known_tool_handlers=None, _dbg=0):
+    def __init__(
+        self,
+        lib_dir: Path,
+        idx_prefix: str,
+        logger: Logger,
+        known_tool_handlers: JSONOBJECT = None,
+        _dbg: int = 0,
+    ):
         pass
 
     def update_templates(self, es_instance):
@@ -140,7 +147,7 @@ class FakeIdxContext:
         self.tracking_id = None
         self.es = None
         self.TS = "FAKE_TS"
-        self.templates = FakePbenchTemplates("path", "test", logger)
+        self.templates = FakePbenchTemplates(Path("path"), "test", logger)
         self._dbg = False
 
     def getpid(self) -> int:


### PR DESCRIPTION
We don't want to derive the location of the library directory hierarchy based off of another configuration parameter since there is an explicit configuration parameter for the library directory itself.