### PR TITLE
Clarify what tool-specific options are (Forward port of #3444 from b0.72 to main)

### DIFF
--- a/agent/tool-scripts/base-tool
+++ b/agent/tool-scripts/base-tool
@@ -190,24 +190,29 @@ vmstat)
 esac
 
 function usage {
-	printf -- "The following options are available:\n\n"
-	printf -- "\t--install                 verify this perf tool will work\n\n"
-	printf -- "\t--start|stop|postprocess  start/stop/postprocess the data collection\n"
-	printf -- "\t-d str|--dir=str          directory to store data collection (required)\n"
+	printf -- "\t-h|--help                 display this help message and exit\n\n"
+
+	printf -- "\nTool-specific options - these may be specified when you register a tool:\n\n"
+
 	case "${tool}" in
-	blktrace|bpftrace|kvmtrace|lockstat|oc|perf|strace|systemtap|tcpdump)
-		:  # These tools don't use interval
+	lockstat)
+		:  # Tools that don't take *any* tool-specific options
+		printf -- "\tNo tool-specific options for this tool\n"
+		;;
+	blktrace|bpftrace|kvmtrace|oc|perf|strace|systemtap|tcpdump)
+		:  # Tools that don't use '--interval' but take other tool-specific options
 		;;
 	*)
 		printf -- "\t--interval=int            number of seconds between each data collection (optional, default is %s seconds)\n" "${def_interval}"
 		;;
 	esac
+
 	case "${tool}" in
 	blktrace)
-		printf -- "\t--devices=str,[str]       the list of block devices to trace (required w/ --start)\n"
+		printf -- "\t--devices=str,[str]       the list of block devices to trace (required)\n"
 		;;
 	bpftrace)
-		printf -- "\t--script=str              path to the bpftrace script (required w/ --start)\n"
+		printf -- "\t--script=str              path to the bpftrace script (required)\n"
 		;;
 	haproxy-ocp)
 		printf -- "\t--counters-clear-all      clear all HAProxy counters at tool start (optional, default: '%s')\n" "${def_counters_clear_all}"
@@ -278,7 +283,6 @@ function usage {
 		printf -- "\t                           but not both at the same time\n"
 		;;
 	esac
-	printf -- "\n\t-h|--help                 display this help message\n"
 }
 
 # Process options and arguments
@@ -582,7 +586,7 @@ install)
 		local _installed_rpm
 		local _rc
 		_installed_rpm="$(require-rpm "${_tpn}" "${_tpv}")"
-		_rc=${?} 
+		_rc=${?}
 		if [[ ${_rc} != 0 ]]; then
 			printf -- "%s: %s is not installed\n" "${tool}" "${_tpn}${_tpv:+-${_tpv}}" >&2
 		else

--- a/agent/tool-scripts/tests/blktrace/gold/stderr
+++ b/agent/tool-scripts/tests/blktrace/gold/stderr
@@ -1,13 +1,10 @@
 blktrace: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
-	--devices=str,[str]       the list of block devices to trace (required w/ --start)
+Tool-specific options - these may be specified when you register a tool:
 
-	-h|--help                 display this help message
+	--devices=str,[str]       the list of block devices to trace (required)
 blktrace: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/blktrace/tools-group/blktrace', missing
 blktrace: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/blktrace/tools-group/blktrace', missing

--- a/agent/tool-scripts/tests/bpftrace/gold/stderr
+++ b/agent/tool-scripts/tests/bpftrace/gold/stderr
@@ -1,13 +1,10 @@
 bpftrace: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
-	--script=str              path to the bpftrace script (required w/ --start)
+Tool-specific options - these may be specified when you register a tool:
 
-	-h|--help                 display this help message
+	--script=str              path to the bpftrace script (required)
 bpftrace: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/bpftrace/tools-group/bpftrace', missing
 bpftrace: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/bpftrace/tools-group/bpftrace', missing

--- a/agent/tool-scripts/tests/cpuacct/gold/stderr
+++ b/agent/tool-scripts/tests/cpuacct/gold/stderr
@@ -1,13 +1,10 @@
 cpuacct: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 cpuacct: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/cpuacct/tools-group/cpuacct', missing
 cpuacct: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/cpuacct/tools-group/cpuacct', missing

--- a/agent/tool-scripts/tests/disk/gold/stderr
+++ b/agent/tool-scripts/tests/disk/gold/stderr
@@ -1,13 +1,10 @@
 disk: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 disk: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/disk/tools-group/disk', missing
 disk: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/disk/tools-group/disk', missing

