### PR TITLE
Disable email validation

### DIFF
--- a/lib/pbench/server/api/resources/users_api.py
+++ b/lib/pbench/server/api/resources/users_api.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta, timezone
 from http import HTTPStatus
 from typing import NamedTuple
 
-from email_validator import EmailNotValidError
 from flask import current_app, jsonify, make_response, request
 from flask_bcrypt import check_password_hash
 from flask_restful import abort, Resource
@@ -128,9 +127,6 @@ class RegisterUser(Resource):
                 "New user registered, username: {}, email: {}", username, email_id
             )
             return "", HTTPStatus.CREATED
-        except EmailNotValidError:
-            current_app.logger.warning("Invalid email {}", email_id)
-            abort(HTTPStatus.BAD_REQUEST, message=f"Invalid email: {email_id}")
         except Exception:
             current_app.logger.exception("Exception while registering a user")
             abort(HTTPStatus.INTERNAL_SERVER_ERROR, message="INTERNAL ERROR")

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -2,7 +2,6 @@ import datetime
 import enum
 from typing import Optional
 
-from email_validator import validate_email
 from flask_bcrypt import generate_password_hash
 from sqlalchemy import Column, DateTime, Enum, Integer, LargeBinary, String
 from sqlalchemy.orm import relationship, validates
@@ -95,12 +94,6 @@ class User(Database.Base):
     @validates("password")
     def evaluate_password(self, key: str, value: str) -> str:
         return generate_password_hash(value)
-
-    # validate the email field
-    @validates("email")
-    def evaluate_email(self, key: str, value: str) -> str:
-        valid = validate_email(value)
-        return valid.email
 
     def add_token(self, auth_token: AuthToken):
         """Add the given token to the database

--- a/lib/pbench/test/unit/server/test_user_auth.py
+++ b/lib/pbench/test/unit/server/test_user_auth.py
@@ -72,24 +72,6 @@ class TestUserAuthentication:
             assert response.status_code == HTTPStatus.BAD_REQUEST
 
     @staticmethod
-    def test_registration_email_validity(client, server_config):
-        """Test for validating an email field during registration"""
-        with client:
-            response = register_user(
-                client,
-                server_config,
-                username="user",
-                firstname="firstname",
-                lastname="lastName",
-                email="user@domain,com",
-                password="12345",
-            )
-            data = response.json
-            assert data["message"] == "Invalid email: user@domain,com"
-            assert response.content_type == "application/json"
-            assert response.status_code == HTTPStatus.BAD_REQUEST
-
-    @staticmethod
     def test_registration_with_registered_user(client, server_config):
         """Test registration with already registered email"""
         user = User(

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,6 @@ aniso8601>=9.0.1
 Bcrypt-Flask
 click>=8.0
 elasticsearch>=7.13.1, <7.14
-email-validator>1.1.1
 flask
 flask_cors
 Flask-HTTPAuth>=4.0.0


### PR DESCRIPTION
The email validator seems to be flaking out on us. We're going to be removing the internal user registration entirely soon, and we don't actually use the email addresses, so validation serves no real purpose. To avoid problems for now, rip out email validation entirely.