### PR TITLE
Ansible fixes

### DIFF
--- a/agent/ansible/collection/roles/pbench_clean_yum_cache/tasks/main.yml
+++ b/agent/ansible/collection/roles/pbench_clean_yum_cache/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
 - name: Clean yum cache
   ansible.builtin.command: yum clean all
-  args:
-    warn: false
 
 - name: Delete /var/cache/yum directory
   ansible.builtin.file:

--- a/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
@@ -3,11 +3,21 @@
 # provided by the `ndokos` COPR user.
 fedoraproject_username: ndokos
 pbench_repo_url_prefix: https://copr-be.cloud.fedoraproject.org/results/{{ fedoraproject_username }}
+pbench_aux_repo_name: pbench
+enable_copr_repo: 1
+enable_copr_aux_repo: 1
 
 repos:
-  - name: "{{ pbench_repo_name }}"
+  - tag: "{{ pbench_repo_name }}"
     user: "{{ fedoraproject_username }}"
     baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_repo_name }}/pubkey.gpg"
     gpgcheck: 1
-    enabled: 1
+    enabled: "{{ enable_copr_repo }}"
+
+  - tag: "{{ pbench_aux_repo_name }}"
+    user: "{{ fedoraproject_username }}"
+    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/{{distrodir}}"
+    gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/pubkey.gpg"
+    gpgcheck: 1
+    enabled: "{{ enable_copr_aux_repo }}"


### PR DESCRIPTION
Forward port of #3407 from b0.72.

* The `ansible.builtin.command' module does not take a warn argument

The argument gives errors now, so delete it.

* There are now two repos for pbench-agent

The `pbench` repo contains RPMs for `pbench-sysstat` and `screen` (the latter for *some* distros, mainly RHEL8 - RHEL9 picks up screen from EPEL).

The `pbench-<version>` repo contains the RPM for the latest release of `pbench-agent` (and possibly a server RPM although we don't install RPMs for the server: containers have taken over).