--- a/agent/tool-scripts/tests/dm-cache/gold/stderr
+++ b/agent/tool-scripts/tests/dm-cache/gold/stderr
@@ -1,13 +1,10 @@
 dm-cache: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 dm-cache: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/dm-cache/tools-group/dm-cache', missing
 dm-cache: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/dm-cache/tools-group/dm-cache', missing

--- a/agent/tool-scripts/tests/docker-info/gold/stderr
+++ b/agent/tool-scripts/tests/docker-info/gold/stderr
@@ -1,13 +1,10 @@
 docker-info: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 docker-info: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/docker-info/tools-group/docker-info', missing
 docker-info: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/docker-info/tools-group/docker-info', missing

--- a/agent/tool-scripts/tests/docker/gold/stderr
+++ b/agent/tool-scripts/tests/docker/gold/stderr
@@ -1,13 +1,10 @@
 docker: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 docker: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/docker/tools-group/docker', missing
 docker: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/docker/tools-group/docker', missing

--- a/agent/tool-scripts/tests/haproxy-ocp/gold/stderr
+++ b/agent/tool-scripts/tests/haproxy-ocp/gold/stderr
@@ -1,14 +1,11 @@
 haproxy-ocp: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--counters-clear-all      clear all HAProxy counters at tool start (optional, default: 'false')
-
-	-h|--help                 display this help message
 haproxy-ocp: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp', missing
 haproxy-ocp: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/haproxy-ocp/tools-group/haproxy-ocp', missing

--- a/agent/tool-scripts/tests/iostat/gold/stderr
+++ b/agent/tool-scripts/tests/iostat/gold/stderr
@@ -1,14 +1,11 @@
 iostat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--options=str             options passed directly to the tool (optional)
-
-	-h|--help                 display this help message
 iostat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/iostat/tools-group/iostat', missing
 iostat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/iostat/tools-group/iostat', missing

--- a/agent/tool-scripts/tests/jmap/gold/stderr
+++ b/agent/tool-scripts/tests/jmap/gold/stderr
@@ -1,15 +1,12 @@
 jmap: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--pid=int                 a process ID to jmap
 	--pattern=str             jmap any PID which name matches this string (via pgrep)
-
-	-h|--help                 display this help message
 jmap: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap', missing
 jmap: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/jmap/tools-group/jmap', missing

--- a/agent/tool-scripts/tests/jstack/gold/stderr
+++ b/agent/tool-scripts/tests/jstack/gold/stderr
@@ -1,15 +1,12 @@
 jstack: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--pid=int                 a process ID to jstack
 	--pattern=str             jstack any PID which name matches this string (via pgrep)
-
-	-h|--help                 display this help message
 jstack: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack', missing
 jstack: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/jstack/tools-group/jstack', missing

--- a/agent/tool-scripts/tests/kvm-spinlock/gold/stderr
+++ b/agent/tool-scripts/tests/kvm-spinlock/gold/stderr
@@ -1,13 +1,10 @@
 kvm-spinlock: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 kvm-spinlock: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvm-spinlock/tools-group/kvm-spinlock', missing
 kvm-spinlock: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvm-spinlock/tools-group/kvm-spinlock', missing

--- a/agent/tool-scripts/tests/kvmstat/gold/stderr
+++ b/agent/tool-scripts/tests/kvmstat/gold/stderr
@@ -1,13 +1,10 @@
 kvmstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 kvmstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvmstat/tools-group/kvmstat', missing
 kvmstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvmstat/tools-group/kvmstat', missing

--- a/agent/tool-scripts/tests/kvmtrace/gold/stderr
+++ b/agent/tool-scripts/tests/kvmtrace/gold/stderr
@@ -1,16 +1,13 @@
 kvmtrace: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--vm=str                  the hostname of the vm running (to get kallsyms)
 	--timeout=int             how long the trace will run (default is 1 second)
 	                          If 0 is used, the trace will not stop until stop-tools is called
 	--start-delay=int         sleep this many seconds before starting the trace (default is 0 seconds)
-
-	-h|--help                 display this help message
 kvmtrace: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvmtrace/tools-group/kvmtrace', missing
 kvmtrace: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/kvmtrace/tools-group/kvmtrace', missing

