### PR TITLE
Restore flexibility in keycloak-js dependency

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "gulp": "^4.0.2",
     "jest": "^27.5.1",
     "js-cookie": "^3.0.1",
-    "keycloak-js": "21.0.2",
+    "keycloak-js": "^21.0.0",
     "less-watch-compiler": "^1.16.3",
     "patternfly": "^3.9.0",
     "react": "^17.0.2",


### PR DESCRIPTION
With 21.1.0-1 the keycloak-masthead dependency has been fixed, so restore the circumflex to allow "21.*" behavior.