### PR TITLE
Use a consistent pull policy during Server deployment

### DIFF
--- a/server/pbenchinacan/deploy
+++ b/server/pbenchinacan/deploy
@@ -55,6 +55,21 @@ NGINX_FAVICON=${NGINX_FAVICON:-"./dashboard/src/assets/logo/color-square.16x16.i
 # Deployment
 #-
 
+# This is the first invocation of the Podman run command in this script, so we
+# execute a trivial containerized command to make Podman apply the requested
+# pull policy here.  After this invocation (if it doesn't fail...), the
+# container image will be present in the local repository, and so we will use
+# the default Podman policy ("missing") for the subsequent invocations.
+# (Otherwise, we risk pulling a remote image when we shouldn't.)  However, if
+# this script was invoked by the run-pbench-in-a-can script, then _it_ will have
+# done the first pull, and it will have set the policy to "missing" to prompt us
+# to skip it here.  In any case, if the pull policy is set to "missing", then
+# the first Podman run invocation below will do the right thing on its own, so
+# we skip the extra one here.
+if [[ ${PB_SERVER_IMAGE_PULL_POLICY} != "missing" ]]; then
+    podman run --entrypoint true --rm --pull ${PB_SERVER_IMAGE_PULL_POLICY} ${PB_SERVER_IMAGE}
+fi
+
 # Update the Dashboard code, removing any existing code and copying in fresh.
 # We expect that the host dashboard directory already exists and contains a
 # build of the Pbench Dashboard application; however, if it is missing, we
@@ -86,11 +101,12 @@ else
 fi
 
 # Run the Pbench Server.
+#
+# See NOTE above on the first Podman run invocation regarding pull policy.
 podman run \
     --detach \
     --name ${PB_SERVER_CONTAINER_NAME} \
     --network host \
-    --pull ${PB_SERVER_IMAGE_PULL_POLICY} \
     --rm \
     --volume ${PB_DEPLOY_FILES}/etc/rsyslog.conf:/etc/rsyslog.conf:Z \
     --volume ${PB_DEPLOY_FILES}/etc/rsyslog.d:/etc/rsyslog.d:Z \

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -66,8 +66,16 @@ mkdir -p -m 0755  \
     ${SRV_PBENCH}/cache
 
 # Set up the static fallback pages for Nginx.
+#
+# NOTE:  This is the first invocation of the Podman run command in this
+#        deployment, so we apply the pull policy here; after this invocation (if
+#        it doesn't fail...), the container image will be present in the local
+#        repository, and so we use the default policy ("missing") for the other
+#        invocations. (Otherwise, we risk pulling a remote image when we
+#        shouldn't.)
 podman run \
     --rm \
+    --pull ${PB_SERVER_IMAGE_PULL_POLICY} \
     --volume ${SRV_PBENCH}:/srv/pbench:Z \
     --entrypoint cp \
     ${PB_SERVER_IMAGE} \
@@ -86,7 +94,9 @@ podman run \
 #+
 # Start the services which the Pbench Server depends upon and then start the
 # Pbench Server itself.
+#
+# See NOTE above on the first Podman run invocation regarding pull policy.
 #-
-
+export PB_SERVER_IMAGE_PULL_POLICY=missing
 server/pbenchinacan/deploy-dependencies
 server/pbenchinacan/deploy


### PR DESCRIPTION
We invoke the Pbench Server container several times during the setup before actually running it in deployment.  The initial invocations of `podman run` currently use the default pull policy while the `PB_SERVER_PULL_POLICY` value is only applied on the deployment run, by which point we've potentially pulled a new image from the remote repository, whether that was desired or not.

Prior to change:
| `PB_SERVER_PULL_POLICY` | Image initially present | Image initially absent | Notes |
| --- | - | - | - |
| always | download once | download twice | If the image is already present, we use the "wrong" (local) image for the setup before downloading the requested one; otherwise, we download it twice.  (Note that re-downloading the same image moves no data). |
| missing | no download | download once | (Coincidentally behaves as expected.) |
| newer | no download or single download | download once | If the image is already present, we use the "wrong" (local) image for the setup; then we'll download the remote image if it is different; if the image is absent, then it will work as expected, as long as the remote image isn't updated between the invocations. |
| never | no download | download once | No error in the initially-absent case!...instead it downloads an unwanted image. |

This PR changes the script to apply the pull policy to the _first_ Podman `run` invocation instead of the deployment run, and uses the default (`missing`) policy for the deployment run and the intervening invocation.

With change:
| `PB_SERVER_PULL_POLICY` | Image initially present | Image initially absent | Notes |
| --- | - | - | - |
| always | download once | download once | The image is downloaded only for the first invocation, and the subsequent invocations use the local image. |
| missing | no downloads | download once | (No difference relative to existing operation.) |
| newer | no downloads or single download | download once | If the image in the remote repository is different, it is downloaded for the first invocation, and the subsequent invocations use the local image (even if the remote image changes between invocations). |
| never | no downloads | error | The first invocation fails with an error if the image is not present locally; otherwise, all the invocations use the local image. |
