### PR TITLE
Add a constraints.txt file to limit python-daemon to versions < 3.0.0

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -244,7 +244,7 @@ install-lib:
 # For some reason, this only seems to be a problem on RHEL platforms prior to 9.
 pver = $(shell /usr/bin/python3 -c 'import sys; print(f"python{sys.version_info.major}.{sys.version_info.minor}")')
 install-python3-setup: install-util-scripts install-lib
-	${COPY} requirements.txt ${DESTDIR}
+	${COPY} requirements.txt constraints.txt ${DESTDIR}
 	mkdir -p ${DESTDIR}/python3
 	cd .. && PYTHONPATH=${DESTDIR}/python3/lib/${pver}/site-packages \
 	  /usr/bin/python3 -m pip install --prefix=${DESTDIR}/python3 -e .

--- a/agent/constraints.txt
+++ b/agent/constraints.txt
@@ -1,0 +1,1 @@
+python-daemon<3.0.0

--- a/agent/rpm/pbench-agent.spec.j2
+++ b/agent/rpm/pbench-agent.spec.j2
@@ -115,7 +115,7 @@ if pip3 show configtools > /dev/null 2>&1 ;then pip3 uninstall -y configtools ;f
 %post
 
 # Install python dependencies
-%{__python3} -m pip --no-cache-dir install --prefix=/%{installdir} -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
+%{__python3} -m pip --no-cache-dir install --prefix=/%{installdir} -c /%{installdir}/constraints.txt -r /%{installdir}/requirements.txt > /%{installdir}/pip3-install.log 2>&1
 
 # link the pbench profile, so it'll automatically be sourced on login
 ln -sf /%{installdir}/profile /etc/profile.d/pbench-agent.sh
@@ -151,6 +151,7 @@ fi
 /%{installdir}/SHA1
 /%{installdir}/profile
 /%{installdir}/requirements.txt
+/%{installdir}/constraints.txt
 
 %config(noreplace) %attr(0664,root,root) /%{installdir}/config/pbench-agent.cfg
 


### PR DESCRIPTION
Add it to the agent Makefile and to the pip invocation in the agent spec file.

Tested by installing the resulting RPM and running an end-to-end smoke test (register tools, run pbench-user-benchmark, push results) on RHEL7.9, RHEL8.7, RHEL8.8, RHEL9.2, CentOS Stream 8, CentOS Stream 9, Fedora 37 and Fedora 38.