### PR TITLE
Fix various problems in the pbench_results_push tests

### DIFF
--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -99,7 +99,6 @@ class TestCopyResults:
                 res = crt.copy_result_tb("token", access)
 
         assert res.status_code == HTTPStatus.CREATED
-        # If we got this far without an exception, then the test passes.
 
     @responses.activate
     @pytest.mark.parametrize(
@@ -143,7 +142,6 @@ class TestCopyResults:
                 res = crt.copy_result_tb("token", access, metadata)
 
         assert res.status_code == HTTPStatus.CREATED
-        # If we got this far without an exception, then the test passes.
 
     @responses.activate
     def test_connection_error(self, monkeypatch, agent_logger):

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -26,7 +26,7 @@ class TestResultsPush:
     @staticmethod
     def add_http_mock_response(
         status_code: HTTPStatus = HTTPStatus.CREATED,
-        message: Optional[Union[str, Dict]] = None,
+        message: Optional[Union[str, Dict, Exception]] = None,
     ):
         parms = {}
         if status_code:
@@ -194,60 +194,20 @@ class TestResultsPush:
     @pytest.mark.parametrize(
         "status_code,message,exit_code",
         (
-            (
-                HTTPStatus.CREATED,
-                None,
-                0,
-            ),
-            (
-                HTTPStatus.OK,
-                {"message": "Dup"},
-                0,
-            ),
-            (
-                HTTPStatus.OK,
-                "Dup",
-                0,
-            ),
-            (
-                HTTPStatus.NO_CONTENT,
-                {"message": "No content"},
-                0,
-            ),
-            (
-                HTTPStatus.NO_CONTENT,
-                "No content",
-                0,
-            ),
+            (HTTPStatus.CREATED, None, 0),
+            (HTTPStatus.OK, {"message": "Dup"}, 0),
+            (HTTPStatus.OK, "Dup", 0),
+            (HTTPStatus.NO_CONTENT, {"message": "No content"}, 0),
+            (HTTPStatus.NO_CONTENT, "No content", 0),
             (
                 HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
                 {"message": "Request Entity Too Large"},
                 1,
             ),
-            (
-                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
-                "Request Entity Too Large",
-                1,
-            ),
-            (
-                HTTPStatus.NOT_FOUND,
-                {"message": "Not Found"},
-                1,
-            ),
-            (
-                HTTPStatus.NOT_FOUND,
-                "Not Found",
-                1,
-            ),
-            (
-                0,
-                requests.exceptions.ConnectionError(
-                    "<urllib3.connection.HTTPConnection object at 0x1080854c0>: "
-                    "Failed to establish a new connection: [Errno 8] "
-                    "nodename nor servname provided, or not known"
-                ),
-                1,
-            ),
+            (HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Request Entity Too Large", 1),
+            (HTTPStatus.NOT_FOUND, {"message": "Not Found"}, 1),
+            (HTTPStatus.NOT_FOUND, "Not Found", 1),
+            (None, requests.exceptions.ConnectionError("Oops"), 1),
         ),
     )
     def test_push_status(status_code, message, exit_code):
@@ -282,6 +242,6 @@ class TestResultsPush:
         else:
             assert False, "message must be dict, string, Exception or None"
 
-        if status_code >= 400:
+        if status_code and status_code >= 400:
             err_msg = f"HTTP Error status: {status_code.value}, message: {err_msg}"
-        assert err_msg in result.stderr.strip()
+        assert err_msg in result.stderr


### PR DESCRIPTION
Fixes #3374

This is a continuation of #3348, implementing fixes to the pbench_results_push tests. The main one is to subsume some exception tests under the parametrized "normal" case and eliminate redundant tests.