### PR TITLE
Fix /datasets?filter to select across namespaces

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -456,11 +456,9 @@ class DatasetsList(ApiBase):
         for key, table in aliases.items():
             terms = [table.dataset_ref == Dataset.id, table.key == key]
             if key == Metadata.USER:
-                if auth_id:
-                    terms.append(table.user_id == auth_id)
-                else:
+                if not auth_id:
                     continue
-            current_app.logger.info("Adding JOIN {}", key)
+                terms.append(table.user_id == auth_id)
             query = query.outerjoin(table, and_(*terms))
 
         if "start" in json and "end" in json:

--- a/lib/pbench/server/database/database.py
+++ b/lib/pbench/server/database/database.py
@@ -93,16 +93,17 @@ class Database:
         )
 
     @staticmethod
-    def dump_query(query: Query, logger: Logger):
+    def dump_query(query: Query, logger: Logger, level: int = DEBUG):
         """Dump a fully resolved SQL query if DEBUG logging is enabled
 
         Args:
             query:  A SQLAlchemy Query object
             logger: A Python logger object
+            level: [DEBUG] level at which to log
         """
-        if logger.isEnabledFor(DEBUG):
+        if logger.isEnabledFor(level):
             try:
                 q_str = query.statement.compile(compile_kwargs={"literal_binds": True})
-                logger.debug("QUERY {}", q_str)
+                logger.log(level, "QUERY {}", q_str)
             except Exception as e:
-                logger.debug("Can't compile query {}: {}", query, e)
+                logger.log(level, "Can't compile query {}: {}", query, e)

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -4,8 +4,9 @@ import re
 
 import pytest
 import requests
+from sqlalchemy import and_
 from sqlalchemy.exc import ProgrammingError
-from sqlalchemy.orm import Query
+from sqlalchemy.orm import aliased, Query
 
 from pbench.server import JSON, JSONARRAY, JSONOBJECT
 from pbench.server.api.resources import APIAbort
@@ -46,6 +47,35 @@ class TestDatasetsList:
     of datasets provided by the `attach_dataset` fixture and the `more_datasets`
     fixture.
     """
+
+    @pytest.fixture()
+    def aliases(self):
+        mtable = aliased(Metadata)
+        stable = aliased(Metadata)
+        gtable = aliased(Metadata)
+        utable = aliased(Metadata)
+        aliases = {
+            Metadata.METALOG: mtable,
+            Metadata.SERVER: stable,
+            Metadata.GLOBAL: gtable,
+            Metadata.USER: utable,
+        }
+        query = (
+            Database.db_session.query(Dataset)
+            .outerjoin(
+                mtable,
+                and_(mtable.dataset_ref == Dataset.id, mtable.key == Metadata.METALOG),
+            )
+            .outerjoin(
+                stable,
+                and_(stable.dataset_ref == Dataset.id, stable.key == Metadata.SERVER),
+            )
+            .outerjoin(
+                gtable,
+                and_(gtable.dataset_ref == Dataset.id, gtable.key == Metadata.GLOBAL),
+            )
+        )
+        yield aliases, query
 
     @pytest.fixture()
     def query_as(
@@ -467,32 +497,26 @@ class TestDatasetsList:
     @pytest.mark.parametrize(
         "filters,expected",
         [
-            (["dataset.name:fio"], "datasets.name = 'fio'"),
+            (["dataset.name:fio"], " WHERE datasets.name = 'fio'"),
             (
                 ["dataset.metalog.pbench.script:fio"],
-                "dataset_metadata.key = 'metalog' "
-                "AND dataset_metadata.value[['pbench', 'script']] = 'fio'",
+                " WHERE dataset_metadata_1.value[['pbench', 'script']] = 'fio'",
             ),
             (
                 ["user.d.f:1"],
-                "dataset_metadata.key = 'user' AND dataset_metadata.value[['d', "
-                "'f']] = '1' AND dataset_metadata.user_id = '3'",
+                ", dataset_metadata AS dataset_metadata_4 WHERE dataset_metadata_4.value[['d', 'f']] = '1'",
             ),
             (
                 ["dataset.name:~fio", "^global.x:1", "^user.y:~yes"],
-                "(datasets.name LIKE '%' || 'fio' || '%') AND "
-                "(dataset_metadata.key = 'global' AND "
-                "dataset_metadata.value[['x']] = '1' OR dataset_metadata.key "
-                "= 'user' AND ((dataset_metadata.value[['y']]) LIKE '%' || "
-                "'yes' || '%') AND dataset_metadata.user_id = '3')",
+                ", dataset_metadata AS dataset_metadata_4 WHERE (datasets.name LIKE '%' || 'fio' || '%') AND (dataset_metadata_3.value[['x']] = '1' OR ((dataset_metadata_4.value[['y']]) LIKE '%' || 'yes' || '%'))",
             ),
             (
                 ["dataset.uploaded:~2000"],
-                "(CAST(datasets.uploaded AS VARCHAR) LIKE '%' || '2000' || '%')",
+                " WHERE (CAST(datasets.uploaded AS VARCHAR) LIKE '%' || '2000' || '%')",
             ),
         ],
     )
-    def test_filter_query(self, monkeypatch, client, filters, expected):
+    def test_filter_query(self, monkeypatch, client, aliases, filters, expected):
         """Test generation of Metadata value filters
 
         Use the filter_query method directly to verify SQL generation from sets
