### PR TITLE
Add `init_indexing()` module method and use

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -9,7 +9,7 @@ import sys
 from flask import Flask
 
 from pbench.common.logger import get_pbench_logger
-from pbench.server import PbenchServerConfig
+from pbench.server import PbenchServerConfig, wait_for_uri
 from pbench.server.api import create_app, get_server_config
 from pbench.server.auth import OpenIDClient
 from pbench.server.database import init_db
@@ -97,7 +97,7 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
 
     logger.debug("Waiting for database instance to become available.")
     try:
-        Database.wait_for_database(db_uri, db_wait_timeout)
+        wait_for_uri(db_uri, db_wait_timeout)
     except ConnectionRefusedError:
         logger.error("Database {} not responding", db_uri)
         return 1

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -85,6 +85,8 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         port = str(server_config.get("pbench-server", "bind_port"))
         db_uri = server_config.get("database", "uri")
         db_wait_timeout = int(server_config.get("database", "wait_timeout"))
+        es_uri = server_config.get("Indexing", "uri")
+        es_wait_timeout = int(server_config.get("Indexing", "wait_timeout"))
         workers = str(server_config.get("pbench-server", "workers"))
         worker_timeout = str(server_config.get("pbench-server", "worker_timeout"))
         crontab_dir = server_config.get("pbench-server", "crontab-dir")
@@ -100,6 +102,13 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         wait_for_uri(db_uri, db_wait_timeout)
     except ConnectionRefusedError:
         logger.error("Database {} not responding", db_uri)
+        return 1
+
+    logger.debug("Waiting for the Elasticsearch instance to become available.")
+    try:
+        wait_for_uri(es_uri, es_wait_timeout)
+    except ConnectionRefusedError:
+        logger.error("Elasticsearch {} not responding", es_uri)
         return 1
 
     try:

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -8,8 +8,10 @@ import sys
 
 from flask import Flask
 
+from pbench.common import wait_for_uri
+from pbench.common.exceptions import BadConfig
 from pbench.common.logger import get_pbench_logger
-from pbench.server import PbenchServerConfig, wait_for_uri
+from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app, get_server_config
 from pbench.server.auth import OpenIDClient
 from pbench.server.database import init_db
@@ -103,6 +105,9 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     )
     try:
         wait_for_uri(db_uri, db_wait_timeout)
+    except BadConfig as exc:
+        logger.error(f"{exc}")
+        return 1
     except ConnectionRefusedError:
         logger.error("Database {} not responding", db_uri)
         return 1
@@ -114,6 +119,9 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     )
     try:
         wait_for_uri(es_uri, es_wait_timeout)
+    except BadConfig as exc:
+        logger.error(f"{exc}")
+        return 1
     except ConnectionRefusedError:
         logger.error("Elasticsearch {} not responding", es_uri)
         return 1

--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -1,4 +1,9 @@
 import configparser
+import socket
+from time import sleep, time
+from urllib.parse import urlparse
+
+from pbench.common.exceptions import BadConfig
 
 
 class MetadataLog(configparser.ConfigParser):
@@ -10,3 +15,37 @@ class MetadataLog(configparser.ConfigParser):
         """Constructor - overrides `interpolation` to always be None."""
         kwargs["interpolation"] = None
         super().__init__(*args, **kwargs)
+
+
+def wait_for_uri(uri: str, timeout: int):
+    """Wait for the given URI to become available.
+
+    While we encounter "connection refused", sleep one second, and then try
+    again.
+
+    Args:
+        timeout : integer number of seconds to wait before giving up
+                  attempts to connect to the URI
+
+    Raises:
+        BadConfig : when the URI does not contain either a host or port
+        ConnectionRefusedError : after the timeout period has been exhausted
+    """
+    url = urlparse(uri)
+    if not url.hostname:
+        raise BadConfig("URI must contain a host name")
+    if not url.port:
+        raise BadConfig("URI must contain a port number")
+    end = time() + timeout
+    while True:
+        try:
+            # The timeout argument to `create_connection()` does not play into
+            # the retry logic, see:
+            #
+            # https://docs.python.org/3.9/library/socket.html#socket.create_connection
+            with socket.create_connection((url.hostname, url.port), timeout=1):
+                break
+        except ConnectionRefusedError:
+            if time() > end:
+                raise
+            sleep(1)

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -6,11 +6,8 @@ from datetime import datetime, timedelta, tzinfo
 from enum import auto, Enum
 from logging import Logger
 from pathlib import Path
