### PR TITLE
Drop internal PUT size limit

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -11,7 +11,6 @@ from typing import Dict, List, Optional, Union
 
 from pbench import PbenchConfig
 from pbench.common.exceptions import BadConfig
-from pbench.server.utils import filesize_bytes
 
 # A type defined to conform to the semantic definition of a JSON structure
 # with Python syntax.
@@ -244,18 +243,6 @@ class PbenchServerConfig(PbenchConfig):
             "pbench-server",
             "default-dataset-retention-days",
             fallback=self.DEFAULT_RETENTION_DAYS,
-        )
-
-    @property
-    def rest_max_content_length(self) -> int:
-        """Produce an integer representing the maximum content length accepted
-        by the REST APIs.
-
-        Returns:
-            An integer number of bytes.
-        """
-        return filesize_bytes(
-            self.get("pbench-server", "rest_max_content_length", fallback="1 gb")
         )
 
     def _get_valid_dir_option(self, env_name: str, section: str, option: str) -> Path:

--- a/lib/pbench/server/utils.py
+++ b/lib/pbench/server/utils.py
@@ -7,34 +7,6 @@ from dateutil import parser as date_parser
 from pbench.common.utils import md5sum
 
 
-def filesize_bytes(size):
-    size = size.strip()
-    size_name = ["B", "KB", "MB", "GB", "TB"]
-    try:
-        parts = size.split(" ", 1)
-        if len(parts) == 1:
-            try:
-                num = int(size)
-            except ValueError:
-                for i, c in enumerate(size):
-                    if not c.isdigit():
-                        break
-                num = int(size[:i])
-                unit = size[i:]
-            else:
-                unit = ""
-        else:
-            num = int(parts[0])
-            unit = parts[1].strip()
-
-        idx = size_name.index(unit.upper()) if unit else 0
-        factor = 1024**idx
-    except Exception as exc:
-        raise Exception("Invalid file size value encountered, '%s': %s", size, exc)
-    else:
-        return num * factor
-
-
 def get_tarball_md5(tarball: Union[Path, str]) -> str:
     """
     Convenience method to locate the MD5 file associated with a dataset

--- a/lib/pbench/test/unit/server/test_utils.py
+++ b/lib/pbench/test/unit/server/test_utils.py
@@ -1,40 +1,7 @@
 from dateutil import parser as date_parser
 import pytest
 
-from pbench.server.utils import filesize_bytes, UtcTimeHelper
-
-_sizes = [("  10  ", 10)]
-for i, mult in [
-    ("B", 1),
-    ("b", 1),
-    ("KB", 1024),
-    ("Kb", 1024),
-    ("kB", 1024),
-    ("kb", 1024),
-    ("MB", 2**20),
-    ("GB", 2**30),
-    ("TB", 2**40),
-]:
-    matrix = [
-        (f"10{i}", 10 * mult),
-        (f"10 {i}", 10 * mult),
-        (f"10   {i}", 10 * mult),
-        (f"10{i}   ", 10 * mult),
-        (f"10 {i}   ", 10 * mult),
-    ]
-    _sizes.extend(matrix)
-
-
-class TestFilesizeBytes:
-    @staticmethod
-    def test_filesize_bytes():
-        for size, exp_val in _sizes:
-            res = filesize_bytes(size)
-            assert (
-                res == exp_val
-            ), f"string '{size}', improperly converted to {res}, expected {exp_val}"
-        with pytest.raises(Exception):
-            res = filesize_bytes("bad")
+from pbench.server.utils import UtcTimeHelper
 
 
 class TestUtcTimeHelper:

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -63,8 +63,6 @@ pbench-tmp-dir = %(pbench-local-dir)s/tmp
 bind_host = 0.0.0.0
 bind_port = 8001
 rest_version = 1
-# max allowed size for tarfile upload, acceptable format {X[unit] or X [unit]}
-rest_max_content_length = 1 gb
 rest_uri = /api/v%(rest_version)s
 
 # WSGI gunicorn specific configs


### PR DESCRIPTION
PBENCH-151

We want to rely on easily configurable NGINX size limits for tarball uploads, while the current server code checks an internal limit that defaults to 1Gb.

A quick survey of the production server shows over 5000 files exceeding 1G and 204 tarballs over 10G.

This PR simply removes the internal check. We never had a test for this since we never found a way to fake the content-length header.