### PR TITLE
Remove left-over `py3-server` tox env

### DIFF
--- a/run-unittests
+++ b/run-unittests
@@ -4,7 +4,7 @@ prog="$(basename "${0}")"
 progdir="$(realpath -e $(dirname "${0}"))"
 
 # List of tox environments to run.
-tox_envs="lint py3-server server"
+tox_envs="lint server"
 
 for toxenv in ${tox_envs}; do
     if [[ -d ${progdir}/.tox/${toxenv} ]]; then

--- a/tox.ini
+++ b/tox.ini
@@ -37,17 +37,6 @@ deps =
 commands =
     bash -c "./server/bin/unittests {posargs}"
 
-[testenv:py3-server]
-description = Runs all Python3-based server unit and functional tests
-basepython = python3.9
-setenv =
-    PYTHONPATH = {env:PYTHONPATH:}:{toxinidir}/server/lib:{toxinidir}/lib
-deps =
-    -r{toxinidir}/server/requirements.txt
-    -r{toxinidir}/server/test-requirements.txt
-commands =
-    pytest {posargs} ./server/lib/pbench/test/unit
-
 [testenv:lint]
 description = Runs all linting tasks
 commands =


### PR DESCRIPTION
Commit message body below, commit summary in PR title:

    Commit 677f8890038b44d00451adf2c297c565a6c81c7c removed the Python3 unit
    tests by failed to remove the `py3-server` tox environment.