### PR TITLE
Get the uri schema from NGINX 

### DIFF
--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -105,7 +105,8 @@ class EndpointConfig(Resource):
                     host_value = header
         if not origin:
             origin = host_value
-        host = f"{request.headers.get('X-Forwarded-Proto')}://{origin}"
+        proto = request.headers.get("X-Forwarded-Proto", "https")
+        host = f"{proto}://{origin}"
         current_app.logger.info(
             "Advertising endpoints at {} relative to {} ({})",
             host,

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -105,7 +105,7 @@ class EndpointConfig(Resource):
                     host_value = header
         if not origin:
             origin = host_value
-        host = f"http://{origin}"
+        host = f"{request.headers.get('X-Forwarded-Proto')}://{origin}"
         current_app.logger.info(
             "Advertising endpoints at {} relative to {} ({})",
             host,

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -17,27 +17,42 @@ class TestEndpointConfig:
         local Flask mocked environment, `request.host` will always be
         "localhost".
         """
-        self.check_config(client, server_config, "localhost")
+        self.check_config(
+            client, server_config, "localhost", {"X-Forwarded-Proto": "https"}
+        )
 
     def test_proxy_query(self, client, server_config):
         host = "proxy.example.com:8901"
         forward = f"by=server.example.com;for=client.example.com;host={host};proto=http"
-        self.check_config(client, server_config, host, {"Forwarded": forward})
+        self.check_config(
+            client,
+            server_config,
+            host,
+            {"Forwarded": forward, "X-Forwarded-Proto": "https"},
+        )
 
     def test_x_forward_proxy_query(self, client, server_config):
         host = "proxy.example.com:8902"
-        self.check_config(client, server_config, host, {"X-Forwarded-Host": host})
+        self.check_config(
+            client,
+            server_config,
+            host,
+            {"X-Forwarded-Host": host, "X-Forwarded-Proto": "https"},
+        )
 
     def test_x_forward_list_proxy_query(self, client, server_config):
         host1 = "proxy.example.com:8902"
         host2 = "proxy2.example.com"
         self.check_config(
-            client, server_config, host1, {"X-Forwarded-Host": f"{host1}, {host2}"}
+            client,
+            server_config,
+            host1,
+            {"X-Forwarded-Host": f"{host1}, {host2}", "X-Forwarded-Proto": "https"},
         )
 
     def check_config(self, client, server_config, host, my_headers={}):
         uri_prefix = server_config.rest_uri
-        host = "http://" + host
+        host = "https://" + host
         uri = urljoin(host, uri_prefix)
         expected_results = {
             "identification": f"Pbench server {server_config.COMMIT_ID}",

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -17,9 +17,7 @@ class TestEndpointConfig:
         local Flask mocked environment, `request.host` will always be
         "localhost".
         """
-        self.check_config(
-            client, server_config, "localhost", {"X-Forwarded-Proto": "https"}
-        )
+        self.check_config(client, server_config, "localhost")
 
     def test_proxy_query(self, client, server_config):
         host = "proxy.example.com:8901"

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -114,9 +114,10 @@ http {
             proxy_request_buffering  on;
             proxy_http_version       1.1;
 
-            proxy_set_header         Host             $http_host;
-            proxy_set_header         X-Forwarded-For  $proxy_add_x_forwarded_for;
-            proxy_set_header         X-Real-IP        $remote_addr;
+            proxy_set_header         Host              $http_host;
+            proxy_set_header         X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header         X-Real-IP         $remote_addr;
+            proxy_set_header         X-Forwarded-Proto $scheme;
 
             client_max_body_size     10G;
         }


### PR DESCRIPTION
Let the Nginx convey schema to our Flask application for building urls instead of hardcoding it in the endpoint_configure.py.

PBENCH-1139