### PR TITLE
Restore floating Flask / Werkzeug dependency

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,7 @@ aniso8601>=9.0.1
 Bcrypt-Flask
 click>=8.0
 elasticsearch>=7.13.1, <7.14
-flask<2.3.0
+flask
 flask_cors
 Flask-HTTPAuth>=4.0.0
 flask-jwt-extended
@@ -20,4 +20,3 @@ requests
 sdnotify
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6
-Werkzeug<2.3.0


### PR DESCRIPTION
Werkzeug 2.3.1 appears to have resolved our problems using Flask 2.3.x, so restore the original floating dependency on flask.

This doesn't address the issue of whether we want to evaluate setting explicit dependencies across the board; the risk is that this forces us to periodically re-evaluate and update to avoid obsolescence and CVE problems, while the benefit is we don't have the sort of fun surprises recently delivered to us by flask and keycloak-js...