### PR TITLE
Update default Linux distros:  drop F35 and add F37 & F38

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -108,7 +108,7 @@ _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 # By default we only build images for the following distributions.
 _DEFAULT_DISTROS = \
 	centos-9 centos-8 centos-7 \
-	fedora-36 fedora-35
+	fedora-38 fedora-37 fedora-36
 #	rhel-9 rhel-8 rhel-7
 
 # This Makefile produces containers named "pbench-agent-<name>-<distro>"; this

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -108,7 +108,7 @@ _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 # By default we only build images for the following distributions.
 _DEFAULT_DISTROS = \
 	centos-9 centos-8 centos-7 \
-	fedora-38 fedora-37 fedora-36
+	fedora-37 fedora-36
 #	rhel-9 rhel-8 rhel-7
 
 # This Makefile produces containers named "pbench-agent-<name>-<distro>"; this

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -24,7 +24,7 @@ CHROOTS =
 # target builds them all.
 RHEL_RPMS = rhel-9-rpm rhel-8-rpm rhel-7-rpm
 CENTOS_RPMS = centos-9-rpm centos-8-rpm centos-7-rpm
-FEDORA_RPMS = fedora-36-rpm fedora-35-rpm
+FEDORA_RPMS = fedora-38-rpm fedora-37-rpm fedora-36-rpm
 ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 
 component = agent

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -19,7 +19,7 @@ include ../utils/utils.mk
 # RPMs
 RPMBUILD_BASEIMAGE_DEFAULTS = \
 	rhel-9 rhel-8 rhel-7 \
-	fedora-36 fedora-35 \
+	fedora-38 fedora-37 fedora-36 \
 	centos-9 centos-8 centos-7
 
 # All Fedora images are based on Fedora 36


### PR DESCRIPTION
This PR drops Fedora 35 from our list of default Linux distributions (it went end-of-life three months ago, and the base container for it is no longer available from Quay.io), and adds Fedora 37 and Fedora 38 to the list.

This affects support for building RPMs (particularly the Agent) and for building Agent containers.