### PR TITLE
Correct alembic database state

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -488,3 +488,27 @@ class PbenchServerClient:
         return self.put(
             api=API.DATASETS_METADATA, uri_params={"dataset": dataset_id}, json=metadata
         ).json()
+
+    def update(
+        self, dataset_id: str, access: Optional[str] = None, owner: Optional[str] = None
+    ) -> JSONOBJECT:
+        """Update the dataset access or owner
+
+        Args:
+            dataset_id: the resource ID of the targeted dataset
+            access: set the access mode of the dataset (private, public)
+            owner: set the owning username of the dataset (requires ADMIN)
+
+        Returns:
+            A JSON document containing the response
+        """
+        params = {}
+        if access:
+            params["access"] = access
+        if owner:
+            params["owner"] = owner
+        return self.post(
+            api=API.DATASETS_UPDATE,
+            uri_params={"dataset": dataset_id},
+            params=params,
+        ).json()

--- a/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
+++ b/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
@@ -24,8 +24,7 @@ def upgrade() -> None:
     # Instead we simply add the new 'UPDATE' value. Having the obsolete
     # values defined in the ENUM isn't a problem, and removing them isn't
     # worth the complication.
-    with op.get_context().autocommit_block():
-        op.execute("ALTER TYPE operationname ADD VALUE 'UPDATE' BEFORE 'UPLOAD'")
+    op.execute("ALTER TYPE operationname ADD VALUE 'UPDATE' BEFORE 'UPLOAD'")
     # ### end Alembic commands ###
 
 

--- a/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
+++ b/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
@@ -1,0 +1,36 @@
+"""Correct operationname ENUM
+
+Alembic does not check or autogenerate ENUM value changes, so this will
+upgrade the original operationname revision to add UPDATE.
+
+Revision ID: 9cc638cb865c
+Revises: 9df060db17de
+Create Date: 2023-03-03 14:32:16.955897
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "9cc638cb865c"
+down_revision = "9df060db17de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # NOTE: the 'BACKUP' and 'UNPACK' operationname ENUM values are now
+    # obsolete. We don't attempt to remove them because dataset_operations
+    # rows with these values record the previous operation of the server.
+    # Instead we simply add the new 'UPDATE' value. Having the obsolete
+    # values defined in the ENUM isn't a problem, and removing them isn't
+    # worth the complication.
+    with op.get_context().autocommit_block():
+        op.execute("ALTER TYPE operationname ADD VALUE 'UPDATE' BEFORE 'UPLOAD'")
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    # Downgrade is problematic, and won't be attempted. Having unused ENUM
+    # values defined shouldn't represent a problem.
+    pass
+    # ### end Alembic commands ###

--- a/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
+++ b/lib/pbench/server/database/alembic/versions/9cc638cb865c_operationname.py
@@ -24,7 +24,7 @@ def upgrade() -> None:
     # Instead we simply add the new 'UPDATE' value. Having the obsolete
     # values defined in the ENUM isn't a problem, and removing them isn't
     # worth the complication.
-    op.execute("ALTER TYPE operationname ADD VALUE 'UPDATE' BEFORE 'UPLOAD'")
+    op.execute("ALTER TYPE operationname ADD VALUE 'UPDATE'")
     # ### end Alembic commands ###
 
 

--- a/lib/pbench/test/functional/server/test_put.py
+++ b/lib/pbench/test/functional/server/test_put.py
@@ -412,7 +412,7 @@ class TestDelete:
             "list_and",
             "list_none",
             "list_or",
-            "publish"
+            "publish",
         ],
         scope="session",
     )


### PR DESCRIPTION
The original `OperationName` ENUM type had the values BACKUP, DELETE, INDEX, REINDEX, TOOLINDEX, UNPACK, and UPLOAD. The BACKUP and UNPACK operations were later removed, and the UPDATE operation was added. However, alembic does not check ENUM values nor does autogenerate provide automated upgrades.

Dropping ENUM values is problematic: it would mean generating code to query the live server database and either drop or change existing rows, which would be difficult to test. Having obsolete values in an ENUM is not problematic, unless the number becomes overwhelming, so this PR doesn't attempt to address that.

However, new server code will attempt to use the UPDATE operation, and this will cause SQLAlchemy failures as the value is unknown. This PR simply adds that value to the ENUM.