### PR TITLE
Implement POST /api/v1/relay

### DIFF
--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -49,6 +49,7 @@ class API(Enum):
     DATASETS_VALUES = "datasets_values"
     ENDPOINTS = "endpoints"
     KEY = "key"
+    RELAY = "relay"
     SERVER_AUDIT = "server_audit"
     SERVER_SETTINGS = "server_settings"
     UPLOAD = "upload"

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -33,9 +33,10 @@ from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleValues,
 )
 from pbench.server.api.resources.query_apis.datasets_search import DatasetsSearch
+from pbench.server.api.resources.relay import Relay
 from pbench.server.api.resources.server_audit import ServerAudit
 from pbench.server.api.resources.server_settings import ServerSettings
-from pbench.server.api.resources.upload_api import Upload
+from pbench.server.api.resources.upload import Upload
 import pbench.server.auth.auth as Auth
 from pbench.server.database import init_db
 from pbench.server.database.database import Database
@@ -144,6 +145,12 @@ def register_endpoints(api: Api, app: Flask, config: PbenchServerConfig):
         f"{base_uri}/server/settings/",
         f"{base_uri}/server/settings/<string:key>",
         endpoint="server_settings",
+        resource_class_args=(config,),
+    )
+    api.add_resource(
+        Relay,
+        f"{base_uri}/relay/<path:uri>",
+        endpoint="relay",
         resource_class_args=(config,),
     )
     api.add_resource(

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -281,7 +281,7 @@ class IntakeBase(ApiBase):
                     Dataset.query(resource_id=intake.md5)
                 except DatasetNotFound as e:
                     raise APIInternalError(
-                        f"Duplicate dataset {intake.md5!r} ({dataset_name!r} is missing"
+                        f"Duplicate dataset {intake.md5!r} ({dataset_name!r}) is missing"
                     ) from e
                 else:
                     response = jsonify(dict(message="Dataset already exists"))

--- a/lib/pbench/server/api/resources/relay.py
+++ b/lib/pbench/server/api/resources/relay.py
@@ -1,0 +1,134 @@
+from http import HTTPStatus
+
+from flask import Response
+from flask.wrappers import Request
+import requests
+
+from pbench.server import PbenchServerConfig
+from pbench.server.api.resources import (
+    APIAbort,
+    ApiAuthorizationType,
+    ApiContext,
+    ApiMethod,
+    ApiParams,
+    ApiSchema,
+    Parameter,
+    ParamType,
+    Schema,
+)
+from pbench.server.api.resources.intake_base import Access, Intake, IntakeBase
+from pbench.server.database.models.audit import AuditType, OperationCode
+from pbench.server.database.models.datasets import Dataset
+
+
+class Relay(IntakeBase):
+    """Download a dataset from a relay server"""
+
+    CHUNK_SIZE = 65536
+
+    def __init__(self, config: PbenchServerConfig):
+        super().__init__(
+            config,
+            ApiSchema(
+                ApiMethod.POST,
+                OperationCode.CREATE,
+                uri_schema=Schema(Parameter("filename", ParamType.STRING)),
+                query_schema=Schema(
+                    Parameter("access", ParamType.ACCESS),
+                    Parameter(
+                        "metadata",
+                        ParamType.LIST,
+                        element_type=ParamType.STRING,
+                        string_list=",",
+                    ),
+                ),
+                audit_type=AuditType.NONE,
+                audit_name="upload",
+                authorization=ApiAuthorizationType.NONE,
+            ),
+        )
+
+    def _prepare(self, args: ApiParams, request: Request) -> Intake:
+        """Prepare to begin the intake operation
+
+        We get the Relay configuration file location from the "uri" API
+        parameter.
+
+        The Relay configuration file is an application/json file which
+        contains the following required fields:
+
+            uri: The Relay URI of the tarball file
+            md5: The tarball's MD5 hash (Pbench Server resource ID)
+            name: The original tarball name (with .tar.xz but no path)
+            access: The desired Dataset access level (default "private")
+            metadata: An optional list of "key:value" metadata strings
+
+        This information will be captured in an Intake instance for use by the
+        base class and by the _access method.
+
+        Args:
+            args: API parameters
+                URI parameters
+                    uri: The full Relay configuration file URI
+            request: The original Request object containing query parameters
+
+        Returns:
+            An Intake object capturing the critical information
+        """
+        uri = args.uri["uri"]
+        response = requests.get(uri, headers={"accept": "application/json"})
+        if not response.ok:
+            raise APIAbort(HTTPStatus.BAD_GATEWAY, "Relay URI does not respond")
+
+        try:
+            information = response.json()
+        except Exception as e:
+            raise APIAbort(
+                HTTPStatus.BAD_GATEWAY,
+                f"Relay URI did not return a JSON document: {str(e)!r}",
+            ) from e
+
+        try:
+            uri = information["uri"]
+            md5 = information["md5"]
+            name = information["name"]
+            access = information.get("access", Dataset.PRIVATE_ACCESS)
+            metadata = information.get("metadata", [])
+        except KeyError as e:
+            raise APIAbort(HTTPStatus.BAD_GATEWAY, f"Relay info missing {str(e)!r}")
+
+        return Intake(name, md5, access, metadata, uri)
+
+    def _access(self, intake: Intake, request: Request) -> Access:
+        """Determine how to access the tarball byte stream
+
+        Using the _intake information captured in the Intake instance, perform
+        a follow-up GET operation to the URI provided by the Relay config file,
+        returning the length header and the IO stream.
+
+        Args:
+            intake: The Intake parameters produced by _intake
+            request: The Flask request object
+
+        Returns:
+            An Access object with the data byte stream and length
+        """
+        response: requests.Response = requests.get(
+            url=intake.uri, stream=True, headers={"accept": "application/octet-stream"}
+        )
+        if not response.ok:
+            raise APIAbort(
+                response.status_code,
+                f"Unable to retrieve relay tarball: {response.reason!r}",
+            )
+        try:
+            length = int(response.headers["content-length"])
+            return Access(length, response.raw)
+        except Exception as e:
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST, f"Unable to retrieve relay tarball: {str(e)!r}"
+            ) from e
+
+    def _post(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+        """Launch the Relay operation from an HTTP POST"""
+        return self._intake(args, request, context)

--- a/lib/pbench/server/api/resources/relay.py
+++ b/lib/pbench/server/api/resources/relay.py
@@ -49,11 +49,11 @@ class Relay(IntakeBase):
     def _identify(self, args: ApiParams, request: Request) -> Intake:
         """Identify the tarball to be streamed.
 
-        We get the Relay inventory file location from the "uri" API
+        We get the Relay manifest file location from the "uri" API
         parameter.
 
-        The Relay inventory file is an application/json file which
-        contains the following required fields:
+        The Relay manifest is an application/json file which contains the
+        following required fields:
 
             uri: The Relay URI of the tarball file
             md5: The tarball's MD5 hash (Pbench Server resource ID)
@@ -62,11 +62,11 @@ class Relay(IntakeBase):
             metadata: An optional list of "key:value" metadata strings
 
         This information will be captured in an Intake instance for use by the
-        base class and by the _access method.
+        base class and by the _stream method.
 
         Args:
             args: API parameters
-                URI parameters: the Relay inventory file URI
+                URI parameters: the Relay manifest URI
             request: The original Request object containing query parameters
 
         Returns:
@@ -88,7 +88,7 @@ class Relay(IntakeBase):
         except Exception as e:
             raise APIAbort(
                 HTTPStatus.BAD_GATEWAY,
-                f"Relay URI did not return a JSON document: {str(e)!r}",
+                f"Relay URI did not return a JSON manifest: {str(e)!r}",
             ) from e
 
         try:
@@ -98,7 +98,9 @@ class Relay(IntakeBase):
             access = information.get("access", Dataset.PRIVATE_ACCESS)
             metadata = information.get("metadata", [])
         except KeyError as e:
-            raise APIAbort(HTTPStatus.BAD_GATEWAY, f"Relay info missing {str(e)!r}")
+            raise APIAbort(
+                HTTPStatus.BAD_GATEWAY, f"Relay info missing {str(e)!r}"
+            ) from e
 
         return Intake(name, md5, access, metadata, uri)
 

--- a/lib/pbench/server/api/resources/upload.py
+++ b/lib/pbench/server/api/resources/upload.py
@@ -1,0 +1,135 @@
+from http import HTTPStatus
+
+from flask import Response
+from flask.wrappers import Request
+
+from pbench.server import PbenchServerConfig
+from pbench.server.api.resources import (
+    APIAbort,
+    ApiAuthorizationType,
+    ApiContext,
+    ApiMethod,
+    ApiParams,
+    ApiSchema,
+    Parameter,
+    ParamType,
+    Schema,
+)
+from pbench.server.api.resources.intake_base import Access, Intake, IntakeBase
+from pbench.server.database.models.audit import AuditType, OperationCode
+from pbench.server.database.models.datasets import Dataset
+
+
+class Upload(IntakeBase):
+    """Upload a dataset from a client"""
+
+    CHUNK_SIZE = 65536
+
+    def __init__(self, config: PbenchServerConfig):
+        super().__init__(
+            config,
+            ApiSchema(
+                ApiMethod.PUT,
+                OperationCode.CREATE,
+                uri_schema=Schema(Parameter("filename", ParamType.STRING)),
+                query_schema=Schema(
+                    Parameter("access", ParamType.ACCESS),
+                    Parameter(
+                        "metadata",
+                        ParamType.LIST,
+                        element_type=ParamType.STRING,
+                        string_list=",",
+                    ),
+                ),
+                audit_type=AuditType.NONE,
+                audit_name="upload",
+                authorization=ApiAuthorizationType.NONE,
+            ),
+        )
+
+    def _prepare(self, args: ApiParams, request: Request) -> Intake:
+        """Prepare to begin the intake operation
+
+        We get the filename from the URI: /api/v1/upload/<filename>.
+
+        We get the dataset's resource ID (which is the tarball's MD5 checksum)
+        from the "content-md5" HTTP header.
+
+        Args:
+            args: API parameters
+                URI parameters
+                    filename: A filename matching the metadata of the uploaded tarball
+                Query parameters
+                    access: The desired access policy (default is "private")
+                    metadata: Metadata key/value pairs to set on dataset
+            request: The original Request object containing query parameters
+
+        Returns:
+            An Intake object capturing the critical information
+        """
+
+        # Used to record what steps have been completed during the upload, and
+        # need to be undone on failure
+        access = args.query.get("access", Dataset.PRIVATE_ACCESS)
+        filename = args.uri["filename"]
+
+        # We allow the client to set metadata on the new dataset. We won't do
+        # anything about this until upload is successful, but we process and
+        # validate it here so we can fail early.
+        metadata = args.query.get("metadata", [])
+
+        try:
+            md5sum = request.headers["Content-MD5"]
+        except KeyError:
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST, "Missing required 'Content-MD5' header"
+            )
+        if not md5sum:
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST,
+                "Missing required 'Content-MD5' header value",
+            )
+
+        return Intake(
+            name=filename, md5=md5sum, access=access, metadata=metadata, uri=None
+        )
+
+    def _access(self, intake: Intake, request: Request) -> Access:
+        """Determine how to access the tarball byte stream
+
+        Check that the "content-length" header value is not 0.
+
+        The Flask request object provides the input data stream.
+
+        Args:
+            intake: The Intake parameters produced by _intake
+            request: The Flask request object
+
+        Returns:
+            An Access object with the data byte stream and length
+        """
+        try:
+            length_string = request.headers["Content-Length"]
+            content_length = int(length_string)
+        except KeyError:
+            # NOTE: Werkzeug is "smart" about header access, and knows that
+            # Content-Length is an integer. Therefore, a non-integer value
+            # will raise KeyError. It's virtually impossible to report the
+            # actual incorrect value as we'd just get a KeyError again.
+            raise APIAbort(
+                HTTPStatus.LENGTH_REQUIRED,
+                "Missing or invalid 'Content-Length' header",
+            )
+        except ValueError:
+            # NOTE: Because of the way Werkzeug works, this should not be
+            # possible: if Content-Length isn't an integer, we'll see the
+            # KeyError. This however serves as a clarifying backup case.
+            raise APIAbort(
+                HTTPStatus.BAD_REQUEST,
+                f"Invalid 'Content-Length' header, not an integer ({length_string})",
+            )
+        return Access(content_length, request.stream)
+
+    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+        """Launch the upload operation from an HTTP PUT"""
+        return self._intake(args, request, context)

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -106,6 +106,10 @@ class TestEndpointConfig:
                     "template": f"{uri}/key/{{key}}",
                     "params": {"key": {"type": "string"}},
                 },
+                "relay": {
+                    "template": f"{uri}/relay/{{uri}}",
+                    "params": {"uri": {"type": "path"}},
+                },
                 "server_audit": {"template": f"{uri}/server/audit", "params": {}},
                 "server_settings": {
                     "template": f"{uri}/server/settings/{{key}}",

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -1,0 +1,268 @@
+from http import HTTPStatus
+from logging import Logger
+from pathlib import Path
+
+import pytest
+import responses
+
+from pbench.server import OperationCode, PbenchServerConfig
+from pbench.server.cache_manager import CacheManager
+from pbench.server.database.models.audit import (
+    Audit,
+    AuditReason,
+    AuditStatus,
+    AuditType,
+)
+from pbench.server.database.models.datasets import Dataset
+from pbench.test.unit.server import DRB_USER_ID
+
+
+class TestRelay:
+    """Test the Relay API.
+
+    This focuses on testing the unique aspects of the _prepare and _access
+    methods rather than repeating coverage of all the common base class code.
+
+    In particular, failure of either of the two external GET operations to the
+    relay, and problems in the Relay configuration file.
+    """
+
+    cachemanager_created = None
+    cachemanager_create_fail = None
+    cachemanager_create_path = None
+    tarball_deleted = None
+    create_metadata = True
+
+    @staticmethod
+    def gen_uri(server_config, uri="https://relay.example.com/sha256"):
+        return f"{server_config.rest_uri}/relay/{uri}"
+
+    def gen_headers(self, auth_token):
+        headers = {"Authorization": "Bearer " + auth_token}
+        return headers
+
+    @pytest.fixture(scope="function", autouse=True)
+    def fake_cache_manager(self, monkeypatch):
+        class FakeTarball:
+            def __init__(self, path: Path):
+                self.tarball_path = path
+                self.name = Dataset.stem(path)
+                self.metadata = None
+
+            def delete(self):
+                TestRelay.tarball_deleted = self.name
+
+        class FakeCacheManager(CacheManager):
+            def __init__(self, options: PbenchServerConfig, logger: Logger):
+                self.controllers = []
+                self.datasets = {}
+                TestRelay.cachemanager_created = self
+
+            def create(self, path: Path) -> FakeTarball:
+                controller = "ctrl"
+                TestRelay.cachemanager_create_path = path
+                if TestRelay.cachemanager_create_fail:
+                    raise TestRelay.cachemanager_create_fail
+                self.controllers.append(controller)
+                tarball = FakeTarball(path)
+                if TestRelay.create_metadata:
+                    tarball.metadata = {"pbench": {"date": "2002-05-16T00:00:00"}}
+                self.datasets[tarball.name] = tarball
+                return tarball
+
+        TestRelay.cachemanager_created = None
+        TestRelay.cachemanager_create_fail = None
+        TestRelay.cachemanager_create_path = None
+        TestRelay.tarball_deleted = None
+        monkeypatch.setattr(CacheManager, "__init__", FakeCacheManager.__init__)
+        monkeypatch.setattr(CacheManager, "create", FakeCacheManager.create)
+
+    def test_missing_authorization_header(self, client, server_config):
+        response = client.post(self.gen_uri(server_config))
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert not self.cachemanager_created
+
+    @responses.activate
+    def test_relay(self, client, server_config, pbench_drb_token, tarball):
+        file, md5file, md5 = tarball
+        responses.add(
+            responses.GET,
+            "https://relay.example.com/uri1",
+            status=HTTPStatus.OK,
+            json={
+                "uri": "https://relay.example.com/uri2",
+                "name": file.name,
+                "md5": md5,
+                "access": "private",
+                "metadata": ["global.pbench.test:data"],
+            },
+        )
+        responses.add(
+            responses.GET,
+            "https://relay.example.com/uri2",
+            status=HTTPStatus.OK,
+            body=file.open("rb"),
+            headers={"content-length": f"{file.stat().st_size}"},
+            content_type="application/octet-stream",
+        )
+        response = client.post(
+            self.gen_uri(server_config, "https://relay.example.com/uri1"),
+            headers=self.gen_headers(pbench_drb_token),
+        )
+        assert (
+            response.status_code == HTTPStatus.CREATED
+        ), f"Unexpected result, {response.text}"
+
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].id == 1
+        assert audit[0].root_id is None
+        assert audit[0].operation == OperationCode.CREATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "upload"
+        assert audit[0].object_type == AuditType.DATASET
+        assert audit[0].object_id == md5
+        assert audit[0].object_name == Dataset.stem(file)
+        assert audit[0].user_id == DRB_USER_ID
+        assert audit[0].user_name == "drb"
+        assert audit[0].reason is None
+        assert audit[0].attributes == {
+            "access": "private",
+            "metadata": {"global.pbench.test": "data"},
+        }
+        assert audit[1].id == 2
+        assert audit[1].root_id == 1
+        assert audit[1].operation == OperationCode.CREATE
+        assert audit[1].status == AuditStatus.SUCCESS
+        assert audit[1].name == "upload"
+        assert audit[1].object_type == AuditType.DATASET
+        assert audit[1].object_id == md5
+        assert audit[1].object_name == Dataset.stem(file)
+        assert audit[1].user_id == DRB_USER_ID
+        assert audit[1].user_name == "drb"
+        assert audit[1].reason is None
+        assert audit[1].attributes == {
+            "access": "private",
+            "metadata": {"global.pbench.test": "data"},
+        }
+
+    @responses.activate
+    def test_relay_tar_fail(self, client, server_config, pbench_drb_token, tarball):
+        file, md5file, md5 = tarball
+        responses.add(
+            responses.GET,
+            "https://relay.example.com/uri1",
+            status=HTTPStatus.OK,
+            json={
+                "uri": "https://relay.example.com/uri2",
+                "name": file.name,
+                "md5": md5,
+                "access": "private",
+                "metadata": [],
+            },
+        )
+        responses.add(
+            responses.GET, "https://relay.example.com/uri2", status=HTTPStatus.NOT_FOUND
+        )
+        response = client.post(
+            self.gen_uri(server_config, "https://relay.example.com/uri1"),
+            headers=self.gen_headers(pbench_drb_token),
+        )
+        assert (
+            response.status_code == HTTPStatus.NOT_FOUND
+        ), f"Unexpected result, {response.text}"
+
+        audit = Audit.query()
+        assert len(audit) == 2
+        assert audit[0].id == 1
+        assert audit[0].root_id is None
+        assert audit[0].operation == OperationCode.CREATE
+        assert audit[0].status == AuditStatus.BEGIN
+        assert audit[0].name == "upload"
+        assert audit[0].object_type == AuditType.DATASET
+        assert audit[0].object_id == md5
+        assert audit[0].object_name == Dataset.stem(file)
+        assert audit[0].user_id == DRB_USER_ID
+        assert audit[0].user_name == "drb"
+        assert audit[0].reason is None
+        assert audit[0].attributes == {
+            "access": "private",
+            "metadata": {},
+        }
+        assert audit[1].id == 2
+        assert audit[1].root_id == 1
+        assert audit[1].operation == OperationCode.CREATE
+        assert audit[1].status == AuditStatus.FAILURE
+        assert audit[1].name == "upload"
+        assert audit[1].object_type == AuditType.DATASET
+        assert audit[1].object_id == md5
+        assert audit[1].object_name == Dataset.stem(file)
+        assert audit[1].user_id == DRB_USER_ID
+        assert audit[1].user_name == "drb"
+        assert audit[1].reason == AuditReason.CONSISTENCY
+        assert audit[1].attributes == {
+            "message": "Unable to retrieve relay tarball: 'Not Found'"
+        }
+
+    @responses.activate
+    def test_relay_no_json(self, client, server_config, pbench_drb_token, tarball):
+        file, md5file, md5 = tarball
+        responses.add(
+            responses.GET, "https://relay.example.com/uri1", status=HTTPStatus.NOT_FOUND
+        )
+        responses.add(
+            responses.GET, "https://relay.example.com/uri2", status=HTTPStatus.NOT_FOUND
+        )
+        response = client.post(
+            self.gen_uri(server_config, "https://relay.example.com/uri1"),
+            headers=self.gen_headers(pbench_drb_token),
+        )
+        assert (
+            response.status_code == HTTPStatus.BAD_GATEWAY
+        ), f"Unexpected result, {response.text}"
+
+    @responses.activate
+    def test_relay_not_json(self, client, server_config, pbench_drb_token):
+        responses.add(
+            responses.GET,
+            "https://relay.example.com/uri1",
+            status=HTTPStatus.OK,
+            body="This isn't JSON",
+        )
+        responses.add(
+            responses.GET, "https://relay.example.com/uri2", status=HTTPStatus.NOT_FOUND
+        )
+        response = client.post(
+            self.gen_uri(server_config, "https://relay.example.com/uri1"),
+            headers=self.gen_headers(pbench_drb_token),
+        )
+        assert (
+            response.status_code == HTTPStatus.BAD_GATEWAY
+        ), f"Unexpected result, {response.text}"
+
+    @responses.activate
+    def test_relay_missing_json_field(
+        self, client, server_config, pbench_drb_token, tarball
+    ):
+        file, md5file, md5 = tarball
+        responses.add(
+            responses.GET,
+            "https://relay.example.com/uri1",
+            status=HTTPStatus.OK,
+            json={
+                "name": "tarball.tar.xz",
+                "md5": md5,
+                "access": "private",
+                "metadata": [],
+            },
+        )
+        responses.add(
+            responses.GET, "https://relay.example.com/uri2", status=HTTPStatus.NOT_FOUND
+        )
+        response = client.post(
+            self.gen_uri(server_config, "https://relay.example.com/uri1"),
+            headers=self.gen_headers(pbench_drb_token),
+        )
+        assert (
+            response.status_code == HTTPStatus.BAD_GATEWAY
+        ), f"Unexpected result, {response.text}"

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -246,7 +246,7 @@ class TestRelay:
         assert response.status_code == HTTPStatus.BAD_GATEWAY
         assert (
             response.json["message"]
-            == "Relay URI did not return a JSON document: 'Expecting value: line 1 column 1 (char 0)'"
+            == "Relay URI did not return a JSON manifest: 'Expecting value: line 1 column 1 (char 0)'"
         )
 
     @responses.activate


### PR DESCRIPTION
PBENCH-1143

This API integrates with the file-relay server by assuming that the client (e.g., the `pbench-results-move` command) creates *two* separate files on the relay. The main artifact is the tarball, identified only by the tarball's computed SHA256 hash, as `http://relay.example.com/<name>/<sha256>`. However the Pbench Server needs the MD5 for the formal `resource_id` and a *name* for the dataset before we can begin "intake". We also want a mechanism to override the default "private" access level, and to set metadata, so by convention we add a second JSON file to which I'm referring as the "Relay configuration file". This provides the dataset "metadata" we require, including the tarball URI:

```json
{
  "name": "tarball.tar.xz",
  "md5": "myMD5",
  "access": "private",
  "metadata": ["server.origin:relay", "global.server.relay:webb"],
  "uri": "http://relay.example.com/<name>/<tarball-sha256>"
}
```

The Pbench Server will first `GET` the URI parameter, which it expects to be the Relay Configuration File. It will then `GET` the `"uri"` parameter in the configuration file.

To accomplish this, the old `Upload` code has been refactored into a base class defining most of the logic, and two subclasses which provide "helper" methods called `_prepare` and `_access` to encapsulate the operational differences between the "push" and "pull" models. Essentially the `Upload` class `_prepare` processes the URI and query parameters while the `Relay` class `_prepare` does the first `GET` and processes the JSON configuration parameters. The `_access` helpers return the content length and an `IO[byte]` stream which is read and processed by the common code.

This has been tested manually by standing up an instance of the `relay` server and I added unit tests to cover the distinct functions of the relay helper methods while not duplicating the `upload` unit test cases that cover the common code.