### PR TITLE
Build the Dashboard

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -1,0 +1,43 @@
+#
+# A Makefile for building the Pbench Dashboard deployment for use in Pbench
+# Server functional test and Staging/Production deployments.
+#
+# This makefile defines the following targets:
+#
+#  all (the default):  runs lint and unit tests and then builds
+#                      the Pbench Dashboard deployment
+#  build:              builds the Pbench Dashboard deployment
+#  clean:              removes the artifacts created by the other targets
+#  run_lint:           runs the Javascript linter
+#  run_unittests:      runs the Dashboard unit tests
+#
+
+# This is the list of all the subdirectories of the `dashboard` directory which
+# contain "source" files for the Dashboard (Javascript, images, style sheets,
+# HTML, et al.) -- anything which, if changed, should prompt a new build -- and
+# the corresponding list of those files.
+SRCDIRS := public src
+FILES := $(shell find ${SRCDIRS} -type f)
+
+all: run_lint run_unittests build
+
+build:  package-lock.json node_modules ${FILES}
+	mkdir -p build
+	npm run build
+
+run_lint:  package-lock.json node_modules
+	npx eslint --max-warnings 0 "src/**"
+
+run_unittests:  package-lock.json node_modules
+	CI=true npm test
+
+package-lock.json node_modules &: ${HOME}/.config package.json
+	npm install
+
+${HOME}/.config:
+	mkdir -p ${HOME}/.config
+
+clean:
+	rm -rf package-lock.json node_modules build
+
+.PHONY: all clean run_lint run_unittests

--- a/jenkins/runlocal
+++ b/jenkins/runlocal
@@ -25,6 +25,9 @@ make -C server/rpm clean rpm
 export RPM_PATH=${HOME}/rpmbuild/RPMS/noarch/pbench-server-*.rpm
 ls -ld ${RPM_PATH}
 
+# Create a Pbench Dashboard deployment
+WORKSPACE_TMP=${WORKSPACE_TMP:-${HOME}} jenkins/run make -C dashboard clean build
+
 source /etc/os-release
 
 if [[ -z ${BASE_IMAGE} ]]; then


### PR DESCRIPTION
This PR adds a Makefile for the Pbench Dashboard, to allow it to be built (and re-built) only as needed and to provide an encapsulated interface for running lint and unit tests, etc.

The `build.sh` script which is used (e.g.) by the CI to "build Pbench" is changed to use `make` to clear and install the Dashboard dependences, to run lint, and to run unit tests.  And, a new `make` invocation is added after we build the Server and Agent RPMs to also build the Dashboard deployment.

Also, `jenkins/runlocal` is modified to build the Dashboard, as well.  (Note that, because we're using `make`, the Dashboard deployment would only be built if it is out of date, but we're specifying `clean` as we do for the Server RPM build, so it will be rebuilt from scratch every time.)

Once the Dashboard has been built, the existing `server/pbenchinacan/deploy` script will pick it up during the Pbench Server deployment.

_[I'm currently unable to test this satisfactorily outside of the CI, so I'm hoping that Mr. Jenkins can do it for me....]_