### PR TITLE
Man pages for pbench-agent commands

### DIFF
--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -1,243 +1,227 @@
 # Man pages
 
-------------
+---
 
 ### pbench-clear-results
 
-------------
+---
 
-
-**NAME**    
+**NAME**  
 pbench-clear-results, Clears the result directory
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-clear-results [-C][--help]`
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 This command clears the results directory from /var/lib/pbench-agent directory
 
-**OPTIONS**     
+**OPTIONS**  
  -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
 
-  --help        
+--help  
 Show this message and exit.
 
-
-------------
+---
 
 ### pbench-clear-tools
 
-------------
+---
 
-
-**NAME**    
+**NAME**  
 pbench-clear-tools, Clear registered tools by name or group
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-clear-tools [-C][-n][-g][-r][--help]
 `
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 Clear all tools which are registered and can filter by name of the group
 
-**OPTIONS**     
+**OPTIONS**  
 -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
 
--n, --name,--names STR    
+-n, --name,--names STR  
 Clear only the <tool-name> tool.
 
--g, --group,--groups STR   
-Clear the tools in the <group-name> group.  If no group is specified, the 'default' group is assumed.
+-g, --group,--groups STR  
+Clear the tools in the <group-name> group. If no group is specified, the 'default' group is assumed.
 
 -r, --remote, --remotes STR  
-Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list.  If no remote is specified, all remotes are cleared
+Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared
 
-  --help    
+--help  
 Show this message and exit.
 
-
-
-------------
-
+---
 
 ### pbench-copy-results
 
-------------
+---
 
-
-**NAME**    
+**NAME**  
 pbench-copy-results, Copies result tarball to the server
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]
 `
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 It keeps the copy of tarball on the pbench-agent and pushes the other to pbench-server
 
-**OPTIONS**     
+**OPTIONS**  
 --user  
 This option value is required if not provided by the
 'PBENCH_USER' environment variable; otherwise, the value provided
 on the command line will override any value provided by the
 environment.
 
---controller    
+--controller  
 This option may be used to override the value
 provided by the 'PBENCH_CONTROLLER' environment variable; if
 neither value is available, the result of 'hostname -f' is used.
 (If no value is available, the command will exit with an error.)
 
---prefix    
+--prefix  
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 tar balls on the pbench server.
 
---show-server    
+--show-server  
 This will not move any results, but resolve and
 then display the pbench server destination for results.
 
---xz-single-threaded    
+--xz-single-threaded  
 This will force the use of a single
 thread for locally compressing the result tar balls.
 
-  --help     
+--help  
 Show this message and exit.
 
-------------
-
+---
 
 ### pbench-list-tools
 
+---
 
-------------
-
-
-**NAME**    
+**NAME**  
 pbench-list-tools, List all the registered tools with group, host, and remote info.
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-list-tools [-C][-n][-g][-o][--help]
 `
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 List all tools that are registered and can filter by name of the group
 
-**OPTIONS**     
+**OPTIONS**  
  -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
 
-  -n, --name STR    
+-n, --name STR  
 list the tool groups in which <tool-name> is used.
 
-  -g, --group STR   
+-g, --group STR  
 list the tools used in this <group-name>
 
-  -o, --with-option  
+-o, --with-option  
 list the options with each tool
 
-  --help  
+--help  
 Show this message and exit.
 
-
-
-------------
+---
 
 ### pbench-list-triggers
 
-------------
+---
 
+**NAME**  
+pbench-list-triggers, Lists the registered triggers by group
 
-**NAME**    
-pbench-list-triggers, Lists the registered triggers by group        
-
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-list-triggers[-C][-g][--help]
 `
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 This command will list all the registered triggers by group-name
 
-**OPTIONS**     
- -C, --config PATH       
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]     
+**OPTIONS**  
+ -C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
 
--g, --group,--groups STR   
-List all the triggers registered in the <group-name> group.  
+-g, --group,--groups STR  
+List all the triggers registered in the <group-name> group.
 
---help                  
+--help  
 Show this message and exit.
 
+---
 
-------------
+### pbench-move-result
 
-###  pbench-move-result
+---
 
-------------
-
-
-**NAME**    
+**NAME**  
 pbench-move-results, Move all results to pbench-server
 
-**SYNOPSIS**    
-`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server   ]
+**SYNOPSIS**  
+`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
 `
 
-**DESCRIPTION**     
-Move result directories to the configured pbench-server. Once the tarball is moved successfully, it clears the local copy of the tarball in the pbench-agent.
+**DESCRIPTION**  
+Move result directories to the configured pbench-server. Once the tarball is moved successfully, it clears the local copy of the tarball in the pbench-agent.This command is used when result tarball is pushed via SSH
 
-**OPTIONS**     
+**OPTIONS**  
 --user  
 This option value is required if not provided by the
 'PBENCH_USER' environment variable; otherwise, the value provided
 on the command line will override any value provided by the
 environment.
 
---controller    
+--controller  
 This option may be used to override the value
 provided by the 'PBENCH_CONTROLLER' environment variable; if
 neither value is available, the result of 'hostname -f' is used.
 (If no value is available, the command will exit with an error.)
 
---prefix    
+--prefix  
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 tar balls on the pbench server.
 
---show-server    
+--show-server  
 This will not move any results, but resolve and
 then display the pbench server destination for results.
 
---xz-single-threaded    
+--xz-single-threaded  
 This will force the use of a single
 thread for locally compressing the result tar balls.
 
-  --help     
+--help  
 Show this message and exit.
 
-------------
-
+---
 
 ### pbench-register-tool
 
-------------
+---
 
-
-**NAME**    
+**NAME**  
 pbench-register-tool, Registers the specified tools
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here][--help]`
 
 `pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=@<remotes-file>] -- [all tool specific options here]`
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 Register the tools that are specified
 
-**OPTIONS**     
+**OPTIONS**  
 --name
+
 List of available tools:
 
 ###### Transient
@@ -281,177 +265,175 @@ List of available tools:
 - 	virsh-migrate
 - 	vmstat
 
-###### Persistent
+##### Persistent
 - node-exporter
 - dcgm
 - pcp
 
 For a list of tool-specific options, run:
-	/opt/pbench-agent/tool-scripts/<tool-name> --help
+/opt/pbench-agent/tool-scripts/<tool-name> --help
 
-[--persistent] [--transient]    
+[--persistent] [--transient]  
 This can be used to specify tool run type.
 
---remotes   
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename.  In this last case, the file should contain a list of hosts and their (optional) labels.  Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+--remotes  
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
 
-  --help    
+--help  
 Show this message and exit.
 
+---
 
-------------
 ### pbench-register-tool-set
 
-------------
+---
 
-**NAME**    
+**NAME**  
 pbench-register-tool-set, Register the specified toolset
 
-**SYNOPSIS**        
+**SYNOPSIS**  
 `pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [<tool-set>]`
 
 `pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>] [<tool-set>]`
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 Register all the tools in the specified toolset.
 
-**OPTIONS**     
+**OPTIONS**  
  --toolset  
 Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
+
 - heavy
 - legacy
 - light
 - medium
 
---remotes    
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename.  In this last case, the file should contain a list of hosts and their (optional) labels.  Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+--remotes  
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
 
---labels    
+--labels  
 Where the list of labels must match the list of remotes.
 
-  --help    
+--help  
 Show this message and exit.
 
-------------
-
+---
 
 ### pbench-register-tool-trigger
 
-------------
+---
 
-**NAME**    
+**NAME**  
 pbench-register-tool-trigger, Registers the tool trigger
 
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-register-tool-trigger[-C][-g][--start-trigger][--stop-trigger][--help]`
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 Registers tool with the given group and start and stop tool trigger text
 
-**OPTIONS**     
- -C, --config PATH       
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]         
+**OPTIONS**  
+ -C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
 
--g, --group,--groups STR   
-Registers the trigger in the <group-name> group.  If no group is specified, the 'default'       
+-g, --group,--groups STR  
+Registers the trigger in the <group-name> group. If no group is specified, the 'default'
 
---start-trigger STR     
-[required]  
+--start-trigger STR  
+[required]
 
---stop-trigger STR      
-[required]      
+--stop-trigger STR  
+[required]
 
---help                  
+--help  
 Show this message and exit.
 
+---
 
-------------
 ### pbench-results-move
 
-------------
-**NAME**    
+---
+
+**NAME**  
 pbench-results-move, Move results tarball to the server
 
-**SYNOPSIS**        
+**SYNOPSIS**  
 `pbench-results-move[-C][--controller][--token][--delete][--xz-single-threaded][--show-server][--help]
 `
 
-**DESCRIPTION**     
-Move result directories to the configured Pbench server.
+**DESCRIPTION**  
+Move result directories to the configured Pbench server.This command is used when pushing result tarball using token.
 
-**OPTIONS**     
- -C, --config PATH       
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable,if defined)  [required]
+**OPTIONS**  
+ -C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable,if defined) [required]
 
---controller STR        
-Override the default controller name    
+--controller STR  
+Override the default controller name
 
---token STR     
-pbench server authentication token  [required]  
+--token STR  
+pbench server authentication token [required]
 
---delete / --no-delete    
-Remove local data after successful copy  [default: delete]  
+--delete / --no-delete  
+Remove local data after successful copy [default: delete]
 
-  --xz-single-threaded    
-Use single-threaded compression with 'xz'   
+--xz-single-threaded  
+Use single-threaded compression with 'xz'
 
-  --show-server STR      
-Display information about the pbench server where the result(s) will be moved (Not implemented)     
+--show-server STR  
+Display information about the pbench server where the result(s) will be moved (Not implemented)
 
-  --help                  
+--help  
 Show this message and exit.
 
-
-------------
-
+---
 
 ### pbench-user-benchmark
 
+---
 
-------------
+**NAME**  
+pbench-user-benchmark, Control start/stop/post-process-tools.
 
-
-**NAME**    
-pbench-user-benchmark,  Control start/stop/post-process-tools.
-
-**SYNOPSIS**    
+**SYNOPSIS**  
 `pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture]-- <script to run>`
 
-**DESCRIPTION**     
+**DESCRIPTION**  
 Collects data from the tools registered. Here are the steps involved
+
 - Invoking pbench-user-benchmark with your workload generator as an argument: that will start the collection tools on all the hosts
 - Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
 - Finally, the postprocessing phase will gather the data from all the remote hosts and run the postprocessing tools on everything.
 
-**OPTIONS**     
--C, --config PATH       
-Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable,if defined)  [required]      
+**OPTIONS**  
+-C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable,if defined) [required]
 
---tool-group    
-The tool group to use for the list of tools     
+--tool-group  
+The tool group to use for the list of tools
 
---iteration-list    
+--iteration-list  
 A file containing a list of iterations to run for the provided script;
-the file should contain one iteration per line, with a leading '#' (hash) character used for comments, blank lines are ignored; each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;    
-_NOTE: --iteration-list is not compatible with --use-tool-triggers_         
+the file should contain one iteration per line, with a leading '#' (hash) character used for comments, blank lines are ignored; each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  
+_NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
---sysinfo STR,[STR]     
-comma-separated values of system information to be collected; available: default, none, all, ara, block, insights, kernel_config, libvirt, security_mitigations, sos, stockpile, topology       
+--sysinfo STR,[STR]  
+comma-separated values of system information to be collected; available: default, none, all, ara, block, insights, kernel_config, libvirt, security_mitigations, sos, stockpile, topology
 
