### PR TITLE
Adapt to the change from F36 to F38 in the CI base container. 

### DIFF
--- a/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/result.json
+++ b/agent/tool-scripts/postprocess/gold/fio-0/result/reference-result/result.json
@@ -861,7 +861,7 @@
                }
             ],
             "uid" : "client_hostname:%client_hostname%",
-            "value" : 4032829.66081469
+            "value" : 4032829.6608147
          },
          {
             "client_hostname" : "perf36-1",

--- a/agent/tool-scripts/postprocess/gold/uperf-0/result.json
+++ b/agent/tool-scripts/postprocess/gold/uperf-0/result.json
@@ -1086,7 +1086,7 @@
                }
             ],
             "uid" : "client_hostname:%client_hostname%-server_hostname:%server_hostname%-server_port:%server_port%",
-            "value" : 92.9351098640984
+            "value" : 92.9351098640983
          }
       ]
    },

--- a/agent/tool-scripts/postprocess/gold/uperf-1/result.json
+++ b/agent/tool-scripts/postprocess/gold/uperf-1/result.json
@@ -1421,7 +1421,7 @@
                }
             ],
             "uid" : "client_hostname:%client_hostname%-server_hostname:%server_hostname%-server_port:%server_port%",
-            "value" : 0.503149997412358
+            "value" : 0.503149997412359
          },
          {
             "client_hostname" : "perf102",

--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,7 @@ isort --check .
 make -C dashboard run_lint
 # We need to invoke the alembic check with host networking so that it can reach
 # the PostgreSQL pod it creates.
-EXTRA_PODMAN_SWITCHES="--network host" jenkins/run tox -e alembic-migration check
+EXTRA_PODMAN_SWITCHES="--network host" jenkins/run tox -e alembic-migration -- check
 set +x
 
 # Run unit tests


### PR DESCRIPTION
With the change in #3433 from a F36 base to F38, some of the floating point calculations in the Agent legacy post-processing tests are off by "half a bit" relative to their gold files. This PR modifies the gold files to match.

Also, apparently F38 brings an updated `tox` which processes the Alembic check script invocation differently, so this PR contains a tweak to address that, as well.

PBENCH-1161