-import socket
-from time import sleep as _sleep
 from time import time as _time
 from typing import Dict, List, Optional, Union
-from urllib.parse import urlparse
 
 from pbench import PbenchConfig
 from pbench.common.exceptions import BadConfig
@@ -310,38 +307,3 @@ class PbenchServerConfig(PbenchConfig):
         if not dir_path:
             raise BadConfig(f"Bad {env_name}={dir_val}")
         return dir_path
-
-
-def wait_for_uri(uri: str, timeout: int):
-    """Wait for the given URI to become available.
-
-    While we encounter "connection refused", sleep one second, and then try
-    again.  No connection attempt is made for a URI without a host name.
-
-    The timeout argument to `create_connection()` does not play into the
-    retry logic, see:
-
-      https://docs.python.org/3.9/library/socket.html#socket.create_connection
-
-    Args:
-        timeout : integer number of seconds to wait before giving up
-                  attempts to connect to the URI
-
-    Raises:
-        BadConfig : when the URI specifies a host without a port
-        ConnectionRefusedError : after the timeout period has been exhausted
-    """
-    url = urlparse(uri)
-    if not url.hostname:
-        return
-    if not url.port:
-        raise BadConfig("URI must contain a port number")
-    end = _time() + timeout
-    while True:
-        try:
-            with socket.create_connection((url.hostname, url.port), timeout=1):
-                break
-        except ConnectionRefusedError:
-            if _time() > end:
-                raise
-            _sleep(1)

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -118,14 +118,7 @@ class ElasticBase(ApiBase):
         """
         super().__init__(config, *schemas)
         self.prefix = config.get("Indexing", "index_prefix")
-        host = config.get("elasticsearch", "host")
-        port = config.get("elasticsearch", "port")
-
-        # TODO: For future flexibility, we should consider reading this entire
-        # Elasticsearch URI from the config file as we do for the database
-        # rather than stitching it together. This would allow backend control
-        # over authentication and http vs https for example.
-        self.es_url = f"http://{host}:{port}"
+        self.es_url = config.get("Indexing", "uri")
 
     def _build_elasticsearch_query(
         self, user: Optional[str], access: Optional[str], terms: List[JSON]
@@ -550,16 +543,10 @@ class ElasticBulkBase(ApiBase):
             require_map: if True, fail if the dataset has no index map
         """
         super().__init__(config, *schemas)
-        host = config.get("elasticsearch", "host")
-        port = config.get("elasticsearch", "port")
 
         api_name = self.__class__.__name__
 
-        # TODO: For future flexibility, we should consider reading this entire
-        # Elasticsearch URI from the config file as we do for the database
-        # rather than stitching it together. This would allow backend control
-        # over authentication and http vs https for example.
-        self.elastic_uri = f"http://{host}:{port}"
+        self.elastic_uri = config.get("Indexing", "uri")
         self.config = config
         self.action = action
         self.require_stable = require_stable

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -252,7 +252,7 @@ class OpenIDClient:
         except (NoOptionError, NoSectionError) as exc:
             raise OpenIDClient.NotConfigured() from exc
 
-        logger.debug("Waiting for OIDC server to become available.")
+        logger.info("Waiting for OIDC server to become available.")
 
         session = requests.Session()
         # The connection check will retry multiple times unless successful, viz.,

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -1,13 +1,9 @@
 from logging import DEBUG, Logger
-import socket
-import time
-from urllib.parse import urlparse
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, Query, scoped_session, sessionmaker
 from sqlalchemy_utils import create_database, database_exists
 
-from pbench.common.exceptions import BadConfig
 from pbench.server import PbenchServerConfig
 
 
