### PR TITLE
Add ADMIN roles through config file

### DIFF
--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -95,6 +95,7 @@ function cleanup {
 }
 trap cleanup INT QUIT TERM EXIT
 
+export PB_ADMIN_NAMES=${PB_ADMIN_NAMES:-testadmin}
 server/pbenchinacan/run-pbench-in-a-can
 exit_status=${?}
 if [[ ${exit_status} -ne 0 ]]; then

--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -8,6 +8,9 @@ export PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-"$(cat jenkins/branch.name)"}
 export PB_POD_NAME=${PB_POD_NAME:-"pbench-in-a-can_${PB_SERVER_IMAGE_TAG}"}
 export PB_SERVER_CONTAINER_NAME=${PB_SERVER_CONTAINER_NAME:-"${PB_POD_NAME}-pbenchserver"}
 
+# For functional testing, assign ADMIN role to the testadmin username
+export PB_ADMIN_NAMES=${PB_ADMIN_NAMES:-testadmin}
+
 SERVER_URL="https://localhost:8443"
 SERVER_API_ENDPOINTS="${SERVER_URL}/api/v1/endpoints"
 
@@ -95,7 +98,6 @@ function cleanup {
 }
 trap cleanup INT QUIT TERM EXIT
 
-export PB_ADMIN_NAMES=${PB_ADMIN_NAMES:-testadmin}
 server/pbenchinacan/run-pbench-in-a-can
 exit_status=${?}
 if [[ ${exit_status} -ne 0 ]]; then

--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -214,6 +214,7 @@ def create_app(server_config: PbenchServerConfig) -> Flask:
     app = Flask(__name__.split(".")[0])
     CORS(app, resources={r"/api/*": {"origins": "*"}})
 
+    app.server_config = server_config
     app.logger = get_pbench_logger(__name__, server_config)
 
     Auth.setup_app(app, server_config)

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -8,7 +8,7 @@ from flask_restful import abort
 from pbench.server import PbenchServerConfig
 from pbench.server.auth import OpenIDClient
 from pbench.server.database.models.api_keys import APIKey
-from pbench.server.database.models.users import User
+from pbench.server.database.models.users import Roles, User
 
 # Module public
 token_auth = HTTPTokenAuth("Bearer")
@@ -159,6 +159,13 @@ def verify_auth_oidc(auth_token: str) -> Optional[User]:
         audiences = token_payload.get("resource_access", {})
         pb_aud = audiences.get(oidc_client.client_id, {})
         roles = pb_aud.get("roles", [])
+        admin_users = current_app.server_config.get(
+            "pbench-server", "admin-role", fallback=""
+        )
+        if Roles.ADMIN.name not in roles:
+            users = admin_users.split(",")
+            if username in users:
+                roles.append(Roles.ADMIN.name)
 
         # Create or update the user in our cache
         user = User.query(id=user_id)

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -159,12 +159,11 @@ def verify_auth_oidc(auth_token: str) -> Optional[User]:
         audiences = token_payload.get("resource_access", {})
         pb_aud = audiences.get(oidc_client.client_id, {})
         roles = pb_aud.get("roles", [])
-        admin_users = current_app.server_config.get(
-            "pbench-server", "admin-role", fallback=""
-        )
         if Roles.ADMIN.name not in roles:
-            users = admin_users.split(",")
-            if username in users:
+            admin_users = current_app.server_config.get(
+                "pbench-server", "admin-role", fallback=""
+            )
+            if username in admin_users.split(","):
                 roles.append(Roles.ADMIN.name)
 
         # Create or update the user in our cache

--- a/lib/pbench/test/functional/server/conftest.py
+++ b/lib/pbench/test/functional/server/conftest.py
@@ -54,13 +54,7 @@ def oidc_admin(server_client: PbenchServerClient):
 
 def register_user(oidc_admin: OIDCAdmin, user: JSONOBJECT):
     try:
-        response = oidc_admin.create_new_user(
-            username=user["username"],
-            email=user["email"],
-            password=user["password"],
-            first_name=user["first_name"],
-            last_name=user["last_name"],
-        )
+        response = oidc_admin.create_new_user(**user)
     except OpenIDClientError as e:
         # To allow testing outside our transient CI containers, allow the tester
         # user to already exist.

--- a/lib/pbench/test/functional/server/conftest.py
+++ b/lib/pbench/test/functional/server/conftest.py
@@ -5,13 +5,24 @@ import pytest
 
 from pbench.client import PbenchServerClient
 from pbench.client.oidc_admin import OIDCAdmin
