### PR TITLE
Build pbench-tools-kill - Backport of #3405 to b0.72

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -61,7 +61,8 @@ click-scripts = \
 	pbench-list-triggers \
 	pbench-results-move \
 	pbench-results-push \
-	pbench-register-tool-trigger
+	pbench-register-tool-trigger \
+	pbench-tools-kill
 
 bench-scripts = \
 	pbench-fio \


### PR DESCRIPTION
Fixes #3404

Add pbench-tools-kill to the click commands in the agent Makefile.