### PR TITLE
Add hook for setting podman switches for Pbench Server deployment

### DIFF
--- a/server/pbenchinacan/deploy
+++ b/server/pbenchinacan/deploy
@@ -112,4 +112,5 @@ podman run \
     --volume ${PB_DEPLOY_FILES}/etc/rsyslog.d:/etc/rsyslog.d:Z \
     --volume ${PB_DEPLOY_FILES}/pbench-server.cfg:/opt/pbench-server/lib/config/pbench-server.cfg:Z \
     --volume ${SRV_PBENCH}:/srv/pbench:Z \
+    ${PB_SERVER_PODMAN_SWITCHES} \
     ${PB_SERVER_IMAGE}


### PR DESCRIPTION
Moving toward deploying the Pbench Server under a `systemctl` service module, we need the ability to add a few switches to the Pbench Server's Podman `run` invocation.

This change provides a new environment variable, `PB_SERVER_PODMAN_SWITCHES`, for this.  (This variable is distinct from the existing `EXTRA_PODMAN_SWITCHES` to prevent crosstalk between the options we specify for `jenkins/run` and the options that we want for the Pbench Server deployment.)  If the variable is undefined, then it will expand vacuously and have no effect.