### PR TITLE
Unit test on jwt exception type instead of string

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -28,11 +28,7 @@ class OpenIDClientError(Exception):
 
 
 class OpenIDTokenInvalid(Exception):
-    def __init__(self, exc_type: Exception):
-        self.exc_type = exc_type
-
-    def __str__(self) -> str:
-        return str(f"Token invalid with exception: {self.exc_type}")
+    pass
 
 
 class Connection:
@@ -381,4 +377,4 @@ class OpenIDClient:
             jwt.InvalidAudienceError,
             jwt.InvalidAlgorithmError,
         ) as exc:
-            raise OpenIDTokenInvalid(exc_type=exc.__class__)
+            raise OpenIDTokenInvalid() from exc

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -28,7 +28,11 @@ class OpenIDClientError(Exception):
 
 
 class OpenIDTokenInvalid(Exception):
-    pass
+    def __init__(self, exc_type: Exception):
+        self.exc_type = exc_type
+
+    def __str__(self) -> str:
+        return str(f"Token invalid with exception: {self.exc_type}")
 
 
 class Connection:
@@ -377,4 +381,4 @@ class OpenIDClient:
             jwt.InvalidAudienceError,
             jwt.InvalidAlgorithmError,
         ) as exc:
-            raise OpenIDTokenInvalid() from exc
+            raise OpenIDTokenInvalid(exc_type=exc.__class__)

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -378,7 +378,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(token)
-        assert exc.value.exc_type == jwt.ExpiredSignatureError, f"{exc.value.exc_type}"
+        assert isinstance(exc.value.__cause__, jwt.exceptions.ExpiredSignatureError)
 
     def test_token_introspect_aud(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via audience error"""
@@ -392,7 +392,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(token)
-        assert exc.value.exc_type == jwt.InvalidAudienceError, f"{exc.value.exc_type}"
+        assert isinstance(exc.value.__cause__, jwt.exceptions.InvalidAudienceError)
 
     def test_token_introspect_sig(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via signature error"""
@@ -409,7 +409,7 @@ class TestOpenIDClient:
         with pytest.raises(OpenIDTokenInvalid) as exc:
             # Make the signature invalid.
             oidc_client.token_introspect(token + "1")
-        assert exc.value.exc_type == jwt.InvalidSignatureError, f"{exc.value.exc_type}"
+        assert isinstance(exc.value.__cause__, jwt.exceptions.InvalidSignatureError)
 
     def test_token_introspect_alg(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via algorithm error"""
@@ -426,7 +426,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(generated_api_key)
-        assert exc.value.exc_type == jwt.InvalidAlgorithmError, f"{exc.value.exc_type}"
+        assert isinstance(exc.value.__cause__, jwt.exceptions.InvalidAlgorithmError)
 
 
 @dataclass

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -378,9 +378,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(token)
-        assert (
-            str(exc.value.__cause__) == "Signature has expired"
-        ), f"{exc.value.__cause__}"
+        assert exc.value.exc_type == jwt.ExpiredSignatureError, f"{exc.value.exc_type}"
 
     def test_token_introspect_aud(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via audience error"""
@@ -394,7 +392,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(token)
-        assert str(exc.value.__cause__) == "Invalid audience", f"{exc.value.__cause__}"
+        assert exc.value.exc_type == jwt.InvalidAudienceError, f"{exc.value.exc_type}"
 
     def test_token_introspect_sig(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via signature error"""
@@ -411,9 +409,7 @@ class TestOpenIDClient:
         with pytest.raises(OpenIDTokenInvalid) as exc:
             # Make the signature invalid.
             oidc_client.token_introspect(token + "1")
-        assert (
-            str(exc.value.__cause__) == "Signature verification failed"
-        ), f"{exc.value.__cause__}"
+        assert exc.value.exc_type == jwt.InvalidSignatureError, f"{exc.value.exc_type}"
 
     def test_token_introspect_alg(self, monkeypatch, rsa_keys):
         """Verify .token_introspect() failure via algorithm error"""
@@ -430,9 +426,7 @@ class TestOpenIDClient:
 
         with pytest.raises(OpenIDTokenInvalid) as exc:
             oidc_client.token_introspect(generated_api_key)
-        assert (
-            str(exc.value.__cause__) == "The specified alg value is not allowed"
-        ), f"{exc.value.__cause__}"
+        assert exc.value.exc_type == jwt.InvalidAlgorithmError, f"{exc.value.exc_type}"
 
 
 @dataclass


### PR DESCRIPTION
Jwt exception (specifically `jwt.exception.InvalidAudienceError`) has changed its string message from `Invalid Audience` to `Audience doesn't match`. In the unit test instead of checking the string message check the type of the exception so we don't run into these problems again.