--- a/agent/tool-scripts/tests/lockstat/gold/stderr
+++ b/agent/tool-scripts/tests/lockstat/gold/stderr
@@ -1,12 +1,10 @@
 lockstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
 
-	-h|--help                 display this help message
+	No tool-specific options for this tool
 lockstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/lockstat/tools-group/lockstat', missing
 lockstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/lockstat/tools-group/lockstat', missing

--- a/agent/tool-scripts/tests/mpstat/gold/stderr
+++ b/agent/tool-scripts/tests/mpstat/gold/stderr
@@ -1,14 +1,11 @@
 mpstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--options=str             options passed directly to the tool (optional)
-
-	-h|--help                 display this help message
 mpstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/mpstat/tools-group/mpstat', missing
 mpstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/mpstat/tools-group/mpstat', missing

--- a/agent/tool-scripts/tests/numastat/gold/stderr
+++ b/agent/tool-scripts/tests/numastat/gold/stderr
@@ -1,14 +1,11 @@
 numastat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--pattern=str             a pattern for matching which processes for reporting per-node memory allocation
-
-	-h|--help                 display this help message
 numastat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/numastat/tools-group/numastat', missing
 numastat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/numastat/tools-group/numastat', missing

--- a/agent/tool-scripts/tests/oc/gold/stderr
+++ b/agent/tool-scripts/tests/oc/gold/stderr
@@ -1,13 +1,10 @@
 oc: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--components=str[,str]    one or more OpenShift component names suitable for use with "oc get" (optional, default: 'rc,ep,pods,pv,pvc,svc,cs')
-
-	-h|--help                 display this help message
 oc: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/oc/tools-group/oc', missing
 oc: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/oc/tools-group/oc', missing

--- a/agent/tool-scripts/tests/openvswitch/gold/stderr
+++ b/agent/tool-scripts/tests/openvswitch/gold/stderr
@@ -1,13 +1,10 @@
 openvswitch: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 openvswitch: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch', missing
 openvswitch: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/openvswitch/tools-group/openvswitch', missing

--- a/agent/tool-scripts/tests/perf/gold/stderr
+++ b/agent/tool-scripts/tests/perf/gold/stderr
@@ -1,15 +1,12 @@
 perf: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	-r str|--record-opts=str  options one would use to record perf data (optional, default: '-a --freq=100')
 	-p str|--report-opts=str  options one would use to report perf data (optional, default: '--show-nr-samples -I')
 	--callgraph               generate a call graph by adding '-g' to the record and report options
-
-	-h|--help                 display this help message
 perf: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/perf/tools-group/perf', missing
 perf: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/perf/tools-group/perf', missing

--- a/agent/tool-scripts/tests/pidstat/gold/stderr
+++ b/agent/tool-scripts/tests/pidstat/gold/stderr
@@ -1,11 +1,10 @@
 pidstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--options=str             options passed directly to the tool
 	--patterns=str[,str]      only collect information on process names
@@ -13,7 +12,5 @@ The following options are available:
 	                          patterns with special characters may not
 	                          work) for kvm, use --patterns=qemu,vhost
 	--threads                 collect per-thread statistics
-
-	-h|--help                 display this help message
 pidstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat', missing
 pidstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/pidstat/tools-group/pidstat', missing

--- a/agent/tool-scripts/tests/pprof/gold/stderr
+++ b/agent/tool-scripts/tests/pprof/gold/stderr
@@ -1,16 +1,13 @@
 pprof: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 60 seconds)
 	--gopath=str              path to the Go directory containing a 'bin' directory (required)
 	--goroot=str              path to the Go installation directory (optional)
 	--inventory=str           path to the inventory file (required)
-
-	-h|--help                 display this help message
 pprof: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/pprof/tools-group/pprof', missing
 pprof: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/pprof/tools-group/pprof', missing

--- a/agent/tool-scripts/tests/proc-interrupts/gold/stderr
+++ b/agent/tool-scripts/tests/proc-interrupts/gold/stderr
@@ -1,13 +1,10 @@
 proc-interrupts: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 proc-interrupts: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-interrupts/tools-group/proc-interrupts', missing
 proc-interrupts: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-interrupts/tools-group/proc-interrupts', missing

--- a/agent/tool-scripts/tests/proc-sched_debug/gold/stderr
+++ b/agent/tool-scripts/tests/proc-sched_debug/gold/stderr
@@ -1,13 +1,10 @@
 proc-sched_debug: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 proc-sched_debug: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-sched_debug/tools-group/proc-sched_debug', missing
 proc-sched_debug: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-sched_debug/tools-group/proc-sched_debug', missing

