### PR TITLE
Unix socket for the nginx and gunicorn communication

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -53,7 +53,6 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     if site.ENABLE_USER_SITE:
         find_the_unicorn(logger)
     try:
-        socket = str(server_config.get("pbench-server", "bind_socket"))
         db_uri = server_config.get("database", "uri")
         db_wait_timeout = int(server_config.get("database", "wait_timeout"))
         es_uri = server_config.get("Indexing", "uri")
@@ -157,7 +156,7 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         "--pid",
         "/run/pbench-server/gunicorn.pid",
         "--bind",
-        f"unix:{socket}",
+        "unix:/run/pbench-server/pbench-server.sock",
         "--log-syslog",
         "--log-syslog-prefix",
         "pbench-server",

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -53,8 +53,7 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     if site.ENABLE_USER_SITE:
         find_the_unicorn(logger)
     try:
-        host = server_config.get("pbench-server", "bind_host")
-        port = str(server_config.get("pbench-server", "bind_port"))
+        socket = str(server_config.get("pbench-server", "bind_socket"))
         db_uri = server_config.get("database", "uri")
         db_wait_timeout = int(server_config.get("database", "wait_timeout"))
         es_uri = server_config.get("Indexing", "uri")
@@ -158,7 +157,7 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         "--pid",
         "/run/pbench-server/gunicorn.pid",
         "--bind",
-        f"{host}:{port}",
+        f"unix:{socket}",
         "--log-syslog",
         "--log-syslog-prefix",
         "pbench-server",

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -138,7 +138,7 @@ class TestShell:
             "--pid",
             "/run/pbench-server/gunicorn.pid",
             "--bind",
-            "0.0.0.0:8001",
+            "unix:/run/pbench-server.sock",
             "--log-syslog",
             "--log-syslog-prefix",
             "pbench-server",
@@ -311,8 +311,7 @@ class TestShell:
     @pytest.mark.parametrize(
         "option",
         [
-            "bind_host",
-            "bind_port",
+            "bind_socket",
             "uri",
             "wait_timeout",
             "workers",

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -138,7 +138,7 @@ class TestShell:
             "--pid",
             "/run/pbench-server/gunicorn.pid",
             "--bind",
-            "unix:/run/pbench-server.sock",
+            "unix:/run/pbench-server/pbench-server.sock",
             "--log-syslog",
             "--log-syslog-prefix",
             "pbench-server",
@@ -311,7 +311,6 @@ class TestShell:
     @pytest.mark.parametrize(
         "option",
         [
-            "bind_socket",
             "uri",
             "wait_timeout",
             "workers",

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -105,7 +105,7 @@ http {
                 return 597;
             }
 
-            proxy_pass               http://127.0.0.1:8001;
+            proxy_pass               http://unix:/run/pbench-server.sock;
             proxy_redirect           off;
             proxy_connect_timeout    20s;
             proxy_read_timeout       120s;

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -105,7 +105,7 @@ http {
                 return 597;
             }
 
-            proxy_pass               http://unix:/run/pbench-server.sock;
+            proxy_pass               http://unix:/run/pbench-server/pbench-server.sock;
             proxy_redirect           off;
             proxy_connect_timeout    20s;
             proxy_read_timeout       120s;

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -53,8 +53,7 @@ pbench-local-dir = %(pbench-top-dir)s
 pbench-tmp-dir = %(pbench-local-dir)s/tmp
 
 # pbench-server rest api variables
-bind_host = 0.0.0.0
-bind_port = 8001
+bind_socket=/run/pbench-server.sock
 rest_version = 1
 rest_uri = /api/v%(rest_version)s
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -53,7 +53,6 @@ pbench-local-dir = %(pbench-top-dir)s
 pbench-tmp-dir = %(pbench-local-dir)s/tmp
 
 # pbench-server rest api variables
-bind_socket=/run/pbench-server.sock
 rest_version = 1
 rest_uri = /api/v%(rest_version)s
 


### PR DESCRIPTION
To avoid employing SSL certificates in both NGINX and Gunicorn we need to make them communicate over a Unix socket and not over TCP port.

PBENCH-1139