### PR TITLE
Use normal logs with JSON to report cull behaviors

### DIFF
--- a/server/bin/gold/test-27.txt
+++ b/server/bin/gold/test-27.txt
@@ -1,32 +1,4 @@
 +++ Running pbench-cull-unpacked-tarballs
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-02 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-02",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-02-14T00:00:00",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-cull-unpacked-tarballs",
-            "text": "Culled 3 unpacked tar ball directories (0 errors) in 0.00 secs\n\nActions Taken:\n  - controller-no-prefixes/tarball_culled_1970.01.01T00.00.00 (0 errors, 0.00 secs)\n      $ rm results/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00  # succ\n      $ mv incoming/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00 incoming/controller-no-prefixes/.delete.tarball_culled_1970.01.01T00.00.00  # succ\n      $ rmtree incoming/controller-no-prefixes/.delete.tarball_culled_1970.01.01T00.00.00  # succ\n  - controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00 (0 errors, 0.00 secs)\n      $ rm results/controller-prefixes/pre0/pre1/pre2/tarball_culled-w-prefix_1970.01.01T00.00.00  # succ\n      $ mv incoming/controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00 incoming/controller-prefixes/.delete.tarball_culled-w-prefix_1970.01.01T00.00.00  # succ\n      $ rmtree incoming/controller-prefixes/.delete.tarball_culled-w-prefix_1970.01.01T00.00.00  # succ\n  - controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00 (0 errors, 0.00 secs)\n      $ rm results/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00  # succ\n      $ rm users/userA/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00  # succ\n      $ mv incoming/controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00 incoming/controller-prefixes/.delete.tarball_culled-w-userA_1970.01.01T00.00.00  # succ\n      $ rmtree incoming/controller-prefixes/.delete.tarball_culled-w-userA_1970.01.01T00.00.00  # succ\n",
-            "total_chunks": 1,
-            "total_size": 1551
-        },
-        "_type": "pbench-server-reports"
-    }
-]
 --- Finished pbench-cull-unpacked-tarballs (status=0)
 +++ Running unit test audit
 --- Finished unit test audit (status=3)
@@ -133,7 +105,7 @@ drwxrwxr-x          - logs/pbench-audit-server
 -rw-rw-r--          0 logs/pbench-audit-server/pbench-audit-server.log
 -rw-rw-r--       1073 logs/pbench-audit-server/report.latest.txt
 drwxrwxr-x          - logs/pbench-cull-unpacked-tarballs
--rw-rw-r--       3465 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
+-rw-rw-r--      10600 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 drwxrwxr-x          - pbench-move-results-receive
 drwxrwxr-x          - pbench-move-results-receive/fs-version-002
 drwxrwxr-x          - quarantine