--- a/agent/tool-scripts/tests/proc-vmstat/gold/stderr
+++ b/agent/tool-scripts/tests/proc-vmstat/gold/stderr
@@ -1,13 +1,10 @@
 proc-vmstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 proc-vmstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-vmstat/tools-group/proc-vmstat', missing
 proc-vmstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/proc-vmstat/tools-group/proc-vmstat', missing

--- a/agent/tool-scripts/tests/prometheus-metrics/gold/stderr
+++ b/agent/tool-scripts/tests/prometheus-metrics/gold/stderr
@@ -1,16 +1,13 @@
 prometheus-metrics: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--gopath=str              path to the Go directory containing a 'bin' directory (required)
 	--goroot=str              path to the Go installation directory (optional)
 	--inventory=str           path to the inventory file (required)
-
-	-h|--help                 display this help message
 prometheus-metrics: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics', missing
 prometheus-metrics: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/prometheus-metrics/tools-group/prometheus-metrics', missing

--- a/agent/tool-scripts/tests/qemu-migrate/gold/stderr
+++ b/agent/tool-scripts/tests/qemu-migrate/gold/stderr
@@ -1,14 +1,11 @@
 qemu-migrate: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--vm=str                  the name of the VM being migrated
-
-	-h|--help                 display this help message
 qemu-migrate: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/qemu-migrate/tools-group/qemu-migrate', missing
 qemu-migrate: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/qemu-migrate/tools-group/qemu-migrate', missing

--- a/agent/tool-scripts/tests/rabbit/gold/stderr
+++ b/agent/tool-scripts/tests/rabbit/gold/stderr
@@ -1,15 +1,12 @@
 rabbit: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--username=str            rabbit user name (default is "guest")
 	--password=str            rabbit password (default is "guest")
-
-	-h|--help                 display this help message
 rabbit: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/rabbit/tools-group/rabbit', missing
 rabbit: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/rabbit/tools-group/rabbit', missing

--- a/agent/tool-scripts/tests/sar/gold/stderr
+++ b/agent/tool-scripts/tests/sar/gold/stderr
@@ -1,14 +1,11 @@
 sar: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--options=str             options passed directly to the tool (optional)
-
-	-h|--help                 display this help message
 sar: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/sar/tools-group/sar', missing
 sar: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/sar/tools-group/sar', missing

--- a/agent/tool-scripts/tests/strace/gold/stderr
+++ b/agent/tool-scripts/tests/strace/gold/stderr
@@ -1,14 +1,11 @@
 strace: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--pid=int                 a process ID to strace
 	--pattern=str             strace any PID which name matches this string (via pgrep)
-
-	-h|--help                 display this help message
 strace: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/strace/tools-group/strace', missing
 strace: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/strace/tools-group/strace', missing

--- a/agent/tool-scripts/tests/sysfs/gold/stderr
+++ b/agent/tool-scripts/tests/sysfs/gold/stderr
@@ -1,16 +1,13 @@
 sysfs: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--path=str                a path (beyond the /sysfs prefix)
 	--pattern=str             a pattern passed to -name option of find command to filter files
 	--maxdepth=int            a maxdepth passed to the find command to limit recursion depth
-
-	-h|--help                 display this help message
 sysfs: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/sysfs/tools-group/sysfs', missing
 sysfs: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/sysfs/tools-group/sysfs', missing

--- a/agent/tool-scripts/tests/systemtap/gold/stderr
+++ b/agent/tool-scripts/tests/systemtap/gold/stderr
@@ -1,13 +1,10 @@
 systemtap: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--script=str              path to the systemtap script (required w/ --install)
-
-	-h|--help                 display this help message
 systemtap: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/systemtap/tools-group/systemtap', missing
 systemtap: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/systemtap/tools-group/systemtap', missing

--- a/agent/tool-scripts/tests/tcpdump/gold/stderr
+++ b/agent/tool-scripts/tests/tcpdump/gold/stderr
@@ -1,14 +1,11 @@
 tcpdump: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interface=str           the network interface to monitor
 	--packets=int             the number of packets to monitor before exiting
-
-	-h|--help                 display this help message
 tcpdump: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/tcpdump/tools-group/tcpdump', missing
 tcpdump: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/tcpdump/tools-group/tcpdump', missing

