### PR TITLE
Quick fix

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "gulp": "^4.0.2",
     "jest": "^27.5.1",
     "js-cookie": "^3.0.1",
-    "keycloak-js": "^21.0.1",
+    "keycloak-js": "21.0.2",
     "less-watch-compiler": "^1.16.3",
     "patternfly": "^3.9.0",
     "react": "^17.0.2",


### PR DESCRIPTION
`keycloak-js` 21.1.0 adds an explicit `keycloak-masthead` dependency that's broken. This went in early this morning, and has broken all users. To mitigate this, back off our `package.json` to depend on the latest previous verion, which is 21.0.2 to get our builds running again.