### PR TITLE
Fix JWT OIDC decode yet again

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -27,10 +27,6 @@ class OpenIDClientError(Exception):
         return self.message
 
 
-class OpenIDTokenInvalid(Exception):
-    pass
-
-
 class Connection:
     """Helper connection class for use by an OpenIDClient instance."""
 
@@ -359,23 +355,14 @@ class OpenIDClient:
                 "sub": <user_id>
             }
         """
-        try:
-            return jwt.decode(
-                token,
-                self._pem_public_key,
-                algorithms=[self._TOKEN_ALG],
-                audience=[self.client_id],
-                options={
-                    "verify_signature": True,
-                    "verify_aud": True,
-                    "verify_exp": True,
-                },
-            )
-        except (
-            jwt.ExpiredSignatureError,
-            jwt.InvalidSignatureError,
-            jwt.InvalidAudienceError,
-            jwt.InvalidAlgorithmError,
-            ValueError,
-        ) as exc:
-            raise OpenIDTokenInvalid() from exc
+        return jwt.decode(
+            token,
+            self._pem_public_key,
+            algorithms=[self._TOKEN_ALG],
+            audience=[self.client_id],
+            options={
+                "verify_signature": True,
+                "verify_aud": True,
+                "verify_exp": True,
+            },
+        )


### PR DESCRIPTION
PBENCH-1182

JWT added yet another `DecodeError` in our API Key validation path in some recent update. Instead of continuing to add specific errors to be converted into a specific internal exception, just handle all exceptions in the primary OIDC decode by attempting the token as an API key. If that fails, report the API key validation error, and re-raise the original OIDC error.

(Note that `verify_auth` will in turn just report this error and act as if no authentication token was given.)