@@ -503,14 +527,17 @@ class TestDatasetsList:
             lambda: DRB_USER_ID,
         )
         prefix = (
-            "SELECT datasets.access, datasets.id, datasets.name, "
-            "datasets.owner_id, datasets.resource_id, datasets.uploaded "
-            "FROM datasets LEFT OUTER JOIN dataset_metadata ON datasets.id "
-            "= dataset_metadata.dataset_ref WHERE "
+            "SELECT datasets.access, datasets.id, datasets.name, datasets.owner_id, datasets.resource_id, datasets.uploaded "
+            "FROM datasets LEFT OUTER JOIN dataset_metadata "
+            "AS dataset_metadata_1 ON dataset_metadata_1.dataset_ref = datasets.id AND dataset_metadata_1.key = 'metalog' "
+            "LEFT OUTER JOIN dataset_metadata AS dataset_metadata_2 "
+            "ON dataset_metadata_2.dataset_ref = datasets.id AND "
+            "dataset_metadata_2.key = 'server' LEFT OUTER JOIN dataset_metadata "
+            "AS dataset_metadata_3 ON dataset_metadata_3.dataset_ref = datasets.id "
+            "AND dataset_metadata_3.key = 'global'"
         )
-        query = DatasetsList.filter_query(
-            filters, Database.db_session.query(Dataset).outerjoin(Metadata)
-        )
+        aliases, query = aliases
+        query = DatasetsList.filter_query(filters, aliases, query)
         assert (
             FLATTEN.sub(
                 " ",
@@ -519,7 +546,7 @@ class TestDatasetsList:
             == prefix + expected
         )
 
-    def test_user_no_auth(self, monkeypatch, db_session):
+    def test_user_no_auth(self, monkeypatch, db_session, aliases):
         """Test the authorization error when a match against a key in the user
         namespace is attempted from an unauthenticated session.
         """
@@ -527,10 +554,9 @@ class TestDatasetsList:
             "pbench.server.api.resources.datasets_list.Auth.get_current_user_id",
             lambda: None,
         )
+        aliases, query = aliases
         with pytest.raises(APIAbort) as e:
-            DatasetsList.filter_query(
-                ["user.foo:1"], Database.db_session.query(Dataset).outerjoin(Metadata)
-            )
+            DatasetsList.filter_query(["user.foo:1"], aliases, query)
         assert e.value.http_status == HTTPStatus.UNAUTHORIZED
 
     @pytest.mark.parametrize(
@@ -542,16 +568,15 @@ class TestDatasetsList:
             ("dataset.notright:10", HTTPStatus.BAD_REQUEST),
         ],
     )
-    def test_filter_errors(self, monkeypatch, db_session, meta, error):
+    def test_filter_errors(self, monkeypatch, db_session, aliases, meta, error):
         """Test invalid filter expressions."""
         monkeypatch.setattr(
             "pbench.server.api.resources.datasets_list.Auth.get_current_user_id",
             lambda: None,
         )
