### PR TITLE
Update CI container to Fedora-38

### DIFF
--- a/agent/test-constraints-3.6.txt
+++ b/agent/test-constraints-3.6.txt
@@ -1,0 +1,3 @@
+# Python version constraints for P3.6 testing
+python-daemon<3.0.0
+setuptools<60.0.0

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -22,8 +22,7 @@ RPMBUILD_BASEIMAGE_DEFAULTS = \
 	fedora-38 fedora-37 \
 	centos-9 centos-8 centos-7
 
-# All Fedora images are based on Fedora 36
-FEDORA_BASE_IMAGE_REF = quay.io/fedora/fedora:36
+CI_BASE_IMAGE = quay.io/fedora/fedora:38
 
 # Templates for the various distributions' base images.  For the moment, for a
 # given distribution, all of the versions can be found by tweaking the image
@@ -87,7 +86,7 @@ ${_DISTROS:%=image-rpmbuild-%}: image-rpmbuild-%:
 
 ci.fedora.Dockerfile: ci.Dockerfile.j2
 	jinja2 ci.Dockerfile.j2 \
-		-D base_image_ref="${FEDORA_BASE_IMAGE_REF}" \
+		-D base_image_ref="${CI_BASE_IMAGE}" \
 		-D fedora=True \
 		> $@
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,7 @@ allowlist_externals =
 description = Runs all agent unit tests under Python 3.6
 basepython = python3.6
 deps =
+    -c{toxinidir}/agent/test-constraints-3.6.txt
     -r{toxinidir}/agent/requirements.txt
     -r{toxinidir}/agent/test-requirements.txt
 


### PR DESCRIPTION
Now that Fedora-36 has reached end-of-life, we need to update the default container image used by the CI and `jenkins/run` to F38.

However, initial attempts at this proved to be problematic.  So, this PR contains two sets of changes:
- a change to the `jenkins/Makefile` to switch the base image for the CI container from F36 to F38; and
- a pair of changes to restrict the legacy Agent testing on Python 3.6 to use older versions of certain packages.

The version restriction has basically no effect under F36, so this PR can be merged without adverse affects.  Once it has been merged, I'll build and push a new version of the CI container, switching it from the F36 base to the F38 base -- this will break all `main`-branch CI builds which haven't yet been rebased on this PR.

PBENCH-1161