### PR TITLE
Add explicit test_auth dependencies

### DIFF
--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -517,7 +517,7 @@ class TestAuthModule:
         assert user is None
 
     @pytest.mark.parametrize("roles", [["ROLE"], ["ROLE1", "ROLE2"], [], None])
-    def test_verify_auth_oidc(self, monkeypatch, rsa_keys, make_logger, roles):
+    def test_verify_auth_oidc(self, monkeypatch, db_session, rsa_keys, make_logger, roles):
         """Verify OIDC token offline verification success path"""
         client_id = "us"
         if roles is None:
@@ -543,7 +543,7 @@ class TestAuthModule:
         assert user.id == "12345"
         assert user.roles == (roles if roles else [])
 
-    def test_verify_auth_oidc_user_update(self, monkeypatch, rsa_keys, make_logger):
+    def test_verify_auth_oidc_user_update(self, monkeypatch, db_session, rsa_keys, make_logger):
         """Verify we update our internal user database when we get updated user
         payload from the OIDC token for an existing user."""
         client_id = "us"

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -517,7 +517,9 @@ class TestAuthModule:
         assert user is None
 
     @pytest.mark.parametrize("roles", [["ROLE"], ["ROLE1", "ROLE2"], [], None])
-    def test_verify_auth_oidc(self, monkeypatch, db_session, rsa_keys, make_logger, roles):
+    def test_verify_auth_oidc(
+        self, monkeypatch, db_session, rsa_keys, make_logger, roles
+    ):
         """Verify OIDC token offline verification success path"""
         client_id = "us"
         if roles is None:
@@ -543,7 +545,9 @@ class TestAuthModule:
         assert user.id == "12345"
         assert user.roles == (roles if roles else [])
 
-    def test_verify_auth_oidc_user_update(self, monkeypatch, db_session, rsa_keys, make_logger):
+    def test_verify_auth_oidc_user_update(
+        self, monkeypatch, db_session, rsa_keys, make_logger
+    ):
         """Verify we update our internal user database when we get updated user
         payload from the OIDC token for an existing user."""
         client_id = "us"


### PR DESCRIPTION
PBENCH-1130

Several tests in `test_auth.py` implicitly depended on previous DB init; they were failing occasionally in CI parallel test runs when scheduled without the prior setup.

Resolves #3381