### PR TITLE
Ansible fixes b0.72

### DIFF
--- a/agent/ansible/collection/roles/pbench_clean_yum_cache/tasks/main.yml
+++ b/agent/ansible/collection/roles/pbench_clean_yum_cache/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - name: Clean yum cache
   ansible.builtin.command: yum clean all
-  args:
-    warn: false
 
 - name: Delete /var/cache/yum directory
   ansible.builtin.file:

--- a/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
@@ -3,11 +3,19 @@
 # provided by the `ndokos` COPR user.
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
+pbench_aux_repo_name: pbench
 
 repos:
-  - name: "{{ pbench_repo_name }}"
-    user: "{{ fedoraproject_username }}"
+  - tag: "{{ pbench_repo_name }}"
+    user: "{{ fedoraproject_user }}"
     baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"
     gpgcheck: 1
-    enabled: 1
+    enabled: "{{ enable_copr_repo }}"
+
+  - tag: "{{ pbench_aux_repo_name }}"
+    user: "{{ fedoraproject_user }}"
+    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/{{distrodir}}"
+    gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/pubkey.gpg"
+    gpgcheck: 1
+    enabled: "{{ enable_copr_aux_repo }}"

--- a/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
@@ -4,17 +4,19 @@
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
 pbench_aux_repo_name: pbench
+enable_copr_repo: 1
+enable_copr_aux_repo: 1
 
 repos:
   - tag: "{{ pbench_repo_name }}"
-    user: "{{ fedoraproject_user }}"
+    user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: "{{ enable_copr_repo }}"
 
   - tag: "{{ pbench_aux_repo_name }}"
-    user: "{{ fedoraproject_user }}"
+    user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/{{distrodir}}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/pubkey.gpg"
     gpgcheck: 1


### PR DESCRIPTION
Fixes #3406 

- Fix an "unknown argument" error that the `command` module raises: it does not like the `warn` argument any longer, so delete the argument.
- Add the version-specific pbench repo to the list of repos that are added to the installation target(s).