### PR TITLE
Add basic relay support to Pbench Agent

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -7,6 +7,6 @@ jinja2
 python-daemon
 python-pidfile
 redis
-requests>=2.31.0  # CVE-2023-32681
+requests>=2.27.0  # JSONDecodeError, TODO CVE-2023-32681 (2.31)
 sh
 state-signals>=1.0.1

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -7,6 +7,6 @@ jinja2
 python-daemon
 python-pidfile
 redis
-requests
+requests>=2.31.0  # CVE-2023-32681
 sh
 state-signals>=1.0.1

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -15,9 +15,9 @@ Options:
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
                                  Option may need to be specified multiple
                                  times for multiple values. Format: key:value
-  --relay TEXT                   Specify a relay server host as
+  --relay TEXT                   Specify a relay server as
                                  http[s]://host[:port]
-  --server TEXT                  Specify the Pbench Server 1.0 host as
+  --server TEXT                  Specify the Pbench Server as
                                  https://host[:port]
   --token TEXT                   pbench server authentication token
   --xz-single-threaded           Use single threaded compression with 'xz'

--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -15,11 +15,11 @@ Options:
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
                                  Option may need to be specified multiple
                                  times for multiple values. Format: key:value
-  --show-server TEXT             Display information about the pbench server
-                                 where the result(s) will be moved (Not
-                                 implemented)
+  --relay TEXT                   Specify a relay server host as
+                                 http[s]://host[:port]
+  --server TEXT                  Specify the Pbench Server 1.0 host as
+                                 https://host[:port]
   --token TEXT                   pbench server authentication token
-                                 [required]
   --xz-single-threaded           Use single threaded compression with 'xz'
   --help                         Show this message and exit.
 --- Finished test-23 pbench-results-move (status=0)

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -14,8 +14,11 @@ Options:
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
                                  Option may need to be specified multiple
                                  times for multiple values. Format: key:value
+  --relay TEXT                   Specify a relay server host as
+                                 http[s]://host[:port]
+  --server TEXT                  Specify the Pbench Server 1.0 host as
+                                 https://host[:port]
   --token TEXT                   pbench server authentication token
-                                 [required]
   --help                         Show this message and exit.
 --- Finished test-24 pbench-results-push (status=0)
 +++ pbench tree state

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -14,9 +14,9 @@ Options:
   -m, --metadata TEXT            list of metadata keys to be sent on PUT.
                                  Option may need to be specified multiple
                                  times for multiple values. Format: key:value
-  --relay TEXT                   Specify a relay server host as
+  --relay TEXT                   Specify a relay server as
                                  http[s]://host[:port]
-  --server TEXT                  Specify the Pbench Server 1.0 host as
+  --server TEXT                  Specify the Pbench Server as
                                  https://host[:port]
   --token TEXT                   pbench server authentication token
   --help                         Show this message and exit.

--- a/docs/Agent/user-guide/man_page.md
+++ b/docs/Agent/user-guide/man_page.md
@@ -35,21 +35,25 @@
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-clear-results` - clears the result directory
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-clear-results [OPTIONS]`
 
-**DESCRIPTION**  
-This command clears the results directory from `/var/lib/pbench-agent` directory.
+**DESCRIPTION**
 
-**OPTIONS**  
- `-C`, `--config PATH`  
+This command clears the results directories from `/var/lib/pbench-agent` directory.
+
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -58,30 +62,34 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-clear-tools` - clear registered tools by name or group
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-clear-tools [OPTIONS]`
 
-**DESCRIPTION**  
+**DESCRIPTION**
+
 Clear all tools which are registered and can filter by name of the group.
 
-**OPTIONS**  
-`-C`, `--config PATH`  
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-n`, `--name`, `--names <name>`  
+[`-n`, `--name`, `--names`] `<name>`\
 Clear only the `<name>` tool.
 
-`-g`, `--group`, `--groups <group>`  
+[`-g`, `--group`, `--groups`] `<group>`\
 Clear the tools in the `<group>`. If no group is specified, the `default` group is assumed.
 
-`-r`, `--remote`, `--remotes STR[,STR...]`  
+[`-r`, `--remote`, `--remotes`] `<host>[,<host>]...`\
 Clear the tool(s) only on the specified remote(s). Multiple remotes may be specified as a comma-separated list. If no remote is specified, all remotes are cleared.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -90,42 +98,48 @@ Show this message and exit.
 
 ---
 
-**NAME**  
-`pbench-copy-results` - copy result tarball to the 0.69 Pbench Server
+**NAME**
 
-**SYNOPSIS**  
+`pbench-copy-results` - copy result tarball to a 0.69 Pbench Server
+
+**SYNOPSIS**
+
 `pbench-copy-results --user=<user> [OPTIONS]`
 
-**DESCRIPTION**  
-Push the benchmark result to the Pbench Server without removing it from the local host. This command requires `/opt/pbench-agent/id_rsa` file with the private SSH key, when pushing to a 0.69 Pbench Server.
+**DESCRIPTION**
 
-**OPTIONS**  
-`--user <user>`  
+Push the benchmark result to a 0.69 Pbench Server without removing it from the
+local host. This command requires an `/opt/pbench-agent/id_rsa` file containing
+a private SSH key for the 0.69 Pbench Server `pbench` account.
+
+**OPTIONS**
+
+`--user <user>`\
 This option value is required if not provided by the
 `PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
-`--controller <controller>`  
+`--controller <controller>`\
 This option may be used to override the value
 provided by the `PBENCH_CONTROLLER` environment variable; if
 neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
-`--prefix <prefix>`  
+`--prefix <prefix>`\
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 files on the 0.69 Pbench Server.
 
-`--show-server`  
+`--show-server`\
 This will not move any results but will resolve and
 then display the pbench server destination for results.
 
-`--xz-single-threaded`  
+`--xz-single-threaded`\
 This will force the use of a single
 thread for locally compressing the result files.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -134,30 +148,34 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-list-tools` - list all the registered tools optionally filtered by name or group
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-list-tools [OPTIONS]`
 
-**DESCRIPTION**  
+**DESCRIPTION**
+
 List tool registrations, optionally filtered by tool name or tool group.
 