@@ -27,42 +23,6 @@ class Database:
             string URI
         """
         return config.get("database", "uri")
-
-    @staticmethod
-    def wait_for_database(db_uri: str, timeout: int):
-        """Wait for the database server to become available.
-
-        While we encounter "connection refused", sleep one second, and then try
-        again.  No connection attempt is made for a database URI without a host
-        name.
-
-        The timeout argument to `create_connection()` does not play into the
-        retry logic, see:
-
-          https://docs.python.org/3.9/library/socket.html#socket.create_connection
-
-        Args:
-            timeout : integer number of seconds to wait before giving up
-                      attempts to connect to the database
-
-        Raises:
-            BadConfig : when the DB URI specifies a host without a port
-            ConnectionRefusedError : after the timeout period has been exhausted
-        """
-        url = urlparse(db_uri)
-        if not url.hostname:
-            return
-        if not url.port:
-            raise BadConfig("Database URI must contain a port number")
-        end = time.time() + timeout
-        while True:
-            try:
-                with socket.create_connection((url.hostname, url.port), timeout=1):
-                    break
-            except ConnectionRefusedError:
-                if time.time() > end:
-                    raise
-                time.sleep(1)
 
     @staticmethod
     def create_if_missing(db_uri: str, logger: Logger):

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -124,7 +124,7 @@ def _get_es_hosts(config, logger):
         raise BadConfig("Indexing URI must contain a port number")
     timeoutobj = Timeout(total=1200, connect=10, read=_read_timeout)
     return [
-        dict(host=url.host, port=url.port, timeout=timeoutobj),
+        dict(host=url.hostname, port=url.port, timeout=timeoutobj),
     ]
 
 
@@ -4124,3 +4124,11 @@ class IdxContext:
 
     def get_tracking_id(self):
         return self.tracking_id
+
+
+def init_indexing(
+    name: str, server_config: pbench.server.PbenchServerConfig, logger: logging.Logger
+):
+    """Initialize the Elasticsearch indexing sub-system."""
+    idxctx = IdxContext(None, name, server_config, logger)
+    idxctx.templates.update_templates(idxctx.es)

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -111,12 +111,7 @@ def _get_es_hosts(config, logger):
     try:
         uri = config.get("Indexing", "uri")
     except (configparser.NoSectionError, configparser.NoOptionError):
-        logger.warning(
-            "Failed to find an [Indexing] section with uri defined in {}"
-            " configuration file.",
-            " ".join(config.files),
-        )
-        return None
+        raise BadConfig("Indexing URI missing")
     url = urlparse(uri)
     if not url.hostname:
         raise BadConfig("Indexing URI must contain a host name")

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -1,0 +1,80 @@
+"""Test wait_for_uri() module method"""
+from contextlib import contextmanager
+import socket
+
+import pytest
+
+import pbench.common
+from pbench.common.exceptions import BadConfig
+
+
+def test_wait_for_uri_succ(monkeypatch):
+    called = [None]
+
+    @contextmanager
+    def success(*args, **kwargs):
+        called[0] = args
+        yield None
+
+    monkeypatch.setattr(socket, "create_connection", success)
+    pbench.common.wait_for_uri("http://localhost:42", 142)
+    first_arg = called[0][0]
+    assert first_arg[0] == "localhost" and first_arg[1] == 42, f"{called[0]!r}"
+
+
+def test_wait_for_uri_bad():
+    with pytest.raises(BadConfig) as exc:
+        pbench.common.wait_for_uri("http://:42", 142)
+    assert str(exc.value).endswith("host name")
+
+    with pytest.raises(BadConfig) as exc:
+        pbench.common.wait_for_uri("http://example.com", 142)
+    assert str(exc.value).endswith("port number")
+
+
+def setup_conn_ref(monkeypatch):
+    clock = [0]
+    called = []
+
+    @contextmanager
+    def conn_ref(*args, **kwargs):
+        called.append(f"conn_ref [{clock[0]}]")
+        if clock[0] < 3:
+            raise ConnectionRefusedError()
+        yield None
+
+    def sleep(*args, **kwargs):
+        called.append("sleep")
+
+    def time() -> int:
+        curr_time = clock[0]
+        clock[0] += 1
+        return curr_time
+
+    monkeypatch.setattr(socket, "create_connection", conn_ref)
+    monkeypatch.setattr(pbench.common, "sleep", sleep)
+    monkeypatch.setattr(pbench.common, "time", time)
+    return called
+
+
+def test_wait_for_uri_conn_ref_succ(monkeypatch):
+    called = setup_conn_ref(monkeypatch)
+    pbench.common.wait_for_uri("http://localhost:42", 42)
+    assert called == [
+        "conn_ref [1]",
+        "sleep",
+        "conn_ref [2]",
+        "sleep",
+        "conn_ref [3]",
+    ], f"{called!r}"
+
+
+def test_wait_for_uri_conn_ref_fail(monkeypatch):
+    called = setup_conn_ref(monkeypatch)
+    with pytest.raises(ConnectionRefusedError):
+        pbench.common.wait_for_uri("http://localhost:42", 1)
+    assert called == [
+        "conn_ref [1]",
+        "sleep",
+        "conn_ref [2]",
+    ], f"{called!r}"

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -92,8 +92,9 @@ def test_wait_for_uri_conn_ref_succ(monkeypatch):
     before the timeout period.
     """
     called = setup_conn_ref(monkeypatch)
