### PR TITLE
Lock flask and Werkzeug below 2.3.0 for now

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,7 @@ aniso8601>=9.0.1
 Bcrypt-Flask
 click>=8.0
 elasticsearch>=7.13.1, <7.14
-flask
+flask<2.3.0
 flask_cors
 Flask-HTTPAuth>=4.0.0
 flask-jwt-extended
@@ -20,3 +20,4 @@ requests
 sdnotify
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6
+Werkzeug<2.3.0


### PR DESCRIPTION
A Flask package update today breaks all Pbench authentication; it's not clear why, and until we can figure it out, let's lock Flask below 2.3 to avoid the issue. This also locks Werkzeug to match because that was causing issues in testing.