### PR TITLE
Backport config file cleanup to 0.72 branch

### DIFF
--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -29,16 +29,10 @@ mailfrom=%(user)s@localhost
 # Token expiration duration in minutes, can be overridden in the main config file, defaults to 60 mins
 token_expiration_duration = 60
 
-# Maximum number of days an unpacked tar ball directory hierarchy will be
-# kept around.
-max-unpacked-age = 30
-
 # Server settings for dataset retention in days; the default can be overridden
 # by user metadata, bounded by the server maximum.
 maximum-dataset-retention-days = 3650
 default-dataset-retention-days = 730
-
-# See pbench-server-setup documentation for filesystem setup.
 
 # WARNING - the pbench-server.cfg file should provide a definition of
 # pbench-top-dir, e.g.:
@@ -69,11 +63,6 @@ rest_uri = /api/v%(rest_version)s
 workers = 3
 # Set the gunicorn worker timeout. Setting it to 0 has the effect of infinite timeouts
 worker_timeout = 9000
-
-# WARNING - the pbench-server.cfg file should provide a definition of
-# pbench-backup-dir, e.g.:
-#     pbench-backup-dir = %(pbench-local-dir)s/archive.backup
-# We won't define it here by default to avoid unintended behaviors.
 
 # Default roles this pbench server takes on, see crontab roles below.
 roles = pbench-results

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -7,13 +7,11 @@ install-dir = /opt/pbench-server
 ###########################################################################
 [pbench-server]
 pbench-top-dir = /srv/pbench
-pbench-backup-dir = %(pbench-top-dir)s/pbench.archive.backup
 environment = container
 realhost = pbenchinacan
-max-unpacked-age = 36500
 maximum-dataset-retention-days = 36500
 default-dataset-retention-days = 730
-roles = pbench-results, pbench-backup
+roles = pbench-results
 
 [Indexing]
 index_prefix = container-pbench


### PR DESCRIPTION
Remove obsolete settings and comments from server config files.