@@ -229,8 +201,20 @@ end-1970-01-01T00:00:42-UTC: users hierarchy: /var/tmp/pbench-test-server/test-2
 1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs remove_symlinks -- Removed symlink '/var/tmp/pbench-test-server/test-27/pbench/public_html/results/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00'
 1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs remove_symlinks -- Removed symlink '/var/tmp/pbench-test-server/test-27/pbench/public_html/users/userA/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00'
 1970-01-01T00:00:42.000000 INFO pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs remove_unpacked -- After 0.00 seconds, finished removal of unpacked tar ball directory, '/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00'
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.indexer update_templates -- done templates (start ts: 1970-02-14T00:00:00-UTC, end ts: 1970-02-14T00:00:00-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.report post_status -- posted status (start ts: 1970-02-14T00:00:00-UTC, end ts: 1970-02-14T00:00:00-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
+1970-01-01T00:00:42.000000 INFO pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- ae9baf5d7f271b3a707e28e10d31e7a8: Culled 3 unpacked tar ball directories (0 errors) in 0.00 secs -- @cee:{"pbench": {"report": {"summary": {"end": "1970-02-14T00:00:00.000000", "errors": 0, "prog": "pbench-cull-unpacked-tarballs", "start": "1970-02-14T00:00:00.000000", "total": 3, "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "duration": 0.0}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action set controller-no-prefixes/tarball_culled_1970.01.01T00.00.00 (0 errors, 0.00 secs) -- @cee:{"pbench": {"report": {"action_set": {"duration": 0.0, "errors": 0, "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "name": "controller-no-prefixes/tarball_culled_1970.01.01T00.00.00"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rm results/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-no-prefixes/tarball_culled_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/results/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00", "status": "succ", "verb": "rm"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ mv incoming/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00  incoming/controller-no-prefixes/.delete.tarball_culled_1970.01.01T00.00.00  # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-no-prefixes/tarball_culled_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-no-prefixes/tarball_culled_1970.01.01T00.00.00", "status": "succ", "verb": "mv"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rmtree incoming/controller-no-prefixes/.delete.tarball_culled_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-no-prefixes/tarball_culled_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-no-prefixes/.delete.tarball_culled_1970.01.01T00.00.00", "status": "succ", "verb": "rmtree"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action set controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00 (0 errors, 0.00 secs) -- @cee:{"pbench": {"report": {"action_set": {"duration": 0.0, "errors": 0, "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "name": "controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rm results/controller-prefixes/pre0/pre1/pre2/tarball_culled-w-prefix_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/results/controller-prefixes/pre0/pre1/pre2/tarball_culled-w-prefix_1970.01.01T00.00.00", "status": "succ", "verb": "rm"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ mv incoming/controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00  incoming/controller-prefixes/.delete.tarball_culled-w-prefix_1970.01.01T00.00.00  # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00", "status": "succ", "verb": "mv"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rmtree incoming/controller-prefixes/.delete.tarball_culled-w-prefix_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-prefix_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-prefixes/.delete.tarball_culled-w-prefix_1970.01.01T00.00.00", "status": "succ", "verb": "rmtree"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action set controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00 (0 errors, 0.00 secs) -- @cee:{"pbench": {"report": {"action_set": {"duration": 0.0, "errors": 0, "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "name": "controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rm results/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/results/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00", "status": "succ", "verb": "rm"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rm users/userA/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/users/userA/controller-prefixes/path0/path1/tarball_culled-w-userA_1970.01.01T00.00.00", "status": "succ", "verb": "rm"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ mv incoming/controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00  incoming/controller-prefixes/.delete.tarball_culled-w-userA_1970.01.01T00.00.00  # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00", "status": "succ", "verb": "mv"}}}}
+1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Action $ rmtree incoming/controller-prefixes/.delete.tarball_culled-w-userA_1970.01.01T00.00.00   # succ -- @cee:{"pbench": {"report": {"action": {"execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8", "in_public_html": true, "name": "controller-prefixes/tarball_culled-w-userA_1970.01.01T00.00.00", "noun": "/var/tmp/pbench-test-server/test-27/pbench/public_html/incoming/controller-prefixes/.delete.tarball_culled-w-userA_1970.01.01T00.00.00", "status": "succ", "verb": "rmtree"}}}}
 ----- pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 ---- pbench-local/logs
 ++++ pbench-satellite-local/logs

--- a/server/bin/gold/test-5.1.txt
+++ b/server/bin/gold/test-5.1.txt
@@ -125,34 +125,6 @@ len(actions) = 1
 +++ Running pbench-clean-up-dangling-results-links
 --- Finished pbench-clean-up-dangling-results-links (status=0)
 +++ Running pbench-cull-unpacked-tarballs
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-cull-unpacked-tarballs",
-            "text": "Culled 0 unpacked tar ball directories (0 errors) in 0.00 secs\n",
-            "total_chunks": 1,
-            "total_size": 63
-        },
-        "_type": "pbench-server-reports"
-    }
-]
 --- Finished pbench-cull-unpacked-tarballs (status=0)
 +++ Running pbench-satellite-cleanup
 --- Finished pbench-satellite-cleanup (status=0)
@@ -233,7 +205,7 @@ drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 drwxrwxr-x          - logs/pbench-cull-unpacked-tarballs
--rw-rw-r--        631 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
+-rw-rw-r--        174 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 drwxrwxr-x          - logs/pbench-dispatch
 -rw-rw-r--          0 logs/pbench-dispatch/pbench-dispatch.error
 -rw-rw-r--        646 logs/pbench-dispatch/pbench-dispatch.log
@@ -316,8 +288,6 @@ drwxrwxr-x          - tmp
 ----- pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 +++++ pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Culling unpacked tar balls 30 days older than 1970-01-01T00:00:42.000000
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 +++++ pbench-dispatch/pbench-dispatch.error
 ----- pbench-dispatch/pbench-dispatch.error

--- a/server/bin/gold/test-5.2.txt
+++ b/server/bin/gold/test-5.2.txt
@@ -195,34 +195,6 @@ len(actions) = 1
 +++ Running pbench-clean-up-dangling-results-links
 --- Finished pbench-clean-up-dangling-results-links (status=0)
 +++ Running pbench-cull-unpacked-tarballs
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-cull-unpacked-tarballs",
-            "text": "Culled 0 unpacked tar ball directories (0 errors) in 0.00 secs\n",
-            "total_chunks": 1,
-            "total_size": 63
-        },
-        "_type": "pbench-server-reports"
-    }
-]
 --- Finished pbench-cull-unpacked-tarballs (status=0)
 +++ Running pbench-satellite-cleanup
 --- Finished pbench-satellite-cleanup (status=0)