+from pbench.client.types import JSONOBJECT
 from pbench.server.auth import OpenIDClientError
 
-USERNAME: str = "tester"
-EMAIL: str = "tester@gmail.com"
-PASSWORD: str = "123456"
-FIRST_NAME: str = "Test"
-LAST_NAME: str = "User"
+USER = {
+    "username": "tester",
+    "email": "tester@gmail.com",
+    "password": "123456",
+    "first_name": "Test",
+    "last_name": "User",
+}
+
+ADMIN = {
+    "username": "testadmin",
+    "email": "testadmin@gmail.com",
+    "password": "123456",
+    "first_name": "Admin",
+    "last_name": "Tester",
+}
 
 
 @pytest.fixture(scope="session")
@@ -41,16 +52,14 @@ def oidc_admin(server_client: PbenchServerClient):
     return OIDCAdmin(server_url=server_client.endpoints["openid"]["server"])
 
 
-@pytest.fixture(scope="session")
-def register_test_user(oidc_admin: OIDCAdmin):
-    """Create a test user for functional tests."""
+def register_user(oidc_admin: OIDCAdmin, user: JSONOBJECT):
     try:
         response = oidc_admin.create_new_user(
-            username=USERNAME,
-            email=EMAIL,
-            password=PASSWORD,
-            first_name=FIRST_NAME,
-            last_name=LAST_NAME,
+            username=user["username"],
+            email=user["email"],
+            password=user["password"],
+            first_name=user["first_name"],
+            last_name=user["last_name"],
         )
     except OpenIDClientError as e:
         # To allow testing outside our transient CI containers, allow the tester
@@ -62,10 +71,31 @@ def register_test_user(oidc_admin: OIDCAdmin):
         assert response.ok, f"Register failed with {response.json()}"
 
 
+@pytest.fixture(scope="session")
+def register_test_user(oidc_admin: OIDCAdmin):
+    """Create a test user for functional tests."""
+    register_user(oidc_admin, USER)
+
+
+@pytest.fixture(scope="session")
+def register_admintest_user(oidc_admin: OIDCAdmin):
+    """Create a test user matching the configured Pbench admin."""
+    register_user(oidc_admin, ADMIN)
+
+
 @pytest.fixture
 def login_user(server_client: PbenchServerClient, register_test_user):
     """Log in the test user and return the authentication token"""
-    server_client.login(USERNAME, PASSWORD)
+    server_client.login(USER["username"], USER["password"])
+    assert server_client.auth_token
+    yield
+    server_client.auth_token = None
+
+
+@pytest.fixture
+def login_admin(server_client: PbenchServerClient, register_admintest_user):
+    """Log in the test user and return the authentication token"""
+    server_client.login(ADMIN["username"], ADMIN["password"])
     assert server_client.auth_token
     yield
     server_client.auth_token = None

--- a/lib/pbench/test/functional/server/test_audit.py
+++ b/lib/pbench/test/functional/server/test_audit.py
@@ -1,0 +1,44 @@
+from pbench.client import API, PbenchServerClient
+
+
+class TestAudit:
+    def test_get_all(self, server_client: PbenchServerClient, login_admin):
+        """
+        Verify that we can retrieve the Pbench Server audit log.
+
+        This relies on a "testadmin" user which has been granted ADMIN role
+        via the pbench-server.cfg file for functional testing. The audit API
+        should succeed without permissions failure, and we'll validate the
+        audit fields of the records we see.
+        """
+        response = server_client.get(API.SERVER_AUDIT, {})
+        json = response.json()
+        assert (
+            response.ok
+        ), f"Reading audit log failed {response.status_code},{json['message']}"
+        assert isinstance(json, list)
+        print(f" ... read {len(json)} audit records")
+        for audit in json:
+            assert isinstance(audit["id"], int)
+            assert audit["name"]
+            assert audit["operation"] in ("CREATE", "READ", "UPDATE", "DELETE")
+            assert audit["reason"] in (None, "PERMISSION", "INTERNAL", "CONSISTENCY")
+            assert "root_id" in audit
+            if audit["root_id"]:
+                assert isinstance(audit["root_id"], int)
+            assert audit["status"] in ("BEGIN", "SUCCESS", "FAILURE", "WARNING")
+            assert audit["timestamp"]
+            assert audit["attributes"]
+            assert audit["object_type"] in (
+                "API_KEY",
+                "CONFIG",
+                "DATASET",
+                "NONE",
+                "TEMPLATE",
+            )
+            if audit["object_type"] != "NONE":
+                assert audit["object_name"]
+                if audit["object_type"] == "DATASET":
+                    assert audit["object_id"]
+            if audit["user_name"] not in (None, "BACKGROUND"):
+                assert audit["user_id"]

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -654,7 +654,7 @@ class TestAuthModule:
         assert user.roles == []
         assert user.username == "dummy"
 