-**OPTIONS**  
- `-C`, `--config PATH`  
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-n`, `--name <name>`  
+[`-n`, `--name`] `<name>`\
 List the tool groups in which tool `<name>` is registered.
 
-`-g`, `--group <group>`  
+[`-g`, `--group`] `<group>`\
 List all the tools registered in the `<group>`.
 
-`-o`, `--with-option`  
+`-o`, `--with-option`\
 List the options with each tool.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -166,24 +184,28 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-list-triggers` - list the registered triggers by group
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-list-triggers [OPTIONS]`
 
-**DESCRIPTION**  
+**DESCRIPTION**
+
 This command will list all the registered triggers by `group-name`.
 
-**OPTIONS**  
- `-C`, `--config PATH`  
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`-g`, `--group`, `--groups <group>`  
+[`-g`, `--group`, `--groups`] `<group>`\
 List all the triggers registered in the `<group>`.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -192,42 +214,49 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-move-results` - move all results to 0.69 Pbench Server
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-move-results [OPTIONS]`
 
-**DESCRIPTION**  
-Push the benchmark result to the 0.69 Pbench Server. Requires a `/opt/pbench-agent/id_rsa` file with the private SSH key of the server's pbench account. On a successful push, this command removes the results from the local host.
+**DESCRIPTION**
 
-**OPTIONS**  
-`--user <user>`  
+Push the benchmark result to a 0.69 Pbench Server. This command requires an
+`/opt/pbench-agent/id_rsa` file containing a private SSH key for the 0.69
+Pbench Server `pbench` account. On a successful push, this command removes the
+results from the local host.
+
+**OPTIONS**
+
+`--user <user>`\
 This option value is required if not provided by the
 `PBENCH_USER` environment variable; otherwise, a value provided
 on the command line will override any value provided by the
 environment.
 
-`--controller <controller>`  
+`--controller <controller>`\
 This option may be used to override the value
 provided by the `PBENCH_CONTROLLER` environment variable; if
 neither value is available, the result of `hostname -f` is used.
 (If no value is available, the command will exit with an error.)
 
-`--prefix <prefix>`  
+`--prefix <prefix>`\
 This option allows the user to specify an optional
 directory-path hierarchy to be used when displaying the result
 tar balls on the pbench server.
 
-`--show-server`  
+`--show-server`\
 This will not move any results but will resolve and
 then display the pbench server destination for results.
 
-`--xz-single-threaded`  
+`--xz-single-threaded`\
 This will force the use of a single
 thread for locally compressing the result files.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -236,14 +265,17 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-register-tool` - registers the specified tool
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-register-tool --name=<tool-name> [OPTIONS] [-- <tool-specific-options>]`
 
-**DESCRIPTION**  
-Register the specified tool.  
+**DESCRIPTION**
+
+Register the specified tool.
 List of available tools:
 
 **Transient**
@@ -298,26 +330,40 @@ For a list of tool-specific options, run:
 
 > `/opt/pbench-agent/tool-scripts/<tool-name> --help`
 
-**OPTIONS**  
-`--name <tool-name>`  
+**OPTIONS**
+
+`--name <tool-name>`\
 `<tool-name>` specifies the name of the tool to be registered.
 
-`-g`, `--group`, `--groups <group>`    
-Register the tool in `<group>`. If no group is specified, the `default` group is assumed.
+[`-g`, `--group`, `--groups`] `<group>`\
+Register the tool in `<group>`. If no group is specified, the `default` group
+is assumed.
 
-`[--persistent | --transient]`  
-For tools which can be run as either "transient" (where they are started and stopped on each iteration) or as "persistent" (where they are started before the first iteration and run continuously over all iterations), these options determine how the tool will be run. (Most tools are configured to run as either one the other, so these options are not necessary in those cases, and specifying the wrong one will produce an error.)
+`[--persistent | --transient]`\
+For tools which can be run as either "transient" (where they are started and
+stopped on each iteration) or as "persistent" (where they are started before
+the first iteration and run continuously over all iterations), these options
+determine how the tool will be run.
 
-`--no-install`  
+Most tools can be run only in one mode, so these options are necessary only
+when a tool (such as `pcp`) can be run in either mode. Specifying a mode the
+tool does not support will produce an error.
+
+`--no-install`\
 [To be supplied]
 
-`--labels=<label>[,<label>]]`  
+`--labels=<label>[,<label>]...`\
 Where the list of labels must match the list of remotes.
 
-`-remotes STR[,STR]...`
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
+`--remotes <host>[,<host>]... | @<file>`\
+A single remote host, a list of remote hosts (comma-separated, no spaces) or an
+"at" sign (`@`) followed by a filename. In this last case, the file should
+contain a list of hosts and their (optional) labels. Each line of the file
+should contain a hostname, optionally followed by a label separated by a comma
+(`,`); empty lines are ignored, and comments are denoted by a leading hash
+(`#`), character.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -326,13 +372,16 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-register-tool-set` - register the specified toolset
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-register-tool-set [OPTIONS] <tool-set>`
 
-**DESCRIPTION**  
+**DESCRIPTION**
+
 Register all the tools in the specified toolset.
 
 Available `<tool-set>` from /opt/pbench-agent/config/pbench-agent.cfg:
@@ -342,23 +391,29 @@ Available `<tool-set>` from /opt/pbench-agent/config/pbench-agent.cfg:
 - light
 - medium
 
-**OPTIONS**  
-`-remotes STR[,STR]...`
-Single remote host, a list of remote hosts (comma-separated, no spaces) or an "at" sign (`@`) followed by a filename. In this last case, the file should contain a list of hosts and their (optional) labels. Each line of the file should contain a hostname, optionally followed by a label separated by a comma (`,`); empty lines are ignored, and comments are denoted by a leading hash (`#`), character.
+**OPTIONS**
 
-`-g`, `--group <group>`  
+`--remotes <host>[,<host>]... | @<file>`\
+Single remote host, a list of remote hosts (comma-separated, no spaces) or an
+"at" sign (`@`) followed by a filename. In this last case, the file should
+contain a list of hosts and their (optional) labels. Each line of the file
+should contain a hostname, optionally followed by a label separated by a comma
+(`,`); empty lines are ignored, and comments are denoted by a leading hash
+(`#`), character.
+
+[`-g`, `--group`] `<group>`\
 Register the toolset in `<group>`. If no group is specified, the `default` group is assumed.
 
-`--labels=<label>[,<label>]]`  
+`--labels=<label>[,<label>]...`\
 Where the list of labels must match the list of remotes.
 
-`--interval=<INT>`  
+`--interval=<interval>`\
 [To be supplied]
 
-`--no-install`  
+`--no-install`\
 [To be supplied]
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -367,30 +422,35 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-register-tool-trigger` - register the tool trigger
 
-**SYNOPSIS**  
+**SYNOPSIS**
+
 `pbench-register-tool-trigger [OPTIONS]`
 
-**DESCRIPTION**  
+**DESCRIPTION**
+
 Register triggers which start and stop data collection for the given tool group.
 
-**OPTIONS**  
- `-C`, `--config PATH`  
-Path to the Pbench Agent configuration file.
-This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
+**OPTIONS**
 
-`-g`, `--group`, `--groups <group>`  
+[ `-C`, `--config`] `<path>`\
+Path to the Pbench Agent configuration file.
+This option is required if not provided by the `_PBENCH_AGENT_CONFIG`
+environment variable.
+
+[`-g`, `--group`, `--groups`] `<group>`\
 Registers the trigger in the `<group>`. If no group is specified, the `default` group is assumed.
 
-`--start-trigger STR`  
+`--start-trigger <string>`\
 [To be supplied]
 
-`--stop-trigger STR`  
+`--stop-trigger <string>`\
 [To be supplied]
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -399,33 +459,63 @@ Show this message and exit.
 
 ---
 
-**NAME**  
-`pbench-results-move` - move results directories to the server to a 1.0 Pbench Server
+**NAME**
 
-**SYNOPSIS**  
+`pbench-results-move` - move results directories to a 1.0 Pbench Server
+
+**SYNOPSIS**
+
 `pbench-results-move [OPTIONS]`
 
-**DESCRIPTION**  
-This command uploads one or more result directories to the configured v1.0 Pbench Server. The specified API Key is used to authenticate the user and to establish ownership of the data on the server. Once the upload is complete, the result directories are, by default, removed from the local system.
+**DESCRIPTION**
 
-**OPTIONS**  
- `-C`, `--config PATH`  
+This command uploads one or more result directories to a 1.0 Pbench Server.
+
+Two modes are supported:
+
+1. The results are pushed directly to a Pbench Server using the API Key
+authentication token specified by `--token`, and will be owned by that user.
+The Pbench Server URI can be specified with `--server`, or will be defaulted
+from the active configuration file.
+2. The results are pushed to a Relay server, which may be anywhere reachable
+both from the Pbench Agent host executing the command and a 1.0 Pbench Server.
+The command will report a URI, which can be presented to a 1.0 Pbench Server
+through the `relay` API or from the Pbench Dashboard to cause the server to
+pull the results from the Relay server.
+
+Once the upload is complete, the result directories
+are, by default, removed from the local system.
+
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--controller <controller>`  
+`--relay <relay>`\
+Instead of pushing results directly to a Pbench Server, push them to a Relay
+server at the specified URI. For example, `https://myrelay.example.com`.
+
+`--server <server>`\
+Override the default server path in the Pbench Agent configuration file and
+push results to the specified Pbench Server URI. For example,
+`https://pbench.example.com`. This is especially useful in a containerized
+Pbench Agent to push results without mapping a customized Pbench Agent
+configuration file into the container.
+
+`--controller <controller>`\
 Override the default controller name.
 