-    # The mock will return successfully after 3 ticks of the mock'd clock, so 42 is
-    # sufficiently long enough (it is greater
+    # The mock will return successfully after 3 ticks of the mock'd clock, so 42
+    # is sufficiently long enough to wait given it is the answer to the ultimate
+    # question of life, the universe, and everything.
     pbench.common.wait_for_uri("http://localhost:42", 42)
     assert called == [
         "time [0]",  # Clock moves from 0 to 1

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -45,10 +45,6 @@ uri = sqlite:///:memory:
 [flask-app]
 secret-key = my_precious
 
-[elasticsearch]
-host = elasticsearch.example.com
-port = 7080
-
 [logging]
 logger_type = null
 # We run with DEBUG level logging during the server unit tests to help
@@ -57,6 +53,7 @@ logging_level = DEBUG
 
 [Indexing]
 index_prefix = unit-test
+uri = http://elasticsearch.example.com:7080
 
 ###########################################################################
 # The rest will come from the default config file.

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -39,9 +39,8 @@ def query_api(client, server_config, provide_metadata):
         query_params: JSON = None,
         **kwargs,
     ) -> requests.Response:
-        host = server_config.get("elasticsearch", "host")
-        port = server_config.get("elasticsearch", "port")
-        es_url = f"http://{host}:{port}{expected_index}{es_uri}"
+        base_uri = server_config.get("Indexing", "uri")
+        es_url = f"{base_uri}{expected_index}{es_uri}"
         assert request_method in (ApiMethod.GET, ApiMethod.POST)
         if request_method == ApiMethod.GET:
             es_method = responses.GET

--- a/lib/pbench/test/unit/server/test_indexer.py
+++ b/lib/pbench/test/unit/server/test_indexer.py
@@ -1,4 +1,7 @@
-from pbench.server.indexer import ResultData
+import pytest
+
+import pbench.server.indexer
+from pbench.server.indexer import init_indexing, ResultData
 
 
 class TestResultData_expand_uid_template:
@@ -52,3 +55,27 @@ class TestResultData_expand_uid_template:
             templ, {"str": "abc", "int": 123, "float": 45.6789012, "other": []}
         )
         assert res == "abc_123_45.678901_%other%_UID"
+
+
+def test_init_indexing(monkeypatch, server_config, make_logger):
+    called = [False]
+
+    class MockPbenchTemplates:
+        def update_templates(self, *args, **kwargs):
+            called[0] = True
+            assert args[0] == "fake-es-obj", f"args={args!r}, kwargs={kwargs!r}"
+            assert not kwargs
+
+    class MockIdxContext:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.templates = MockPbenchTemplates()
+            self.es = "fake-es-obj"
+
+    monkeypatch.setattr(pbench.server.indexer, "IdxContext", MockIdxContext)
+    try:
+        init_indexing("test", server_config, make_logger)
+    except Exception as exc:
+        pytest.fail(f"Unexpected exception raised: {exc}")
+    assert called[0], "Mocked update_templates() was not called"

--- a/lib/pbench/test/unit/server/test_indexer.py
+++ b/lib/pbench/test/unit/server/test_indexer.py
@@ -68,8 +68,6 @@ def test_init_indexing(monkeypatch, server_config, make_logger):
 
     class MockIdxContext:
         def __init__(self, *args, **kwargs):