@@ -488,7 +460,7 @@ drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 drwxrwxr-x          - logs/pbench-cull-unpacked-tarballs
--rw-rw-r--        631 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
+-rw-rw-r--        174 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 drwxrwxr-x          - logs/pbench-dispatch
 -rw-rw-r--        876 logs/pbench-dispatch/pbench-dispatch.error
 -rw-rw-r--       2081 logs/pbench-dispatch/pbench-dispatch.log
@@ -611,8 +583,6 @@ drwxrwxr-x          - tmp
 ----- pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 +++++ pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Culling unpacked tar balls 30 days older than 1970-01-01T00:00:42.000000
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 +++++ pbench-dispatch/pbench-dispatch.error
 run-1970-01-01T00:00:42-UTC: Quarantined: /var/tmp/pbench-test-server/test-5.2/pbench-local/pbench-move-results-receive/fs-version-002/controller-a-missing-tb/tarball_have-md5-no-tb_1970.01.01T00.00.00.tar.xz failed MD5 check

--- a/server/bin/gold/test-5.txt
+++ b/server/bin/gold/test-5.txt
@@ -125,34 +125,6 @@ len(actions) = 1
 +++ Running pbench-clean-up-dangling-results-links
 --- Finished pbench-clean-up-dangling-results-links (status=0)
 +++ Running pbench-cull-unpacked-tarballs
-Template:  pbench-unittests.v3.server-reports
-Index:  pbench-unittests.v3.server-reports.1970-01 1
-len(actions) = 1
-[
-    {
-        "_id": "5ca1ab1e70015f100dedfab1ed0ff1ce",
-        "_index": "pbench-unittests.v3.server-reports.1970-01",
-        "_op_type": "create",
-        "_source": {
-            "@generated-by": {
-                "commit_id": "unit-test",
-                "group_id": 43,
-                "hostname": "example.com",
-                "pid": 42,
-                "user_id": 44,
-                "version": ""
-            },
-            "@timestamp": "1970-01-01T00:00:42",
-            "chunk_id": 1,
-            "doctype": "status",
-            "name": "pbench-cull-unpacked-tarballs",
-            "text": "Culled 0 unpacked tar ball directories (0 errors) in 0.00 secs\n",
-            "total_chunks": 1,
-            "total_size": 63
-        },
-        "_type": "pbench-server-reports"
-    }
-]
 --- Finished pbench-cull-unpacked-tarballs (status=0)
 +++ Running pbench-satellite-cleanup
 --- Finished pbench-satellite-cleanup (status=0)
@@ -233,7 +205,7 @@ drwxrwxr-x          - logs/pbench-clean-up-dangling-results-links
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.error
 -rw-rw-r--          0 logs/pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 drwxrwxr-x          - logs/pbench-cull-unpacked-tarballs
--rw-rw-r--        631 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
+-rw-rw-r--        174 logs/pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 drwxrwxr-x          - logs/pbench-dispatch
 -rw-rw-r--          0 logs/pbench-dispatch/pbench-dispatch.error
 -rw-rw-r--        646 logs/pbench-dispatch/pbench-dispatch.log
@@ -316,8 +288,6 @@ drwxrwxr-x          - tmp
 ----- pbench-clean-up-dangling-results-links/pbench-clean-up-dangling-results-links.log
 +++++ pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.pbench-cull-unpacked-tarballs main -- Culling unpacked tar balls 30 days older than 1970-01-01T00:00:42.000000
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.indexer update_templates -- done templates (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, retries: 0)
-1970-01-01T00:00:42.000000 DEBUG pbench-cull-unpacked-tarballs.report post_status -- posted status (start ts: 1970-01-01T00:00:42-UTC, end ts: 1970-01-01T00:00:42-UTC, duration: 0.00s, successes: 1, duplicates: 0, failures: 0, retries: 0)
 ----- pbench-cull-unpacked-tarballs/pbench-cull-unpacked-tarballs.log
 +++++ pbench-dispatch/pbench-dispatch.error
 ----- pbench-dispatch/pbench-dispatch.error

