### PR TITLE
Add `utcnow()` module method; drop _time() use

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -52,16 +52,26 @@ class SimpleUTC(tzinfo):
         return timedelta(0)
 
 
+UTC = SimpleUTC()
+
+
+def utcnow(ts: float = None) -> datetime:
+    """Convenience method for obtaining a datetime object with a UTC time zone.
+
+    Returns:
+        A datetime object with a UTC time zone.
+    """
+    ts = _time() if ts is None else ts
+    return datetime.utcfromtimestamp(ts).replace(tzinfo=UTC)
+
+
 def tstos(ts: float = None) -> str:
     """Convert a floating point seconds from the Epoch into a string.
 
     Returns:
         A string representation of a datetime object with a UTC time zone.
     """
-    if ts is None:
-        ts = _time()
-    dt = datetime.utcfromtimestamp(ts).replace(tzinfo=SimpleUTC())
-    return dt.strftime("%Y-%m-%dT%H:%M:%S-%Z")
+    return utcnow(ts).strftime("%Y-%m-%dT%H:%M:%S-%Z")
 
 
 def get_resolved_dir(
@@ -111,7 +121,7 @@ def timestamp() -> str:
         The current timestamp formatted as a string of the following form:
             <YYYY>-<MM>-<DD>T<hh>:<mm>:<ss>-<TZ>
     """
-    return tstos(_time())
+    return tstos()
 
 
 class PbenchServerConfig(PbenchConfig):

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -58,11 +58,15 @@ UTC = SimpleUTC()
 def utcnow(ts: float = None) -> datetime:
     """Convenience method for obtaining a datetime object with a UTC time zone.
 
+    Args:
+        ts : Optional seconds-since-the-epoch time stamp to use instead of the
+            current time
+
     Returns:
         A datetime object with a UTC time zone.
     """
-    ts = _time() if ts is None else ts
-    return datetime.utcfromtimestamp(ts).replace(tzinfo=UTC)
+    tv = _time() if ts is None else ts
+    return datetime.utcfromtimestamp(tv).replace(tzinfo=UTC)
 
 
 def tstos(ts: float = None) -> str:

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -4083,10 +4083,6 @@ class IdxContext:
                     " contain a period ('.')".format(self.idx_prefix)
                 )
 
-        # We expose the pbench.server module's internal _time() method here
-        # for convenience, allowing us to more easily mock out "time" for unit
-        # test environments.
-        self.time = pbench.server._time
         self.gethostname = socket.gethostname
         self.getpid = os.getpid
         self.getgid = os.getgid

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -280,7 +280,7 @@ class Index:
         # We use the "start" report ID as the tracking ID for all indexed
         # documents.
         try:
-            tracking_id = self.report.post_status(tstos(idxctx.time()), "start")
+            tracking_id = self.report.post_status(tstos(), "start")
         except SigTermException:
             # Re-raise a SIGTERM to avoid it being lumped in with general
             # exception handling below.
@@ -705,9 +705,7 @@ class Index:
                             for line in sorted(sfp):
                                 print(line.strip(), file=fp)
                 try:
-                    self.report.post_status(
-                        tstos(idxctx.time()), "status", report_fname
-                    )
+                    self.report.post_status(tstos(), "status", report_fname)
                 except SigTermException:
                     # Re-raise a SIGTERM to avoid it being lumped in with general
                     # exception handling below.

--- a/server/bin/pbench-reindex
+++ b/server/bin/pbench-reindex
@@ -24,7 +24,7 @@ import sys
 
 from pbench import BadConfig
 from pbench.common.logger import get_pbench_logger
-import pbench.server
+from pbench.server import PbenchServerConfig, UTC, utcnow
 from pbench.server.database import init_db
 from pbench.server.database.models.datasets import Dataset, DatasetError, Metadata
 from pbench.server.utils import get_tarball_md5
@@ -146,7 +146,7 @@ def gen_reindex_list(archive, oldest_dt, newest_dt):
                             int(match.group(1)),
                             int(match.group(2)),
                             int(match.group(3)),
-                        )
+                        ).replace(tzinfo=UTC)
                     except ValueError:
                         continue
                     if tb_dt < oldest_dt or newest_dt < tb_dt:
@@ -166,7 +166,7 @@ def main(options):
         return 1
 
     try:
-        config = pbench.server.PbenchServerConfig.create(options.cfg_name)
+        config = PbenchServerConfig.create(options.cfg_name)
     except BadConfig as e:
         print(f"{_NAME_}: {e}", file=sys.stderr)
         return 2
@@ -196,8 +196,8 @@ def main(options):
 
     _fmt = "%Y-%m-%d"
     try:
-        oldest_dt = datetime.strptime(options.oldest, _fmt)
-        newest_dt = datetime.strptime(options.newest, _fmt)
+        oldest_dt = datetime.strptime(options.oldest, _fmt).replace(tzinfo=UTC)
+        newest_dt = datetime.strptime(options.newest, _fmt).replace(tzinfo=UTC)
     except Exception as exc:
         print(
             f"Invalid time range, {options.oldest} to {options.newest}, "
@@ -213,19 +213,19 @@ def main(options):
     print(f"Re-indexing tar balls in the range {oldest_dt} to {newest_dt}")
 
     actions = []
-    start = pbench.server._time()
+    start = utcnow()
     for _val in gen_reindex_list(archive_p, oldest_dt, newest_dt):
         controller_name, tb_name = _val
         act_set = reindex(
             controller_name, tb_name, archive_p, incoming_p, options.dry_run
         )
         actions.append(act_set)
-    end = pbench.server._time()
+    end = utcnow()
 
     for act_set in sorted(actions):
         print(f"{act_set!r}")
 
-    print(f"Run-time: {start} {end} {end - start}")
+    print(f"Run-time: {start} {end} {(end - start).total_seconds()}")
     return 0
 
 


### PR DESCRIPTION
"Well ... it's about time!"
"Now would be a good time, Scotty!"

Add an intermediate `utcnow()` module method to expose as an alternative to a string based timestamp.

We also drop the use of `_time()` where possible.