### PR TITLE
Add API Key functional testing

### DIFF
--- a/lib/pbench/client/types.py
+++ b/lib/pbench/client/types.py
@@ -49,6 +49,14 @@ class JSONMap:
         """
         return self.json[key]
 
+    def __repr__(self) -> str:
+        """Represent by returning the JSON representation"""
+        return repr(self.json)
+
+    def __str__(self) -> str:
+        """Stringify by returning the stringified JSON"""
+        return str(self.json)
+
 
 class Dataset(JSONMap):
     @staticmethod
@@ -67,3 +75,7 @@ class Dataset(JSONMap):
         """
         md5_file = Path(f"{str(tarball)}.md5")
         return md5_file.read_text().split()[0]
+
+    def __str__(self) -> str:
+        """Identify the dataset by ID and name"""
+        return f"Dataset({self.resource_id}, {self.name!r})"

--- a/lib/pbench/server/database/alembic.migration
+++ b/lib/pbench/server/database/alembic.migration
@@ -56,6 +56,9 @@ elif [[ "${1}" == "create" ]]; then
     # We have been asked to auto-generate a migration based on the existing
     # model compared against the most recent migration "head".
     alembic revision --autogenerate
+elif [[ "${1}" == "show" ]]; then
+    alembic heads
+    alembic history
 else
     printf "Unsupported operation requested, '%s'\n" "${1}" >&2
     exit 1


### PR DESCRIPTION
PBENCH-1135

Add mechanism and a test case to verify that we can authenticate and identify the client user from an API key, simplistically using `GET /datasets?mine`.

This also adds a new `alembic-migration` command, `show` to display what alembic sees as the "heads" and "history" of the revision chain. I added this when I accidentally constructed multiple heads and got weird errors while I was building the `AuthType.API_KEY` upgrade, but didn't include it in that final PR. It seems useful, so I'm sweeping it in here.