-`--token <token>`  
-Pbench Server API key [required].
+`--token <token>`\
+Pbench Server API key [required unless `--relay` is specified].
 
-`--delete` | `--no-delete`  
+`--delete` | `--no-delete`\
 Remove local data after successful copy [default: `delete`]
 
-`--xz-single-threaded`  
+`--xz-single-threaded`\
 Use single-threaded compression with `xz`.
 
-`--help`  
+`--help`\
 Show this message and exit.
 
 ---
@@ -434,13 +524,16 @@ Show this message and exit.
 
 ---
 
-**NAME**  
+**NAME**
+
 `pbench-user-benchmark` - run a workload and collect performance data
 
-**SYNOPSIS**  
-`pbench-user-benchmark [OPTIONS] -- <command-to-run>`
+**SYNOPSIS**
 
-**DESCRIPTION**  
+`pbench-user-benchmark [OPTIONS] <command-to-run>`
+
+**DESCRIPTION**
+
 Collects data from the registered tools while running a user-specified action. This can be a specific synthetic benchmark workload, a real workload, or simply a delay to measure system activity.
 
 Invoking `pbench-user-benchmark` with a workload generator as an argument will perform the following steps:
@@ -450,44 +543,51 @@ Invoking `pbench-user-benchmark` with a workload generator as an argument will p
 - Stop the collection tools on all the hosts.
 - Gather the data from all the remote hosts and generate a `result.txt` file by running the tools' post-processing on the collected data.
 
-`<command-to-run>`
+`<command-to-run>`\
 A script, executable, or shell command to run while gathering tool data. Use `--`
 to stop processing of `pbench-user-benchmark` options if your command includes
 options, like
 
 > `pbench-user-benchmark --config string -- fio --bs 16k`
 
-**OPTIONS**  
-`-C`, `--config PATH`  
+**OPTIONS**
+
+[`-C`, `--config`] `<path>`\
 Path to the Pbench Agent configuration file.
 This option is required if not provided by the `_PBENCH_AGENT_CONFIG` environment variable.
 
-`--tool-group STR`  
+`--tool-group <tool-group>`\
 The tool group to use for data collection.
 
-`--iteration-list STR`  
-A file containing a list of iterations to run for the provided script;
-the file should contain one iteration per line. With a leading hash (`#`) character used for comments and blank lines are ignored.
-Each iteration line should use alpha-numeric characters before the first space to name the iteration, with the rest of the line provided as arguments to the script.  
+`--iteration-list <file>`\
+A file containing a list of iterations to run for the provided script. The file
+must contain one iteration per line. Blank lines are ignored, and you can use a
+leading hash (`#`) character for comments. Each iteration line should use
+alpha-numeric characters before the first space to name the iteration, with the
+rest of the line provided as arguments to the script.
 _NOTE: --iteration-list is not compatible with --use-tool-triggers_
 
-`--sysinfo STR[,STR...]`  
-Comma-separated values of system information to be collected; available: `default`, `none`, `all`, `ara`, `block`, `insights`, `kernel_config`, `libvirt`, `security_mitigations`, `sos`, `stockpile`, `topology`
+`--sysinfo STR[,STR]...`\
+Comma-separated values of system information to be collected; available:
+`default`, `none`, `all`, `ara`, `block`, `insights`, `kernel_config`,
+`libvirt`, `security_mitigations`, `sos`, `stockpile`, `topology`
 
-`--pbench-pre STR`  
-Path to the script which will be executed before tools are started.  
+`--pbench-pre <pre-script>`\
+Path to the script which will be executed before tools are started.
 _NOTE: --pbench-pre is not compatible with --use-tool-triggers_
 
-`--pbench-post STR`  
-Path to the script which will be executed after tools are stopped and postprocessing is complete.  
+`--pbench-post <post-script>`\
+Path to the script which will be executed after tools are stopped and
+postprocessing is complete.
 _NOTE: --pbench-post is not compatible with --use-tool-triggers_
 
-`--use-tool-triggers`  
-Use tool triggers instead of normal start/stop around script.  
-_NOTE: --use-tool-triggers is not compatible with --iteration-list,--pbench-pre, or --pbench-post_
+`--use-tool-triggers`\
+Use tool triggers instead of normal start/stop around script.
+_NOTE: --use-tool-triggers is not compatible with --iteration-list,
+--pbench-pre, or --pbench-post_
 
-`--no-stderr-capture`  
+`--no-stderr-capture`\
 Do not capture the standard error output of the script in the `result.txt` file
 
-`--help`  
+`--help`\
 Show this message and exit.

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -459,9 +459,9 @@ class CopyResultToRelay(CopyResult):
 
         This involves three steps:
 
-        1. PUT the tarball to the relay server with a SHA256 object ID
-        2. Compile information about the tarball into a relay manifest file,
-        3. PUT the relay manifest file with its own SHA256 object ID
+        1. PUT the tarball to the relay server with a SHA256 object ID.
+        2. Compile information about the tarball into a relay manifest file.
+        3. PUT the relay manifest file with its own SHA256 object ID.
 
         If either PUT operation fails, the response object is returned to the
         caller for error diagnosis. If both PUT operations succeed, the relay

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -291,12 +291,15 @@ class CopyResult:
         pass
 
     def __init__(
-        self, logger: Logger, access: Optional[str], metadata: Optional[List[str]]
+        self,
+        logger: Logger,
+        access: Optional[str] = None,
+        metadata: Optional[List[str]] = None,
     ):
         """Hold generic context applicable to both Server and Relay
 
         Args
-            logger: A Python logger object in Agent configuration
+            logger: A Python logger object
             access: A desired dataset access scope (private|public) [private]
             metadata: An optional list of metadata "key:value" pairs to apply
                     to the dataset.
@@ -327,16 +330,16 @@ class CopyResult:
     def create(
         config: PbenchAgentConfig,
         logger: Logger,
-        relay: Optional[str],
-        server: Optional[str],
-        token: Optional[str],
-        access: Optional[str],
-        metadata: Optional[List[str]],
+        relay: Optional[str] = None,
+        server: Optional[str] = None,
+        token: Optional[str] = None,
+        access: Optional[str] = None,
+        metadata: Optional[List[str]] = None,
     ) -> "CopyResult":
         """Factory method to create a CopyResults object
 
         Args:
-            config: Pbench Agent config file
+            config: Pbench Agent configuration object
             logger: Python logger object
             relay: The value of the --relay option if specified
             server: The value of the --server option if specified
@@ -350,7 +353,7 @@ class CopyResult:
         if relay:
             return CopyResultToRelay(logger, relay, access, metadata)
         else:
-            return CopyResultToServer(config, logger, server, token, access, metadata)
+            return CopyResultToServer(config, logger, token, server, access, metadata)
 
     @classmethod
     def cli_create(
@@ -382,17 +385,18 @@ class CopyResultToServer(CopyResult):
         self,
         config: PbenchAgentConfig,
         logger: Logger,
-        server: Optional[str],
         token: str,
-        access: Optional[str],
-        metadata: Optional[List[str]],
+        server: Optional[str] = None,
+        access: Optional[str] = None,
+        metadata: Optional[List[str]] = None,
     ):
-        """Configure an object to manage result upload to a Pbench Server.
+        """Configure an object to manage results upload to a Pbench Server.
 
         Args