+        aliases, query = aliases
         with pytest.raises(APIAbort) as e:
-            DatasetsList.filter_query(
-                [meta], Database.db_session.query(Dataset).outerjoin(Metadata)
-            )
+            DatasetsList.filter_query([meta], aliases, query)
         assert e.value.http_status == error
 
     @pytest.mark.parametrize(

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -65,10 +65,9 @@ class TestDatasetsList:
         for key, table in aliases.items():
             terms = [table.dataset_ref == Dataset.id, table.key == key]
             if key == Metadata.USER:
-                if auth_id:
-                    terms.append(table.user_id == auth_id)
-                else:
+                if not auth_id:
                     continue
+                terms.append(table.user_id == auth_id)
             query = query.outerjoin(table, and_(*terms))
         return aliases, query
 
@@ -572,10 +571,6 @@ class TestDatasetsList:
             "LEFT OUTER JOIN dataset_metadata AS dataset_metadata_2 ON dataset_metadata_2.dataset_ref = datasets.id AND dataset_metadata_2.key = 'server' "
             "LEFT OUTER JOIN dataset_metadata AS dataset_metadata_3 ON dataset_metadata_3.dataset_ref = datasets.id AND dataset_metadata_3.key = 'global' WHERE "
         )
-
-        # SELECT datasets.access, datasets.id, datasets.name, datasets.owner_id, datasets.resource_id, datasets.uploaded FROM datasets LEFT OUTER JOIN dataset_metadata AS dataset_metadata_1 ON dataset_metadata_1.dataset_ref = datasets.id AND dataset_metadata_1.key = 'metalog' LEFT OUTER JOIN dataset_metadata AS dataset_metadata_2 ON dataset_metadata_2.dataset_ref = datasets.id AND dataset_metadata_2.key = 'server' LEFT OUTER JOIN dataset_metadata AS dataset_metadata_3 ON dataset_metadata_3.dataset_ref = datasets.id AND dataset_metadata_3.key = 'global' WHERE datasets.name = 'fio'
-        # SELECT datasets.access, datasets.id, datasets.name, datasets.owner_id, datasets.resource_id, datasets.uploaded FROM datasets LEFT OUTER JOIN dataset_metadata AS dataset_metadata_1 ON dataset_metadata_1.dataset_ref = datasets.id AND dataset_metadata_1.key = 'metalog' LEFT OUTER JOIN dataset_metadata AS dataset_metadata_2 ON dataset_metadata_2.dataset_ref = datasets.id AND dataset_metadata_2.key = 'server' LEFT OUTER JOIN dataset_metadata AS dataset_metadata_3 ON dataset_metadata_3.dataset_ref = datasets.id AND dataset_metadata_3.key = 'global' LEFT OUTER JOIN dataset_metadata AS dataset_metadata_4 ON dataset_metadata_4.dataset_ref = datasets.id AND dataset_metadata_4.key = 'user' AND dataset_metadata_4.user_id = '3' WHERE datasets.name = 'fio'
-
         aliases, query = self.filter_setup(None)
         query = DatasetsList.filter_query(filters, aliases, query)
         assert (


### PR DESCRIPTION
PBENCH-1117

I discovered that the single simplistic `LEFT JOIN` allows combining native `Dataset` and `Metadata` terms in a `SELECT`, but with limitations: because the SQL join constructs a row for each `Metadata` match, matches for, e.g., `server.origin` and `dataset.metalog.pbench.script` or `global.server.legacy` will appear on separate table rows. Each has duplicate `Dataset` columns, but that doesn't help when trying to select across namespaces.

The only effective solution I was able to find was to cascade the joins in order to build a new table with a separate column for each metadata namespace row matching the dataset. This allows a single `SELECT` to work across the columns in the new table.

This broke the `keysummary` code, requiring some adjustment there. With the join now renaming multiple copies of the `Metadata` table, the simplistic override of the `SELECT` terms doesn't work. Instead of trying to "optimize" the `SELECT`, the new code just iterates through the returned datasets and their metadata collections.