-        # Generate a new token with a role for the same user
+        # Generate a token with a new username for the same UUID
         token, expected_payload = gen_rsa_token(
             client_id,
             rsa_keys["private_key"],
@@ -689,7 +689,7 @@ class TestAuthModule:
         monkeypatch.setattr(Auth, "oidc_client", oidc_client)
         server_config._conf.set("pbench-server", "admin-role", "friend,dummy,admin")
 
-        app = Flask("test-verify-auth-oidc-user-update")
+        app = Flask("test-verify-auth-oidc-user-admin")
         app.logger = make_logger
         app.server_config = server_config
         with app.app_context():
@@ -699,7 +699,7 @@ class TestAuthModule:
         assert user.roles == ["ADMIN"]
         assert user.username == "dummy"
 
-        # Generate a new token with a role for the same user
+        # Generate a token with a role and new username for the same UUID
         token, expected_payload = gen_rsa_token(
             client_id,
             rsa_keys["private_key"],

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -25,6 +25,12 @@ admin-email=%(user)s@localhost
 mailto=%(admin-email)s
 mailfrom=%(user)s@localhost
 
+# A list of usernames to be given ADMIN access on the server. These are SSO ID
+# provider usernames matched against decrypted OIDC2 authorization tokens. If
+# not specified, no users have ADMIN access. NOTE: this is a temporary measure
+# until we work out Keycloak / LDAP roles.
+#admin-role=user1,user2
+
 # Token expiration duration in minutes, can be overridden in the main config file, defaults to 60 mins
 token_expiration_duration = 60
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -25,9 +25,10 @@ admin-email=%(user)s@localhost
 mailto=%(admin-email)s
 mailfrom=%(user)s@localhost
 
-# A list of usernames to be given ADMIN access on the server. These are SSO ID
-# provider usernames matched against decrypted OIDC2 authorization tokens. If
-# not specified, no users have ADMIN access. NOTE: this is a temporary measure
+# A comma-separated list of OIDC usernames with no spaces. These usernames
+# will be granted ADMIN access on the server. These are OIDC ID provider
+# usernames matched against decrypted authorization tokens. If no usernames
+# are specified, no users have ADMIN access. NOTE: this is a temporary measure
 # until we work out Keycloak / LDAP roles.
 #admin-role=user1,user2
 

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -12,6 +12,7 @@ realhost = pbenchinacan
 maximum-dataset-retention-days = 36500
 default-dataset-retention-days = 730
 roles = pbench-results
+admin-role = ##ADMIN_NAMES##
 
 [Indexing]
 index_prefix = container-pbench

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -67,6 +67,7 @@ sed -Ei \
     -e "/^ *realhost/ s/=.*/= $(hostname -f)/" \
     -e "s/<keycloak_realm>/${KEYCLOAK_REALM}/" \
     -e "s/<keycloak_client>/${KEYCLOAK_CLIENT}/" \
+    -e "s/##ADMIN_NAMES##/${PB_ADMIN_NAMES}/" \
     ${PB_DEPLOY_FILES}/pbench-server.cfg
 
 # Set up the /srv/pbench file tree


### PR DESCRIPTION
PBENCH-1197

With the change to SSO, we've lost our own private realm and the ability to manage roles within it. We may be able to restore roles through Keycloak and LDAP groups, but this provides a temporary "quick and dirty" mechanism to define ADMIN roles for a server based on the username provided and cached from OIDC tokens.

We define a simple `admin-role` config variable which can be defined to a comma-separated list of usernames to be granted ADMIN role. This value is processed by the authorization code when it caches local `User` objects for validation.

I've added a functional test for the `audit` API, which requires ADMIN role, both to prove that it works and to provide a long-delayed minimal validation of auditing. (I decided not to merge this into the overloaded "datasets" test file, which means it can't easily be run last: this makes it a less rigorous "audit test", but that can be addressed later and it provides an "ADMIN role test" that's necessary now.)