### PR TITLE
Remove left over `boto3` requirement

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,4 +1,3 @@
-boto3
 elasticsearch1
 humanize>=3.11, <4.0.0
 jinja2>=3.0


### PR DESCRIPTION
Commit body below (commit summary is PR title):

    PR #3296 (commit 7e78b1d) failed to remove the `boto3` requirement.