-            self.args = args
-            self.kwargs = kwargs
             self.templates = MockPbenchTemplates()
             self.es = "fake-es-obj"
 

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -306,13 +306,13 @@ class TestShell:
     def test_main_wait_for_database_exc(
         monkeypatch, make_logger, mock_get_server_config
     ):
-        def wait_for_database(
+        def wait_for_uri(
             server_config: PbenchServerConfig, logger: logging.Logger
         ) -> str:
             raise ConnectionRefusedError("database exception")
 
         monkeypatch.setattr(shell.site, "ENABLE_USER_SITE", False)
-        monkeypatch.setattr(shell.Database, "wait_for_database", wait_for_database)
+        monkeypatch.setattr(shell, "wait_for_uri", wait_for_uri)
 
         ret_val = shell.main()
 

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -195,7 +195,7 @@ class TestShell:
             called.append("find_the_unicorn")
 
         def wait_for_uri(*args, **kwargs):
-            called.append("wait_for_uri")
+            called.append(f"wait_for_uri({args[0]},{args[1]})")
 
         def init_indexing(*args, **kwargs):
             called.append("init_indexing")
@@ -227,10 +227,13 @@ class TestShell:
         ret_val = shell.main()
 
         assert ret_val == 42
-        assert not user_site or called[0] == "find_the_unicorn"
-        assert called[-3] == "wait_for_uri"
-        assert called[-3] == called[-2]
-        assert called[-1] == "init_indexing"
+        expected_called = ["find_the_unicorn"] if user_site else []
+        expected_called += [
+            "wait_for_uri(sqlite:///:memory:,120)",
+            "wait_for_uri(http://elasticsearch.example.com:7080,120)",
+            "init_indexing",
+        ]
+        assert called == expected_called
         assert len(commands) == 3, f"{commands!r}"
         assert commands[0][0] == "pbench-create-crontab"
         assert commands[1][0] == "crontab"

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -112,17 +112,13 @@ lowerbound = 820
 #secret_access_key =
 #bucket_name =
 
-# NOTE: No defaults are provided for the "Indexing" section deliberately.
-#[Indexing]
+[Indexing]
+#uri = https://indexer.example.com:9000
+wait_timeout = 120
 #index_prefix =
 
-# These should be overridden in the env-specific config file.
-#[elasticsearch]
-#host =
-#port =
-
 [database]
-# uri = driver://user:password@hostname/dbname
+#uri = driver://user:password@hostname/dbname
 wait_timeout = 120
 
 [flask-app]

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -17,10 +17,7 @@ roles = pbench-results, pbench-backup
 
 [Indexing]
 index_prefix = container-pbench
-
-[elasticsearch]
-host = localhost
-port = 9200
+uri = http://localhost:9200
 
 [database]
 uri = postgresql://pbenchcontainer:pbench@localhost:5432/pbenchcontainer


### PR DESCRIPTION
Remove the stack traces posted in the logs by all the cron jobs when the Pbench Server container starts up.  We do this by having the "shell" process first wait for the Elasticsearch instance to show up, and then load / update all the index templates before starting all the cron jobs.  This avoids the stack traces generated by race conditions across the various cron processes.

----

1. Rename `wait_for_database` to `wait_for_uri`
2. Wait for Elasticsearch using URI
3. Add `init_indexing()` module method and use
   * The new `init_indexing()` module method is used to ensure that the indexing configuration is working before we start all the cron jobs, thus avoiding stack traces from cron jobs competing to load the indexing templates

----

Commit message:

    Ensure Elasticsearch instance setup before cron

    * Rename `wait_for_database()` to common `wait_for_uri()`

      Added an explict test for `wait_for_uri()`.

    * Wait for Elasticsearch using new `wait_for_uri()`

    * Add `init_indexing()` module method and use

      The new `init_indexing()` module method is used to ensure that the
      indexing configuration is working before we start all the cron jobs,
      thus avoiding stack traces from cron jobs competing to load the
      indexing templates.

    * Move startup sequence log messages to info

      We also add some additional messages, merge an existing message, while
      ensuring all related messages are at `info` level.