### PR TITLE
Remove Fedora-36 support from the Agent

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -108,7 +108,7 @@ _ALL_RPMS = ${_TOOL_RPMS} ${_WORKLOAD_RPMS}
 # By default we only build images for the following distributions.
 _DEFAULT_DISTROS = \
 	centos-9 centos-8 centos-7 \
-	fedora-38 fedora-37 fedora-36
+	fedora-38 fedora-37
 #	rhel-9 rhel-8 rhel-7
 
 # This Makefile produces containers named "pbench-agent-<name>-<distro>"; this

--- a/agent/containers/images/README.md
+++ b/agent/containers/images/README.md
@@ -52,8 +52,8 @@ localhost/pbench-agent-all-centos-8   v0.69.3-1  9396f0337681 ...
 ```
 
 There are make targets for each of the five supported distributions, CentOS 9
-(`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 36
-(`fedora-36`), and Fedora 35 (`fedora-35`).  There are also make targets for
+(`centos-9`), CentOS 8 (`centos-8`), CentOS 7 (`centos-7`), Fedora 38
+(`fedora-38`), and Fedora 37 (`fedora-37`).  There are also make targets for
 each subset of the container image kinds (`all`, `tool-data-sink`,
 `tool-meister`, `tools`, `workloads`, `base`) built for each distribution, e.g.
 `centos-8-tools-tagged`, `fedora-35-base-tagged`, etc.

--- a/agent/rpm/Makefile
+++ b/agent/rpm/Makefile
@@ -24,7 +24,7 @@ CHROOTS =
 # target builds them all.
 RHEL_RPMS = rhel-9-rpm rhel-8-rpm rhel-7-rpm
 CENTOS_RPMS = centos-9-rpm centos-8-rpm centos-7-rpm
-FEDORA_RPMS = fedora-38-rpm fedora-37-rpm fedora-36-rpm
+FEDORA_RPMS = fedora-38-rpm fedora-37-rpm
 ALL_RPMS = ${RHEL_RPMS} ${CENTOS_RPMS} ${FEDORA_RPMS}
 
 component = agent

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -68,11 +68,7 @@ Requires: python3-docutils
 %if 0%{?fedora} != 0
 # RPMs for modules in requirements.txt
 Requires:  python3-bottle, python3-click, python3-daemon
-Requires:  python3-jinja2, python3-redis, python3-sh
-%endif
-
-%if 0%{?fedora} >= 36
-Requires: python3-ifaddr
+Requires:  python3-ifaddr python3-jinja2, python3-redis, python3-sh
 %endif
 
 # Common requirements

--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -16,7 +16,7 @@ alias pbench="$(git rev-parse --show-toplevel)"/contrib/containerized-pbench/pbe
 
 FIOTEST=${PWD}/fiotest
 export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
-export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-36:main
+export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-38:main
 
 mkdir -p "${FIOTEST}"
 

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -19,7 +19,7 @@ include ../utils/utils.mk
 # RPMs
 RPMBUILD_BASEIMAGE_DEFAULTS = \
 	rhel-9 rhel-8 rhel-7 \
-	fedora-38 fedora-37 fedora-36 \
+	fedora-38 fedora-37 \
 	centos-9 centos-8 centos-7
 
 # All Fedora images are based on Fedora 36

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -65,7 +65,7 @@ pipeline {
         }
         stage('Build the Pbench Agent Containers') {
             environment {
-                PB_AGENT_DISTRO="fedora-36"
+                PB_AGENT_DISTRO="fedora-38"
             }
             steps {
                 sh 'buildah login -u="${PB_CI_REG_CRED_USR}" -p="${PB_CI_REG_CRED_PSW}" ${PB_CI_REGISTRY}'


### PR DESCRIPTION
Now that Fedora-36 has reached end-of-life, this PR removes support from `main` for building, testing, and publishing F36 artifacts and updates testing to F38.

- Removes F36 from the list of Agent containers which we build by default (the target is still be available if specified explicitly); updates the `README.md` to match.
- Removes F36 from the list of RPMs to be built by default (again, it can still be built by specifying it explicitly).
- Removes F36 from the list of RPM-build containers built by default (again, it can still be built by specifying it explicitly).
- Simplifies a conditional in the Pbench Agent RPM spec file, now that no Fedora versions below 36 are supported.
- Modifies the containerized Agent demo to pull the F38 image instead of the F36 one.
- Switches the CI container test-build from F36 to F38.

PBENCH-1162