--- a/server/bin/test-bin/verify_cee
+++ b/server/bin/test-bin/verify_cee
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+#
+# Verify that JSON text follows the marker, "@cee:", in a givne file.
+#
+# Returns 0 on success, 1 on JSON validation failures, 2 on bad arguments.
+
+import sys
+import json
+from pathlib import Path
+
+prog = Path(sys.argv[0]).name
+try:
+    file_name = sys.argv[1]
+except IndexError:
+    print(f"{prog}: Missing file name argument", file=sys.stderr)
+    sys.exit(2)
+
+file_name_p = Path(file_name).resolve()
+if not file_name_p.exists():
+    print(f"{prog}: file '{file_name_p}' does not exist", file=sys.stderr)
+    sys.exit(2)
+
+exit_code = 0
+line_number = 0
+with file_name_p.open("r") as fp:
+    for line in fp.readlines():
+        line_number += 1
+        loc = line.find("@cee:")
+        if loc < 0:
+            continue
+        try:
+            json.loads(line[loc+5:].strip())
+        except Exception as exc:
+            print(f"{prog}: invalid JSON at line {line_number} of {file_name_p}: {exc}", file=sys.stderr)
+            exit_code = 1
+
+sys.exit(exit_code)

--- a/server/bin/unittests
+++ b/server/bin/unittests
@@ -199,6 +199,7 @@ function _dump_logs {
                 while read fname; do
                     echo "+++++ ${fname}" >> $_testout
                     _normalize_output ${dir}/logs/${fname} >> $_testout 2>&1
+                    ${_tdir}/test-bin/verify_cee ${dir}/logs/${fname} >> $_testout 2>&1 || echo "Bad CEE JSON in ${dir}/logs/${fname}" >> ${_testout} 2>&1
                     echo "----- ${fname}" >> $_testout
                 done
             echo "---- $(basename ${dir})/logs" >> $_testout


### PR DESCRIPTION
Commit message body follows, summary is PR title:

    Instead of using the `Report` class to index a report document, we
    change to use individual log entries to record the actions taken by
    `pbench-cull-unpacked-tarballs`.

    There are three types of JSON records emitted, `summary`, `action_set`,
    and `action` (examples below), where a unique "execution ID" is
    generated for all report logs, and included as a field value.  This
    allows somebody to search for all report logs from a given execution,
    e.g. `pbench.report.action.execution_id: ae9baf5d7*` (lucene syntax),
    or look for a certain status (`succ`, `fail`, or `part`), e.g.
    `NOT pbench.report.action.status:succ`.

        ae9baf5d7f271b3a707e28e10d31e7a8: Culled 3 unpacked tar ball \
        directories (0 errors) in 0.00 secs -- @cee:\
        {
          "pbench": {
            "report": {
              "summary": {
                "end": "1970-02-14T00:00:00.000000",
                "errors": 0,
                "prog": "pbench-cull-unpacked-tarballs",
                "start": "1970-02-14T00:00:00.000000",
                "total": 3,
                "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8",
                "duration": 0.0
              }
            }
          }
        }

        Action set controller/tarball_ed_1970.01.01T00.00.00 \
        (0 errors, 0.00 secs    ) -- @cee:\
        {
          "pbench": {
            "report": {
              "action_set": {
                "duration": 0.0,
                "errors": 0,
                "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8",
                "name": "controller/tarball_ed_1970.01.01T00.00.00"
              }
            }
          }
        }

        Action $ rm results/controller/tarball_ed_1970.01.01T00.00.00 \
        # succ -- @cee:\
        {
          "pbench": {
            "report": {
              "action": {
                "execution_id": "ae9baf5d7f271b3a707e28e10d31e7a8",
                "in_public_html": true,
                "name": "controller/tarball_ed_1970.01.01T00.00.00",
                "noun": ".../controller/tarball_ed_1970.01.01T00.00.00",
                "status": "succ",
                "verb": "rm"
              }
            }
          }
        }

----

Layered on top of PR #3308.