### PR TITLE
Add an explicit ENTRYPOINT to the Agent "all" containers

### DIFF
--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -1,6 +1,11 @@
 # {{ distro }} pbench-agent {{ kind }} image
 FROM pbench-agent-base-{{ distro }}:{{ tag }}
 
+{% if kind == 'all' %}
+COPY ./container_entrypoint /container_entrypoint
+ENTRYPOINT ["/container_entrypoint"]
+{% endif %}
+
 {% if kind in ('tools', 'all') %}
 {% if distro.startswith('fedora') or distro == 'centos-7' or distro == 'centos-8' %}
 COPY ./{{ distro }}-pcp.repo /etc/yum.repos.d/pcp.repo

--- a/agent/containers/images/container_entrypoint
+++ b/agent/containers/images/container_entrypoint
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is the entrypoint for the Agent containers.
+#
+# Since execution in these environments does not follow the normal login path,
+# we first execute the `agent/profile` script to set up the environment for
+# Agent commands.  Then we exec the requested command.
+
+source /opt/pbench-agent/profile
+
+exec "${@}"

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -1,0 +1,70 @@
+#! /bin/bash
+#
+# This script is a wrapper to facilitate the invocation of a Pbench Agent
+# command using a containerized deployment of the Pbench Agent.  Simply prefix
+# a Pbench Agent command line with the path to this script to run it inside a
+# container, without needing to install the Agent on the host system.
+#
+# Invocation options are provided as environment variables:
+#    PB_AGENT_IMAGE_NAME:  the full image name for the containerized Pbench Agent
+#    _PBENCH_AGENT_CONFIG:  the location of the Pbench Agent configuration file
+#    PB_AGENT_RUN_DIR:  the directory for use as the Pbench Agent "run directory"
+#    PB_AGENT_SERVER_LOC:  the host and port for the Pbench Server
+#    PB_AGENT_PODMAN_OPTIONS:  Additional options to be supplied to Podman run
+#
+# In all cases, reasonable defaults are supplied if the environment variables
+# are not defined.
+#
+# This script checks for the presence of a `~/.ssh` directory, an existing
+# Pbench Agent configuration file, and a Pbench Agent "run directory" and maps
+# them into the container if they exist.  If the configuration file is missing
+# but the location of the Pbench Server is available, then this script will
+# generate the configuration file, and the script creates the run directory if
+# it does not exist.  The script then invokes the Pbench Agent container with
+# these options and any others which the user has specified and passes in the
+# command to be executed.
+
+image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:latest}
+config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
+pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
+pbench_server=${PB_AGENT_SERVER_LOC}
+other_options=${PB_AGENT_PODMAN_OPTIONS}
+
+if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
+    echo "Usage:  ${0} <Pbench Agent Command> [<arg>...]" >&2
+    exit 2
+fi
+
+if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
+    other_options="-v ${HOME}/.ssh:/root/.ssh:z ${other_options}"
+fi
+
+if [[ -f "${config_file}" && -r "${config_file}" ]]; then
+    other_options="-v ${config_file}:/opt/pbench-agent/config/pbench-agent.cfg:z ${other_options}"
+elif [[ -n "${pbench_server}" ]]; then
+    echo "Warning:  the Pbench Agent config file is missing; attempting to generate one in ${config_file}" >&2
+    # TODO:  this should be handled by a separate Pbench Agent command which
+    #        provides a "configuration wizard".
+    mkdir -p $(dirname ${config_file})
+    cat > ${config_file} <<- EOF
+		[DEFAULT]
+		pbench_install_dir = /opt/pbench-agent
+		pbench_web_server = ${pbench_server}
+		[config]
+		path = %(pbench_install_dir)s/config
+		files = pbench-agent-default.cfg
+		EOF
+else
+    echo "Warning:  the Pbench Agent config file (e.g., ${config_file}) is missing or inaccessible -- using default configuration." >&2
+fi
+
+mkdir -p ${pbench_run_dir}
+other_options="-v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
+
+podman run \
+    -it \
+    --rm \
+    --network host \
+    --name pbench-agent \
+    ${other_options} \
+    ${image_name} "${@}"

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -16,7 +16,7 @@ alias pbench=$(git rev-parse --show-toplevel)/contrib/containerized-pbench/pbenc
 
 FIOTEST=${PWD}/fiotest
 export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
-export PB_AGENT_IMAGE_NAME=images.paas.redhat.com/pbench/pbench-agent-all-fedora-36:3320
+export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-36:main
 
 mkdir -p ${FIOTEST}
 

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -1,0 +1,33 @@
+#! /bin/bash -xe
+#
+# This script provides a demonstration of the contrib/containerized-pbench/pbench
+# wrapper script.
+#
+
+#+
+# Set up a few things to make life simpler.  Typically, these would already be
+# set in the users environment (e.g., the `pbench` command alias would be done
+# by the user's login script; we wouldn't need the `shopt` command if these
+# commands were being run interactively; and, we only need `PB_AGENT_IMAGE_NAME`
+# here because we're not using the default image).
+#-
+shopt -s expand_aliases
+alias pbench=$(git rev-parse --show-toplevel)/contrib/containerized-pbench/pbench
+
+FIOTEST=${PWD}/fiotest
+export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
+export PB_AGENT_IMAGE_NAME=images.paas.redhat.com/pbench/pbench-agent-all-fedora-36:3320
+
+mkdir -p ${FIOTEST}
+
+#+
+# Run the demo!
+#-
+pbench pbench-register-tool-set light
+pbench pbench-list-tools
+pbench pbench-user-benchmark --config example-workload -- \
+    fio --directory=/fiotest --name fio_test_file --direct=1 --rw=randread \
+        --bs=16k --size=100M --numjobs=16 --time_based --runtime=20s \
+        --group_reporting --norandommap
+pbench pbench-generate-token --output=/var/lib/pbench-agent/.token
+pbench pbench-results-move --token=$(< /var/tmp/pbench/pbench-agent/run/.token)


### PR DESCRIPTION
The Agent commands require the environment which the `agent/profile` script sets up.  This script is normally run automatically when a user logs in by virtue of a symbolic link in `/etc/profile.d`; however, when a user invokes containerized Agent commands, although the profile script exists inside the container, there is no login performed, and so the script isn't run...and it is cumbersome to cause it to run inside the container environment in conjunction with running a pbench command (the easiest approach is to create a script (see [`contrib/containerized-pbench/README.md`](https://github.com/distributed-system-analysis/pbench/blob/main/contrib/containerized-pbench/README.md)), but the user has to map that into the container in order to use it; otherwise, the user has to run an interactive shell inside the container, which is not much better).

This change provides a little script which `source`'s the Agent profile script and then `exec`'s the requested command inside the container, and makes use of it as the default entrypoint for the Agent "all" containers.  This enables users to use a command line something like
```
$ podman run <cid> pbench-results-push
```

This PR makes the following changes:
- Adds a utility script for use as the containers entrypoint.
- Modifies the Agent container build to specify the new script as the container entrypoint if the container "type" is "all".

This PR also includes two new files in `contrib/containerized-pbench`:
- a `pbench` command script which wraps the container invocation and provides some helpful defaults; and,
- a "demo" script which shows how a user might run a benchmark using the containerized Agent commands.

These last two files don't need to be merged into the repo -- they are mostly provided as "functional documentation" showing how this change is useful.  However, they do make it easy to run Agent commands, and they work without having to install the Agent.