### PR TITLE
Add URI to TOC API

### DIFF
--- a/dashboard/src/actions/tableOfContentActions.js
+++ b/dashboard/src/actions/tableOfContentActions.js
@@ -21,7 +21,7 @@ export const fetchTOC =
       }
     } catch (error) {
       const msg = error.response?.data?.message;
-      dispatch(showToast(DANGER, msg ? msg : `Error response: ERROR_MSG`));
+      dispatch(showToast(DANGER, msg ?? `Error response: ${error}`));
     }
   };
 

--- a/dashboard/src/actions/tableOfContentActions.js
+++ b/dashboard/src/actions/tableOfContentActions.js
@@ -1,6 +1,8 @@
 import * as TYPES from "./types";
 import API from "../utils/axiosInstance";
 import { uriTemplate } from "../utils/helper";
+import { showToast } from "./toastActions";
+import { DANGER } from "assets/constants/toastConstants";
 
 export const fetchTOC =
   (param, parent, callForSubData) => async (dispatch, getState) => {
@@ -18,7 +20,8 @@ export const fetchTOC =
         });
       }
     } catch (error) {
-      return error;
+      const msg = error.response?.data?.message;
+      dispatch(showToast(DANGER, msg ? msg : `Error response: ERROR_MSG`));
     }
   };
 

--- a/dashboard/src/modules/components/TableOfContent/index.jsx
+++ b/dashboard/src/modules/components/TableOfContent/index.jsx
@@ -195,7 +195,7 @@ const TableOfContent = () => {
         ? initialBreadcrumb(breadCrumbLabels)
         : appGroupingBreadcrumb(false, breadCrumbLabels)
     );
-    const dirPath = param.concat(`${firstHierarchyLevel ? "" : "/"}`, data);
+    const dirPath = param.concat(firstHierarchyLevel ? "" : "/", data);
     setParam(dirPath);
     setIsLoading(true);
     getSubFolderData(dirPath);
@@ -288,7 +288,7 @@ const TableOfContent = () => {
                         }
                       >
                         <FolderIcon />
-                        {data}
+                        {data.name}
                       </MenuItem>
                     );
                   })}

--- a/dashboard/src/modules/components/TableOfContent/index.jsx
+++ b/dashboard/src/modules/components/TableOfContent/index.jsx
@@ -241,7 +241,7 @@ const TableOfContent = () => {
                         key={index}
                         direction="down"
                         onClick={() => {
-                          attachBreadCrumbs(data, true);
+                          attachBreadCrumbs(data.name, true);
                         }}
                         drilldownMenu={
                           <DrilldownMenu id="drilldownMenuStart">
@@ -255,11 +255,11 @@ const TableOfContent = () => {
                                     key={index}
                                     direction="down"
                                     onClick={() => {
-                                      attachBreadCrumbs(data, false);
+                                      attachBreadCrumbs(data.name, false);
                                     }}
                                   >
                                     <FolderIcon />
-                                    {data}
+                                    {data.name}
                                   </MenuItem>
                                 );
                               } else {

--- a/dashboard/src/reducers/tableOfContentReducer.js
+++ b/dashboard/src/reducers/tableOfContentReducer.js
@@ -36,7 +36,7 @@ const TableOfContentReducer = (state = initialState, action = {}) => {
         stack: [...state.stack, payload],
         searchSpace: payload.files,
         tableData: payload.files,
-        currData: payload,
+        contentData: payload,
         isLoading: false,
       };
 

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -468,6 +468,7 @@ class ElasticBase(ApiBase):
             uri_params: URI encoded keyword-arg supplied by the Flask
                 framework
         """
+        context["request"] = request
         return self._call(requests.post, params, context)
 
     def _get(
@@ -484,6 +485,7 @@ class ElasticBase(ApiBase):
             uri_params: URI encoded keyword-arg supplied by the Flask
                 framework
         """
+        context["request"] = request
         return self._call(requests.get, params, context)
 
 

--- a/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/query_apis/test_datasets_contents.py
@@ -159,7 +159,12 @@ class TestDatasetsContents(Commons):
         if expected_status == HTTPStatus.OK:
             res_json = response.json
             expected_result = {
-                "directories": ["sample1"],
+                "directories": [
+                    {
+                        "name": "sample1",
+                        "uri": "https://localhost/datasets/random_md5_string1/contents/1-default/sample1",
+                    }
+                ],
                 "files": [
                     {
                         "name": "reference-result",
@@ -168,6 +173,7 @@ class TestDatasetsContents(Commons):
                         "mode": "0o777",
                         "type": "sym",
                         "linkpath": "sample1",
+                        "uri": "https://localhost/datasets/random_md5_string1/inventory/1-default/reference-result",
                     }
                 ],
             }
@@ -270,7 +276,15 @@ class TestDatasetsContents(Commons):
         )
         if expected_status == HTTPStatus.OK:
             res_json = response.json
-            expected_result = {"directories": ["sample1"], "files": []}
+            expected_result = {
+                "directories": [
+                    {
+                        "name": "sample1",
+                        "uri": "https://localhost/datasets/random_md5_string1/contents/1-default/sample1",
+                    }
+                ],
+                "files": [],
+            }
             assert expected_result == res_json
 
     def test_files_query(
@@ -353,6 +367,7 @@ class TestDatasetsContents(Commons):
                         "size": 122,
                         "mode": "0o644",
                         "type": "reg",
+                        "uri": "https://localhost/datasets/random_md5_string1/inventory/1-default/default.csv",
                     }
                 ],
             }


### PR DESCRIPTION
PBENCH-624

We're not quite ready to rebuild the `/datasets/{dataset}/contents` API on the cache manager. (I actually tried; it's not all there, and currently would need to be built via a full tarball unpack each time we build a `CacheManager` instance, while the changes to persist it via SQL or Redis, which I'd like to do soon, seemed too big a lift right now.)

However, we have planned for some time to supplement the TOC information with a uri element for each file and subdirectory; this much smaller change makes the code match the API documentation.