### PR TITLE
Add the syslog "ident" field back

### DIFF
--- a/server/lib/pbench/__init__.py
+++ b/server/lib/pbench/__init__.py
@@ -174,14 +174,14 @@ def get_pbench_logger(caller, config):
             handler = logging.FileHandler(os.path.join(logdir, "{}.log".format(caller)))
         elif config.logger_type == "devlog":
             handler = handlers.SysLogHandler(address="/dev/log")
-            handler.ident = caller
+            handler.ident = f"{caller}: "
         elif (
             config.logger_type == "hostport"
         ):  # hostport logger type uses UDP-based logging
             handler = handlers.SysLogHandler(
                 address=(config.logger_host, int(config.logger_port))
             )
-            handler.ident = caller
+            handler.ident = f"{caller}: "
         else:
             raise Exception("Unsupported logger type")
 


### PR DESCRIPTION
(Back-port of PR #3297, commit xxxxxxxxx)

According to the SysLogHandler documentation [1], the `ident` field can be set on every instance of a SysLogHandler to have a "ident" or "tag" prefix to identify the source of the message.

When reviewing logs generated via `journalctl -f`, without the `ident` field set, a log entry generated by the pbench server code might look like:

    Mar 01 00:37:23 host.example.com python3[2737452]: \
        2023-03-01T00:37:23.909096 DEBUG 2737452 140124701973376 \
        my-logger.logger my_func 146 -- foo - debug

Where the "my-logger.logger" string is the logger "name" and the module name _inside_ the log mesasge, but `journalctl` uses an identifer of:

    <program name>[<PID>]

after the host name.

This is because `journalctl` emits the log message "ident" field using its trusted fields of `_COMM` ("python3") and `_PID` ("2737452") when no `SYSLOG_IDENTIFIER` field is generated, (see the output from `journalctl -f -o json`).  The `python3` program name is fairly generic and makes it difficult to filter logs to look for a specific sub-set generated by the Pbench Server.

By setting the `SysLogHandler` handler instance's `ident` field, the journald sub-system will set that value in its stored log entries as the `SYSLOG_IDENTIFIER` journal field).  For example, the above message becomes:

    Mar 01 00:37:23 host.example.com my-logger[2737452]: \
        2023-03-01T00:37:23.909096 DEBUG 2737452 140124701973376 \
        my-logger.logger my_func 146 -- foo - debug

Further, any logging sub-system which aggregates logs will typically know about RFC 5424 [2] log message formats, where that `ident` is the `APP-NAME` field value.  For example, see the Elastic Common Schema [3].

[1] https://docs.python.org/3.9/library/logging.handlers.html#logging.handlers.SysLogHandler.emit [2] https://www.rfc-editor.org/rfc/rfc5424 (Section 6, Syslog Message
    Format)
[3] https://www.elastic.co/guide/en/ecs/master/ecs-log.html#field-log-syslog-appname