### PR TITLE
Fix the section name in wait_for_oidc_server function

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -111,6 +111,7 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         logger.warning("OpenID Connect client not configured, {}", exc)
         notifier.notify("STOPPING=1")
         notifier.notify("STATUS=OPENID broker not responding")
+        return 1
     else:
         logger.info("Pbench server using OIDC server {}", oidc_server)
 

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -112,10 +112,10 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         notifier.notify("STOPPING=1")
         notifier.notify("STATUS=OPENID broker not configured")
         return 1
-    except [
+    except (
         OpenIDClient.ServerConnectionError,
         OpenIDClient.ServerConnectionTimedOut,
-    ] as exc:
+    ) as exc:
         logger.warning("OpenID Connect client not reachable, {}", exc)
         notifier.notify("STOPPING=1")
         notifier.notify("STATUS=OPENID broker not responding")

--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -110,6 +110,14 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
     except OpenIDClient.NotConfigured as exc:
         logger.warning("OpenID Connect client not configured, {}", exc)
         notifier.notify("STOPPING=1")
+        notifier.notify("STATUS=OPENID broker not configured")
+        return 1
+    except [
+        OpenIDClient.ServerConnectionError,
+        OpenIDClient.ServerConnectionTimedOut,
+    ] as exc:
+        logger.warning("OpenID Connect client not reachable, {}", exc)
+        notifier.notify("STOPPING=1")
         notifier.notify("STATUS=OPENID broker not responding")
         return 1
     else:

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -50,7 +50,7 @@ class EndpointConfig(Resource):
         Return server configuration information required by web clients
         including the Pbench dashboard UI. This includes:
 
-        openid-connect: A JSON object containing the OpenID Connect parameters
+        openid: A JSON object containing the OpenID Connect parameters
                 required for the web client to use OIDC authentication.
         identification: The Pbench server name and version
         uri:    A dict of server API templates, where each template defines a

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -1,4 +1,3 @@
-from configparser import NoOptionError, NoSectionError
 from http import HTTPStatus
 import re
 from typing import Any, Dict
@@ -150,18 +149,15 @@ class EndpointConfig(Resource):
             "uri": templates,
         }
 
-        try:
-            client = self.server_config.get("openid", "client")
-            realm = self.server_config.get("openid", "realm")
-            server = self.server_config.get("openid", "server_url")
-        except (NoOptionError, NoSectionError):
-            pass
-        else:
-            endpoints["openid"] = {
-                "client": client,
-                "realm": realm,
-                "server": server,
-            }
+        client = self.server_config.get("openid", "client")
+        realm = self.server_config.get("openid", "realm")
+        server = self.server_config.get("openid", "server_url")
+
+        endpoints["openid"] = {
+            "client": client,
+            "realm": realm,
+            "server": server,
+        }
 
         try:
             response = jsonify(endpoints)

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -208,7 +208,7 @@ class OpenIDClient:
                 times out.
         """
         try:
-            oidc_server = server_config.get("openid-connect", "server_url")
+            oidc_server = server_config.get("openid", "server_url")
         except (NoOptionError, NoSectionError) as exc:
             raise OpenIDClient.NotConfigured() from exc
 

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -292,7 +292,7 @@ class TestOpenIDClient:
 
     @responses.activate
     def test_wait_for_oidc_server_fail(self, make_logger):
-        """Verfiy .wait_for_oidc_server() failure mode"""
+        """Verify .wait_for_oidc_server() failure mode"""
         # Start with an empty configuration, no openid section
         config = configparser.ConfigParser()
         with pytest.raises(OpenIDClient.NotConfigured):
@@ -329,7 +329,7 @@ class TestOpenIDClient:
 
     @responses.activate
     def test_wait_for_oidc_server_succ(self, make_logger):
-        """Verfiy .wait_for_oidc_server() success mode"""
+        """Verify .wait_for_oidc_server() success mode"""
 
         config = configparser.ConfigParser()
         section = {"server_url": "https://example.com"}

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -12,6 +12,7 @@ import pytest
 import pbench.cli.server.shell as shell
 from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.server import PbenchServerConfig
+from pbench.server.auth import OpenIDClient
 
 
 @pytest.fixture
@@ -226,6 +227,24 @@ class TestShell:
             shell.OpenIDClient, "wait_for_oidc_server", wait_for_oidc_server
         )
 
+        ret_val = shell.main()
+
+        assert called[0]
+        assert ret_val == 1
+
+        called = [False]
+
+        # Test when specifically OpenIDClient.NotConfigured is raised from
+        # wait_for_oidc_server
+        def wait_for_oidc_server(
+            server_config: PbenchServerConfig, logger: logging.Logger
+        ) -> str:
+            called[0] = True
+            raise OpenIDClient.NotConfigured
+
+        monkeypatch.setattr(
+            shell.OpenIDClient, "wait_for_oidc_server", wait_for_oidc_server
+        )
         ret_val = shell.main()
 
         assert called[0]

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -12,7 +12,6 @@ import pytest
 import pbench.cli.server.shell as shell
 from pbench.common.exceptions import BadConfig, ConfigFileNotSpecified
 from pbench.server import PbenchServerConfig
-from pbench.server.auth import OpenIDClient
 
 
 @pytest.fixture

--- a/lib/pbench/test/unit/server/test_shell_cli.py
+++ b/lib/pbench/test/unit/server/test_shell_cli.py
@@ -71,10 +71,7 @@ class TestShell:
 
     @staticmethod
     @pytest.mark.parametrize("user_site", [False, True])
-    @pytest.mark.parametrize("oidc_conf", [False, True])
-    def test_main(
-        monkeypatch, make_logger, mock_get_server_config, user_site, oidc_conf
-    ):
+    def test_main(monkeypatch, make_logger, mock_get_server_config, user_site):
         called = []
 
         def find_the_unicorn(logger: logging.Logger):
@@ -89,10 +86,8 @@ class TestShell:
         def wait_for_oidc_server(
             server_config: PbenchServerConfig, logger: logging.Logger
         ) -> str:
-            if oidc_conf:
-                return "https://oidc.example.com"
-            else:
-                raise OpenIDClient.NotConfigured()
+            called.append("wait_for_oidc_server")
+            return "https://oidc.example.com"
 
         commands = []
 
@@ -117,6 +112,7 @@ class TestShell:
         expected_called += [
             "wait_for_uri(sqlite:///:memory:,120)",
             "wait_for_uri(http://elasticsearch.example.com:7080,120)",
+            "wait_for_oidc_server",
             "init_indexing",
         ]
         assert called == expected_called

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -22,7 +22,7 @@ KEYCLOAK_REDIRECT_URI=${KEYCLOAK_REDIRECT_URI:-"http://localhost:8080/*"}
 ADMIN_USERNAME=${ADMIN_USERNAME:-"admin"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 # These values must match the options "realm" and "client in the
-# "openid-connect" section of the pbench server configuration file.
+# "openid" section of the pbench server configuration file.
 REALM=${KEYCLOAK_REALM:-"pbench-server"}
 CLIENT=${KEYCLOAK_CLIENT:-"pbench-client"}
 


### PR DESCRIPTION
We missed this change earlier, our `wait_for_oidc_server` function wasn't working at all. We use `[openid]` as a section name in our config file but the `wait_for_oidc_server` function was still using `[openid-connect]` which results in openid not configured error and we were silently ignoring it.