-            logger: A Python logger object in Agent configuration
+            config: The Pbench Agent configuration object
+            logger: A Python logger object
             server: The URI of a Pbench Server [defaults to Pbench Agent config
-                    file value]
+                    "server_rest_uri" value]
             token: A Pbench Server authentication token, generally an API key
             access: A desired dataset access scope (private|public) [private]
             metadata: An optional list of metadata "key:value" pairs to apply
@@ -434,11 +438,11 @@ class CopyResultToRelay(CopyResult):
     def __init__(
         self,
         logger: Logger,
-        relay: Optional[str],
-        access: Optional[str],
-        metadata: Optional[List[str]],
+        relay: Optional[str] = None,
+        access: Optional[str] = None,
+        metadata: Optional[List[str]] = None,
     ):
-        """Hold generic context applicable to both Server and Relay
+        """Configure an object to manage results upload to a Relay server.
 
         Args
             logger: A Python logger object in Agent configuration
@@ -460,8 +464,8 @@ class CopyResultToRelay(CopyResult):
         3. PUT the relay manifest file with its own SHA256 object ID
 
         If either PUT operation fails, the response object is returned to the
-        caller for error diagnosis. Assuming both PUT operations succeed, the
-        relay manifest PUT response object is returned so that the caller can
+        caller for error diagnosis. If both PUT operations succeed, the relay
+        manifest PUT response object is returned so that the caller can
         determine the SHA256 object ID and report the relay URI which the
         Pbench Server relay API will require to pull the result.
 
@@ -470,7 +474,8 @@ class CopyResultToRelay(CopyResult):
             tarball_md5: the MD5 hash of tarball
 
         Returns:
-            A Response object representing the manifest HTTP PUT call
+            A Response object representing the last HTTP operation response; if
+            response.ok then response.url is the Relay manifest URI.
 
         Raises:
             FileNotFoundError: the tarball doesn't exist

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -8,7 +8,7 @@ import click
 import requests
 
 from pbench.agent.base import BaseCommand
-from pbench.agent.results import CopyResultTb, MakeResultTb
+from pbench.agent.results import CopyResult, MakeResultTb
 from pbench.cli import CliContext, pass_cli_context, sort_click_command_parameters
 from pbench.cli.agent.commands.results.results_options import results_common_options
 from pbench.cli.agent.options import common_options
@@ -36,6 +36,7 @@ class MoveResults(BaseCommand):
         runs_copied = 0
         failures = 0
         no_of_tb = 0