--- a/agent/tool-scripts/tests/turbostat/gold/stderr
+++ b/agent/tool-scripts/tests/turbostat/gold/stderr
@@ -1,13 +1,10 @@
 turbostat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 turbostat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/turbostat/tools-group/turbostat', missing
 turbostat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/turbostat/tools-group/turbostat', missing

--- a/agent/tool-scripts/tests/user-tool/gold/stderr
+++ b/agent/tool-scripts/tests/user-tool/gold/stderr
@@ -1,11 +1,10 @@
 user-tool: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--tool-name=str            you must provide a unique name for this user tool
 	--start-script=str         run this user-provided script when starting this tool
@@ -14,7 +13,5 @@ The following options are available:
 	--file-to-capture=str      capture the contents of this file at each interval
 	                           you can use this option, or the start/stop/postprocess-script,
 	                           but not both at the same time
-
-	-h|--help                 display this help message
 user-tool: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42', missing
 user-tool: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/user-tool/tools-group/user-tool-foo42', missing

--- a/agent/tool-scripts/tests/virsh-migrate/gold/stderr
+++ b/agent/tool-scripts/tests/virsh-migrate/gold/stderr
@@ -1,14 +1,11 @@
 virsh-migrate: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
 	--vm=str                  the name of the VM being migrated
-
-	-h|--help                 display this help message
 virsh-migrate: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/virsh-migrate/tools-group/virsh-migrate', missing
 virsh-migrate: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/virsh-migrate/tools-group/virsh-migrate', missing

--- a/agent/tool-scripts/tests/vmstat/gold/stderr
+++ b/agent/tool-scripts/tests/vmstat/gold/stderr
@@ -1,13 +1,10 @@
 vmstat: Error, one of the following options is required, --install|--start|--stop|--postprocess
 
-The following options are available:
+	-h|--help                 display this help message and exit
 
-	--install                 verify this perf tool will work
 
-	--start|stop|postprocess  start/stop/postprocess the data collection
-	-d str|--dir=str          directory to store data collection (required)
+Tool-specific options - these may be specified when you register a tool:
+
 	--interval=int            number of seconds between each data collection (optional, default is 10 seconds)
-
-	-h|--help                 display this help message
 vmstat: WARNING - postprocess - tool output directory, '/var/tmp/pbench-test-tool-scripts/vmstat/tools-group/vmstat', missing
 vmstat: WARNING - stop - tool output directory, '/var/tmp/pbench-test-tool-scripts/vmstat/tools-group/vmstat', missing

--- a/agent/util-scripts/gold/pbench-register-tool/test-44.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-44.txt
@@ -65,6 +65,7 @@ Available tools:
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help
+
 --- Finished test-44 pbench-register-tool (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-register-tool/test-46.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-46.txt
@@ -65,6 +65,7 @@ Available tools:
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help
+
 --- Finished test-46 pbench-register-tool (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/pbench-register-tool/test-47.txt
+++ b/agent/util-scripts/gold/pbench-register-tool/test-47.txt
@@ -65,6 +65,7 @@ Available tools:
 
 For a list of tool specific options, run:
 	/var/tmp/pbench-test-utils/opt/pbench-agent/tool-scripts/<tool-name> --help
+
 --- Finished test-47 pbench-register-tool (status=1)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/pbench-register-tool
+++ b/agent/util-scripts/pbench-register-tool
@@ -132,7 +132,8 @@ function usage() {
 	#                     1         2         3         4         5         6         7         8
 	# (no tab)   12345678901234567890123456789012345678901234567890123456789012345678901234567890
 	printf -- "\nFor a list of tool specific options, run:\n"
-	printf -- "\t${pbench_bin}/tool-scripts/<tool-name> --help\n"
+	printf -- "\t${pbench_bin}/tool-scripts/<tool-name> --help\n\n"
+
 }
 
 # Process options and arguments


### PR DESCRIPTION
Fixes #3443

Modify the help message of pbench-register-tool to warn against using operational options (i.e. options used internally by pbench) for a tool when it is registered.

Modify the help message of base-tool (and everybody who is symlinked to it) to clarify which are operational options and which are tool-specific options: operational options should not be specified when registering a tool: they are used by pbench internally; only tool-specific options are specifed when registering the tool (on the RHS of `--` in the invocation of `pbench-register-tool`).

PBENCH-1173