### PR TITLE
Fix dashboard logout

### DIFF
--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -108,6 +108,7 @@ CLIENT_CONF=$(curl -si -f -X POST "${KEYCLOAK_HOST_PORT}/admin/realms/${REALM}/c
        "directAccessGrantsEnabled": true,
        "serviceAccountsEnabled": true,
        "enabled": true,
+       "attributes": {"post.logout.redirect.uris": "'${KEYCLOAK_REDIRECT_URI}'"},
        "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'"]}')
 
 CLIENT_ID=$(grep -o -e 'http://[^[:space:]]*' <<< ${CLIENT_CONF} | sed -e 's|.*/||')


### PR DESCRIPTION
PBENCH-1185

Starting relatively recently, Keycloak has a distinct callback URI setting for "post logout", which I noticed while debugging my Postman configuration on the staging server. Adding the proper "post logout callback URI" solved the problem and allowed a clean logout. Then it only took me an hour of searching to figure out how to specify this in the REST call; to say that it's "not excessively well documented" is understating the point ...