+        crt = CopyResult.cli_create(self.context, self.config, self.logger)
 
         with tempfile.TemporaryDirectory(
             dir=self.config.pbench_tmp, prefix="pbench-results-move."
@@ -51,7 +52,7 @@ class MoveResults(BaseCommand):
 
                 try:
                     mrt = MakeResultTb(
-                        result_dir,
+                        str(result_dir),
                         temp_dir,
                         self.context.controller,
                         self.config,
@@ -73,7 +74,7 @@ class MoveResults(BaseCommand):
                     continue
 
                 try:
-                    result_tb_name, result_tb_len, result_tb_md5 = mrt.make_result_tb(
+                    result_tb_name, _, result_tb_md5 = mrt.make_result_tb(
                         single_threaded=single_threaded
                     )
                 except BadMDLogFormat as exc:
@@ -98,24 +99,17 @@ class MoveResults(BaseCommand):
                     continue
 
                 try:
-                    crt = CopyResultTb(
-                        result_tb_name,
-                        result_tb_len,
-                        result_tb_md5,
-                        self.config,
-                        self.logger,
-                    )
-                    res = crt.copy_result_tb(
-                        self.context.token, self.context.access, self.context.metadata
-                    )
+                    res = crt.push(result_tb_name, result_tb_md5)
+                    if res.ok and self.context.relay:
+                        click.echo(f"RELAY {result_tb_name.name}: {res.url}")
                     if not res.ok:
                         try:
                             msg = res.json()["message"]
                         except requests.exceptions.JSONDecodeError:
                             msg = res.text if res.text else res.reason
-                        raise CopyResultTb.FileUploadError(msg)
+                        raise CopyResult.FileUploadError(msg)
                 except Exception as exc:
-                    if isinstance(exc, (CopyResultTb.FileUploadError, RuntimeError)):
+                    if isinstance(exc, (CopyResult.FileUploadError, RuntimeError)):
                         msg = "Error uploading file"
                     else:
                         msg = "Unexpected error occurred copying tar ball remotely"
@@ -204,13 +198,6 @@ class MoveResults(BaseCommand):
     is_flag=True,
     help="Use single threaded compression with 'xz'",
 )
-@click.option(
-    "--show-server",
-    help=(
-        "Display information about the pbench server where the result(s) will"
-        " be moved (Not implemented)"
-    ),
-)
 @pass_cli_context
 def main(
     context: CliContext,
@@ -220,7 +207,8 @@ def main(
     delete: bool,
     metadata: List,
     xz_single_threaded: bool,
-    show_server: str,
+    server: str,
+    relay: str,
 ):
     """Move result directories to the configured Pbench server."""
     clk_ctx = click.get_current_context()
@@ -237,19 +225,23 @@ def main(
                 err=True,
             )
             clk_ctx.exit(1)
+
+    if relay and server:
+        click.echo("Cannot use both relay and Pbench Server destination.", err=True)
+        clk_ctx.exit(2)
+
     if validate_hostname(controller) != 0:
         # We check once to avoid having to deal with a bad controller each
         # time we try to copy the results.
         click.echo(f"Controller, {controller!r}, is not a valid host name")
         clk_ctx.exit(1)
-    context.controller = controller
 
+    context.controller = controller
     context.access = access
     context.token = token
     context.metadata = metadata
-
-    if show_server:
-        click.echo("WARNING -- Option '--show-server' is not implemented", err=True)
+    context.server = server
+    context.relay = relay
 
     try:
         rv = MoveResults(context).execute(xz_single_threaded, delete=delete)

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -100,14 +100,14 @@ class MoveResults(BaseCommand):
 
                 try:
                     res = crt.push(result_tb_name, result_tb_md5)
-                    if res.ok and self.context.relay:
-                        click.echo(f"RELAY {result_tb_name.name}: {res.url}")
                     if not res.ok:
                         try:
                             msg = res.json()["message"]
                         except requests.exceptions.JSONDecodeError:
                             msg = res.text if res.text else res.reason
                         raise CopyResult.FileUploadError(msg)
+                    if self.context.relay:
+                        click.echo(f"RELAY {result_tb_name.name}: {res.url}")
                 except Exception as exc:
                     if isinstance(exc, (CopyResult.FileUploadError, RuntimeError)):
                         msg = "Error uploading file"

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -34,11 +34,11 @@ def results_common_options(f):
         ),
         click.option(
             "--server",
-            help=("Specify the Pbench Server 1.0 host as https://host[:port]"),
+            help="Specify the Pbench Server as https://host[:port]",
         ),
         click.option(
             "--relay",
-            help=("Specify a relay server host as http[s]://host[:port]"),
+            help="Specify a relay server as http[s]://host[:port]",
         ),
         click.option(
             "--token",

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -6,6 +6,11 @@ from pbench.cli import compose_options
 def results_common_options(f):
     """Common options for results command"""
 
+    def server_token_required(ctx, param, value):
+        if not ctx.params.get("relay") and value is None:
+            raise click.BadParameter("Pbench Server connection requires '--token'")
+        return value
+
     options = [
         click.option(
             "-a",
@@ -28,10 +33,19 @@ def results_common_options(f):
             ),
         ),
         click.option(
+            "--server",
+            help=("Specify the Pbench Server 1.0 host as https://host[:port]"),
+        ),
+        click.option(
+            "--relay",
+            help=("Specify a relay server host as http[s]://host[:port]"),
+        ),
+        click.option(
             "--token",
-            required=True,
+            required=False,
             envvar="PBENCH_ACCESS_TOKEN",
             prompt=False,
+            callback=server_token_required,
             help="pbench server authentication token",
         ),
     ]

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from pbench.cli import compose_options
@@ -7,8 +9,8 @@ def results_common_options(f):
     """Common options for results command"""
 
     def server_token_required(ctx, param, value):
-        if not ctx.params.get("relay") and value is None:
-            raise click.BadParameter("Pbench Server connection requires '--token'")
+        if not (ctx.params.get("relay") or "--help" in sys.argv[1:] or value):
+            raise click.MissingParameter()
         return value
 
     options = [
@@ -23,8 +25,6 @@ def results_common_options(f):
         click.option(
             "-m",
             "--metadata",
-            required=False,
-            default=[],
             multiple=True,
             help=(
                 "list of metadata keys to be sent on PUT."
@@ -42,9 +42,7 @@ def results_common_options(f):
         ),
         click.option(
             "--token",
-            required=False,
             envvar="PBENCH_ACCESS_TOKEN",
-            prompt=False,
             callback=server_token_required,
             help="pbench server authentication token",
         ),

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -194,14 +194,10 @@ class TestCopyResults:
                 Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
 
-            with pytest.raises(RuntimeError) as excinfo:
+            with pytest.raises(requests.exceptions.ConnectionError) as excinfo:
                 CopyResultToServer(
                     self.config, agent_logger, None, None, None, None
                 ).push(Path(tb_name), "someMD5")
-
-        assert str(excinfo.value).startswith(
-            expected_error_message
-        ), f"expected='...{expected_error_message}', found='{str(excinfo.value)}'"
 
     @responses.activate
     def test_unexpected_error(self, monkeypatch, agent_logger):
@@ -218,9 +214,7 @@ class TestCopyResults:
                 Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
 
-            with pytest.raises(CopyResult.FileUploadError) as excinfo:
+            with pytest.raises(RuntimeError, match="uh-oh") as excinfo:
                 CopyResultToServer(
                     self.config, agent_logger, None, None, None, None
                 ).push(Path(tb_name), "someMD5")
-
-        assert f"{upload_url!r} failed:" in str(excinfo.value)

--- a/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
+++ b/lib/pbench/test/unit/agent/task/test_copy_result_tb.py
@@ -1,5 +1,7 @@
+import hashlib
 from http import HTTPStatus
 import io
+import json
 import os
 from pathlib import Path
 from typing import Callable
@@ -9,17 +11,17 @@ import requests
 import responses
 
 from pbench.agent import PbenchAgentConfig
-from pbench.agent.results import CopyResultTb
+from pbench.agent.results import CopyResult, CopyResultToRelay, CopyResultToServer
 
 
 class TestCopyResults:
     @pytest.fixture(autouse=True)
     def config(self):
         # Setup the configuration
-        self.config = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
+        TestCopyResults.config = PbenchAgentConfig(os.environ["_PBENCH_AGENT_CONFIG"])
         yield
         # Teardown the setup
-        self.config = None
+        TestCopyResults.config = None
 
     @staticmethod
     def get_path_exists_mock(path: str, result: bool) -> Callable:
@@ -48,23 +50,25 @@ class TestCopyResults:
             )
 
             with pytest.raises(FileNotFoundError) as excinfo:
-                CopyResultTb(
-                    bad_tarball_name,
-                    0,
-                    "ignoremd5",
+                CopyResultToServer(
                     self.config,
                     agent_logger,
-                )
+                    "http://example.com",
+                    "token",
+                    "private",
+                    None,
+                ).push(Path(bad_tarball_name), "ignoremd5")
 
         assert str(excinfo.value).endswith(
             expected_error_message
         ), f"expected='...{expected_error_message}', found='{str(excinfo.value)}'"
 
     @responses.activate
+    @pytest.mark.parametrize("server", (None, "http://test.foo.example.com"))
     @pytest.mark.parametrize("access", ("public", "private", None))
-    def test_with_access(self, access: str, monkeypatch, agent_logger):
+    def test_with_access(self, monkeypatch, agent_logger, server: str, access: str):
         tb_name = "test_tarball.tar.xz"
-        tb_contents = "I'm a result!"
+        tb_contents = b"I'm a result!"
 
         def request_callback(request: requests.Request):
             if access is None:
@@ -74,29 +78,22 @@ class TestCopyResults:
                 assert request.params["access"] == access
             return HTTPStatus.CREATED, {}, ""
 
+        api = self.config.get("results", "rest_endpoint")
+        rest_uri = self.config.get("results", "server_rest_url")
+        mock_uri = f"{server}/{api}" if server else rest_uri
         responses.add_callback(
-            responses.PUT,
-            f"{self.config.get('results', 'server_rest_url')}/upload/{tb_name}",
-            callback=request_callback,
+            responses.PUT, f"{mock_uri}/upload/{tb_name}", callback=request_callback
         )
 
         with monkeypatch.context() as m:
             m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
             m.setattr(
-                Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
+                Path, "open", self.get_path_open_mock(tb_name, io.BytesIO(tb_contents))
             )
 
-            crt = CopyResultTb(
-                tb_name,
-                len(tb_contents),
-                "someMD5",
-                self.config,
-                agent_logger,
-            )
-            if access is None:
-                res = crt.copy_result_tb("token")
-            else:
-                res = crt.copy_result_tb("token", access)
+            res = CopyResultToServer(
+                self.config, agent_logger, server, None, access, None
+            ).push(Path(tb_name), "someMD5")
 
         assert res.status_code == HTTPStatus.CREATED
 
@@ -107,7 +104,6 @@ class TestCopyResults:
     def test_with_metadata(self, metadata, monkeypatch, agent_logger):
         tb_name = "test_tarball.tar.xz"
         tb_contents = "I'm a result!"
-        access = "private"
 
         def request_callback(request: requests.Request):
             if metadata:
@@ -117,10 +113,9 @@ class TestCopyResults:
                 assert "metadata" not in request.params
             return HTTPStatus.CREATED, {}, ""
 
+        uri = self.config.get("results", "server_rest_url")
         responses.add_callback(
-            responses.PUT,
-            f"{self.config.get('results', 'server_rest_url')}/upload/{tb_name}",
-            callback=request_callback,
+            responses.PUT, f"{uri}/upload/{tb_name}", callback=request_callback
         )
 
         with monkeypatch.context() as m:
@@ -129,17 +124,56 @@ class TestCopyResults:
                 Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
 
-            crt = CopyResultTb(
-                tb_name,
-                len(tb_contents),
-                "someMD5",
-                self.config,
-                agent_logger,
+            res = CopyResultToServer(
+                self.config, agent_logger, None, "token", "private", metadata
+            ).push(Path(tb_name), "someMD5")
+
+        assert res.status_code == HTTPStatus.CREATED
+
+    @responses.activate
+    @pytest.mark.parametrize("access", ("public", "private", None))
+    def test_relay(self, access: str, monkeypatch, agent_logger):
+        tb_name = "test_tarball.tar.xz"
+        tb_contents = b"I'm a result!"
+        metadata = ["dataset.name:foo", "global.server:FOO"]
+        sha256 = hashlib.sha256(tb_contents, usedforsecurity=False).hexdigest()
+        md5 = hashlib.md5(tb_contents, usedforsecurity=False).hexdigest()
+        uri = "http://relay.example.com"
+
+        manifest = {
+            "metadata": metadata,
+            "name": tb_name,
+            "uri": f"{uri}/{sha256}",
+            "md5": md5,
+        }
+        if access:
+            manifest["access"] = access
+
+        serialized = bytes(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+        man_sha256 = hashlib.sha256(serialized, usedforsecurity=False).hexdigest()
+
+        def man_callback(request: requests.PreparedRequest):
+            assert json.load(fp=request.body) == manifest
+            return HTTPStatus.CREATED, {}, ""
+
+        def tar_callback(request: requests.PreparedRequest):
+            assert request.headers["content-length"] == str(len(tb_contents))
+            return HTTPStatus.CREATED, {}, ""
+
+        responses.add_callback(
+            responses.PUT, f"{uri}/{man_sha256}", callback=man_callback
+        )
+        responses.add_callback(responses.PUT, f"{uri}/{sha256}", callback=tar_callback)
+
+        with monkeypatch.context() as m:
+            m.setattr(Path, "exists", self.get_path_exists_mock(tb_name, True))
+            m.setattr(
+                Path, "open", self.get_path_open_mock(tb_name, io.BytesIO(tb_contents))
             )
-            if metadata is None:
-                res = crt.copy_result_tb("token")
-            else:
-                res = crt.copy_result_tb("token", access, metadata)
+
+            res = CopyResultToRelay(agent_logger, uri, access, metadata).push(
+                Path(tb_name), md5
+            )
 
         assert res.status_code == HTTPStatus.CREATED
 
@@ -147,7 +181,8 @@ class TestCopyResults:
     def test_connection_error(self, monkeypatch, agent_logger):
         tb_name = "test_tarball.tar.xz"
         tb_contents = "I'm a result!"
-        upload_url = f"{self.config.get('results', 'server_rest_url')}/upload/{tb_name}"
+        uri = self.config.get("results", "server_rest_url")
+        upload_url = f"{uri}/upload/{tb_name}"
         expected_error_message = f"Cannot connect to '{upload_url}'"
         responses.add(
             responses.PUT, upload_url, body=requests.exceptions.ConnectionError("uh-oh")
@@ -160,14 +195,9 @@ class TestCopyResults:
             )
 
             with pytest.raises(RuntimeError) as excinfo:
-                crt = CopyResultTb(
-                    tb_name,
-                    len(tb_contents),
-                    "someMD5",
-                    self.config,
-                    agent_logger,
-                )
-                crt.copy_result_tb("token")
+                CopyResultToServer(
+                    self.config, agent_logger, None, None, None, None
+                ).push(Path(tb_name), "someMD5")
 
         assert str(excinfo.value).startswith(
             expected_error_message
@@ -177,7 +207,8 @@ class TestCopyResults:
     def test_unexpected_error(self, monkeypatch, agent_logger):
         tb_name = "test_tarball.tar.xz"
         tb_contents = "I'm a result!"
-        upload_url = f"{self.config.get('results', 'server_rest_url')}/upload/{tb_name}"
+        uri = self.config.get("results", "server_rest_url")
+        upload_url = f"{uri}/upload/{tb_name}"
 
         responses.add(responses.PUT, upload_url, body=RuntimeError("uh-oh"))
 
@@ -187,14 +218,9 @@ class TestCopyResults:
                 Path, "open", self.get_path_open_mock(tb_name, io.StringIO(tb_contents))
             )
 
-            with pytest.raises(CopyResultTb.FileUploadError) as excinfo:
-                crt = CopyResultTb(
-                    tb_name,
-                    len(tb_contents),
-                    "someMD5",
-                    self.config,
-                    agent_logger,
-                )
-                crt.copy_result_tb("token")
+            with pytest.raises(CopyResult.FileUploadError) as excinfo:
+                CopyResultToServer(
+                    self.config, agent_logger, None, None, None, None
+                ).push(Path(tb_name), "someMD5")
 
-        assert "something wrong" in str(excinfo.value)
+        assert f"{upload_url!r} failed:" in str(excinfo.value)

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -1,5 +1,7 @@
 import datetime
+import json
 import logging
+import re
 
 from click.testing import CliRunner
 import responses
@@ -43,11 +45,13 @@ class TestMoveResults:
     DELY_SWITCH = "--delete"
     DELN_SWITCH = "--no-delete"
     XZST_SWITCH = "--xz-single-threaded"
-    SWSR_SWITCH = "--show-server"
+    RELAY_SWITCH = "--relay"
+    SRVR_SWITCH = "--server"
     CTRL_TEXT = "ctrl"
     TOKN_TEXT = "what is a token but 139 characters of gibberish"
     ACCESS_TEXT = "private"
-    SWSR_TEXT = None
+    RELAY_TEXT = "http://relay.example.com"
+    SRVR_TEXT = "http://pbench.test.example.com"
     META_SWITCH = "--metadata"
     META_TEXT_FOO = "pbench.sat:FOO"
     META_TEXT_TEST = "pbench.test:TEST"
@@ -78,8 +82,8 @@ class TestMoveResults:
                 TestMoveResults.TOKN_TEXT,
                 TestMoveResults.DELY_SWITCH,
                 TestMoveResults.XZST_SWITCH,
-                TestMoveResults.SWSR_SWITCH,
-                TestMoveResults.SWSR_TEXT,
+                TestMoveResults.SRVR_SWITCH,
+                TestMoveResults.SRVR_TEXT,
                 TestMoveResults.ACCESS_SWITCH,
                 TestMoveResults.ACCESS_TEXT,
             ],
@@ -108,8 +112,6 @@ class TestMoveResults:
                 TestMoveResults.TOKN_TEXT,
                 TestMoveResults.DELY_SWITCH,
                 TestMoveResults.XZST_SWITCH,
-                TestMoveResults.SWSR_SWITCH,
-                TestMoveResults.SWSR_TEXT,
                 TestMoveResults.ACCESS_SWITCH,
                 TestMoveResults.ACCESS_TEXT,
                 TestMoveResults.META_SWITCH,
@@ -121,6 +123,29 @@ class TestMoveResults:
             result.exit_code == 2
         ), f"Expected exit code of 2: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
         assert "Error: Got unexpected extra argument (pbench.sat:FOO)" in result.stderr
+
+    @staticmethod
+    @responses.activate
+    def test_server_relay():
+        """Test metadata with conflicting server and relay"""
+        runner = CliRunner(mix_stderr=False)
+        result = runner.invoke(
+            main,
+            args=[
+                TestMoveResults.CTRL_SWITCH,
+                TestMoveResults.CTRL_TEXT,
+                TestMoveResults.DELY_SWITCH,
+                TestMoveResults.XZST_SWITCH,
+                TestMoveResults.SRVR_SWITCH,
+                TestMoveResults.SRVR_TEXT,
+                TestMoveResults.RELAY_SWITCH,
+                TestMoveResults.RELAY_TEXT,
+            ],
+        )
+        assert (
+            result.exit_code == 2
+        ), f"Expected exit code of 2: exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        assert "Cannot use both relay and Pbench Server destination." in result.stderr
 
     @staticmethod
     @responses.activate
@@ -136,8 +161,6 @@ class TestMoveResults:
                 TestMoveResults.TOKN_TEXT,
                 TestMoveResults.DELY_SWITCH,
                 TestMoveResults.XZST_SWITCH,
-                TestMoveResults.SWSR_SWITCH,
-                TestMoveResults.SWSR_TEXT,
                 TestMoveResults.ACCESS_SWITCH,
                 TestMoveResults.ACCESS_TEXT,
                 TestMoveResults.META_SWITCH,
@@ -178,12 +201,6 @@ class TestMoveResults:
 
         caplog.set_level(logging.DEBUG)
 
-        responses.add(
-            responses.GET,
-            "http://pbench.example.com/api/v1/host_info",
-            status=200,
-            body="pbench@pbench-server:/srv/pbench/pbench-move-results-receive/fs-version-002",
-        )
         responses.add(
             responses.PUT,
             f"http://pbench.example.com/api/v1/upload/{script}_{config}_{date}.tar.xz",
@@ -250,3 +267,128 @@ class TestMoveResults:
             result.stdout
             == "Status: total # of result directories considered 1, successfully moved 1, encountered 0 failures\n"
         )
+
+    @staticmethod
+    @responses.activate
+    def test_results_move_server(monkeypatch, caplog, setup):
+        monkeypatch.setenv("_pbench_full_hostname", "localhost")
+        monkeypatch.setattr(datetime, "datetime", MockDatetime)
+
+        # In order for a pbench tar ball to be moved/copied to a pbench-server
+        # the run directory has to have one file in it, a "metadata.log" file.
+        # We make a run directory and populate it with our test specific
+        # information.
+        pbrun = setup["tmp"] / "var" / "lib" / "pbench-agent"
+        script = "pbench-user-benchmark"
+        config = "test-results-move"
+        date = "YYYY.MM.DDTHH.MM.SS"
+        name = f"{script}_{config}_{date}"
+        res_dir = pbrun / name
+        res_dir.mkdir(parents=True, exist_ok=True)
+        mlog = res_dir / "metadata.log"
+        mlog.write_text(mdlog_tmpl.format(**locals()))
+
+        caplog.set_level(logging.DEBUG)
+
+        responses.add(
+            responses.PUT,
+            f"{TestMoveResults.SRVR_TEXT}/api/v1/upload/{script}_{config}_{date}.tar.xz",
+            status=200,
+        )
+
+        runner = CliRunner(mix_stderr=False)
+
+        # Test --no-delete
+        result = runner.invoke(
+            main,
+            args=[
+                TestMoveResults.CTRL_SWITCH,
+                TestMoveResults.CTRL_TEXT,
+                TestMoveResults.TOKN_SWITCH,
+                TestMoveResults.TOKN_TEXT,
+                TestMoveResults.DELN_SWITCH,
+                TestMoveResults.SRVR_SWITCH,
+                TestMoveResults.SRVR_TEXT,
+            ],
+        )
+        assert (
+            result.exit_code == 0
+        ), f"Expected a successful operation, exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        assert (
+            result.stdout
+            == "Status: total # of result directories considered 1, successfully copied 1, encountered 0 failures\n"
+        )
+        # This should raise an unexpected exception if it was not created.
+        (pbrun / f"{name}.copied").unlink()
+
+    @staticmethod
+    @responses.activate
+    def test_results_move_relay(monkeypatch, caplog, setup):
+        monkeypatch.setenv("_pbench_full_hostname", "localhost")
+        monkeypatch.setattr(datetime, "datetime", MockDatetime)
+
+        # In order for a pbench tar ball to be moved/copied to a pbench-server
+        # the run directory has to have one file in it, a "metadata.log" file.
+        # We make a run directory and populate it with our test specific
+        # information.
+        pbrun = setup["tmp"] / "var" / "lib" / "pbench-agent"
+        script = "pbench-user-benchmark"
+        config = "test-results-move"
+        date = "YYYY.MM.DDTHH.MM.SS"
+        name = f"{script}_{config}_{date}"
+        res_dir = pbrun / name
+        res_dir.mkdir(parents=True, exist_ok=True)
+        mlog = res_dir / "metadata.log"
+        mlog.write_text(mdlog_tmpl.format(**locals()))
+
+        caplog.set_level(logging.DEBUG)
+
+        responses.add(
+            responses.PUT, re.compile(f"{TestMoveResults.RELAY_TEXT}/[a-z0-9]+")
+        )
+
+        runner = CliRunner(mix_stderr=False)
+
+        # Test --no-delete
+        result = runner.invoke(
+            main,
+            args=[
+                TestMoveResults.CTRL_SWITCH,
+                TestMoveResults.CTRL_TEXT,
+                TestMoveResults.DELN_SWITCH,
+                TestMoveResults.RELAY_SWITCH,
+                TestMoveResults.RELAY_TEXT,
+            ],
+        )
+
+        # We expect two PUT calls using the relay base URI: a JSON manifest
+        # object followed by the tarball. Responses stores "calls" in reverse
+        # order. While we can effect random access by searching for URIs, we
+        # can't easily know either SHA256 as the tarball and manifest are both
+        # generated internally. Instead, we traverse the list of calls in
+        # reversed order, expecting the first to resolve to a JSON file and the
+        # second to provide a URL corresponding to the tarball, which we assert
+        # must appear in the manifest "uri" field.
+        manifest = {}
+        uris = []
+        assert len(responses.calls) == 2
+        for c in reversed(responses.calls):
+            if not manifest:
+                manifest.update(json.load(c.request.body))
+            else:
+                uris.append(c.request.url)
+
+        assert manifest["uri"] == uris[0]
+        assert manifest["name"] == f"{script}_{config}_{date}.tar.xz"
+        assert (
+            result.exit_code == 0
+        ), f"Expected a successful operation, exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
+        assert re.match(
+            (
+                r"RELAY pbench-user-benchmark_test-results-move_YYYY.MM.DDTHH.MM.SS.tar.xz: http://relay.example.com/[a-z0-9]+\n"
+                "Status: total # of result directories considered 1, successfully copied 1, encountered 0 failures\n"
+            ),
+            result.stdout,
+        )
+        # This should raise an unexpected exception if it was not created.
+        (pbrun / f"{name}.copied").unlink()

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -361,12 +361,10 @@ class TestResultsMove:
             ],
         )
 
