### PR TITLE
pbench-results-push: logging fixes and better reporting 

### DIFF
--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -9,12 +9,6 @@ pbench_log = %(pbench_run)s/pbench.log
 # RPM requirement mode: strict vs relaxed
 rpm_requirement_mode = strict
 
-[logging]
-logger_type = file
-# # "log_dir" is only considered when "logger_type" is set to "file"; And by
-# # default the log file directory is the "pbench_run" directory.
-# log_dir =
-
 [results]
 user = pbench
 host_info_uri = pbench-results-host-info.versioned/pbench-results-host-info.URL002

--- a/lib/pbench/agent/__init__.py
+++ b/lib/pbench/agent/__init__.py
@@ -61,13 +61,6 @@ class PbenchAgentConfig(PbenchConfig):
             )
             self.pbench_lib_dir = self.pbench_install_dir / "lib"
 
-        if self.logger_type == "file" and self.log_dir is None:
-            # The configuration file has a logging section configured to use
-            # "file" logging, but no log directory is set.  We'll set the log
-            # directory to be the directory of the legacy ${pbench_log} value
-            # determined above.
-            self.log_dir = str(self.pbench_log.parent)
-
         try:
             self.ssh_opts = self.get("results", "ssh_opts", fallback=DEFAULT_SSH_OPTS)
         except (NoOptionError, NoSectionError):

--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -54,11 +54,6 @@ class BaseCommand(metaclass=abc.ABCMeta):
             )
             click.get_current_context().exit(1)
 
-        # log file - N.B. not a directory
-        self.pbench_log = self.config.pbench_log
-        if self.pbench_log is None:
-            self.pbench_log = self.pbench_run / "pbench.log"
-
         self.pbench_install_dir = self.config.pbench_install_dir
         if self.pbench_install_dir is None:
             self.pbench_install_dir = "/opt/pbench-agent"
@@ -71,7 +66,7 @@ class BaseCommand(metaclass=abc.ABCMeta):
         self.pbench_bspp_dir = self.pbench_install_dir / "bench-scripts" / "postprocess"
         self.pbench_lib_dir = self.pbench_install_dir / "lib"
 
