### PR TITLE
Update contrib scripts for Perfconf demo

### DIFF
--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -36,7 +36,7 @@ if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
 fi
 
 if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
-    other_options="-v ${HOME}/.ssh:/root/.ssh ${other_options}"
+    other_options="--security-opt=label=disable -v ${HOME}/.ssh:/root/.ssh ${other_options}"
 fi
 
 if [[ -f "${config_file}" && -r "${config_file}" ]]; then

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -24,7 +24,7 @@
 # these options and any others which the user has specified and passes in the
 # command to be executed.
 
-image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:latest}
+image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:main}
 config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
 pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
 pbench_server=${PB_AGENT_SERVER_LOC}
@@ -36,15 +36,14 @@ if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
 fi
 
 if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
-    other_options="-v ${HOME}/.ssh:/root/.ssh:z ${other_options}"
+    other_options="-v ${HOME}/.ssh:/root/.ssh ${other_options}"
 fi
 
 if [[ -f "${config_file}" && -r "${config_file}" ]]; then
     other_options="-v ${config_file}:/opt/pbench-agent/config/pbench-agent.cfg:z ${other_options}"
 elif [[ -n "${pbench_server}" ]]; then
     echo "Warning:  the Pbench Agent config file is missing; attempting to generate one in ${config_file}" >&2
-    # TODO:  this should be handled by a separate Pbench Agent command which
-    #        provides a "configuration wizard".
+    # TODO:  this should be handled by a separate Pbench Agent "configuration wizard".
     mkdir -p $(dirname ${config_file})
     cat > ${config_file} <<- EOF
 		[DEFAULT]

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -23,11 +23,11 @@ mkdir -p ${FIOTEST}
 #+
 # Run the demo!
 #-
+pbench pbench-generate-token --output=/var/lib/pbench-agent/.token
 pbench pbench-register-tool-set light
 pbench pbench-list-tools
 pbench pbench-user-benchmark --config example-workload -- \
     fio --directory=/fiotest --name fio_test_file --direct=1 --rw=randread \
-        --bs=16k --size=100M --numjobs=16 --time_based --runtime=20s \
+        --bs=16k --size=100M --numjobs=8 --time_based --runtime=5s \
         --group_reporting --norandommap
-pbench pbench-generate-token --output=/var/lib/pbench-agent/.token
 pbench pbench-results-move --token=$(< /var/tmp/pbench/pbench-agent/run/.token)

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -32,6 +32,4 @@ pbench pbench-user-benchmark --config example-workload -- \
         --group_reporting --norandommap
 # Note that the token file location below is evaluated -outside- the container,
 # unlike in the pbench-generate-token command above.
-pbench pbench-results-move \
-        --token=$(< /var/tmp/${USER}/pbench-agent/run/.token) \
-        --metadata global.perfconf.year:2023,global.perfconf.location:Westford
+pbench pbench-results-move --token=$(< /var/tmp/${USER}/pbench-agent/run/.token)

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -30,5 +30,8 @@ pbench pbench-user-benchmark --config example-workload -- \
     fio --directory=/fiotest --name fio_test_file --direct=1 --rw=randread \
         --bs=16k --size=100M --numjobs=8 --time_based --runtime=5s \
         --group_reporting --norandommap
-pbench pbench-results-move --token=$(< /var/tmp/pbench/pbench-agent/run/.token) \
+# Note that the token file location below is evaluated -outside- the container,
+# unlike in the pbench-generate-token command above.
+pbench pbench-results-move \
+        --token=$(< /var/tmp/${USER}/pbench-agent/run/.token) \
         --metadata global.perfconf.year:2023,global.perfconf.location:Westford

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -30,4 +30,5 @@ pbench pbench-user-benchmark --config example-workload -- \
     fio --directory=/fiotest --name fio_test_file --direct=1 --rw=randread \
         --bs=16k --size=100M --numjobs=8 --time_based --runtime=5s \
         --group_reporting --norandommap
-pbench pbench-results-move --token=$(< /var/tmp/pbench/pbench-agent/run/.token)
+pbench pbench-results-move --token=$(< /var/tmp/pbench/pbench-agent/run/.token) \
+        --metadata global.perfconf.year:2023,global.perfconf.location:Westford


### PR DESCRIPTION
In the `pbench` script:
- Change the container tag from `latest` (which is the latest _release_) to `main` (which is the latest "published" image).
- Use `--security-opt=label=disable` to avoid problems with relabeling the `~/.ssh` directory contents.

In the `pbench_demo` script:
- Move the invocation of `pbench-generate-token` to the beginning of the commands, to help "fail early" in the event of configuration problems.
- Change the run-time from 20s to 5s.
- Add an explanatory comment to a bit of subtlety.