### PR TITLE
Add `--output` option to `pbench-generate-token`

### DIFF
--- a/lib/pbench/cli/agent/commands/generate_token.py
+++ b/lib/pbench/cli/agent/commands/generate_token.py
@@ -38,7 +38,11 @@ class GenerateToken(BaseCommand):
             payload = {"message": response.text}
 
         if response.ok and "auth_token" in payload:
-            click.echo(payload["auth_token"])
+            if not self.context.output:
+                click.echo(payload["auth_token"])
+            else:
+                with open(self.context.output, "w") as ofp:
+                    ofp.write(f"{payload['auth_token']}\n")
             return 0
 
         click.echo(
@@ -70,11 +74,17 @@ class GenerateToken(BaseCommand):
     show_default=True,
     help="number of seconds",
 )
+@click.option(
+    "--output",
+    required=False,
+    help="Output file to which to write the generated token",
+)
 @pass_cli_context
-def main(context, username, password, token_duration):
+def main(context, username, password, token_duration, output):
     context.username = username
     context.password = password
     context.token_duration = token_duration
+    context.output = output
 
     try:
         rv = GenerateToken(context).execute()


### PR DESCRIPTION
This option makes it a bit easier to script the invocation of `pbench-generate-token` where username and/or password prompts are required (the prompt does not get mixed up into the token output).

----

Separated into its own PR from PR #3259.