### PR TITLE
Update CodeQL scanning

### DIFF
--- a/.github/codeql/javascript-config.yml
+++ b/.github/codeql/javascript-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config for Javascript"
+
+paths:
+  - dashboard/src/**

--- a/.github/codeql/python-config.yml
+++ b/.github/codeql/python-config.yml
@@ -1,0 +1,5 @@
+name: "CodeQL config for Python"
+
+paths-ignore:
+  - agent/bench-scripts/test-bin/fio-histo-log-pctiles.py
+  - web-server/v0.3/demo.py

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -45,6 +34,7 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
+        config-file: ./.github/codeql/${{ matrix.language }}-config.yml
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
- exclude certain Python files
- scan only certain Javascript directories

This (hopefully) addresses the warnings which just started appearing in #3410.