### PR TITLE
Fix run-server-func-tests to handle interrupts properly

### DIFF
--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -39,6 +39,8 @@ function cleanup {
     else
         echo "No clean up requested -- the Pbench Server container and support services pod likely still running!" >&2
     fi
+    trap - $(trap -p | sed -e 's/.* //')
+    exit ${exit_status}
 }
 trap cleanup INT QUIT TERM EXIT
 


### PR DESCRIPTION
The previous change in #3268 was incomplete:  in case of an interrupt, we actually need to exit the script (otherwise, apparently, `trap` returns from the handler back to the point of interruption...), and, we need to remove the handler for `exit` in order for that to actually work.  😊 

Note that I've intentionally left the removal of the trap handling to the _end_ of the trap handler:  this enables handling of traps during the handling of traps, which improves the likelihood that the cleanup will happen (if requested...if not requested, it's a pretty small window to hit).  It does create the possibility of being trapped in the trap handler, but I think that retrying the cleanup is worth the risk (FWIW, the `podman` commands run a little faster the each time you interrupt them 😉).

BTW, if you omit `--cleanup` when you run the script and wish you hadn't, you can simply run the script again with `--cleanup` -- it will fail quickly and then _clean up_...and then you are back where you started (except that you have the proper command in your command recall buffer, now 😁).