### PR TITLE
Add `AuthToken.API_KEY` SQL ENUM

### DIFF
--- a/lib/pbench/server/database/alembic/versions/80c8c690f09b_api_key.py
+++ b/lib/pbench/server/database/alembic/versions/80c8c690f09b_api_key.py
@@ -31,6 +31,7 @@ def upgrade() -> None:
         ),
         sa.PrimaryKeyConstraint("api_key"),
     )
+    op.execute("ALTER TYPE audittype ADD VALUE 'API_KEY'")
     op.drop_index("ix_auth_tokens_expiration", table_name="auth_tokens")
     op.drop_index("ix_auth_tokens_token", table_name="auth_tokens")
     op.drop_table("auth_tokens")


### PR DESCRIPTION
PBENCH-1136

Stage one: this doesn't fix the API key encryption problem (Nikhil is working on that), but this adds the missing SQL ENUM value.

Rather than creating a new Alembic revision file (which would be the normal process) I decided to keep this simple by updating the general API KEY revision file. As we have no database deployments we'll need to upgrade over this period, this strategy avoids adding another revision to the tree.