### PR TITLE
Add OpenSSL to container build

### DIFF
--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -55,7 +55,7 @@ if [[ "${BASE_IMAGE}" == *"ubi9:latest" || "${BASE_IMAGE}" == *"centos:stream9" 
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 fi
 buildah run $container dnf install -y --nodocs \
-    /tmp/pbench-server.rpm nginx less rsyslog rsyslog-mmjsonparse
+    /tmp/pbench-server.rpm less nginx openssl rsyslog rsyslog-mmjsonparse
 buildah run $container dnf clean all
 buildah run $container rm -f /tmp/pbench-server.rpm
 


### PR DESCRIPTION
PBENCH-1188

Running now on an up-to-date Fedora 38 laptop, I'm finally able to use `jenkins/runlocal` without overriding the `BASE_IMAGE`... except that I had to manually install the `openssl` package on my laptop, and it apparently also needs to be manually installed inside the container base image.