### PR TITLE
Some API documentation fixes

### DIFF
--- a/docs/Server/API/README.md
+++ b/docs/Server/API/README.md
@@ -9,8 +9,12 @@ or just "datasets".
 
 The [V1 API](V1/README.md) provides a REST-like functional interface.
 
-The Pbench Server APIs use a combination of parameters embedded in the URI path
-along with query parameters and serialized JSON parameters (mimetype
-`application/json`) for requests. A few exceptions use raw byte streams
-(`application/octet-stream`) to allow uploading new datasets and to access
-individual files from a dataset.
+The Pbench Server APIs accept parameters from a variety of sources. See the
+individual API documentation for details.
+1. Some parameters, especially "resource ids", are embedded in the URI, such as
+`/api/v1/datasets/<resource_id>`;
+2. Some parameters are passed as query parameters, such as
+`/api/v1/datasets?name:fio`;
+3. For `PUT` and `POST` APIs, parameters may also be passed as a JSON
+(`application/json` content type) request payload, such as
+`{"metadata": {"dataset.name": "new name"}}`

--- a/docs/Server/API/README.md
+++ b/docs/Server/API/README.md
@@ -7,11 +7,10 @@ The Pbench Server provides a set of HTTP endpoints to manage user
 authentication and curated performance information, called "dataset resources"
 or just "datasets".
 
-The [V1 API](V1/README.md) provides a functional interface that's not quite
-standard REST. The intent is to migrate to a cleaner resource-oriented REST
-style for a future V2 API.
+The [V1 API](V1/README.md) provides a REST-like functional interface.
 
-The Pbench Server primarily uses serialized JSON parameters (mimetype
-`application/json`) both for request bodies and response bodies. A few
-exceptions use raw byte streams (`application/octet-stream`) to allow uploading
-new datasets and to access individual files from a dataset.
+The Pbench Server APIs use a combination of parameters embedded in the URI path
+along with query parameters and serialized JSON parameters (mimetype
+`application/json`) for requests. A few exceptions use raw byte streams
+(`application/octet-stream`) to allow uploading new datasets and to access
+individual files from a dataset.

--- a/docs/Server/API/V1/README.md
+++ b/docs/Server/API/V1/README.md
@@ -132,20 +132,3 @@ through the `directories` list of each
 The [inventory](inventory.md) API returns the raw byte stream of any regular
 file within the directory hierarchy, including log files, postprocessed JSON
 files, and benchmark result text files.
-
-### Example
-
-```
-    def directory(request, url: str, name: str = "/", level: int = 0):
-        ls = request.get(url).get_json()
-        print(f"{'  '*level}{name}")
-        for d in ls.directories:
-            directory(request, level + 1, d.name, d.url)
-        for f in ls.files:
-            print(f"{'  '*(level+1)}{f.name})
-            bytes = request.get(f.url)
-            # display byte stream:
-            # inline on terminal doesn't really make sense
-
-    directory(request, "http://host.example.com/api/v1/datasets/<dataset>/contents/")
-```

--- a/docs/Server/API/V1/README.md
+++ b/docs/Server/API/V1/README.md
@@ -147,5 +147,5 @@ files, and benchmark result text files.
             # display byte stream:
             # inline on terminal doesn't really make sense
 
-    directory(request, "http://host.example.com/api/v1/contents/<dataset>/")
+    directory(request, "http://host.example.com/api/v1/datasets/<dataset>/contents/")
 ```

--- a/docs/Server/API/V1/contents.md
+++ b/docs/Server/API/V1/contents.md
@@ -75,33 +75,33 @@ Pbench returns a JSON object with two list fields:
 {
     "directories": [
         {
-            "name": "1-iter1",
+            "name": "dir1",
             "type": "dir",
-            "uri": "http://hostname/api/v1/datasets/contents/<id>/1-iter1"
+            "uri": "http://hostname/api/v1/datasets/<id>/contents/dir1"
         },
         {
-            "sysinfo",
+            "name": "dir2",
             "type": "dir",
-            "uri": "http://hostname/api/v1/datasets/contents/<id>/sysinfo"
+            "uri": "http://hostname/api/v1/datasets/<id>/contents/dir2"
         },
         ...
     ],
     "files": [
         {
-        "name": ".iterations",
+        "name": "file.txt",
         "mtime": "2022-05-18T16:02:30",
         "size": 24,
         "mode": "0o644",
         "type": "reg",
-        "uri": "http://hostname/api/v1/datasets/inventory/<id>/.iterations"
+        "uri": "http://hostname/api/v1/datasets/<id>/inventory/file.txt"
         },
         {
-        "name": "iteration.lis",
+        "name": "data.lis",
         "mtime": "2022-05-18T16:02:06",
         "size": 18,
         "mode": "0o644",
         "type": "reg",
-        "uri": "http://hostname/api/v1/datasets/inventory/<id>/iteration.lis"
+        "uri": "http://hostname/api/v1/datasets/<id>/inventory/data.lis"
         },
         ...
     ]
@@ -126,7 +126,7 @@ The `type` codes are:
 {
     "name": "reference-result",
     "type": "sym",
-    "uri": "http://hostname/api/v1/datasets/contents/<id>/sample1"
+    "uri": "http://hostname/api/v1/datasets/<id>/contents/linkresult"
 }
 ```
 
