### PR TITLE
Build pbench-tools-kill

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -60,7 +60,8 @@ click-scripts = \
 	pbench-list-triggers \
 	pbench-results-move \
 	pbench-results-push \
-	pbench-register-tool-trigger
+	pbench-register-tool-trigger \
+	pbench-tools-kill
 
 bench-scripts = \
 	pbench-fio \


### PR DESCRIPTION
Fixes #3404

Add pbench-tools-kill to the click commands in the agent Makefile.