### PR TITLE
Restore endpoints.identification in container

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -175,6 +175,9 @@ class PbenchServerConfig(PbenchConfig):
         # Initial common timestamp format
         self.TS = f"run-{timestamp()}"
 
+        # Server version
+        self.version = None  # Defer discovery until needed
+
     @property
     def TOP(self) -> Path:
         return self._get_valid_dir_option("TOP", "pbench-server", "pbench-top-dir")
@@ -234,7 +237,12 @@ class PbenchServerConfig(PbenchConfig):
 
     @property
     def COMMIT_ID(self) -> str:
-        return self.get("pbench-server", "commit_id", fallback="(unknown)")
+        if not self.version:
+            install = Path(self.get("DEFAULT", "install-dir"))
+            version = (install / "VERSION").read_text().strip()
+            sha1 = (install / "SHA1").read_text().strip()
+            self.version = f"{version}-{sha1}"
+        return self.version
 
     @property
     def rest_uri(self) -> str:

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -96,6 +96,8 @@ def do_setup(tmp_d: Path) -> Path:
 
     cfg_file = pbench_cfg / "pbench-server.cfg"
     cfg_file.write_text(server_cfg_tmpl.format(TMP=str(tmp_d)))
+    (opt_pbench / "VERSION").write_text("0.0.0")
+    (opt_pbench / "SHA1").write_text("abdcefg")
 
     return pbench_cfg
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -25,7 +25,6 @@ group=%(default-group)s
 admin-email=%(user)s@localhost
 mailto=%(admin-email)s
 mailfrom=%(user)s@localhost
-commit_id=unknown
 
 # Token expiration duration in minutes, can be overridden in the main config file, defaults to 60 mins
 token_expiration_duration = 60


### PR DESCRIPTION
PBENCH-996

In our containerized deployment model, we don't have the commit key in `PbenchServerConfig` so the `/api/v1/endpoints` API populates the `"identification"` field with the default of `"(unknown)"`.

Restore the version by reading the `VERSION` and `SHA1` files written in `/opt/pbench-server` by the installer.