### PR TITLE
Finish migration to resource-based APIs

### DIFF
--- a/dashboard/src/actions/overviewActions.js
+++ b/dashboard/src/actions/overviewActions.js
@@ -5,6 +5,7 @@ import API from "../utils/axiosInstance";
 import { DANGER } from "assets/constants/toastConstants";
 import { findNoOfDays } from "utils/dateFunctions";
 import { showToast } from "./toastActions";
+import { expandUriTemplate } from "../utils/helper";
 
 export const getDatasets = () => async (dispatch, getState) => {
   const alreadyRendered = getState().overview.loadingDone;
@@ -117,8 +118,9 @@ export const updateDataset =
       const method = metaDataActions[actionType];
 
       const endpoints = getState().apiEndpoint.endpoints;
+      const uri = expandUriTemplate(endpoints, 'datasets_metadata', { dataset: dataset.resource_id });
       const response = await API.put(
-        `${endpoints?.api?.datasets_metadata}/${dataset.resource_id}`,
+        uri,
         {
           metadata: { [method]: actionValue },
         }
@@ -206,8 +208,8 @@ export const updateMultipleDataset =
         method === "delete"
           ? "Deleted!"
           : method === "save"
-          ? "Saved!"
-          : "Updated!";
+            ? "Saved!"
+            : "Updated!";
       dispatch(showToast(CONSTANTS.SUCCESS, toastMsg));
       dispatch(setSelectedRuns([]));
     } else {

--- a/dashboard/src/actions/tableOfContentActions.js
+++ b/dashboard/src/actions/tableOfContentActions.js
@@ -1,16 +1,13 @@
 import * as TYPES from "./types";
 import API from "../utils/axiosInstance";
+import { expandUriTemplate } from "../utils/helper";
 
 export const fetchTOC =
   (param, parent, callForSubData) => async (dispatch, getState) => {
     try {
       const endpoints = getState().apiEndpoint.endpoints;
-      const response = await API.post(
-        `${endpoints?.api?.datasets_contents}/${param}`,
-        {
-          parent: parent,
-        }
-      );
+      const uri = expandUriTemplate(endpoints, 'datasets_contents', { dataset: param, target: parent });
+      const response = await API.get(uri);
       if (response.status === 200 && response.data) {
         dispatch({
           type: callForSubData ? "GET_SUB_DIR_DATA" : "GET_TOC_DATA",

--- a/dashboard/src/modules/components/TableOfContent/index.jsx
+++ b/dashboard/src/modules/components/TableOfContent/index.jsx
@@ -59,7 +59,7 @@ const TableOfContent = () => {
   let fileCount = 0;
   useEffect(() => {
     if (Object.keys(endpoints).length > 0)
-      dispatch(fetchTOC(params["dataset_id"], "/", false));
+      dispatch(fetchTOC(params["dataset_id"], "", false));
   }, [dispatch, endpoints, params]);
   const { stack, searchSpace, tableData, contentData, currData, isLoading } =
     useSelector((state) => state.tableOfContent);
@@ -185,7 +185,7 @@ const TableOfContent = () => {
     setBreadCrumbLabels([]);
   };
   const getSubFolderData = (data) => {
-    dispatch(fetchTOC(params["dataset_id"], `/${data}`, true));
+    dispatch(fetchTOC(params["dataset_id"], data, true));
   };
   const attachBreadCrumbs = (data, firstHierarchyLevel) => {
     breadCrumbLabels.push(data);

--- a/dashboard/src/utils/helper.js
+++ b/dashboard/src/utils/helper.js
@@ -35,3 +35,19 @@ export const validateEmail = (email) => {
     email: !/\S+@\S+\.\S+/.test(email) ? "Enter a valid Email" : "",
   };
 };
+
+/**
+ * Expand a templated API URI like a Python `.format`
+ *
+ * @param {Object} endpoints - endpoint object from server
+ * @param {string} name - name of the API to expand
+ * @param {Object} args - value for each templated parameter
+ * @return {string} - formatted URI
+ */
+export const expandUriTemplate = (endpoints, name, args) => {
+  let uri = endpoints.uri[name].template;
+  for (const [key, value] of Object.entries(args)) {
+    uri = uri.replace(`{${key}}`, value)
+  }
+  return uri
+}

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -64,8 +64,8 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
     )
     api.add_resource(
         DatasetsContents,
-        f"{base_uri}/datasets/contents/<string:dataset>/",
-        f"{base_uri}/datasets/contents/<string:dataset>/<path:target>",
+        f"{base_uri}/datasets/<string:dataset>/contents/",
+        f"{base_uri}/datasets/<string:dataset>/contents/<path:target>",
         endpoint="datasets_contents",
         resource_class_args=(config,),
     )
@@ -77,13 +77,13 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
     )
     api.add_resource(
         DatasetsDetail,
-        f"{base_uri}/datasets/detail/<string:dataset>",
+        f"{base_uri}/datasets/<string:dataset>/detail",
         endpoint="datasets_detail",
         resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsList,
-        f"{base_uri}/datasets/list",
+        f"{base_uri}/datasets",
         endpoint="datasets_list",
         resource_class_args=(config,),
     )
@@ -95,27 +95,27 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
     )
     api.add_resource(
         DatasetsMetadata,
-        f"{base_uri}/datasets/metadata/<string:dataset>",
+        f"{base_uri}/datasets/<string:dataset>/metadata",
         endpoint="datasets_metadata",
         resource_class_args=(config,),
     )
     api.add_resource(
         DatasetsInventory,
-        f"{base_uri}/datasets/inventory/<string:dataset>",
-        f"{base_uri}/datasets/inventory/<string:dataset>/",
-        f"{base_uri}/datasets/inventory/<string:dataset>/<path:target>",
+        f"{base_uri}/datasets/<string:dataset>/inventory",
+        f"{base_uri}/datasets/<string:dataset>/inventory/",
+        f"{base_uri}/datasets/<string:dataset>/inventory/<path:target>",
         endpoint="datasets_inventory",
         resource_class_args=(config,),
     )
     api.add_resource(
         SampleNamespace,
-        f"{base_uri}/datasets/namespace/<string:dataset>/<string:dataset_view>",
+        f"{base_uri}/datasets/<string:dataset>/namespace/<string:dataset_view>",
         endpoint="datasets_namespace",
         resource_class_args=(config,),
     )
     api.add_resource(
         SampleValues,
-        f"{base_uri}/datasets/values/<string:dataset>/<string:dataset_view>",
+        f"{base_uri}/datasets/<string:dataset>/values/<string:dataset_view>",
         endpoint="datasets_values",
         resource_class_args=(config,),
     )

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -22,27 +22,25 @@ class TestDatasetsContents(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=DatasetsContents(client.config),
-            pbench_endpoint="/datasets/contents/random_md5_string1/1-default",
+            pbench_endpoint="/datasets/random_md5_string1/contents/1-default",
             elastic_endpoint="/_search",
             index_from_metadata="run-toc",
         )
 
     api_method = ApiMethod.GET
 
-    def test_with_no_index_document(self, client, server_config):
+    def test_with_no_uri_args(self, client, server_config):
         """
-        Check the DatasetsContents API when no index name is provided
+        Check the DatasetsContents API when no dataset or path is provided
         """
         # remove the last two components of the pbench_endpoint
-        incorrect_endpoint = "/".join(self.pbench_endpoint.split("/")[:-2])
+        incorrect_endpoint = "/datasets/contents/"
         response = client.get(f"{server_config.rest_uri}{incorrect_endpoint}/")
         assert response.status_code == HTTPStatus.NOT_FOUND
 
-    def test_with_incorrect_index_document(
-        self, client, server_config, pbench_drb_token
-    ):
+    def test_with_incorrect_path(self, client, server_config, pbench_drb_token):
         """
-        Check the Contents API when an incorrect index name is provided.
+        Check the Contents API when an incorrect path is provided.
         """
         incorrect_endpoint = (
             "/".join(self.pbench_endpoint.split("/")[:-1]) + "/random_md5_string2"

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_detail.py
@@ -23,7 +23,7 @@ class TestDatasetsDetail(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=DatasetsDetail(client.config),
-            pbench_endpoint="/datasets/detail/random_md5_string1",
+            pbench_endpoint="/datasets/random_md5_string1/detail",
             elastic_endpoint="/_search?ignore_unavailable=true",
             index_from_metadata="run-data",
             empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -23,7 +23,7 @@ class TestSampleNamespace(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=SampleNamespace(client.config),
-            pbench_endpoint="/datasets/namespace/random_md5_string1/iterations",
+            pbench_endpoint="/datasets/random_md5_string1/namespace/iterations",
             elastic_endpoint="/_search",
             index_from_metadata="result-data-sample",
             empty_es_response_payload=self.EMPTY_ES_RESPONSE_PAYLOAD,
@@ -405,7 +405,7 @@ class TestSampleValues(Commons):
     def _setup(self, client):
         super()._setup(
             cls_obj=SampleValues(client.config),
-            pbench_endpoint="/datasets/values/random_md5_string1/iterations",
+            pbench_endpoint="/datasets/random_md5_string1/values/iterations",
             elastic_endpoint="/_search",
             payload={},
             index_from_metadata="result-data-sample",

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -33,7 +33,7 @@ class TestDatasetsAccess:
             headers = {"authorization": f"bearer {pbench_drb_token}"}
             k = "" if target is None else f"/{target}"
             response = client.get(
-                f"{server_config.rest_uri}/datasets/inventory/{dataset_id}{k}",
+                f"{server_config.rest_uri}/datasets/{dataset_id}/inventory{k}",
                 headers=headers,
             )
             assert response.status_code == expected_status

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -82,7 +82,7 @@ class TestDatasetsList:
                 token = get_token_func(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
-                f"{server_config.rest_uri}/datasets/list",
+                f"{server_config.rest_uri}/datasets",
                 headers=headers,
                 query_string=payload,
             )
@@ -116,7 +116,7 @@ class TestDatasetsList:
             else:
                 query["offset"] = next_offset
                 next_url = (
-                    f"http://localhost{server_config.rest_uri}/datasets/list?"
+                    f"http://localhost{server_config.rest_uri}/datasets?"
                     + urlencode_json(query)
                 )
         else:
@@ -282,7 +282,7 @@ class TestDatasetsList:
         token = get_token_func("drb")
         headers = {"authorization": f"bearer {token}"}
         response = client.get(
-            f"{server_config.rest_uri}/datasets/list?mine" "&metadata=dataset.uploaded",
+            f"{server_config.rest_uri}/datasets?mine&metadata=dataset.uploaded",
             headers=headers,
         )
         assert response.status_code == HTTPStatus.OK

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -37,7 +37,7 @@ class TestDatasetsMetadataGet:
                 token = get_token_func(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.get(
-                f"{server_config.rest_uri}/datasets/metadata/{dataset}",
+                f"{server_config.rest_uri}/datasets/{dataset}/metadata",
                 headers=headers,
                 query_string=payload,
             )
@@ -239,7 +239,7 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
                 token = get_token_func(username)
                 headers = {"authorization": f"bearer {token}"}
             response = client.put(
-                f"{server_config.rest_uri}/datasets/metadata/{dataset}",
+                f"{server_config.rest_uri}/datasets/{dataset}/metadata",
                 headers=headers,
                 json=payload,
             )
@@ -272,14 +272,14 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
         specified but not required.
         """
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata/drb", json={}
+            f"{server_config.rest_uri}/datasets/drb/metadata", json={}
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST
         assert response.json.get("message") == "Missing required parameters: metadata"
 
     def test_put_no_dataset(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata/foobar",
+            f"{server_config.rest_uri}/datasets/foobar/metadata",
             json={"metadata": {"global.seen": True, "global.saved": False}},
         )
         assert response.status_code == HTTPStatus.NOT_FOUND
@@ -287,7 +287,7 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
 
     def test_put_bad_keys(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata/drb",
+            f"{server_config.rest_uri}/datasets/drb/metadata",
             json={
                 "metadata": {"xyzzy": "private", "what": "sup", "global.saved": True}
             },
@@ -299,7 +299,7 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
 
     def test_put_reserved_metadata(self, client, server_config, attach_dataset):
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata/drb",
+            f"{server_config.rest_uri}/datasets/drb/metadata",
             json={"metadata": {"dataset.access": "private"}},
         )
         assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -47,7 +47,7 @@ class TestEndpointConfig:
                 "datasets_daterange": f"{uri}/datasets/daterange",
                 "datasets_detail": f"{uri}/datasets/detail",
                 "datasets_inventory": f"{uri}/datasets/inventory",
-                "datasets_list": f"{uri}/datasets/list",
+                "datasets_list": f"{uri}/datasets",
                 "datasets_mappings": f"{uri}/datasets/mappings",
                 "datasets_metadata": f"{uri}/datasets/metadata",
                 "datasets_namespace": f"{uri}/datasets/namespace",
@@ -68,7 +68,7 @@ class TestEndpointConfig:
                     "params": {"dataset": {"type": "string"}},
                 },
                 "datasets_contents": {
-                    "template": f"{uri}/datasets/contents/{{dataset}}/{{target}}",
+                    "template": f"{uri}/datasets/{{dataset}}/contents/{{target}}",
                     "params": {
                         "dataset": {"type": "string"},
                         "target": {"type": "path"},
@@ -79,27 +79,27 @@ class TestEndpointConfig:
                     "params": {},
                 },
                 "datasets_detail": {
-                    "template": f"{uri}/datasets/detail/{{dataset}}",
+                    "template": f"{uri}/datasets/{{dataset}}/detail",
                     "params": {"dataset": {"type": "string"}},
                 },
                 "datasets_inventory": {
-                    "template": f"{uri}/datasets/inventory/{{dataset}}/{{target}}",
+                    "template": f"{uri}/datasets/{{dataset}}/inventory/{{target}}",
                     "params": {
                         "dataset": {"type": "string"},
                         "target": {"type": "path"},
                     },
                 },
-                "datasets_list": {"template": f"{uri}/datasets/list", "params": {}},
+                "datasets_list": {"template": f"{uri}/datasets", "params": {}},
                 "datasets_mappings": {
                     "template": f"{uri}/datasets/mappings/{{dataset_view}}",
                     "params": {"dataset_view": {"type": "string"}},
                 },
                 "datasets_metadata": {
-                    "template": f"{uri}/datasets/metadata/{{dataset}}",
+                    "template": f"{uri}/datasets/{{dataset}}/metadata",
                     "params": {"dataset": {"type": "string"}},
                 },
                 "datasets_namespace": {
-                    "template": f"{uri}/datasets/namespace/{{dataset}}/{{dataset_view}}",
+                    "template": f"{uri}/datasets/{{dataset}}/namespace/{{dataset_view}}",
                     "params": {
                         "dataset": {"type": "string"},
                         "dataset_view": {"type": "string"},
@@ -107,7 +107,7 @@ class TestEndpointConfig:
                 },
                 "datasets_search": {"template": f"{uri}/datasets/search", "params": {}},
                 "datasets_values": {
-                    "template": f"{uri}/datasets/values/{{dataset}}/{{dataset_view}}",
+                    "template": f"{uri}/datasets/{{dataset}}/values/{{dataset_view}}",
                     "params": {
                         "dataset": {"type": "string"},
                         "dataset_view": {"type": "string"},

--- a/lib/pbench/test/unit/server/test_server_settings.py
+++ b/lib/pbench/test/unit/server/test_server_settings.py
@@ -263,7 +263,7 @@ class TestServerSettings:
                 }
             },
         )
-        response = client.get(f"{server_config.rest_uri}/datasets/list")
+        response = client.get(f"{server_config.rest_uri}/datasets")
         assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
         assert response.json == {
             "contact": "test@example.com",
@@ -285,13 +285,13 @@ class TestServerSettings:
             },
         )
         response = client.get(
-            f"{server_config.rest_uri}/datasets/list?owner=drb",
+            f"{server_config.rest_uri}/datasets?owner=drb",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
         )
         assert response.status_code == HTTPStatus.OK
         assert response.json["total"] == 2
         response = client.put(
-            f"{server_config.rest_uri}/datasets/metadata/drb",
+            f"{server_config.rest_uri}/datasets/drb/metadata",
             headers={"authorization": f"Bearer {pbench_drb_token}"},
             json={"metadata": {"dataset.name": "Test"}},
         )


### PR DESCRIPTION
PBENCH-1108

With the recent consolidation of `DELETE|POST /datasets/{id}` to modify a dataset, there are only a few remaining changes to make the datasets APIs consistently resource-oriented, treating the metadata and index data as sub-resources under `/datasets/{id}`.

`GET /datasets/list` -> `GET /datasets`: query the resource *collection*
`GET /datasets/detail/{id}` -> `GET /datasets/{id}/detail`: query ES run doc
`GET|PUT /datasets/metadata/{id}` -> `GET|PUT /datasets/{id}/metadata`

And so forth.

The server is updated simply by changing the `add_resource` strings, although a bit more work was required on the "unit" tests with hardcoded URIs. The functional tests were already templated, and aren't affected.

The dashboard has generally preferred to use `endpoints.api.{name}` for a simple string with argument(s) appended at the end, which no longer works. I created an `expandUriTemplate` method to handle this cleanly, and adapted both the TOC and Overview actions to use it.

I found that the TOC action hadn't been updated when we moved "parent" from JSON body to URI, so it was broken anyway. There's still some deeper logic problem, and it's not correctly accumulating deeper paths; I didn't attempt to fix that since it's beyond the scope of the URI schema change.