### PR TITLE
Change the base image for the Pbench Server container to ubi8

### DIFF
--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -39,12 +39,12 @@ RPMBUILD_BASEIMAGE_centos = quay.io/centos/centos:stream${VER}
 RPMBUILD_BASEIMAGE_REPO = $(subst ${VER},${DIST_VERSION},${RPMBUILD_BASEIMAGE_${DIST_NAME}})
 
 # List of packages required to build RPMs, to be installed in the build
-# containers.
+# containers.  (python39 is required for the Server build.)
 #
 # TODO:  The Jinja2 CLI is not currently available as an RPM on RHEL, so we
 #        install it via pip for all platforms, to keep things simple; we should
 #        reevaluate this dependency in the future.
-RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build
+RPMBUILD_PACKAGES = git make python3-jinja2 python3-pip rpmlint rpm-build python39
 
 # Default package manager tool (may be overridden for some distros)
 PKGMGR = dnf

--- a/jenkins/ci.Dockerfile.j2
+++ b/jenkins/ci.Dockerfile.j2
@@ -49,7 +49,7 @@ RUN \
         redis \
         rpmdevtools \
         `#` \
-        `# Required for server legacy unit tests` \
+        `# Required for server python unit tests` \
         `#` \
         sqlite \
         `#` \
@@ -81,6 +81,10 @@ RUN \
         `# Required for Alembic migration test` \
         `#` \
         nc \
+        `#` \
+        `# Required for Server functional test` \
+        `#` \
+        openssl \
         && \
     `#` \
     `# Save space in the container image.` \

--- a/jenkins/runlocal
+++ b/jenkins/runlocal
@@ -1,19 +1,17 @@
 #!/bin/bash -e
-
+#
 # Build the Pbench Server RPM and container, and run functional tests locally.
-# Requires a Fedora, CentOS, or RHEL environment to run.
-
+#
 # NOTE WELL: By default, when the functional tests are run, the infrastructure
 # pod and Pbench Server container are left running by default.  Add the switch,
 # `--cleanup` to direct `jenkins/run-server-func-tests` to cleanup when
 # finished (success or failure).
 
-# Build the pbench-server RPM locally, then build the containers locally, and
-# then run the functional tests against the locally built CI container image.
 export PB_SERVER_IMAGE_NAME=pbench-server
 
 # We use the current user name as the tag to avoid any conflict with what the CI
 # environment does.
+export PB_CONTAINER_REG=images.paas.redhat.com/pbench
 export PB_SERVER_IMAGE_TAG=${USER}
 
 # We use the image pull policy of `never` here to ensure our locally built image
@@ -21,9 +19,11 @@ export PB_SERVER_IMAGE_TAG=${USER}
 export PB_SERVER_IMAGE_PULL_POLICY=never
 
 # Create an RPM from the current source tree and double check it exists.
-make -C server/rpm clean rpm
-export RPM_PATH=${HOME}/rpmbuild/RPMS/noarch/pbench-server-*.rpm
-ls -ld ${RPM_PATH}
+# Set the workspace to the home directory so that the RPM built inside the
+# container will be available after it exits.
+WORKSPACE_TMP=${WORKSPACE_TMP:-${HOME}} jenkins/run make -C server/rpm distclean ci
+export RPM_PATH=${HOME}/rpmbuild/RPMS/noarch/'pbench-server-*.rpm'
+ls -ld "${RPM_PATH}"
 
 # Create a Pbench Dashboard deployment
 WORKSPACE_TMP=${WORKSPACE_TMP:-${HOME}} jenkins/run make -C dashboard clean build

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -50,9 +50,12 @@ buildah config \
 
 buildah copy $container ${RPM_PATH} /tmp/pbench-server.rpm
 buildah run $container dnf update -y
-if [[ "${BASE_IMAGE}" == *"ubi9:latest" || "${BASE_IMAGE}" == *"centos:stream9" ]]; then
+if [[ "${BASE_IMAGE}" == *"ubi9:"* || "${BASE_IMAGE}" == *"centos:stream9" ]]; then
     buildah run $container dnf install -y --nodocs \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+elif [[ "${BASE_IMAGE}" == *"ubi8:"* ]]; then
+    buildah run $container dnf install -y --nodocs \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 fi
 buildah run $container dnf install -y --nodocs \
     /tmp/pbench-server.rpm less nginx openssl rsyslog rsyslog-mmjsonparse

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -8,7 +8,7 @@
 #-
 GITTOP=${GITTOP:-$(git rev-parse --show-toplevel)}
 
-BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
+BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi8:latest}
 PB_SERVER_IMAGE_NAME=${PB_SERVER_IMAGE_NAME:-"pbench-server"}
 PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
 RPM_PATH=${RPM_PATH:-/root/sandbox/rpmbuild/RPMS/noarch/pbench-server-*.rpm}

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -108,31 +108,21 @@ podman run \
 # match the host that the container is running on, so we generate it on the fly
 # and place it in the deployment files directory.
 #
-# We do this in the Pbench Server container so that we get a known version of
-# openssl (the native one on the Jenkins executors appears to be ancient).
-#
-# Note that this command, if successful, dumps the status of the factorization
-# search to stderr which produces a bunch of junk in the output; thus, we
-# redirect stderr to stdout and then pipe it through sed to remove any complete
-# lines consisting solely of any combination of periods, plus signs, asterisks,
-# and hyphens.
-podman run \
-    --rm \
-    --volume ${PB_DEPLOY_FILES}:/data:Z \
-    --volume ${PWD}/${pbiac_etc}/pki/tls:/pki_tls:Z \
-    --entrypoint /usr/bin/openssl \
-    ${PB_SERVER_IMAGE} \
-    req -batch -new -noenc -sha256 -days 365 -newkey rsa:2048 \
-    -out /data/pbench-server.crt \
-    -keyout /data/pbench-server.key \
-    -subj "/C=US/ST=Massachusetts/L=Westford/O=Red Hat/OU=Performance & Scale/CN=${host_name}" \
-    -CA /pki_tls/certs/pbench_CA.crt \
-    -CAkey /pki_tls/private/pbench_CA.key \
-    -addext "authorityKeyIdentifier = keyid,issuer" \
-    -addext "basicConstraints=CA:FALSE" \
-    -addext "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment" \
-    -addext "subjectAltName = IP.2:${PB_HOST_IP}" \
-    2>&1 | sed -E -e '/^[.+*-]*$/ d'
+# We do this in the CI container so that we get a known version of openssl (the
+# native one on the Jenkins executors appears to be ancient).
+EXTRA_PODMAN_SWITCHES="--volume ${PB_DEPLOY_FILES}:/data:Z --volume ${PWD}/${pbiac_etc}/pki/tls:/pki_tls:Z" \
+    jenkins/run \
+        openssl req -batch -new -noenc -sha256 -days 365 -newkey rsa:2048 \
+        -out /data/pbench-server.crt \
+        -keyout /data/pbench-server.key \
+        -subj "/C=US/ST=Massachusetts/L=Westford/O=Red Hat/OU=Performance & Scale/CN=${host_name}" \
+        -CA /pki_tls/certs/pbench_CA.crt \
+        -CAkey /pki_tls/private/pbench_CA.key \
+        -addext "authorityKeyIdentifier = keyid,issuer" \
+        -addext "basicConstraints=CA:FALSE" \
+        -addext "keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment" \
+        -addext "subjectAltName = IP.2:${PB_HOST_IP}" \
+        2>&1 | sed -E -e '/^[.+*-]*$/ d'
 
 #+
 # Start the services which the Pbench Server depends upon and then start the

--- a/server/rpm/Makefile
+++ b/server/rpm/Makefile
@@ -36,4 +36,4 @@ endif
 
 include ../../utils/rpm.mk
 
-ci: rhel-9-rpm
+ci: rhel-8-rpm

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -8,7 +8,7 @@ URL:            http://github.com/distributed-systems-analysis/pbench
 Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
-Requires: python3 python3-devel tar xz util-linux-core hostname
+Requires: python3 python3-devel tar xz util-linux hostname
 
 # policycoreutils for semanage and restorecon
 Requires:       policycoreutils

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -8,7 +8,7 @@ URL:            http://github.com/distributed-systems-analysis/pbench
 Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
-Requires: python3 python3-devel tar xz util-linux hostname
+Requires: python39 python3-devel tar xz util-linux hostname
 
 # policycoreutils for semanage and restorecon
 Requires:       policycoreutils
@@ -56,7 +56,7 @@ Requires: python3-certifi python3-bcrypt python3-greenlet
 %define installdir opt/pbench-server
 %define static html/static
 
-%define __python python3
+%define __python python3.9
 
 %description
 The pbench server scripts.


### PR DESCRIPTION
Since running a container using a "newer" base image on an "older" kernel is not reliable, this PR changes the default base image used to build the Pbench Server container from ubi9 to ubi8 so that it can be run on our Production server (which is currently RHEL-8.7).

PBENCH-1181