### PR TITLE
Don't report API Keys as errors

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -376,5 +376,6 @@ class OpenIDClient:
             jwt.InvalidSignatureError,
             jwt.InvalidAudienceError,
             jwt.InvalidAlgorithmError,
+            ValueError,
         ) as exc:
             raise OpenIDTokenInvalid() from exc


### PR DESCRIPTION
PBENCH-1168

Our API Key structure causes the primary OIDC key validation to fail with a `ValueError` exception. This isn't caught by the handler, and propagates to the caller's `except Exception` where it's reported as an error with traceback, which we don't want for a routine key validation.

This just adds `ValueError` to the catch to avoid the annoying log message.