-        self.logger = setup_logging(debug=False, logfile=self.pbench_log)
+        self.logger = setup_logging(debug=False, logfile=None)
 
         self.ssh_opts = os.environ.get("ssh_opts", self.config.ssh_opts)
         self.scp_opts = os.environ.get("scp_opts", self.config.scp_opts)

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -313,7 +313,7 @@ class CopyResultTb:
 
     def copy_result_tb(
         self, token: str, access: Optional[str] = None, metadata: Optional[List] = None
-    ) -> None:
+    ) -> requests.Response:
         """Copies the tar ball from the agent to the configured server using upload
         API.
 
@@ -326,6 +326,9 @@ class CopyResultTb:
                 the result will be the server default.
             metadata: list of metadata keys to be sent on PUT. (Optional)
                 Format: key:value
+
+        Returns:
+            response from the PUT request
 
         Raises:
             RuntimeError     if a connection to the server fails
@@ -367,17 +370,12 @@ class CopyResultTb:
                     )
                 )
 
-                response = requests.Session().send(request)
-                response.raise_for_status()
-                self.logger.info("File uploaded successfully")
+                return requests.Session().send(request)
             except requests.exceptions.ConnectionError as exc:
                 raise RuntimeError(f"Cannot connect to '{self.upload_url}': {exc}")
             except Exception as exc:
                 raise self.FileUploadError(
-                    "There was something wrong with file upload request: "
+                    "There was something wrong with the file upload request: "
                     f"file: '{self.tarball}', URL: '{self.upload_url}';"
                     f" error: '{exc}'"
                 )
-        assert (
-            response.ok
-        ), f"Logic error!  Unexpected error response, '{response.reason}' ({response.status_code})"

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -18,16 +18,20 @@ class ResultsPush(BaseCommand):
 
     def execute(self) -> int:
         tarball_len, tarball_md5 = md5sum(self.context.result_tb_name)
-        crt = CopyResultTb(
-            self.context.result_tb_name,
-            tarball_len,
-            tarball_md5,
-            self.config,
-            self.logger,
-        )
-        res = crt.copy_result_tb(
-            self.context.token, self.context.access, self.context.metadata
-        )
+        try:
+            crt = CopyResultTb(
+                self.context.result_tb_name,
+                tarball_len,
+                tarball_md5,
+                self.config,
+                self.logger,
+            )
+            res = crt.copy_result_tb(
+                self.context.token, self.context.access, self.context.metadata
+            )
+        except (RuntimeError, CopyResultTb.FileUploadError) as e:
+            click.echo(e.args[0], err=True)
+            return 1
 
         # success
         if res.status_code == 201:

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -19,20 +19,16 @@ class ResultsPush(BaseCommand):
 
     def execute(self) -> int:
         tarball_len, tarball_md5 = md5sum(self.context.result_tb_name)
-        try:
-            crt = CopyResultTb(
-                self.context.result_tb_name,
-                tarball_len,
-                tarball_md5,
-                self.config,
-                self.logger,
-            )
-            res = crt.copy_result_tb(
-                self.context.token, self.context.access, self.context.metadata
-            )
-        except (RuntimeError, CopyResultTb.FileUploadError) as e:
-            click.echo(e.args[0], err=True)
-            return 1
+        crt = CopyResultTb(
+            self.context.result_tb_name,
+            tarball_len,
+            tarball_md5,
+            self.config,
+            self.logger,
+        )
+        res = crt.copy_result_tb(
+            self.context.token, self.context.access, self.context.metadata
+        )
 
         # success
         if res.status_code == HTTPStatus.CREATED:

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from pathlib import Path
 from typing import List
 
@@ -34,7 +35,7 @@ class ResultsPush(BaseCommand):
             return 1
 
         # success
-        if res.status_code == 201:
+        if res.status_code == HTTPStatus.CREATED:
             return 0
 
         try:

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -169,11 +169,7 @@ class TestCopyResults:
                     self.config,
                     agent_logger,
                 )
-                res = crt.copy_result_tb("token")
-                # we should never get here but flake8 flakes out
-                # complaining about the unused variable, so we
-                # might as well use it.
-                assert not res.ok
+                crt.copy_result_tb("token")
 
         assert str(excinfo.value).startswith(
             expected_error_message
@@ -201,10 +197,6 @@ class TestCopyResults:
                     self.config,
                     agent_logger,
                 )
-                res = crt.copy_result_tb("token")
-                # we should never get here but flake8 flakes out
-                # complaining about the unused variable, so we
-                # might as well use it.
-                assert not res.ok
+                crt.copy_result_tb("token")
 
         assert "something wrong" in str(excinfo.value)

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -170,6 +170,9 @@ class TestCopyResults:
                     agent_logger,
                 )
                 res = crt.copy_result_tb("token")
+                # we should never get here but flake8 flakes out
+                # complaining about the unused variable, so we
+                # might as well use it.
                 assert not res.ok
 
         assert str(excinfo.value).startswith(
@@ -199,6 +202,9 @@ class TestCopyResults:
                     agent_logger,
                 )
                 res = crt.copy_result_tb("token")
+                # we should never get here but flake8 flakes out
+                # complaining about the unused variable, so we
+                # might as well use it.
                 assert not res.ok
 
         assert "something wrong" in str(excinfo.value)

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -91,9 +91,11 @@ class TestCopyResults:
             agent_logger,
         )
         if access is None:
-            crt.copy_result_tb("token")
+            res = crt.copy_result_tb("token")
         else:
-            crt.copy_result_tb("token", access)
+            res = crt.copy_result_tb("token", access)
+
+        assert res.ok
         # If we got this far without an exception, then the test passes.
 
     @responses.activate
@@ -132,9 +134,11 @@ class TestCopyResults:
             agent_logger,
         )
         if metadata is None:
-            crt.copy_result_tb("token")
+            res = crt.copy_result_tb("token")
         else:
-            crt.copy_result_tb("token", access, metadata)
+            res = crt.copy_result_tb("token", access, metadata)
+
+        assert res.ok
         # If we got this far without an exception, then the test passes.
 
     @responses.activate

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -42,18 +42,20 @@ class TestCopyResults:
         bad_tarball_name = "nonexistent-tarball.tar.xz"
         expected_error_message = f"Tar ball '{bad_tarball_name}' does not exist"
 
-        monkeypatch.setattr(
-            Path, "exists", self.get_path_exists_mock(bad_tarball_name, False)
-        )
-
-        with pytest.raises(FileNotFoundError) as excinfo:
-            CopyResultTb(
-                bad_tarball_name,
-                0,
-                "ignoremd5",
-                self.config,
-                agent_logger,
+        with monkeypatch.context() as m:
+            m.setattr(
+                Path, "exists", self.get_path_exists_mock(bad_tarball_name, False)
             )
+
+            with pytest.raises(FileNotFoundError) as excinfo:
+                CopyResultTb(
+                    bad_tarball_name,
+                    0,
+                    "ignoremd5",
+                    self.config,
+                    agent_logger,
+                )
+
         assert str(excinfo.value).endswith(
             expected_error_message
         ), f"expected='...{expected_error_message}', found='{str(excinfo.value)}'"
@@ -70,7 +72,7 @@ class TestCopyResults:
             else:
                 assert "access" in request.params
                 assert request.params["access"] == access
-            return HTTPStatus.OK, {}, ""
+            return HTTPStatus.CREATED, {}, ""
 
         responses.add_callback(
             responses.PUT,
@@ -78,24 +80,25 @@ class TestCopyResults:
             callback=request_callback,
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
-        monkeypatch.setattr(
-            Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
-        )
+        with monkeypatch.context() as m:
+            m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+            m.setattr(
+                Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
+            )
 
-        crt = CopyResultTb(
-            tb_name,
-            len(tb_contents),
-            "someMD5",
-            self.config,
-            agent_logger,
-        )
-        if access is None:
-            res = crt.copy_result_tb("token")
-        else:
-            res = crt.copy_result_tb("token", access)
+            crt = CopyResultTb(
+                tb_name,
+                len(tb_contents),
+                "someMD5",
+                self.config,
+                agent_logger,
+            )
+            if access is None:
+                res = crt.copy_result_tb("token")
+            else:
+                res = crt.copy_result_tb("token", access)
 
-        assert res.ok
+        assert res.status_code == HTTPStatus.CREATED
         # If we got this far without an exception, then the test passes.
 
     @responses.activate
@@ -113,7 +116,7 @@ class TestCopyResults:
                 assert request.params["metadata"] == metadata
             else:
                 assert "metadata" not in request.params
-            return HTTPStatus.OK, {}, ""
+            return HTTPStatus.CREATED, {}, ""
 
         responses.add_callback(
             responses.PUT,
@@ -121,24 +124,25 @@ class TestCopyResults:
             callback=request_callback,
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
-        monkeypatch.setattr(
-            Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
-        )
+        with monkeypatch.context() as m:
+            m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+            m.setattr(
+                Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
+            )
 
-        crt = CopyResultTb(
-            tb_name,
-            len(tb_contents),
-            "someMD5",
-            self.config,
-            agent_logger,
-        )
-        if metadata is None:
-            res = crt.copy_result_tb("token")
-        else:
-            res = crt.copy_result_tb("token", access, metadata)
+            crt = CopyResultTb(
+                tb_name,
+                len(tb_contents),
+                "someMD5",
+                self.config,
+                agent_logger,
+            )
+            if metadata is None:
+                res = crt.copy_result_tb("token")
+            else:
+                res = crt.copy_result_tb("token", access, metadata)
 
-        assert res.ok
+        assert res.status_code == HTTPStatus.CREATED
         # If we got this far without an exception, then the test passes.
 
     @responses.activate
@@ -151,20 +155,22 @@ class TestCopyResults:
             responses.PUT, upload_url, body=requests.exceptions.ConnectionError("uh-oh")
         )
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
-        monkeypatch.setattr(
-            Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
-        )
-
-        with pytest.raises(RuntimeError) as excinfo:
-            crt = CopyResultTb(
-                tb_name,
-                len(tb_contents),
-                "someMD5",
-                self.config,
-                agent_logger,
+        with monkeypatch.context() as m:
+            m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+            m.setattr(
+                Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
-            crt.copy_result_tb("token")
+
+            with pytest.raises(RuntimeError) as excinfo:
+                crt = CopyResultTb(
+                    tb_name,
+                    len(tb_contents),
+                    "someMD5",
+                    self.config,
+                    agent_logger,
+                )
+                res = crt.copy_result_tb("token")
+                assert not res.ok
 
         assert str(excinfo.value).startswith(
             expected_error_message
@@ -178,18 +184,21 @@ class TestCopyResults:
 
         responses.add(responses.PUT, upload_url, body=RuntimeError("uh-oh"))
 
-        monkeypatch.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
-        monkeypatch.setattr(
-            Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
-        )
-
-        with pytest.raises(CopyResultTb.FileUploadError) as excinfo:
-            crt = CopyResultTb(
-                tb_name,
-                len(tb_contents),
-                "someMD5",
-                self.config,
-                agent_logger,
+        with monkeypatch.context() as m:
+            m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+            m.setattr(
+                Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
-            crt.copy_result_tb("token")
+
+            with pytest.raises(CopyResultTb.FileUploadError) as excinfo:
+                crt = CopyResultTb(
+                    tb_name,
+                    len(tb_contents),
+                    "someMD5",
+                    self.config,
+                    agent_logger,
+                )
+                res = crt.copy_result_tb("token")
+                assert not res.ok
+
         assert "something wrong" in str(excinfo.value)

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -1,10 +1,7 @@
 from http import HTTPStatus
 import logging
 import os
-
-# python >= 3.10 - :-(
-# from types import NoneType
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 
 from click.testing import CliRunner
 import pytest
@@ -29,7 +26,7 @@ class TestResultsPush:
 
     @staticmethod
     def add_http_mock_response(
-        status_code: HTTPStatus = None, message: Union[str, Dict, type(None)] = None
+        status_code: HTTPStatus = None, message: Optional[Union[str, Dict]] = None
     ):
         if status_code:
             if message is None:
@@ -45,14 +42,6 @@ class TestResultsPush:
                     status=status_code,
                     json=message,
                 )
-            # I can only add a `json' attribute to the response. Trying `text' or `reason' makes
-            # responses.add() barf:
-            #   File "/var/tmp/nick/tox/py39/lib/python3.9/site-packages/responses/__init__.py", line 770, in add
-            #     response = Response(method=method, url=url, body=body, **kwargs)
-            #   File "/var/tmp/nick/tox/py39/lib/python3.9/site-packages/responses/__init__.py", line 563, in __init__
-            #     super().__init__(method, url, **kwargs)
-            # TypeError: __init__() got an unexpected keyword argument 'reason'
-
         else:
             responses.add(
                 responses.PUT,

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -34,7 +34,7 @@ class TestResultsPush:
 
         if isinstance(message, dict):
             parms["json"] = message
-        elif isinstance(message, (str, Exception)):
+        elif isinstance(message, str):
             parms["body"] = message
 
         responses.add(

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -28,32 +28,20 @@ class TestResultsPush:
     def add_http_mock_response(
         status_code: HTTPStatus = None, message: Optional[Union[str, Dict]] = None
     ):
+        parms = {}
         if status_code:
-            if message is None:
-                responses.add(
-                    responses.PUT,
-                    f"{TestResultsPush.URL}/upload/{os.path.basename(tarball)}",
-                    status=status_code,
-                )
-            elif isinstance(message, dict):
-                responses.add(
-                    responses.PUT,
-                    f"{TestResultsPush.URL}/upload/{os.path.basename(tarball)}",
-                    status=status_code,
-                    json=message,
-                )
-            else:
-                responses.add(
-                    responses.PUT,
-                    f"{TestResultsPush.URL}/upload/{os.path.basename(tarball)}",
-                    status=status_code,
-                    body=message,
-                )
-        else:
-            responses.add(
-                responses.PUT,
-                f"{TestResultsPush.URL}/upload/{os.path.basename(tarball)}",
-            )
+            parms["status"] = status_code
+
+        if isinstance(message, dict):
+            parms["json"] = message
+        elif isinstance(message, (str, Exception)):
+            parms["body"] = message
+
+        responses.add(
+            responses.PUT,
+            f"{TestResultsPush.URL}/upload/{os.path.basename(tarball)}",
+            **parms,
+        )
 
     @staticmethod
     def add_connectionerr_mock_response():


### PR DESCRIPTION
This PR consists of seven commits:

- the first commit disables file logging from all agent python commands. It also cleans up some now unnecessary cruft.
-  the second commit changes `copy_result-tb` to return the server response without interpreting it (although it still raises exceptions on some errors, e.g. connection errors). The response status codes are interpreted in `push.py` and `move.py`. `push.py` is silent on success; it outputs an error message but still exits with 0 on any other OK status; otherwise, it outputs an error message  and exits with 1. `move.py` translates all non-OK responses to exceptions.
- the third commit is undone by that last commit, so it will disappear after the squashing.
- the fourth limits the scope of monkeypatching some `pathlib' components that were used by pytest in checking assertions and were causing internal failures in `pytest' itself.
- the fifth replaces a numeric by a symbolic constant
- the sixth parametrizes some tests of `pbench-results-push` - there is more to be done here, but I'll deal with it in some other PR.
- the seventh deals with review comments: undoing the third commit (as already noted) and adding some comments to explain why I chose not to do the second part of the suggested changes.
