### PR TITLE
Fix the image tag

### DIFF
--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -16,7 +16,7 @@ alias pbench="$(git rev-parse --show-toplevel)"/contrib/containerized-pbench/pbe
 
 FIOTEST=${PWD}/fiotest
 export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
-export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-36:main
+export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-36:b0.72
 
 mkdir -p "${FIOTEST}"
 


### PR DESCRIPTION
Fixes #3445

pbench_demo uses an image downloaded from Quay.io. It assumes that the image will contain `pbench-generate-token` which is available currently but it is deprecated and will not be available in the future.  In particular, the specified image
`quay.io/pbench/pbench-agent-all-fedora-36:main` does *not* contain the script. We need to make use of
`quay.io/pbench/pbench-agent-all-fedora-36:b0.72` instead.

PBENCH-1129