### PR TITLE
Avoid Sync message overflow

### DIFF
--- a/lib/pbench/server/database/alembic/versions/5679217a62bb_sync_message.py
+++ b/lib/pbench/server/database/alembic/versions/5679217a62bb_sync_message.py
@@ -1,0 +1,37 @@
+"""Remove size limit on Sync messages
+
+Revision ID: 5679217a62bb
+Revises: 80c8c690f09b
+Create Date: 2023-04-18 20:03:26.080554
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "5679217a62bb"
+down_revision = "80c8c690f09b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "dataset_operations",
+        "message",
+        existing_type=sa.VARCHAR(length=255),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "dataset_operations",
+        "message",
+        existing_type=sa.Text(),
+        type_=sa.VARCHAR(length=255),
+        existing_nullable=True,
+    )
+    # ### end Alembic commands ###

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -6,7 +6,7 @@ import re
 from typing import Any, Dict, List, Optional, Union
 
 from dateutil import parser as date_parser
-from sqlalchemy import Column, Enum, event, ForeignKey, Integer, JSON, String
+from sqlalchemy import Column, Enum, event, ForeignKey, Integer, JSON, String, Text
 from sqlalchemy.exc import DataError, IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Query, relationship, validates
 
@@ -524,7 +524,7 @@ class Operation(Database.Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     name = Column(Enum(OperationName), index=True)
     state = Column(Enum(OperationState))
-    message = Column(String(255))
+    message = Column(Text)
     dataset_ref = Column(Integer, ForeignKey("datasets.id"))
     dataset = relationship("Dataset", back_populates="operations")
 

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -178,16 +178,14 @@ class Index:
             for dataset in self.sync.next():
                 tb = Metadata.getvalue(dataset, Metadata.TARBALL_PATH)
                 if not tb:
-                    self.sync.error(dataset, f"{dataset} does not have a tarball-path")
+                    self.sync.error(dataset, "Dataset does not have a tarball-path")
                     continue
 
                 try:
                     # get size
                     size = os.stat(tb).st_size
                 except OSError as e:
-                    self.sync.error(
-                        dataset, f"Could not fetch tar ball size for {tb}: {e}"
-                    )
+                    self.sync.error(dataset, f"Could not fetch tarball size: {e!s}")
                     continue
                 else:
                     tarballs.append(TarballData(dataset=dataset, tarball=tb, size=size))
@@ -379,7 +377,7 @@ class Index:
                             except TarballNotFound as e:
                                 self.sync.error(
                                     dataset,
-                                    f"Unable to unpack dataset: {e!r}",
+                                    f"Unable to unpack dataset: {e!s}",
                                 )
                                 continue
 

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -412,7 +412,7 @@ class TestIndexingTarballs:
         FakeMetadata.no_tarball = ["ds2"]
         tb_list = index.collect_tb()
         assert FakeSync.called == ["next-INDEX"]
-        assert FakeSync.errors["ds2"] == "ds2 does not have a tarball-path"
+        assert FakeSync.errors["ds2"] == "Dataset does not have a tarball-path"
         assert tb_list == (0, [tarball_1])
 
     def test_collect_tb_fail(self, mocks, index):


### PR DESCRIPTION
PBENCH-1120

A SQL error was observed in deployment where `pbench-index` logged an error on the `INDEX` sync object because a tarball was somehow not present. The message string generated by `indexing_tarballs.py` exceeded the `VARCHAR(255)` column specification.

This isn't an attempt to address the root problem, but to address the symptom of overloading the operation table message column in the future so at least errors are properly recorded.

This reworks some of the `indexing_tarballs.py` messages to avoid redundancy (e.g., naming the dataset or tarball isn't necessary as the records are linked to the `Dataset`), but also removes the limit on the message column as a precaution.

(_NOTE_: it also adds some unit test cases, although these are more documentation than "real tests" as sqlite3, unlike PostgreSQL, doesn't implement column limits.)

Resolves #3366 