---pbench-pre STR        
-Path to the script which will be executed before tools are started              
-_NOTE: --pbench-pre is not compatible with --use-tool-triggers_     
+--pbench-pre STR  
+Path to the script which will be executed before tools are started  
+_NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
---pbench-post STR     
-Path to the script which will be executed after tools are stopped and postprocessing is complete        
-_NOTE: --pbench-post is not compatible with --use-tool-triggers_        
+--pbench-post STR  
+Path to the script which will be executed after tools are stopped and postprocessing is complete  
+_NOTE: --pbench-post is not compatible with --use-tool-triggers_
 
---use-tool-triggers     
-Use tool triggers instead of normal start/stop around script;       
-_NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_      
+--use-tool-triggers  
+Use tool triggers instead of normal start/stop around script;  
+_NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_
 
---no-stderr-capture     
-Do not capture the stderr of the script to the result.txt file          
+--no-stderr-capture  
+Do not capture the stderr of the script to the result.txt file
 
---help                  
+--help  
 Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -12,7 +12,7 @@
 -  [pbench-register-tool-trigger](#pbench-register-tool-trigger)
 #### Benchmark commands
 -  [pbench-user-benchmark](#pbench-user-benchmark)
-#### Publish to Pbench Server
+#### Upload to Pbench Server
 ###### Pbench Server 0.69
 - [pbench-move-result](#pbench-move-result)
 - [pbench-copy-results](#pbench-copy-results) 
@@ -30,15 +30,16 @@
 `pbench-clear-results`, Clears the result directory
 
 **SYNOPSIS**  
-`pbench-clear-results [-C][--help]`
+`pbench-clear-results [OPTIONS]`
 
 **DESCRIPTION**  
-This command clears the results directory from /var/lib/pbench-agent directory
+This command clears the results directory from `/var/lib/pbench-agent` directory
 
 **OPTIONS**  
  `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
+
 
 `--help`  
 Show this message and exit.
@@ -53,24 +54,68 @@ Show this message and exit.
 `pbench-clear-tools`, Clear registered tools by name or group
 
 **SYNOPSIS**  
-`pbench-clear-tools [-C][-n][-g][-r][--help]`
+`pbench-clear-tools [OPTIONS]`
 
 **DESCRIPTION**  
 Clear all tools which are registered and can filter by name of the group
 
 **OPTIONS**  
 `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
 
 `-n`, `--name`, `--names` STR  
-Clear only the <`tool-name`> tool.
+Clear only the <`STR`> tool.
 
-`-g`, `--group`,`--groups` STR  
-Clear the tools in the <group-name> group. If no group is specified, the `default` group is assumed.
+`-g`, `--group`, `--groups` STR  
+Clear the tools in the <`STR`> group. If no group is specified, the `default` group is assumed.
 
 `-r`, `--remote`, `--remotes` STR  
 Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared
+
+`--help`  
+Show this message and exit.
+
+---
+
+##### pbench-copy-results
+
+---
+
+**NAME**  
+`pbench-copy-results`, Copies result tarball to the 0.69 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]`
+
+**DESCRIPTION**  
+Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key,when pushing to a 0.69 Pbench Server.
+
+**OPTIONS**  
+`--user`  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, a value provided
+on the command line will override any value provided by the
+environment.
+
+`--controller`  
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+`--prefix`  
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+files on the 0.69 Pbench Server.
+
+`--show-server`  
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+`--xz-single-threaded`  
+This will force the use of a single
+thread for locally compressing the result tar balls.
 
 `--help`  
 Show this message and exit.
@@ -86,21 +131,21 @@ Show this message and exit.
 `pbench-list-tools`, List all the registered tools with group, host, and remote info.
 
 **SYNOPSIS**  
-`pbench-list-tools [-C][-n][-g][-o][--help]`
+`pbench-list-tools [OPTIONS]`
 
 **DESCRIPTION**  
 List all tools that are registered and can filter by name of the group
 
 **OPTIONS**  
  `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
 
 `-n`, `--name` STR  
-list the tool groups in which <`tool-name`> is used.
+list the tool groups in which <`STR`> is used.
 
 `-g`, `--group` STR  
-list the tools used in this <group-name>
+list the tools used in this <`STR`>
 
 `-o`, `--with-option`  
 list the options with each tool
@@ -121,15 +166,59 @@ Show this message and exit.
 `pbench-list-triggers[-C][-g][--help]`
 
 **DESCRIPTION**  
-This command will list all the registered triggers by group-name
+This command will list all the registered triggers by `group-name`
 
 **OPTIONS**  
  `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
 
 `-g`, `--group`, `--groups` STR  
-List all the triggers registered in the <group-name> group.
+List all the triggers registered in the <`STR`> group.
+
+`--help`  
+Show this message and exit.
+
+---
+
+##### pbench-move-result
+
+---
+
+**NAME**  
+`pbench-move-results`, Move all results to 0.69 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]`
+
+**DESCRIPTION**  
+This command can only be used for a 0.69 Pbench Server destination, and requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account.
+
+**OPTIONS**  
+`--user`  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, a value provided
+on the command line will override any value provided by the
+environment.
+
+`--controller`
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+`--prefix`  
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+`--show-server`  
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+`--xz-single-threaded`  
+This will force the use of a single
+thread for locally compressing the result tar balls.
 
 `--help`  
 Show this message and exit.
@@ -144,20 +233,16 @@ Show this message and exit.
 `pbench-register-tool`, Registers the specified tools
 
 **SYNOPSIS**  
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here][--help]`
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- <tool-specific-options> [--help]`
 
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=@<remotes-file>] -- [all tool specific options here]`
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=@<remotes-file>] -- <tool-specific-options>`
 
 **DESCRIPTION**  
-Register the tools that are specified
-
-**OPTIONS**  
-`--name`
-
+Register the tools that are specified .
 List of available tools:
 
-###### Transient
-- 	blktrace
+**Transient**
+- blktrace
 - 	bpftrace
 - 	cpuacct
 - 	disk
@@ -197,19 +282,22 @@ List of available tools:
 - 	virsh-migrate
 - 	vmstat
 
-##### Persistent
+ **Persistent**
 - node-exporter
 - dcgm
 - pcp
 
+**OPTIONS**  
+`--name` STR
+This can be used register a specific tool by name.
 For a list of tool-specific options, run:
 /opt/pbench-agent/tool-scripts/<`tool-name`> --help
 
-`--persistent`, `--transient`  
+`[--persistent | --transient]`  
 This can be used to specify tool run type.
 
 `--remotes`  
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash, or pound (`#`), character.
 
 `--help`  
 Show this message and exit.
@@ -241,7 +329,7 @@ Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
 - medium
 
 `--remotes`  
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash, or pound (`#`), character.
 
 `--labels`  
 Where the list of labels must match the list of remotes.
@@ -259,18 +347,18 @@ Show this message and exit.
 `pbench-register-tool-trigger`, Registers the tool trigger
 
 **SYNOPSIS**  
-`pbench-register-tool-trigger[-C][-g][--start-trigger][--stop-trigger][--help]`
+`pbench-register-tool-trigger [OPTIONS]`
 
 **DESCRIPTION**  
 Registers tool with the given group and start and stop tool trigger text
 
 **OPTIONS**  
  `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
 
 `-g`, `--group`, `--groups` STR  
-Registers the trigger in the <group-name> group. If no group is specified, the 'default'
+Registers the trigger in the <`STR`> group. If no group is specified, the 'default'
 
 `--start-trigger` STR  
 [required]
@@ -281,6 +369,44 @@ Registers the trigger in the <group-name> group. If no group is specified, the '
 `--help`  
 Show this message and exit.
 
+---
+
+##### pbench-results-move
+
+---
+
+**NAME**  
+`pbench-results-move`, Move results tarball to the server to a 1.0 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-results-move [OPTIONS]`
+
+**DESCRIPTION**  
+This command uploads one or more result directories to the configured v1.0 Pbench Server. The specified API Key is used to authenticate the user and to establish ownership of the data on the server. Once the upload is complete, the result directories are, by default, removed from the local system.
+
+
+**OPTIONS**  
+ `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+
+`--controller` STR  
+Override the default controller name
+
+`--token` STR  
+pbench server authentication token [required]
+
+`--delete` | `--no-delete`  
+Remove local data after successful copy [default: delete]
+
+`--xz-single-threaded`  
+Use single-threaded compression with `xz`
+
+`--show-server` STR  
+Display information about the pbench server where the result(s) will be moved (Not implemented)
+
+`--help`  
+Show this message and exit.
 
 ---
 
@@ -300,26 +426,29 @@ Collects data from the registered tools while running a user-specified action. T
 
 Here are the steps involved
 
-- Invoking pbench-user-benchmark with your workload generator as an argument: that will start the collection tools on all the hosts
+- Invoking `pbench-user-benchmark` with your workload generator as an argument: that will start the collection tools on all the hosts
 - Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
-- Finally, the postprocessing phase will gather the data from all the remote hosts and run the postprocessing tools on everything.
+- Finally, the postprocessing phase will gather the data from all the remote hosts and generates `result.txt` file by running the postprocessing tools on everything 
+
+`--<command to run>`
+ It can be a script, or an executable, or a shell command 
 
 **OPTIONS**  
 `-C`, `--config` PATH  
+Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
 
 `--tool-group`  
 The tool group to use for the list of tools
 
 `--iteration-list`  
 A file containing a list of iterations to run for the provided script;
-the file should contain one iteration per line . With a leading '#' (hash) character used for comments and blank lines are ignored.
+the file should contain one iteration per line. With a leading `#` (hash) character used for comments and blank lines are ignored.
 Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
-`--sysinfo` STR,[STR]  
-comma-separated values of system information to be collected; available: default, none, all, ara, block, insights, kernel_config, libvirt, security_mitigations, sos, stockpile, topology
+`--sysinfo` STR[,STR...]  
+comma-separated values of system information to be collected; available: `default` `none` `all` `ara` `block` `insights` `kernel_config` `libvirt` `security_mitigations` `sos` `stockpile` `topology`
 
 `--pbench-pre` STR  
 Path to the script which will be executed before tools are started  
@@ -334,136 +463,7 @@ Use tool triggers instead of normal start/stop around script;
 _NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_
 
 `--no-stderr-capture`  
-Do not capture the stderr of the script to the result.txt file
-
-`--<command to run>`
- It can be a script, or an executable, or a shell command 
-
-`--help`  
-Show this message and exit.
-
----
-
-##### pbench-move-result
-
----
-
-**NAME**  
-`pbench-move-results`, Move all results to 0.69 Pbench Server.
-
-**SYNOPSIS**  
-`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]`
-
-**DESCRIPTION**  
-This command can only be used for a 0.69 Pbench Server destination, and requires a /opt/pbench-agent/id_rsa file with the private SSH key of the server's pbench account.
-
-**OPTIONS**  
-`--user`  
-This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, a value provided
-on the command line will override any value provided by the
-environment.
-
-`--controller`
-This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
-(If no value is available, the command will exit with an error.)
-
-`--prefix`  
-This option allows the user to specify an optional
-directory-path hierarchy to be used when displaying the result
-tar balls on the pbench server.
-
-`--show-server`  
-This will not move any results, but resolve and
-then display the pbench server destination for results.
-
-`--xz-single-threaded`  
-This will force the use of a single
-thread for locally compressing the result tar balls.
-
-`--help`  
-Show this message and exit.
-
----
-
-##### pbench-copy-results
-
----
-
-**NAME**  
-`pbench-copy-results`, Copies result tarball to the 0.69 Pbench Server.
-
-**SYNOPSIS**  
-`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]`
-
-**DESCRIPTION**
-Push the benchmark result to the Pbench Server without removing it from the local host .We use id_rsa when pushing to a 0.69 Pbench Server.
-
-**OPTIONS**  
-`--user`  
-This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, a value provided
-on the command line will override any value provided by the
-environment.
-
-`--controller`  
-This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
-(If no value is available, the command will exit with an error.)
-
-`--prefix`  
-This option allows the user to specify an optional
-directory-path hierarchy to be used when displaying the result
-files on the 0.69 Pbench Server.
-
-`--show-server`  
-This will not move any results, but resolve and
-then display the pbench server destination for results.
-
-`--xz-single-threaded`  
-This will force the use of a single
-thread for locally compressing the result tar balls.
-
-`--help`  
-Show this message and exit.
-
----
-
-##### pbench-results-move
-
----
-
-**NAME**  
-`pbench-results-move`, Move results tarball to the server to a 1.0 Pbench Server.
-
-**SYNOPSIS**  
-`pbench-results-move[-C][--controller][--token][--delete][--xz-single-threaded][--show-server][--help]`
-
-**DESCRIPTION**  
-Move result directories to the configured Pbench server. We use an API Key authentication token when pushing results to a 1.0 Pbench Server
-
-**OPTIONS**  
- `-C`, `--config` PATH  
-This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-Path to the pbench-agent configuration file.
-
-`--controller` STR  
-Override the default controller name
-
-`--token` STR  
-pbench server authentication token [required]
-
-`--delete` | `--no-delete`  
-Remove local data after successful copy [default: delete]
-
-`--xz-single-threaded`  
-Use single-threaded compression with 'xz'
-
-`--show-server` STR  
-Display information about the pbench server where the result(s) will be moved (Not implemented)
+Do not capture the  standard error output of the script to the `result.txt` file
 
 `--help`  
 Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -1,13 +1,33 @@
 # Man pages
+ 
+**Contents**
+
+#### Performance tool management commands
+-  [pbench-clear-results](#pbench-clear-results)
+-  [pbench-clear-tools](#pbench-clear-tools)
+-  [pbench-list-tools](#pbench-list-tools)
+-  [pbench-list-triggers](#pbench-list-triggers)
+-  [pbench-register-tool](#pbench-register-tool)
+-  [pbench-register-tool-set](#pbench-register-tool-set)
+-  [pbench-register-tool-trigger](#pbench-register-tool-trigger)
+#### Benchmark commands
+-  [pbench-user-benchmark](#pbench-user-benchmark)
+#### Publish to Pbench Server
+###### Pbench Server 0.69
+- [pbench-move-result](#pbench-move-result)
+- [pbench-copy-results](#pbench-copy-results) 
+###### Pbench Server 1.0
+-  [pbench-results-move](pbench-results-move)
+
 
 ---
 
-### pbench-clear-results
+##### pbench-clear-results
 
 ---
 
 **NAME**  
-pbench-clear-results, Clears the result directory
+`pbench-clear-results`, Clears the result directory
 
 **SYNOPSIS**  
 `pbench-clear-results [-C][--help]`
@@ -16,200 +36,112 @@ pbench-clear-results, Clears the result directory
 This command clears the results directory from /var/lib/pbench-agent directory
 
 **OPTIONS**  
- -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
+ `-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
---help  
+`--help`  
 Show this message and exit.
 
 ---
 
-### pbench-clear-tools
+##### pbench-clear-tools
 
 ---
 
 **NAME**  
-pbench-clear-tools, Clear registered tools by name or group
+`pbench-clear-tools`, Clear registered tools by name or group
 
 **SYNOPSIS**  
-`pbench-clear-tools [-C][-n][-g][-r][--help]
-`
+`pbench-clear-tools [-C][-n][-g][-r][--help]`
 
 **DESCRIPTION**  
 Clear all tools which are registered and can filter by name of the group
 
 **OPTIONS**  
--C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
+`-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
--n, --name,--names STR  
-Clear only the <tool-name> tool.
+`-n`, `--name`, `--names` STR  
+Clear only the <`tool-name`> tool.
 
--g, --group,--groups STR  
-Clear the tools in the <group-name> group. If no group is specified, the 'default' group is assumed.
+`-g`, `--group`,`--groups` STR  
+Clear the tools in the <group-name> group. If no group is specified, the `default` group is assumed.
 
--r, --remote, --remotes STR  
+`-r`, `--remote`, `--remotes` STR  
 Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared
 
---help  
+`--help`  
 Show this message and exit.
+
 
 ---
 
-### pbench-copy-results
+##### pbench-list-tools
 
 ---
 
 **NAME**  
-pbench-copy-results, Copies result tarball to the server
+`pbench-list-tools`, List all the registered tools with group, host, and remote info.
 
 **SYNOPSIS**  
-`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]
-`
-
-**DESCRIPTION**  
-It keeps the copy of tarball on the pbench-agent and pushes the other to pbench-server
-
-**OPTIONS**  
---user  
-This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, the value provided
-on the command line will override any value provided by the
-environment.
-
---controller  
-This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
-(If no value is available, the command will exit with an error.)
-
---prefix  
-This option allows the user to specify an optional
-directory-path hierarchy to be used when displaying the result
-tar balls on the pbench server.
-
---show-server  
-This will not move any results, but resolve and
-then display the pbench server destination for results.
-
---xz-single-threaded  
-This will force the use of a single
-thread for locally compressing the result tar balls.
-
---help  
-Show this message and exit.
-
----
-
-### pbench-list-tools
-
----
-
-**NAME**  
-pbench-list-tools, List all the registered tools with group, host, and remote info.
-
-**SYNOPSIS**  
-`pbench-list-tools [-C][-n][-g][-o][--help]
-`
+`pbench-list-tools [-C][-n][-g][-o][--help]`
 
 **DESCRIPTION**  
 List all tools that are registered and can filter by name of the group
 
 **OPTIONS**  
- -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
+ `-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
--n, --name STR  
-list the tool groups in which <tool-name> is used.
+`-n`, `--name` STR  
+list the tool groups in which <`tool-name`> is used.
 
--g, --group STR  
+`-g`, `--group` STR  
 list the tools used in this <group-name>
 
--o, --with-option  
+`-o`, `--with-option`  
 list the options with each tool
 
---help  
+`--help`  
 Show this message and exit.
 
 ---
 
-### pbench-list-triggers
+##### pbench-list-triggers
 
 ---
 
 **NAME**  
-pbench-list-triggers, Lists the registered triggers by group
+`pbench-list-triggers`, Lists the registered triggers by group
 
 **SYNOPSIS**  
-`pbench-list-triggers[-C][-g][--help]
-`
+`pbench-list-triggers[-C][-g][--help]`
 
 **DESCRIPTION**  
 This command will list all the registered triggers by group-name
 
 **OPTIONS**  
- -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
+ `-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
--g, --group,--groups STR  
+`-g`, `--group`, `--groups` STR  
 List all the triggers registered in the <group-name> group.
 
---help  
+`--help`  
 Show this message and exit.
 
 ---
 
-### pbench-move-result
+##### pbench-register-tool
 
 ---
 
 **NAME**  
-pbench-move-results, Move all results to pbench-server
-
-**SYNOPSIS**  
-`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]
-`
-
-**DESCRIPTION**  
-Move result directories to the configured pbench-server. Once the tarball is moved successfully, it clears the local copy of the tarball in the pbench-agent.This command is used when result tarball is pushed via SSH
-
-**OPTIONS**  
---user  
-This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, the value provided
-on the command line will override any value provided by the
-environment.
-
---controller  
-This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
-(If no value is available, the command will exit with an error.)
-
---prefix  
-This option allows the user to specify an optional
-directory-path hierarchy to be used when displaying the result
-tar balls on the pbench server.
-
---show-server  
-This will not move any results, but resolve and
-then display the pbench server destination for results.
-
---xz-single-threaded  
-This will force the use of a single
-thread for locally compressing the result tar balls.
-
---help  
-Show this message and exit.
-
----
-
-### pbench-register-tool
-
----
-
-**NAME**  
-pbench-register-tool, Registers the specified tools
+`pbench-register-tool`, Registers the specified tools
 
 **SYNOPSIS**  
 `pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here][--help]`
@@ -220,7 +152,7 @@ pbench-register-tool, Registers the specified tools
 Register the tools that are specified
 
 **OPTIONS**  
---name
+`--name`
 
 List of available tools:
 
@@ -271,25 +203,25 @@ List of available tools:
 - pcp
 
 For a list of tool-specific options, run:
-/opt/pbench-agent/tool-scripts/<tool-name> --help
+/opt/pbench-agent/tool-scripts/<`tool-name`> --help
 
-[--persistent] [--transient]  
+`--persistent`, `--transient`  
 This can be used to specify tool run type.
 
---remotes  
+`--remotes`  
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
 
---help  
+`--help`  
 Show this message and exit.
 
 ---
 
-### pbench-register-tool-set
+##### pbench-register-tool-set
 
 ---
 
 **NAME**  
-pbench-register-tool-set, Register the specified toolset
+`pbench-register-tool-set`, Register the specified toolset
 
 **SYNOPSIS**  
 `pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [<tool-set>]`
@@ -300,7 +232,7 @@ pbench-register-tool-set, Register the specified toolset
 Register all the tools in the specified toolset.
 
 **OPTIONS**  
- --toolset  
+ `--toolset`  
 Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
 
 - heavy
@@ -308,23 +240,23 @@ Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
 - light
 - medium
 
---remotes  
+`--remotes`  
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
 
---labels  
+`--labels`  
 Where the list of labels must match the list of remotes.
 
---help  
+`--help`  
 Show this message and exit.
 
 ---
 
-### pbench-register-tool-trigger
+##### pbench-register-tool-trigger
 
 ---
 
 **NAME**  
-pbench-register-tool-trigger, Registers the tool trigger
+`pbench-register-tool-trigger`, Registers the tool trigger
 
 **SYNOPSIS**  
 `pbench-register-tool-trigger[-C][-g][--start-trigger][--stop-trigger][--help]`
@@ -333,107 +265,205 @@ pbench-register-tool-trigger, Registers the tool trigger
 Registers tool with the given group and start and stop tool trigger text
 
 **OPTIONS**  
- -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable, if defined) [required]
+ `-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
--g, --group,--groups STR  
+`-g`, `--group`, `--groups` STR  
 Registers the trigger in the <group-name> group. If no group is specified, the 'default'
 
---start-trigger STR  
+`--start-trigger` STR  
 [required]
 
---stop-trigger STR  
+`--stop-trigger` STR  
 [required]
 
---help  
+`--help`  
 Show this message and exit.
+
 
 ---
 
-### pbench-results-move
+##### pbench-user-benchmark
 
 ---
 
 **NAME**  
-pbench-results-move, Move results tarball to the server
+`pbench-user-benchmark`, Control start/stop/post-process-tools.
 
 **SYNOPSIS**  
-`pbench-results-move[-C][--controller][--token][--delete][--xz-single-threaded][--show-server][--help]
-`
+`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture] --<command to run>`
 
 **DESCRIPTION**  
-Move result directories to the configured Pbench server.This command is used when pushing result tarball using token.
 
-**OPTIONS**  
- -C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable,if defined) [required]
+Collects data from the registered tools while running a user-specified action. This can be a specific synthetic benchmark workload, a real workload, or simply a delay to measure system activity.
 
---controller STR  
-Override the default controller name
-
---token STR  
-pbench server authentication token [required]
-
---delete / --no-delete  
-Remove local data after successful copy [default: delete]
-
---xz-single-threaded  
-Use single-threaded compression with 'xz'
-
---show-server STR  
-Display information about the pbench server where the result(s) will be moved (Not implemented)
-
---help  
-Show this message and exit.
-
----
-
-### pbench-user-benchmark
-
----
-
-**NAME**  
-pbench-user-benchmark, Control start/stop/post-process-tools.
-
-**SYNOPSIS**  
-`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture]-- <script to run>`
-
-**DESCRIPTION**  
-Collects data from the tools registered. Here are the steps involved
+Here are the steps involved
 
 - Invoking pbench-user-benchmark with your workload generator as an argument: that will start the collection tools on all the hosts
 - Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
 - Finally, the postprocessing phase will gather the data from all the remote hosts and run the postprocessing tools on everything.
 
 **OPTIONS**  
--C, --config PATH  
-Path to a pbench-agent configuration file (defaults to the '\_PBENCH_AGENT_CONFIG' environment variable,if defined) [required]
+`-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
 
---tool-group  
+`--tool-group`  
 The tool group to use for the list of tools
 
---iteration-list  
+`--iteration-list`  
 A file containing a list of iterations to run for the provided script;
-the file should contain one iteration per line, with a leading '#' (hash) character used for comments, blank lines are ignored; each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  
+the file should contain one iteration per line . With a leading '#' (hash) character used for comments and blank lines are ignored.
+Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
---sysinfo STR,[STR]  
+`--sysinfo` STR,[STR]  
 comma-separated values of system information to be collected; available: default, none, all, ara, block, insights, kernel_config, libvirt, security_mitigations, sos, stockpile, topology
 
---pbench-pre STR  
+`--pbench-pre` STR  
 Path to the script which will be executed before tools are started  
 _NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
---pbench-post STR  
+`--pbench-post` STR  
 Path to the script which will be executed after tools are stopped and postprocessing is complete  
 _NOTE: --pbench-post is not compatible with --use-tool-triggers_
 
---use-tool-triggers  
+`--use-tool-triggers`  
 Use tool triggers instead of normal start/stop around script;  
 _NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_
 
---no-stderr-capture  
+`--no-stderr-capture`  
 Do not capture the stderr of the script to the result.txt file
 
---help  
+`--<command to run>`
+ It can be a script, or an executable, or a shell command 
+
+`--help`  
+Show this message and exit.
+
+---
+
+##### pbench-move-result
+
+---
+
+**NAME**  
+`pbench-move-results`, Move all results to 0.69 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]`
+
+**DESCRIPTION**  
+This command can only be used for a 0.69 Pbench Server destination, and requires a /opt/pbench-agent/id_rsa file with the private SSH key of the server's pbench account.
+
+**OPTIONS**  
+`--user`  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, a value provided
+on the command line will override any value provided by the
+environment.
+
+`--controller`
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+`--prefix`  
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+`--show-server`  
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+`--xz-single-threaded`  
+This will force the use of a single
+thread for locally compressing the result tar balls.
+
+`--help`  
+Show this message and exit.
+
+---
+
+##### pbench-copy-results
+
+---
+
+**NAME**  
+`pbench-copy-results`, Copies result tarball to the 0.69 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]`
+
+**DESCRIPTION**
+Push the benchmark result to the Pbench Server without removing it from the local host .We use id_rsa when pushing to a 0.69 Pbench Server.
+
+**OPTIONS**  
+`--user`  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, a value provided
+on the command line will override any value provided by the
+environment.
+
+`--controller`  
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+`--prefix`  
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+files on the 0.69 Pbench Server.
+
+`--show-server`  
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+`--xz-single-threaded`  
+This will force the use of a single
+thread for locally compressing the result tar balls.
+
+`--help`  
+Show this message and exit.
+
+---
+
+##### pbench-results-move
+
+---
+
+**NAME**  
+`pbench-results-move`, Move results tarball to the server to a 1.0 Pbench Server.
+
+**SYNOPSIS**  
+`pbench-results-move[-C][--controller][--token][--delete][--xz-single-threaded][--show-server][--help]`
+
+**DESCRIPTION**  
+Move result directories to the configured Pbench server. We use an API Key authentication token when pushing results to a 1.0 Pbench Server
+
+**OPTIONS**  
+ `-C`, `--config` PATH  
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+Path to the pbench-agent configuration file.
+
+`--controller` STR  
+Override the default controller name
+
+`--token` STR  
+pbench server authentication token [required]
+
+`--delete` | `--no-delete`  
+Remove local data after successful copy [default: delete]
+
+`--xz-single-threaded`  
+Use single-threaded compression with 'xz'
+
+`--show-server` STR  
+Display information about the pbench server where the result(s) will be moved (Not implemented)
+
+`--help`  
 Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -27,7 +27,7 @@
 ---
 
 **NAME**  
-`pbench-clear-results`, Clears the result directory
+`pbench-clear-results`:
 
 **SYNOPSIS**  
 `pbench-clear-results [OPTIONS]`
@@ -94,14 +94,14 @@ Push the benchmark result to the Pbench Server without removing it from the loca
 **OPTIONS**  
 `--user`  
 This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, a value provided
+`PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
 `--controller`  
 This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
+provided by the `PBENCH_CONTROLLER` environment variable; if
+neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
 `--prefix`  
@@ -197,14 +197,14 @@ This command can only be used for a 0.69 Pbench Server destination, and requires
 **OPTIONS**  
 `--user`  
 This option value is required if not provided by the
-'PBENCH_USER' environment variable; otherwise, a value provided
+`PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
 `--controller`
 This option may be used to override the value
-provided by the 'PBENCH_CONTROLLER' environment variable; if
-neither value is available, the result of 'hostname -f' is used.
+provided by the `PBENCH_CONTROLLER` environment variable; if
+neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
 `--prefix`  
@@ -358,7 +358,7 @@ Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
 `-g`, `--group`, `--groups` STR  
-Registers the trigger in the <`STR`> group. If no group is specified, the 'default'
+Registers the trigger in the <`STR`> group. If no group is specified, the `default` group is assumed. 
 
 `--start-trigger` STR  
 [required]
@@ -418,7 +418,7 @@ Show this message and exit.
 `pbench-user-benchmark`, Control start/stop/post-process-tools.
 
 **SYNOPSIS**  
-`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture] --<command to run>`
+`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture] -- <command-to-run>`
 
 **DESCRIPTION**  
 
@@ -430,7 +430,7 @@ Here are the steps involved
 - Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
 - Finally, the postprocessing phase will gather the data from all the remote hosts and generates `result.txt` file by running the postprocessing tools on everything 
 
-`--<command to run>`
+`-- <command to run>`
  It can be a script, or an executable, or a shell command 
 
 **OPTIONS**  
@@ -438,10 +438,10 @@ Here are the steps involved
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--tool-group`  
+`--tool-group` STR
 The tool group to use for the list of tools
 
-`--iteration-list`  
+`--iteration-list` STR  
 A file containing a list of iterations to run for the provided script;
 the file should contain one iteration per line. With a leading `#` (hash) character used for comments and blank lines are ignored.
 Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -14,7 +14,7 @@
 -  [pbench-user-benchmark](#pbench-user-benchmark)
 ### Upload to Pbench Server
 #### Pbench Server 0.69
-- [pbench-move-result](#pbench-move-result)
+- [pbench-move-results](#pbench-move-results)
 - [pbench-copy-results](#pbench-copy-results) 
 #### Pbench Server 1.0
 -  [pbench-results-move](pbench-results-move)
@@ -28,13 +28,13 @@
 ---
 
 **NAME**  
-`pbench-clear-results`, Clears the result directory
+`pbench-clear-results` - clears the result directory
 
 **SYNOPSIS**  
 `pbench-clear-results [OPTIONS]`
 
 **DESCRIPTION**  
-This command clears the results directory from `/var/lib/pbench-agent` directory
+This command clears the results directory from `/var/lib/pbench-agent` directory.
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -52,13 +52,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-clear-tools`, Clear registered tools by name or group
+`pbench-clear-tools` - clear registered tools by name or group
 
 **SYNOPSIS**  
 `pbench-clear-tools [OPTIONS]`
 
 **DESCRIPTION**  
-Clear all tools which are registered and can filter by name of the group
+Clear all tools which are registered and can filter by name of the group.
 
 **OPTIONS**  
 `-C`, `--config` PATH  
@@ -84,13 +84,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-copy-results`, Copies result tarball to the 0.69 Pbench Server.
+`pbench-copy-results` - copy result tarball to the 0.69 Pbench Server
 
 **SYNOPSIS**  
 `pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]`
 
 **DESCRIPTION**  
-Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key,when pushing to a 0.69 Pbench Server.
+Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key, when pushing to a 0.69 Pbench Server.
 
 **OPTIONS**  
 `--user`  
@@ -111,7 +111,7 @@ directory-path hierarchy to be used when displaying the result
 files on the 0.69 Pbench Server.
 
 `--show-server`  
-This will not move any results, but resolve and
+This will not move any results but will resolve and
 then display the pbench server destination for results.
 
 `--xz-single-threaded`  
@@ -129,13 +129,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-list-tools`, List all the registered tools with group, host, and remote info.
+`pbench-list-tools` - list all the registered tools optionally filtered by name or group
 
 **SYNOPSIS**  
 `pbench-list-tools [OPTIONS]`
 
 **DESCRIPTION**  
-List all tools that are registered and can filter by name of the group
+List tool registrations, optionally filtered by tool name or tool group.
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -143,13 +143,13 @@ Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
 `-n`, `--name` STR  
-list the tool groups in which <`STR`> is used.
+List the tool groups in which tool <`STR`> is registered.
 
 `-g`, `--group` STR  
-list the tools used in this <`STR`>
+List all the tools registered in the <`STR`> group.
 
 `-o`, `--with-option`  
-list the options with each tool
+List the options with each tool
 
 `--help`  
 Show this message and exit.
@@ -161,13 +161,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-list-triggers`, Lists the registered triggers by group
+`pbench-list-triggers` - lists the registered triggers by group
 
 **SYNOPSIS**  
 `pbench-list-triggers[-C][-g][--help]`
 
 **DESCRIPTION**  
-This command will list all the registered triggers by `group-name`
+This command will list all the registered triggers by `group-name`. 
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -182,18 +182,18 @@ Show this message and exit.
 
 ---
 
-### pbench-move-result
+### pbench-move-results
 
 ---
 
 **NAME**  
-`pbench-move-results`, Move all results to 0.69 Pbench Server.
+`pbench-move-results` - move all results to 0.69 Pbench Server
 
 **SYNOPSIS**  
 `pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]`
 
 **DESCRIPTION**  
-This command can only be used for a 0.69 Pbench Server destination, and requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account.
+Push the benchmark result to the 0.69 Pbench Server , and requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account.
 
 **OPTIONS**  
 `--user`  
@@ -214,7 +214,7 @@ directory-path hierarchy to be used when displaying the result
 tar balls on the pbench server.
 
 `--show-server`  
-This will not move any results, but resolve and
+This will not move any results but will resolve and
 then display the pbench server destination for results.
 
 `--xz-single-threaded`  
@@ -231,19 +231,19 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-register-tool`, Registers the specified tools
+`pbench-register-tool` - registers the specified tool
 
-**SYNOPSIS**  
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- <tool-specific-options> [--help]`
+**SYNOPSIS**
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [--help] [-- <tool-specific-options>]`
 
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=@<remotes-file>] -- <tool-specific-options>`
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=@<remotes-file>] [--help] [-- <tool-specific-options>]`
 
 **DESCRIPTION**  
-Register the tools that are specified .
+Register the tool that are specified.
 List of available tools:
 
 **Transient**
-- blktrace
+-   blktrace
 - 	bpftrace
 - 	cpuacct
 - 	disk
@@ -288,17 +288,19 @@ List of available tools:
 - dcgm
 - pcp
 
-**OPTIONS**  
-`--name` STR
-This can be used register a specific tool by name.
 For a list of tool-specific options, run:
-/opt/pbench-agent/tool-scripts/<`tool-name`> --help
+>`/opt/pbench-agent/tool-scripts/[<tool-name>] --help`
+
+**OPTIONS**  
+`--name` STR  
+<`STR`> specifies the name of the tool to be registered.
+
 
 `[--persistent | --transient]`  
 This can be used to specify tool run type.
 
 `--remotes`  
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash, or pound (`#`), character.
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
 
 `--help`  
 Show this message and exit.
@@ -310,27 +312,19 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-register-tool-set`, Register the specified toolset
+`pbench-register-tool-set` - register the specified toolset
 
 **SYNOPSIS**  
-`pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [<tool-set>]`
+`pbench-register-tool-set [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [--help]`
 
-`pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>] [<tool-set>]`
+`pbench-register-tool-set [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>] [--help]`
 
 **DESCRIPTION**  
 Register all the tools in the specified toolset.
 
-**OPTIONS**  
- `--toolset`  
-Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
-
-- heavy
-- legacy
-- light
-- medium
-
+**OPTIONS**
 `--remotes`  
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash, or pound (`#`), character.
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
 
 `--labels`  
 Where the list of labels must match the list of remotes.
@@ -345,13 +339,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-register-tool-trigger`, Registers the tool trigger
+`pbench-register-tool-trigger` - registers the tool trigger
 
 **SYNOPSIS**  
 `pbench-register-tool-trigger [OPTIONS]`
 
 **DESCRIPTION**  
-Registers tool with the given group and start and stop tool trigger text
+Registers tool with the given group and start and stop tool trigger text.
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -377,7 +371,7 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-results-move`, Move results tarball to the server to a 1.0 Pbench Server.
+`pbench-results-move` - move results tarball to the server to a 1.0 Pbench Server
 
 **SYNOPSIS**  
 `pbench-results-move [OPTIONS]`
@@ -395,16 +389,13 @@ This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environmen
 Override the default controller name
 
 `--token` STR  
-pbench server authentication token [required]
+Pbench Server API key [required]
 
 `--delete` | `--no-delete`  
 Remove local data after successful copy [default: delete]
 
 `--xz-single-threaded`  
 Use single-threaded compression with `xz`
-
-`--show-server` STR  
-Display information about the pbench server where the result(s) will be moved (Not implemented)
 
 `--help`  
 Show this message and exit.
@@ -416,7 +407,7 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-user-benchmark`, Control start/stop/post-process-tools.
+`pbench-user-benchmark` - run a workload and collect performance data
 
 **SYNOPSIS**  
 `pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture] -- <command-to-run>`
@@ -425,36 +416,38 @@ Show this message and exit.
 
 Collects data from the registered tools while running a user-specified action. This can be a specific synthetic benchmark workload, a real workload, or simply a delay to measure system activity.
 
-Here are the steps involved
+Invoking pbench-user-benchmark with a workload generator as an argument will perform the following steps:
 
-- Invoking `pbench-user-benchmark` with your workload generator as an argument: that will start the collection tools on all the hosts
-- Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
-- Finally, the postprocessing phase will gather the data from all the remote hosts and generates `result.txt` file by running the postprocessing tools on everything 
+- start the collection tools on all the hosts
+- execute the workload generator
+- stop the collection tools on all the hosts
+- gather the data from all the remote hosts and generates a result.txt file by running the tools' post-processing on the collected data
 
 `<command-to-run>`
 A script, executable, or shell command to run while gathering tool data. Use `--`
 to stop processing of `pbench-user-benchmark` options if your command includes
-options, like `pbench-user-benchmark --config string -- fio --bs 16k`.
+options, like 
+> `pbench-user-benchmark --config string -- fio --bs 16k`
 
 **OPTIONS**  
 `-C`, `--config` PATH  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--tool-group` STR
-The tool group to use for the list of tools
+`--tool-group` STR  
+The tool group to use for data collection.
 
 `--iteration-list` STR  
 A file containing a list of iterations to run for the provided script;
-the file should contain one iteration per line. With a leading `#` (hash) character used for comments and blank lines are ignored.
-Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;  
+the file should contain one iteration per line. With a leading hash (`#`) character used for comments and blank lines are ignored.
+Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script.    
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
 `--sysinfo` STR[,STR...]  
-comma-separated values of system information to be collected; available: `default` `none` `all` `ara` `block` `insights` `kernel_config` `libvirt` `security_mitigations` `sos` `stockpile` `topology`
+comma-separated values of system information to be collected; available: `default`,`none`,`all`,`ara`,`block`,`insights`,`kernel_config`,`libvirt`,`security_mitigations`,`sos`,`stockpile`,`topology`
 
 `--pbench-pre` STR  
-Path to the script which will be executed before tools are started  
+Path to the script which will be executed before tools are started.  
 _NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
 `--pbench-post` STR  
@@ -462,11 +455,11 @@ Path to the script which will be executed after tools are stopped and postproces
 _NOTE: --pbench-post is not compatible with --use-tool-triggers_
 
 `--use-tool-triggers`  
-Use tool triggers instead of normal start/stop around script;  
+Use tool triggers instead of normal start/stop around script.  
 _NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_
 
 `--no-stderr-capture`  
-Do not capture the  standard error output of the script to the `result.txt` file
+Do not capture the standard error output of the script in the `result.txt` file
 
 `--help`  
 Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -25,7 +25,7 @@
 
 #### Pbench Server 1.0
 
-- [pbench-results-move](pbench-results-move)
+- [pbench-results-move](#pbench-results-move)
 
 ## Commands
 
@@ -45,7 +45,7 @@
 This command clears the results directory from `/var/lib/pbench-agent` directory.
 
 **OPTIONS**  
- `-C`, `--config` PATH  
+ `-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
@@ -68,17 +68,17 @@ Show this message and exit.
 Clear all tools which are registered and can filter by name of the group.
 
 **OPTIONS**  
-`-C`, `--config` PATH  
+`-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-n`, `--name`, `--names` STR  
-Clear only the <`STR`> tool.
+`-n`, `--name`, `--names <name>`  
+Clear only the `<name>` tool.
 
-`-g`, `--group`, `--groups` STR  
-Clear the tools in the <`STR`> group. If no group is specified, the `default` group is assumed.
+`-g`, `--group`, `--groups <group>`  
+Clear the tools in the `<group>`. If no group is specified, the `default` group is assumed.
 
-`-r`, `--remote`, `--remotes` STR[,STR...]  
+`-r`, `--remote`, `--remotes STR[,STR...]`  
 Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared.
 
 `--help`  
@@ -94,25 +94,25 @@ Show this message and exit.
 `pbench-copy-results` - copy result tarball to the 0.69 Pbench Server
 
 **SYNOPSIS**  
-`pbench-copy-results [OPTIONS]`
+`pbench-copy-results --user=<user> [OPTIONS]`
 
 **DESCRIPTION**  
 Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key, when pushing to a 0.69 Pbench Server.
 
 **OPTIONS**  
-`--user`  
+`--user <user>`  
 This option value is required if not provided by the
 `PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
-`--controller`  
+`--controller <controller>`  
 This option may be used to override the value
 provided by the `PBENCH_CONTROLLER` environment variable; if
 neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
-`--prefix`  
+`--prefix <prefix>`  
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 files on the 0.69 Pbench Server.
@@ -144,15 +144,15 @@ Show this message and exit.
 List tool registrations, optionally filtered by tool name or tool group.
 
 **OPTIONS**  
- `-C`, `--config` PATH  
+ `-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-n`, `--name` STR  
-List the tool groups in which tool <`STR`> is registered.
+`-n`, `--name <name>`  
+List the tool groups in which tool `<name>` is registered.
 
-`-g`, `--group` STR  
-List all the tools registered in the <`STR`> group.
+`-g`, `--group <group>`  
+List all the tools registered in the `<group>`.
 
 `-o`, `--with-option`  
 List the options with each tool.
@@ -176,12 +176,12 @@ Show this message and exit.
 This command will list all the registered triggers by `group-name`.
 
 **OPTIONS**  
- `-C`, `--config` PATH  
+ `-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-g`, `--group`, `--groups` STR  
-List all the triggers registered in the <`STR`> group.
+`-g`, `--group`, `--groups <group>`  
+List all the triggers registered in the `<group>`.
 
 `--help`  
 Show this message and exit.
@@ -202,19 +202,19 @@ Show this message and exit.
 Push the benchmark result to the 0.69 Pbench Server. Requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account. On a successful push, this command removes the results from the local host.
 
 **OPTIONS**  
-`--user`  
+`--user <user>`  
 This option value is required if not provided by the
 `PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
-`--controller`  
+`--controller <controller>`  
 This option may be used to override the value
 provided by the `PBENCH_CONTROLLER` environment variable; if
 neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
-`--prefix`  
+`--prefix <prefix>`  
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 tar balls on the pbench server.
@@ -240,7 +240,7 @@ Show this message and exit.
 `pbench-register-tool` - registers the specified tool
 
 **SYNOPSIS**  
-`pbench-register-tool [OPTIONS]`
+`pbench-register-tool --name=<tool-name> [OPTIONS] [-- <tool-specific-options>]`
 
 **DESCRIPTION**  
 Register the specified tool.  
@@ -299,16 +299,22 @@ For a list of tool-specific options, run:
 > `/opt/pbench-agent/tool-scripts/<tool-name> --help`
 
 **OPTIONS**  
-`--name` STR  
-<`STR`> specifies the name of the tool to be registered.
+`--name <tool-name>`  
+`<tool-name>` specifies the name of the tool to be registered.
 
-`-g`, `--group`, `--groups` STR  
-Register the tool in <`STR`> group. If no group is specified, the `default` group is assumed.
+`-g`, `--group`, `--groups <group>`    
+Register the tool in `<group>`. If no group is specified, the `default` group is assumed.
 
 `[--persistent | --transient]`  
-For tools which can be run as either "transient" (where they are started and stopped on each iteration) or as "persistent" (where they are started before the first iteration and run continuously over all iterations), these options determine how the tool will be run. (Most tools are configured to run as either or the other, so these options are not necessary in those cases, and specifying the wrong one will produce an error.)
+For tools which can be run as either "transient" (where they are started and stopped on each iteration) or as "persistent" (where they are started before the first iteration and run continuously over all iterations), these options determine how the tool will be run. (Most tools are configured to run as either one the other, so these options are not necessary in those cases, and specifying the wrong one will produce an error.)
 
-`--remotes`  
+`--no-install`  
+[To be supplied]
+
+`--labels=<label>[,<label>]]`  
+Where the list of labels must match the list of remotes.
+
+`-remotes STR[,STR]...`
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
 
 `--help`  
@@ -324,31 +330,33 @@ Show this message and exit.
 `pbench-register-tool-set` - register the specified toolset
 
 **SYNOPSIS**  
-`pbench-register-tool-set [OPTIONS]`
+`pbench-register-tool-set [OPTIONS] <tool-set>`
 
 **DESCRIPTION**  
 Register all the tools in the specified toolset.
 
-Available <`tool-set`> from /opt/pbench-agent/config/pbench-agent.cfg:
+Available `<tool-set>` from /opt/pbench-agent/config/pbench-agent.cfg:
 
 - heavy
 - legacy
 - light
 - medium
 
-**OPTIONS**
-
-`<tool-set>`
-A named tool set argument from one of: `heavy`, `legacy`, `light`, `medium`.
-
-`--remotes`  
+**OPTIONS**  
+`-remotes STR[,STR]...`
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
 
-`-g`, `--group` STR  
-Register the toolset in <`STR`> group. If no group is specified, the `default` group is assumed.
+`-g`, `--group <group>`  
+Register the toolset in `<group>`. If no group is specified, the `default` group is assumed.
 
-`--labels`  
+`--labels=<label>[,<label>]]`  
 Where the list of labels must match the list of remotes.
+
+`--interval=<INT>`  
+[To be supplied]
+
+`--no-install`  
+[To be supplied]
 
 `--help`  
 Show this message and exit.
@@ -369,18 +377,18 @@ Show this message and exit.
 Register triggers which start and stop data collection for the given tool group.
 
 **OPTIONS**  
- `-C`, `--config` PATH  
+ `-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-g`, `--group`, `--groups` STR  
-Registers the trigger in the <`STR`> group. If no group is specified, the `default` group is assumed.
+`-g`, `--group`, `--groups <group>`  
+Registers the trigger in the `<group>`. If no group is specified, the `default` group is assumed.
 
-`--start-trigger` STR  
-[required]
+`--start-trigger STR`  
+[To be supplied]
 
-`--stop-trigger` STR  
-[required]
+`--stop-trigger STR`  
+[To be supplied]
 
 `--help`  
 Show this message and exit.
@@ -401,14 +409,14 @@ Show this message and exit.
 This command uploads one or more result directories to the configured v1.0 Pbench Server. The specified API Key is used to authenticate the user and to establish ownership of the data on the server. Once the upload is complete, the result directories are, by default, removed from the local system.
 
 **OPTIONS**  
- `-C`, `--config` PATH  
+ `-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--controller` STR  
+`--controller <controller>`  
 Override the default controller name.
 
-`--token` STR  
+`--token <token>`  
 Pbench Server API key [required].
 
 `--delete` | `--no-delete`  
@@ -450,27 +458,27 @@ options, like
 > `pbench-user-benchmark --config string -- fio --bs 16k`
 
 **OPTIONS**  
-`-C`, `--config` PATH  
+`-C`, `--config PATH`  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--tool-group` STR  
+`--tool-group STR`  
 The tool group to use for data collection.
 
-`--iteration-list` STR  
+`--iteration-list STR`  
 A file containing a list of iterations to run for the provided script;
 the file should contain one iteration per line. With a leading hash (`#`) character used for comments and blank lines are ignored.
 Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script.  
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
-`--sysinfo` STR[,STR...]  
+`--sysinfo STR[,STR...]`  
 Comma-separated values of system information to be collected; available: `default`, `none`, `all`, `ara`, `block`, `insights`, `kernel_config`, `libvirt`, `security_mitigations`, `sos`, `stockpile`, `topology`
 
-`--pbench-pre` STR  
+`--pbench-pre STR`  
 Path to the script which will be executed before tools are started.  
 _NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
-`--pbench-post` STR  
+`--pbench-post STR`  
 Path to the script which will be executed after tools are stopped and postprocessing is complete.  
 _NOTE: --pbench-post is not compatible with --use-tool-triggers_
 

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -1,1 +1,457 @@
-# Man Page
+# Man pages
+
+------------
+
+### pbench-clear-results
+
+------------
+
+
+**NAME**    
+pbench-clear-results, Clears the result directory
+
+**SYNOPSIS**    
+`pbench-clear-results [-C][--help]`
+
+**DESCRIPTION**     
+This command clears the results directory from /var/lib/pbench-agent directory
+
+**OPTIONS**     
+ -C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+
+  --help        
+Show this message and exit.
+
+
+------------
+
+### pbench-clear-tools
+
+------------
+
+
+**NAME**    
+pbench-clear-tools, Clear registered tools by name or group
+
+**SYNOPSIS**    
+`pbench-clear-tools [-C][-n][-g][-r][--help]
+`
+
+**DESCRIPTION**     
+Clear all tools which are registered and can filter by name of the group
+
+**OPTIONS**     
+-C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+
+-n, --name,--names STR    
+Clear only the <tool-name> tool.
+
+-g, --group,--groups STR   
+Clear the tools in the <group-name> group.  If no group is specified, the 'default' group is assumed.
+
+-r, --remote, --remotes STR  
+Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list.  If no remote is specified, all remotes are cleared
+
+  --help    
+Show this message and exit.
+
+
+
+------------
+
+
+### pbench-copy-results
+
+------------
+
+
+**NAME**    
+pbench-copy-results, Copies result tarball to the server
+
+**SYNOPSIS**    
+`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]
+`
+
+**DESCRIPTION**     
+It keeps the copy of tarball on the pbench-agent and pushes the other to pbench-server
+
+**OPTIONS**     
+--user  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, the value provided
+on the command line will override any value provided by the
+environment.
+
+--controller    
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+--prefix    
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+--show-server    
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+--xz-single-threaded    
+This will force the use of a single
+thread for locally compressing the result tar balls.
+
+  --help     
+Show this message and exit.
+
+------------
+
+
+### pbench-list-tools
+
+
+------------
+
+
+**NAME**    
+pbench-list-tools, List all the registered tools with group, host, and remote info.
+
+**SYNOPSIS**    
+`pbench-list-tools [-C][-n][-g][-o][--help]
+`
+
+**DESCRIPTION**     
+List all tools that are registered and can filter by name of the group
+
+**OPTIONS**     
+ -C, --config PATH  
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]
+
+  -n, --name STR    
+list the tool groups in which <tool-name> is used.
+
+  -g, --group STR   
+list the tools used in this <group-name>
+
+  -o, --with-option  
+list the options with each tool
+
+  --help  
+Show this message and exit.
+
+
+
+------------
+
+### pbench-list-triggers
+
+------------
+
+
+**NAME**    
+pbench-list-triggers, Lists the registered triggers by group        
+
+**SYNOPSIS**    
+`pbench-list-triggers[-C][-g][--help]
+`
+
+**DESCRIPTION**     
+This command will list all the registered triggers by group-name
+
+**OPTIONS**     
+ -C, --config PATH       
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]     
+
+-g, --group,--groups STR   
+List all the triggers registered in the <group-name> group.  
+
+--help                  
+Show this message and exit.
+
+
+------------
+
+###  pbench-move-result
+
+------------
+
+
+**NAME**    
+pbench-move-results, Move all results to pbench-server
+
+**SYNOPSIS**    
+`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server   ]
+`
+
+**DESCRIPTION**     
+Move result directories to the configured pbench-server. Once the tarball is moved successfully, it clears the local copy of the tarball in the pbench-agent.
+
+**OPTIONS**     
+--user  
+This option value is required if not provided by the
+'PBENCH_USER' environment variable; otherwise, the value provided
+on the command line will override any value provided by the
+environment.
+
+--controller    
+This option may be used to override the value
+provided by the 'PBENCH_CONTROLLER' environment variable; if
+neither value is available, the result of 'hostname -f' is used.
+(If no value is available, the command will exit with an error.)
+
+--prefix    
+This option allows the user to specify an optional
+directory-path hierarchy to be used when displaying the result
+tar balls on the pbench server.
+
+--show-server    
+This will not move any results, but resolve and
+then display the pbench server destination for results.
+
+--xz-single-threaded    
+This will force the use of a single
+thread for locally compressing the result tar balls.
+
+  --help     
+Show this message and exit.
+
+------------
+
+
+### pbench-register-tool
+
+------------
+
+
+**NAME**    
+pbench-register-tool, Registers the specified tools
+
+**SYNOPSIS**    
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] -- [all tool specific options here][--help]`
+
+`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent] [--transient] [--remotes=@<remotes-file>] -- [all tool specific options here]`
+
+**DESCRIPTION**     
+Register the tools that are specified
+
+**OPTIONS**     
+--name
+List of available tools:
+
+###### Transient
+- 	blktrace
+- 	bpftrace
+- 	cpuacct
+- 	disk
+- 	dm-cache
+- 	docker
+- 	docker-info
+- 	external-data-source
+- 	haproxy-ocp
+- 	iostat
+- 	jmap
+- 	jstack
+- 	kvm-spinlock
+- 	kvmstat
+- 	kvmtrace
+- 	lockstat
+- 	mpstat
+- 	numastat
+- 	oc
+- 	openvswitch
+- 	pcp-transient
+- 	perf
+- 	pidstat
+- 	pprof
+- 	proc-interrupts
+- 	proc-sched_debug
+- 	proc-vmstat
+- 	prometheus-metrics
+- 	qemu-migrate
+- 	rabbit
+- 	sar
+- 	strace
+- 	sysfs
+- 	systemtap
+- 	tcpdump
+- 	turbostat
+- 	user-tool
+- 	virsh-migrate
+- 	vmstat
+
+###### Persistent
+- node-exporter
+- dcgm
+- pcp
+
+For a list of tool-specific options, run:
+	/opt/pbench-agent/tool-scripts/<tool-name> --help
+
+[--persistent] [--transient]    
+This can be used to specify tool run type.
+
+--remotes   
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename.  In this last case, the file should contain a list of hosts and their (optional) labels.  Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+
+  --help    
+Show this message and exit.
+
+
+------------
+### pbench-register-tool-set
+
+------------
+
+**NAME**    
+pbench-register-tool-set, Register the specified toolset
+
+**SYNOPSIS**        
+`pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [<tool-set>]`
+
+`pbench-register-tool-set [--toolset=<tool-set>] [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>] [<tool-set>]`
+
+**DESCRIPTION**     
+Register all the tools in the specified toolset.
+
+**OPTIONS**     
+ --toolset  
+Available tool sets from /opt/pbench-agent/config/pbench-agent.cfg:
+- heavy
+- legacy
+- light
+- medium
+
+--remotes    
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign ("@") followed by a filename.  In this last case, the file should contain a list of hosts and their (optional) labels.  Each line of the file should contain a hostname, optionally followed by a label separated by a comma (","); empty lines are ignored, and comments are denoted by a leading hash, or pound ("#"), character.
+
+--labels    
+Where the list of labels must match the list of remotes.
+
+  --help    
+Show this message and exit.
+
+------------
+
+
+### pbench-register-tool-trigger
+
+------------
+
+**NAME**    
+pbench-register-tool-trigger, Registers the tool trigger
+
+**SYNOPSIS**    
+`pbench-register-tool-trigger[-C][-g][--start-trigger][--stop-trigger][--help]`
+
+**DESCRIPTION**     
+Registers tool with the given group and start and stop tool trigger text
+
+**OPTIONS**     
+ -C, --config PATH       
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable, if defined)  [required]         
+
+-g, --group,--groups STR   
+Registers the trigger in the <group-name> group.  If no group is specified, the 'default'       
+
+--start-trigger STR     
+[required]  
+
+--stop-trigger STR      
+[required]      
+
+--help                  
+Show this message and exit.
+
+
+------------
+### pbench-results-move
+
+------------
+**NAME**    
+pbench-results-move, Move results tarball to the server
+
+**SYNOPSIS**        
+`pbench-results-move[-C][--controller][--token][--delete][--xz-single-threaded][--show-server][--help]
+`
+
+**DESCRIPTION**     
+Move result directories to the configured Pbench server.
+
+**OPTIONS**     
+ -C, --config PATH       
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable,if defined)  [required]
+
+--controller STR        
+Override the default controller name    
+
+--token STR     
+pbench server authentication token  [required]  
+
+--delete / --no-delete    
+Remove local data after successful copy  [default: delete]  
+
+  --xz-single-threaded    
+Use single-threaded compression with 'xz'   
+
+  --show-server STR      
+Display information about the pbench server where the result(s) will be moved (Not implemented)     
+
+  --help                  
+Show this message and exit.
+
+
+------------
+
+
+### pbench-user-benchmark
+
+
+------------
+
+
+**NAME**    
+pbench-user-benchmark,  Control start/stop/post-process-tools.
+
+**SYNOPSIS**    
+`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture]-- <script to run>`
+
+**DESCRIPTION**     
+Collects data from the tools registered. Here are the steps involved
+- Invoking pbench-user-benchmark with your workload generator as an argument: that will start the collection tools on all the hosts
+- Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
+- Finally, the postprocessing phase will gather the data from all the remote hosts and run the postprocessing tools on everything.
+
+**OPTIONS**     
+-C, --config PATH       
+Path to a pbench-agent configuration file (defaults to the '_PBENCH_AGENT_CONFIG' environment variable,if defined)  [required]      
+
+--tool-group    
+The tool group to use for the list of tools     
+
+--iteration-list    
+A file containing a list of iterations to run for the provided script;
+the file should contain one iteration per line, with a leading '#' (hash) character used for comments, blank lines are ignored; each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script;    
+_NOTE: --iteration-list is not compatible with --use-tool-triggers_         
+
+--sysinfo STR,[STR]     
+comma-separated values of system information to be collected; available: default, none, all, ara, block, insights, kernel_config, libvirt, security_mitigations, sos, stockpile, topology       
+
+--pbench-pre STR        
+Path to the script which will be executed before tools are started              
+_NOTE: --pbench-pre is not compatible with --use-tool-triggers_     
+
+--pbench-post STR     
+Path to the script which will be executed after tools are stopped and postprocessing is complete        
+_NOTE: --pbench-post is not compatible with --use-tool-triggers_        
+
+--use-tool-triggers     
+Use tool triggers instead of normal start/stop around script;       
+_NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_      
+
+--no-stderr-capture     
+Do not capture the stderr of the script to the result.txt file          
+
+--help                  
+Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -1,8 +1,8 @@
 # Man pages
  
-**Contents**
+## Commands by functional group
 
-## Performance tool management commands
+### Performance tool management commands
 -  [pbench-clear-results](#pbench-clear-results)
 -  [pbench-clear-tools](#pbench-clear-tools)
 -  [pbench-list-tools](#pbench-list-tools)
@@ -10,19 +10,20 @@
 -  [pbench-register-tool](#pbench-register-tool)
 -  [pbench-register-tool-set](#pbench-register-tool-set)
 -  [pbench-register-tool-trigger](#pbench-register-tool-trigger)
-## Benchmark commands
+### Benchmark commands
 -  [pbench-user-benchmark](#pbench-user-benchmark)
-## Upload to Pbench Server
-### Pbench Server 0.69
+### Upload to Pbench Server
+#### Pbench Server 0.69
 - [pbench-move-result](#pbench-move-result)
 - [pbench-copy-results](#pbench-copy-results) 
-### Pbench Server 1.0
+#### Pbench Server 1.0
 -  [pbench-results-move](pbench-results-move)
 
+## Commands
 
 ---
 
-#### pbench-clear-results
+### pbench-clear-results
 
 ---
 
@@ -46,7 +47,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-clear-tools
+### pbench-clear-tools
 
 ---
 
@@ -78,7 +79,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-copy-results
+### pbench-copy-results
 
 ---
 
@@ -123,7 +124,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-list-tools
+### pbench-list-tools
 
 ---
 
@@ -155,7 +156,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-list-triggers
+### pbench-list-triggers
 
 ---
 
@@ -181,7 +182,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-move-result
+### pbench-move-result
 
 ---
 
@@ -225,7 +226,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-register-tool
+### pbench-register-tool
 
 ---
 
@@ -304,7 +305,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-register-tool-set
+### pbench-register-tool-set
 
 ---
 
@@ -339,7 +340,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-register-tool-trigger
+### pbench-register-tool-trigger
 
 ---
 
@@ -371,7 +372,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-results-move
+### pbench-results-move
 
 ---
 
@@ -410,7 +411,7 @@ Show this message and exit.
 
 ---
 
-#### pbench-user-benchmark
+### pbench-user-benchmark
 
 ---
 

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -2,7 +2,7 @@
  
 **Contents**
 
-#### Performance tool management commands
+## Performance tool management commands
 -  [pbench-clear-results](#pbench-clear-results)
 -  [pbench-clear-tools](#pbench-clear-tools)
 -  [pbench-list-tools](#pbench-list-tools)
@@ -10,24 +10,24 @@
 -  [pbench-register-tool](#pbench-register-tool)
 -  [pbench-register-tool-set](#pbench-register-tool-set)
 -  [pbench-register-tool-trigger](#pbench-register-tool-trigger)
-#### Benchmark commands
+## Benchmark commands
 -  [pbench-user-benchmark](#pbench-user-benchmark)
-#### Upload to Pbench Server
-###### Pbench Server 0.69
+## Upload to Pbench Server
+### Pbench Server 0.69
 - [pbench-move-result](#pbench-move-result)
 - [pbench-copy-results](#pbench-copy-results) 
-###### Pbench Server 1.0
+### Pbench Server 1.0
 -  [pbench-results-move](pbench-results-move)
 
 
 ---
 
-##### pbench-clear-results
+#### pbench-clear-results
 
 ---
 
 **NAME**  
-`pbench-clear-results`:
+`pbench-clear-results`, Clears the result directory
 
 **SYNOPSIS**  
 `pbench-clear-results [OPTIONS]`
@@ -46,7 +46,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-clear-tools
+#### pbench-clear-tools
 
 ---
 
@@ -78,7 +78,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-copy-results
+#### pbench-copy-results
 
 ---
 
@@ -123,7 +123,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-list-tools
+#### pbench-list-tools
 
 ---
 
@@ -155,7 +155,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-list-triggers
+#### pbench-list-triggers
 
 ---
 
@@ -181,7 +181,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-move-result
+#### pbench-move-result
 
 ---
 
@@ -225,7 +225,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-register-tool
+#### pbench-register-tool
 
 ---
 
@@ -304,7 +304,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-register-tool-set
+#### pbench-register-tool-set
 
 ---
 
@@ -339,7 +339,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-register-tool-trigger
+#### pbench-register-tool-trigger
 
 ---
 
@@ -371,7 +371,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-results-move
+#### pbench-results-move
 
 ---
 
@@ -410,7 +410,7 @@ Show this message and exit.
 
 ---
 
-##### pbench-user-benchmark
+#### pbench-user-benchmark
 
 ---
 
@@ -430,8 +430,10 @@ Here are the steps involved
 - Next, it will run your workload generator; when that finishes, it will stop the collection tools on all the hosts
 - Finally, the postprocessing phase will gather the data from all the remote hosts and generates `result.txt` file by running the postprocessing tools on everything 
 
-`-- <command to run>`
- It can be a script, or an executable, or a shell command 
+`<command-to-run>`
+A script, executable, or shell command to run while gathering tool data. Use `--`
+to stop processing of `pbench-user-benchmark` options if your command includes
+options, like `pbench-user-benchmark --config string -- fio --bs 16k`.
 
 **OPTIONS**  
 `-C`, `--config` PATH  

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -418,10 +418,10 @@ Collects data from the registered tools while running a user-specified action. T
 
 Invoking pbench-user-benchmark with a workload generator as an argument will perform the following steps:
 
-- start the collection tools on all the hosts
-- execute the workload generator
-- stop the collection tools on all the hosts
-- gather the data from all the remote hosts and generates a result.txt file by running the tools' post-processing on the collected data
+- Start the collection tools on all the hosts
+- Execute the workload generator
+- Stop the collection tools on all the hosts
+- Gather the data from all the remote hosts and generates a result.txt file by running the tools' post-processing on the collected data
 
 `<command-to-run>`
 A script, executable, or shell command to run while gathering tool data. Use `--`
@@ -444,7 +444,7 @@ Each iteration line should use alpha-numeric characters before the first space t
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
 `--sysinfo` STR[,STR...]  
-comma-separated values of system information to be collected; available: `default`,`none`,`all`,`ara`,`block`,`insights`,`kernel_config`,`libvirt`,`security_mitigations`,`sos`,`stockpile`,`topology`
+Comma-separated values of system information to be collected; available: `default`,`none`,`all`,`ara`,`block`,`insights`,`kernel_config`,`libvirt`,`security_mitigations`,`sos`,`stockpile`,`topology`
 
 `--pbench-pre` STR  
 Path to the script which will be executed before tools are started.  

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -1,23 +1,31 @@
 # Man pages
- 
+
 ## Commands by functional group
 
 ### Performance tool management commands
--  [pbench-clear-results](#pbench-clear-results)
--  [pbench-clear-tools](#pbench-clear-tools)
--  [pbench-list-tools](#pbench-list-tools)
--  [pbench-list-triggers](#pbench-list-triggers)
--  [pbench-register-tool](#pbench-register-tool)
--  [pbench-register-tool-set](#pbench-register-tool-set)
--  [pbench-register-tool-trigger](#pbench-register-tool-trigger)
+
+- [pbench-clear-results](#pbench-clear-results)
+- [pbench-clear-tools](#pbench-clear-tools)
+- [pbench-list-tools](#pbench-list-tools)
+- [pbench-list-triggers](#pbench-list-triggers)
+- [pbench-register-tool](#pbench-register-tool)
+- [pbench-register-tool-set](#pbench-register-tool-set)
+- [pbench-register-tool-trigger](#pbench-register-tool-trigger)
+
 ### Benchmark commands
--  [pbench-user-benchmark](#pbench-user-benchmark)
+
+- [pbench-user-benchmark](#pbench-user-benchmark)
+
 ### Upload to Pbench Server
+
 #### Pbench Server 0.69
+
 - [pbench-move-results](#pbench-move-results)
-- [pbench-copy-results](#pbench-copy-results) 
+- [pbench-copy-results](#pbench-copy-results)
+
 #### Pbench Server 1.0
--  [pbench-results-move](pbench-results-move)
+
+- [pbench-results-move](pbench-results-move)
 
 ## Commands
 
@@ -40,7 +48,6 @@ This command clears the results directory from `/var/lib/pbench-agent` directory
  `-C`, `--config` PATH  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
-
 
 `--help`  
 Show this message and exit.
@@ -71,8 +78,8 @@ Clear only the <`STR`> tool.
 `-g`, `--group`, `--groups` STR  
 Clear the tools in the <`STR`> group. If no group is specified, the `default` group is assumed.
 
-`-r`, `--remote`, `--remotes` STR  
-Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared
+`-r`, `--remote`, `--remotes` STR[,STR...]  
+Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared.
 
 `--help`  
 Show this message and exit.
@@ -87,7 +94,7 @@ Show this message and exit.
 `pbench-copy-results` - copy result tarball to the 0.69 Pbench Server
 
 **SYNOPSIS**  
-`pbench-copy-results [--help] --user=<user> [--controller=<controller>] [--prefix=<path>][--xz-single-threaded] [--show-server]`
+`pbench-copy-results [OPTIONS]`
 
 **DESCRIPTION**  
 Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key, when pushing to a 0.69 Pbench Server.
@@ -116,11 +123,10 @@ then display the pbench server destination for results.
 
 `--xz-single-threaded`  
 This will force the use of a single
-thread for locally compressing the result tar balls.
+thread for locally compressing the result files.
 
 `--help`  
 Show this message and exit.
-
 
 ---
 
@@ -149,7 +155,7 @@ List the tool groups in which tool <`STR`> is registered.
 List all the tools registered in the <`STR`> group.
 
 `-o`, `--with-option`  
-List the options with each tool
+List the options with each tool.
 
 `--help`  
 Show this message and exit.
@@ -161,13 +167,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-list-triggers` - lists the registered triggers by group
+`pbench-list-triggers` - list the registered triggers by group
 
 **SYNOPSIS**  
-`pbench-list-triggers[-C][-g][--help]`
+`pbench-list-triggers [OPTIONS]`
 
 **DESCRIPTION**  
-This command will list all the registered triggers by `group-name`. 
+This command will list all the registered triggers by `group-name`.
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -190,10 +196,10 @@ Show this message and exit.
 `pbench-move-results` - move all results to 0.69 Pbench Server
 
 **SYNOPSIS**  
-`pbench-move-results [--help] [--user=<user>] [--controller=<controller>] [--prefix=<path>] [--xz-single-threaded] [--show-server]`
+`pbench-move-results [OPTIONS]`
 
 **DESCRIPTION**  
-Push the benchmark result to the 0.69 Pbench Server , and requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account.
+Push the benchmark result to the 0.69 Pbench Server. Requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account. On a successful push, this command removes the results from the local host.
 
 **OPTIONS**  
 `--user`  
@@ -202,7 +208,7 @@ This option value is required if not provided by the
 on the command line will override any value provided by the
 environment.
 
-`--controller`
+`--controller`  
 This option may be used to override the value
 provided by the `PBENCH_CONTROLLER` environment variable; if
 neither value is available, the result of `hostname -f` is used.
@@ -219,7 +225,7 @@ then display the pbench server destination for results.
 
 `--xz-single-threaded`  
 This will force the use of a single
-thread for locally compressing the result tar balls.
+thread for locally compressing the result files.
 
 `--help`  
 Show this message and exit.
@@ -233,71 +239,74 @@ Show this message and exit.
 **NAME**  
 `pbench-register-tool` - registers the specified tool
 
-**SYNOPSIS**
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [--help] [-- <tool-specific-options>]`
-
-`pbench-register-tool --name=<tool-name> [--group=<group-name>] [--no-install] [--persistent | --transient] [--remotes=@<remotes-file>] [--help] [-- <tool-specific-options>]`
+**SYNOPSIS**  
+`pbench-register-tool [OPTIONS]`
 
 **DESCRIPTION**  
-Register the tool that are specified.
+Register the specified tool.  
 List of available tools:
 
 **Transient**
--   blktrace
-- 	bpftrace
-- 	cpuacct
-- 	disk
-- 	dm-cache
-- 	docker
-- 	docker-info
-- 	external-data-source
-- 	haproxy-ocp
-- 	iostat
-- 	jmap
-- 	jstack
-- 	kvm-spinlock
-- 	kvmstat
-- 	kvmtrace
-- 	lockstat
-- 	mpstat
-- 	numastat
-- 	oc
-- 	openvswitch
-- 	pcp-transient
-- 	perf
-- 	pidstat
-- 	pprof
-- 	proc-interrupts
-- 	proc-sched_debug
-- 	proc-vmstat
-- 	prometheus-metrics
-- 	qemu-migrate
-- 	rabbit
-- 	sar
-- 	strace
-- 	sysfs
-- 	systemtap
-- 	tcpdump
-- 	turbostat
-- 	user-tool
-- 	virsh-migrate
-- 	vmstat
 
- **Persistent**
+- blktrace
+- bpftrace
+- cpuacct
+- disk
+- dm-cache
+- docker
+- docker-info
+- external-data-source
+- haproxy-ocp
+- iostat
+- jmap
+- jstack
+- kvm-spinlock
+- kvmstat
+- kvmtrace
+- lockstat
+- mpstat
+- numastat
+- oc
+- openvswitch
+- pcp-transient
+- perf
+- pidstat
+- pprof
+- proc-interrupts
+- proc-sched_debug
+- proc-vmstat
+- prometheus-metrics
+- qemu-migrate
+- rabbit
+- sar
+- strace
+- sysfs
+- systemtap
+- tcpdump
+- turbostat
+- user-tool
+- virsh-migrate
+- vmstat
+
+**Persistent**
+
 - node-exporter
 - dcgm
 - pcp
 
 For a list of tool-specific options, run:
->`/opt/pbench-agent/tool-scripts/[<tool-name>] --help`
+
+> `/opt/pbench-agent/tool-scripts/<tool-name> --help`
 
 **OPTIONS**  
 `--name` STR  
 <`STR`> specifies the name of the tool to be registered.
 
+`-g`, `--group`, `--groups` STR  
+Register the tool in <`STR`> group. If no group is specified, the `default` group is assumed.
 
 `[--persistent | --transient]`  
-This can be used to specify tool run type.
+For tools which can be run as either "transient" (where they are started and stopped on each iteration) or as "persistent" (where they are started before the first iteration and run continuously over all iterations), these options determine how the tool will be run. (Most tools are configured to run as either or the other, so these options are not necessary in those cases, and specifying the wrong one will produce an error.)
 
 `--remotes`  
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
@@ -315,16 +324,28 @@ Show this message and exit.
 `pbench-register-tool-set` - register the specified toolset
 
 **SYNOPSIS**  
-`pbench-register-tool-set [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=<remote-host>[,<remote-host>]] [--labels=<label>[,<label>]] [--help]`
-
-`pbench-register-tool-set [--group=<group-name>] [--interval=<interval>] [--no-install] [--remotes=@<remotes-file>] [--help]`
+`pbench-register-tool-set [OPTIONS]`
 
 **DESCRIPTION**  
 Register all the tools in the specified toolset.
 
+Available <`tool-set`> from /opt/pbench-agent/config/pbench-agent.cfg:
+
+- heavy
+- legacy
+- light
+- medium
+
 **OPTIONS**
+
+`<tool-set>`
+A named tool set argument from one of: `heavy`, `legacy`, `light`, `medium`.
+
 `--remotes`  
 Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
+
+`-g`, `--group` STR  
+Register the toolset in <`STR`> group. If no group is specified, the `default` group is assumed.
 
 `--labels`  
 Where the list of labels must match the list of remotes.
@@ -339,13 +360,13 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-register-tool-trigger` - registers the tool trigger
+`pbench-register-tool-trigger` - register the tool trigger
 
 **SYNOPSIS**  
 `pbench-register-tool-trigger [OPTIONS]`
 
 **DESCRIPTION**  
-Registers tool with the given group and start and stop tool trigger text.
+Register triggers which start and stop data collection for the given tool group.
 
 **OPTIONS**  
  `-C`, `--config` PATH  
@@ -353,7 +374,7 @@ Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
 `-g`, `--group`, `--groups` STR  
-Registers the trigger in the <`STR`> group. If no group is specified, the `default` group is assumed. 
+Registers the trigger in the <`STR`> group. If no group is specified, the `default` group is assumed.
 
 `--start-trigger` STR  
 [required]
@@ -371,7 +392,7 @@ Show this message and exit.
 ---
 
 **NAME**  
-`pbench-results-move` - move results tarball to the server to a 1.0 Pbench Server
+`pbench-results-move` - move results directories to the server to a 1.0 Pbench Server
 
 **SYNOPSIS**  
 `pbench-results-move [OPTIONS]`
@@ -379,23 +400,22 @@ Show this message and exit.
 **DESCRIPTION**  
 This command uploads one or more result directories to the configured v1.0 Pbench Server. The specified API Key is used to authenticate the user and to establish ownership of the data on the server. Once the upload is complete, the result directories are, by default, removed from the local system.
 
-
 **OPTIONS**  
  `-C`, `--config` PATH  
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
 `--controller` STR  
-Override the default controller name
+Override the default controller name.
 
 `--token` STR  
-Pbench Server API key [required]
+Pbench Server API key [required].
 
 `--delete` | `--no-delete`  
-Remove local data after successful copy [default: delete]
+Remove local data after successful copy [default: `delete`]
 
 `--xz-single-threaded`  
-Use single-threaded compression with `xz`
+Use single-threaded compression with `xz`.
 
 `--help`  
 Show this message and exit.
@@ -410,23 +430,23 @@ Show this message and exit.
 `pbench-user-benchmark` - run a workload and collect performance data
 
 **SYNOPSIS**  
-`pbench-user-benchmark[-C][--tool-group][--iteration-list][--sysinfo][--pbench-pre][--pbench-post][--use-tool-triggers][--no-stderr-capture] -- <command-to-run>`
+`pbench-user-benchmark [OPTIONS] -- <command-to-run>`
 
 **DESCRIPTION**  
-
 Collects data from the registered tools while running a user-specified action. This can be a specific synthetic benchmark workload, a real workload, or simply a delay to measure system activity.
 
-Invoking pbench-user-benchmark with a workload generator as an argument will perform the following steps:
+Invoking `pbench-user-benchmark` with a workload generator as an argument will perform the following steps:
 
-- Start the collection tools on all the hosts
-- Execute the workload generator
-- Stop the collection tools on all the hosts
-- Gather the data from all the remote hosts and generates a result.txt file by running the tools' post-processing on the collected data
+- Start the collection tools on all the hosts.
+- Execute the workload generator.
+- Stop the collection tools on all the hosts.
+- Gather the data from all the remote hosts and generate a `result.txt` file by running the tools' post-processing on the collected data.
 
 `<command-to-run>`
 A script, executable, or shell command to run while gathering tool data. Use `--`
 to stop processing of `pbench-user-benchmark` options if your command includes
-options, like 
+options, like
+
 > `pbench-user-benchmark --config string -- fio --bs 16k`
 
 **OPTIONS**  
@@ -440,18 +460,18 @@ The tool group to use for data collection.
 `--iteration-list` STR  
 A file containing a list of iterations to run for the provided script;
 the file should contain one iteration per line. With a leading hash (`#`) character used for comments and blank lines are ignored.
-Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script.    
+Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script.  
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
 `--sysinfo` STR[,STR...]  
-Comma-separated values of system information to be collected; available: `default`,`none`,`all`,`ara`,`block`,`insights`,`kernel_config`,`libvirt`,`security_mitigations`,`sos`,`stockpile`,`topology`
+Comma-separated values of system information to be collected; available: `default`, `none`, `all`, `ara`, `block`, `insights`, `kernel_config`, `libvirt`, `security_mitigations`, `sos`, `stockpile`, `topology`
 
 `--pbench-pre` STR  
 Path to the script which will be executed before tools are started.  
 _NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
 `--pbench-post` STR  
-Path to the script which will be executed after tools are stopped and postprocessing is complete  
+Path to the script which will be executed after tools are stopped and postprocessing is complete.  
 _NOTE: --pbench-post is not compatible with --use-tool-triggers_
 
 `--use-tool-triggers`  


### PR DESCRIPTION
Add man_page.md file for the pbench-agent commands. 

Note: This PR doesn't cover all the pbench-agent commands. For the 1st iteration, decided to cover the commonly used pbench-agent commands. If needed we can add more in subsequent iterations