@@ -154,6 +154,6 @@ URI returning the linked file's byte stream.
     "size": 18,
     "mode": "0o644",
     "type": "reg",
-    "uri": "http://hostname/api/v1/datasets/inventory/<id>/<path>"
+    "uri": "http://hostname/api/v1/datasets/<id>/inventory/<path>"
 }
 ```

--- a/docs/Server/API/V1/contents.md
+++ b/docs/Server/API/V1/contents.md
@@ -127,6 +127,11 @@ The `type` codes are:
     "name": "reference-result",
     "type": "sym",
     "uri": "http://hostname/api/v1/datasets/<id>/contents/linkresult"
+},
+{
+    "name": "directory",
+    "type": "dir",
+    "uri": "http://hostname/api/v1/datasets/<id>/contents/directory"
 }
 ```
 

--- a/docs/Server/API/V1/inventory.md
+++ b/docs/Server/API/V1/inventory.md
@@ -11,8 +11,10 @@ The resource ID of a Pbench dataset on the server.
 
 `<path>`    string \
 The resource path of an item in the dataset inventory, as captured by the
-Pbench Agent packaging; for example, `/metadata.log` for the dataset metadata,
-or `/1-default/sample1/result.txt` for the default first iteration results.
+Pbench Agent packaging; for example, `/metadata.log` for a file named
+`metadata.log` at the top level of the dataset tarball, or `/dir1/dir2/file.txt`
+for a `file.txt` file in a directory named `dir2` within a directory called
+`dir1` at the top level of the dataset tarball.
 
 ## Request headers
 
@@ -24,6 +26,23 @@ E.g., `authorization: bearer <token>`
 
 `content-type: application/octet-stream` \
 The return is a raw byte stream representing the contents of the named file.
+
+`content-disposition: <action>; filename=<name>` \
+This header defines the recommended client action on receiving the byte stream.
+The `<action>` types are either `inline` which suggests that the data can be
+displayed "inline" by a web browser or `attachment` which suggests that the data
+should be saved into a new file. The `<name>` is the original filename on the
+Pbench Server. For example,
+
+```
+content-disposition: attachment; filename=pbench-fio-config-2023-06-29-00:14:50.tar.xz
+```
+
+or
+
+```
+content-disposition: inline; filename=data.txt
+```
 
 ## Resource access
 
@@ -48,7 +67,7 @@ exist.
 
 `415` **UNSUPPORTED MEDIA TYPE** \
 The `<path>` refers to a directory. Use
-`/api/v1/dataset/contents/<dataset><path>` to request a JSON response document
+`/api/v1/dataset/<dataset>/contents/<path>` to request a JSON response document
 describing the directory contents.
 
 `503`   **SERVICE UNAVAILABLE** \

--- a/docs/Server/API/V1/relay.md
+++ b/docs/Server/API/V1/relay.md
@@ -3,15 +3,14 @@
 This API creates a dataset resource by reading data from a Relay server. There
 are two distinct steps involved:
 
-1. A `GET` on the provided URI returns a "manifest file" stored on the Relay
-server. This is a JSON file (`application/json` MIME format) defining the
-original tarball filename, the tarball's MD5 hash value, the URI of the
-performance data tarball file, and optionally metadata key/value pairs to be
-applied to the new dataset.
-2. A `GET` on the Relay manifest file's `uri` field value returns an
-`application/octet-stream` payload for a file created by `tar` and compressed
-with the `xz` program, which will be stored by the Pbench Server as a
-dataset.
+1. A `GET` on the provided URI must return a "Relay manifest file". This is a
+JSON file (`application/json` MIME format) providing the original tarball
+filename, the tarball's MD5 hash value, a URI to read the tarball file, and
+optionally metadata key/value pairs to be applied to the new dataset. (See
+[Manifest file keys](#manifest-file-keys).)
+2. A `GET` on the Relay manifest file's `uri` field value must return the
+tarball file as an `application/octet-stream` payload, which will be stored by
+the Pbench Server as a dataset.
 
 ## URI parameters
 
@@ -87,7 +86,7 @@ The return is a serialized JSON object with status information.
 Successful request. The dataset MD5 hash is identical to that of a dataset
 previously uploaded to the Pbench Server. This is assumed to be an identical
 tarball, and the secondary URI (the `uri` field in the Relay manifest file)
-has not been consumed.
+has not been accessed.
 
 `201`   **CREATED** \
 The tarball was successfully uploaded and the dataset has been created.

--- a/docs/Server/API/V1/upload.md
+++ b/docs/Server/API/V1/upload.md
@@ -82,8 +82,10 @@ a message, and optional JSON data provided by the system administrator.
 
 ## Response body
 
-The `application/json` response body consists of a JSON object giving a detailed
-message on success or failure:
+The `application/json` response body consists of a JSON object containing a
+`message` field. On failure this will describe the nature of the problem and
+in some cases an `errors` array will provide details for cases where multiple
+problems can occur.
 
 ```json
 {


### PR DESCRIPTION
PBENCH-819

This is primarily a minor "cleanup pass" to make some specific example paths more generic and retire a long-standing story.

Along the way I also found a few places I'd missed during the REST API changes so I fixed them as well. Finally, I added a `relay.md` API file for the new Relay API.

Any other bugs, omissions, or other comments in API documentation could also be considered "in scope" here.