-        # We expect two PUT calls using the relay base URI: a JSON manifest
-        # object followed by the tarball. Responses stores "calls" in reverse
-        # order. We expect the first (index 1) to resolve to a JSON relay
-        # manifest file and the second (index 0) to provide a URL corresponding
-        # to the tarball, which we assert must appear in the manifest "uri"
-        # field.
+        # We expect two PUT calls using the relay base URI: first the tarball
+        # itself, and then a JSON manifest file. The manifest JSON must contain
+        # a "uri" field with a value matching the tarball URI, and a "name"
+        # field identifying the original tarball name.
         assert len(responses.calls) == 2
         calls = list(responses.calls)
         manifest = json.load(calls[1].request.body)

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -37,7 +37,7 @@ user_script = sleep
 """
 
 
-class TestMoveResults:
+class TestResultsMove:
 
     CTRL_SWITCH = "--controller"
     TOKN_SWITCH = "--token"
@@ -76,16 +76,16 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
-                TestMoveResults.DELY_SWITCH,
-                TestMoveResults.XZST_SWITCH,
-                TestMoveResults.SRVR_SWITCH,
-                TestMoveResults.SRVR_TEXT,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
+                TestResultsMove.DELY_SWITCH,
+                TestResultsMove.XZST_SWITCH,
+                TestResultsMove.SRVR_SWITCH,
+                TestResultsMove.SRVR_TEXT,
+                TestResultsMove.ACCESS_SWITCH,
+                TestResultsMove.ACCESS_TEXT,
             ],
         )
         assert (
@@ -106,17 +106,17 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
-                TestMoveResults.DELY_SWITCH,
-                TestMoveResults.XZST_SWITCH,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
-                TestMoveResults.META_SWITCH,
-                TestMoveResults.META_TEXT_TEST,
-                TestMoveResults.META_TEXT_FOO,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
+                TestResultsMove.DELY_SWITCH,
+                TestResultsMove.XZST_SWITCH,
+                TestResultsMove.ACCESS_SWITCH,
+                TestResultsMove.ACCESS_TEXT,
+                TestResultsMove.META_SWITCH,
+                TestResultsMove.META_TEXT_TEST,
+                TestResultsMove.META_TEXT_FOO,
             ],
         )
         assert (
@@ -132,14 +132,14 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.DELY_SWITCH,
-                TestMoveResults.XZST_SWITCH,
-                TestMoveResults.SRVR_SWITCH,
-                TestMoveResults.SRVR_TEXT,
-                TestMoveResults.RELAY_SWITCH,
-                TestMoveResults.RELAY_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.DELY_SWITCH,
+                TestResultsMove.XZST_SWITCH,
+                TestResultsMove.SRVR_SWITCH,
+                TestResultsMove.SRVR_TEXT,
+                TestResultsMove.RELAY_SWITCH,
+                TestResultsMove.RELAY_TEXT,
             ],
         )
         assert (
@@ -155,18 +155,18 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
-                TestMoveResults.DELY_SWITCH,
-                TestMoveResults.XZST_SWITCH,
-                TestMoveResults.ACCESS_SWITCH,
-                TestMoveResults.ACCESS_TEXT,
-                TestMoveResults.META_SWITCH,
-                TestMoveResults.META_TEXT_TEST,
-                TestMoveResults.META_SWITCH,
-                TestMoveResults.META_TEXT_FOO,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
+                TestResultsMove.DELY_SWITCH,
+                TestResultsMove.XZST_SWITCH,
+                TestResultsMove.ACCESS_SWITCH,
+                TestResultsMove.ACCESS_TEXT,
+                TestResultsMove.META_SWITCH,
+                TestResultsMove.META_TEXT_TEST,
+                TestResultsMove.META_SWITCH,
+                TestResultsMove.META_TEXT_FOO,
             ],
         )
         assert (
@@ -213,11 +213,11 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
-                TestMoveResults.DELN_SWITCH,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
+                TestResultsMove.DELN_SWITCH,
             ],
         )
         assert (
@@ -235,10 +235,10 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
             ],
         )
         assert (
@@ -254,10 +254,10 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
             ],
         )
         assert (
@@ -292,7 +292,7 @@ class TestMoveResults:
 
         responses.add(
             responses.PUT,
-            f"{TestMoveResults.SRVR_TEXT}/api/v1/upload/{script}_{config}_{date}.tar.xz",
+            f"{TestResultsMove.SRVR_TEXT}/api/v1/upload/{script}_{config}_{date}.tar.xz",
             status=200,
         )
 
@@ -302,13 +302,13 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.TOKN_SWITCH,
-                TestMoveResults.TOKN_TEXT,
-                TestMoveResults.DELN_SWITCH,
-                TestMoveResults.SRVR_SWITCH,
-                TestMoveResults.SRVR_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.TOKN_SWITCH,
+                TestResultsMove.TOKN_TEXT,
+                TestResultsMove.DELN_SWITCH,
+                TestResultsMove.SRVR_SWITCH,
+                TestResultsMove.SRVR_TEXT,
             ],
         )
         assert (
@@ -344,7 +344,7 @@ class TestMoveResults:
         caplog.set_level(logging.DEBUG)
 
         responses.add(
-            responses.PUT, re.compile(f"{TestMoveResults.RELAY_TEXT}/[a-z0-9]+")
+            responses.PUT, re.compile(f"{TestResultsMove.RELAY_TEXT}/[a-z0-9]+")
         )
 
         runner = CliRunner(mix_stderr=False)
@@ -353,11 +353,11 @@ class TestMoveResults:
         result = runner.invoke(
             main,
             args=[
-                TestMoveResults.CTRL_SWITCH,
-                TestMoveResults.CTRL_TEXT,
-                TestMoveResults.DELN_SWITCH,
-                TestMoveResults.RELAY_SWITCH,
-                TestMoveResults.RELAY_TEXT,
+                TestResultsMove.CTRL_SWITCH,
+                TestResultsMove.CTRL_TEXT,
+                TestResultsMove.DELN_SWITCH,
+                TestResultsMove.RELAY_SWITCH,
+                TestResultsMove.RELAY_TEXT,
             ],
         )
 

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -29,7 +29,7 @@ class TestResultsPush:
     URL = "http://pbench.example.com/api/v1"
 
     @staticmethod
-    def add_server_mock_response(
+    def server_mock(
         status_code: HTTPStatus = HTTPStatus.CREATED,
         message: Optional[Union[str, Dict, Exception]] = None,
     ):
@@ -49,7 +49,6 @@ class TestResultsPush:
         )
 
     @staticmethod
-    @pytest.fixture
     def relay_mock(
         status_code: HTTPStatus = HTTPStatus.CREATED,
         error: Optional[Exception] = None,
@@ -129,7 +128,8 @@ class TestResultsPush:
 
     @staticmethod
     @responses.activate
-    def test_relay(relay_mock):
+    def test_relay():
+        __class__.relay_mock()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -188,7 +188,7 @@ class TestResultsPush:
     def test_multiple_meta_args_single_option():
         """Test normal operation when all arguments and options are specified"""
 
-        TestResultsPush.add_server_mock_response()
+        TestResultsPush.server_mock()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -210,7 +210,7 @@ class TestResultsPush:
     def test_multiple_meta_args():
         """Test normal operation when all arguments and options are specified"""
 
-        TestResultsPush.add_server_mock_response()
+        TestResultsPush.server_mock()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,
@@ -245,7 +245,7 @@ class TestResultsPush:
         """Test normal operation with the token in an environment variable"""
 
         monkeypatch.setenv("PBENCH_ACCESS_TOKEN", TestResultsPush.TOKN_TEXT)
-        TestResultsPush.add_server_mock_response()
+        TestResultsPush.server_mock()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 0, result.stderr
@@ -295,7 +295,7 @@ class TestResultsPush:
     def test_push_status(status_code, message, exit_code):
         """Test normal operation when all arguments and options are specified"""
 
-        TestResultsPush.add_server_mock_response(status_code, message)
+        TestResultsPush.server_mock(status_code, message)
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -129,7 +129,7 @@ class TestResultsPush:
     @staticmethod
     @responses.activate
     def test_relay():
-        __class__.relay_mock()
+        TestResultsPush.relay_mock()
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(
             main,

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -237,7 +237,7 @@ class TestResultsPush:
         runner = CliRunner(mix_stderr=False)
         result = runner.invoke(main, args=[tarball])
         assert result.exit_code == 2, result.stderr
-        assert "Pbench Server connection requires '--token'" in str(result.stderr)
+        assert "Error: Missing option '--token'" in str(result.stderr)
 
     @staticmethod
     @responses.activate

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,7 +16,7 @@ psycopg2
 pyesbulk>=2.0.1
 PyJwt[crypto]
 python-dateutil
-requests
+requests>=2.31.0  # CVE-2023-32681
 sdnotify
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6


### PR DESCRIPTION
PBENCH-1142

This changes the Pbench Agent `results` mechanism to support a new mode, refactoring the `CopyResults` class into a hierarchy with `CopyResultToServer` and `CopyResultToRelay` and an overloaded `push` to do the work. The `--token` option is now required only when `--relay` is not specified.

In addition to `--relay <relay>` to push a manifest and tarball to a Relay, I added a `--server <server>` to override the default config file value, which should allow us to deploy a containerized Pbench Agent without needing to map in a customized config file just to set the Pbench Server URI.

The agent "man pages" have been updated with the new options, and some general cleanup left over from #3442.

_NOTE_: with this change we have a full end-to-end relay mechanism, but it's simplistic. You need to start a relay server manually from the file relay repo at `distributed-system-analysis/file-relay`, and supply that URI to the `pbench-results-move --relay <relay>` command. In the future we'd like to package the relay and allow management and hosting through Pbench Agent commands within a standard container.