### PR TITLE
Remove directory check, replace with index.html

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -125,7 +125,7 @@ http {
             # See if the URI exists, as a file or as a directory, under
             # /srv/pbench/public_html and serve that. If it doesn't, just serve
             # /dashboard/index.html.
-            try_files  $uri $uri/  /dashboard/index.html;
+            try_files  $uri $uri/index.html  /dashboard/index.html;
         }
 
         location /static/ {


### PR DESCRIPTION
The `try_files` directive in nginx will issue a 301 response if the given URI (`$uri`) exists as a directory (though this behavior is not explicitly documented).  We remove the directory check and replace it with an explicit check for `index.html`.