### PR TITLE
Fix transient "Area 51" failures

### DIFF
--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-51.txt
@@ -26,7 +26,6 @@ pbench-tool-meister-stop: constructed SignalExporter() object
 pbench-tool-meister-stop: constructing SignalExporter() object using host localhost:17001, name: stop-pbench-client
 pbench-tool-meister-stop: publish state signal for state end with metadata: {'group': 'default', 'directory': '/var/tmp/pbench-test-utils/pbench/mock-run/tools-default', 'args': None}
 pbench-tool-meister-stop: publish state signal for state terminate with metadata: {'group': 'default', 'directory': None, 'args': {'interrupt': False}}
-pbench-tool-meister-stop: waiting for tool-data-sink (#####) to exit
 --- Finished test-51 test-start-stop-tool-meister (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
+++ b/agent/util-scripts/gold/test-start-stop-tool-meister/test-52.txt
@@ -26,7 +26,6 @@ pbench-tool-meister-stop: constructed SignalExporter() object
 pbench-tool-meister-stop: constructing SignalExporter() object using host localhost:17001, name: stop-pbench-client
 pbench-tool-meister-stop: publish state signal for state end with metadata: {'group': 'mygroup', 'directory': '/var/tmp/pbench-test-utils/pbench/mock-run/tools-mygroup', 'args': None}
 pbench-tool-meister-stop: publish state signal for state terminate with metadata: {'group': 'mygroup', 'directory': None, 'args': {'interrupt': False}}
-pbench-tool-meister-stop: waiting for tool-data-sink (#####) to exit
 --- Finished test-52 test-start-stop-tool-meister (status=0)
 +++ pbench tree state
 /var/tmp/pbench-test-utils/pbench

--- a/agent/util-scripts/unittests
+++ b/agent/util-scripts/unittests
@@ -262,7 +262,7 @@ function _verify_output {
            -e 's;v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*;v#.##.##;g' \
            -e 's;"pid": [0-9][0-9]*\([,}]\);"pid": NNNNN\1;g' \
            -e "s;'pid': [0-9][0-9]*\([,}]\);'pid': NNNNN\1;g" \
-           -e "s;\(waiting for tool-data-sink\) ([0-9][0-9]*) \(to exit\);\1 (#####) \2;g" \
+           -e "/waiting for tool-data-sink ([0-9][0-9]*) to exit/ d" \
            -e 's;tar up [0-9][0-9]* bytes;tar up ##### bytes;g' \
            ${_testout}
     if [[ ${?} -ne 0 ]]; then

--- a/exec-tests
+++ b/exec-tests
@@ -243,7 +243,13 @@ if [[ "${major}" == "all" || "${major}" == "server" ]]; then
         shift
         posargs="${@}"
         # We use SQLALCHEMY_SILENCE_UBER_WARNING here ... (see above).
-        REQUESTS_CA_BUNDLE=${PWD}/server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt SQLALCHEMY_SILENCE_UBER_WARNING=1 PYTHONUNBUFFERED=True PBENCH_SERVER=${server_arg} KEEP_DATASETS="${keep_datasets}" pytest --tb=native -v -s -rs --pyargs ${posargs} pbench.test.functional.server
+        REQUESTS_CA_BUNDLE=${PWD}/server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt \
+            SQLALCHEMY_SILENCE_UBER_WARNING=1 \
+            PYTHONUNBUFFERED=True \
+            PBENCH_SERVER=${server_arg} \
+            KEEP_DATASETS="${keep_datasets}" \
+                pytest --tb=native -v -s -rs --pyargs ${posargs} \
+                    pbench.test.functional.server
         rc=${?}
     fi
 fi

--- a/server/pbenchinacan/deploy
+++ b/server/pbenchinacan/deploy
@@ -44,7 +44,6 @@ PB_DEPLOY_FILES=${PB_DEPLOY_FILES:-${HOME}/Deploy}
 SRV_PBENCH=${SRV_PBENCH:-/srv/pbench}
 PB_SSL_CERT_FILE=${PB_SSL_CERT_FILE:-${PB_DEPLOY_FILES}/pbench-server.crt}
 PB_SSL_KEY_FILE=${PB_SSL_KEY_FILE:-${PB_DEPLOY_FILES}/pbench-server.key}
-PB_SSL_CA_FILE=${PB_SSL_CA_FILE:-${PWD}/server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt}
 
 # Locations inside the container
 #


### PR DESCRIPTION
This PR addresses an instability in Agent legacy tests `test-51` and `test-52`.

In `graceful_shutdown()` in [`tool_meister_stop.py`](https://github.com/distributed-system-analysis/pbench/blob/3b8bf2f018434c8b242a2639ab4d7a4f8548ed9e/lib/pbench/agent/tool_meister_stop.py#L96), the code issues a debug log message if it has to wait for the Tool Data Sync to exit.  However, if, by the time control reaches this point, the TDS has already exited, then the PID file will have been removed, and the attempt to read it produces an exception which is discarded and the wait is skipped.

This results in a race condition which may or may not produce the log message output.  There is no correctness issue associated with the presence or absence of the message in the log, but the legacy unit test system won't tolerate variable output, and, since the "gold" file includes the message, the test is considered to have failed any time the race goes the other way.

This PR modifies the output filtering for this message to, instead of masking just the PID value, remove the line from the log altogether if it is present.  And, it updates the two relevant "gold" files.  This should enable a deterministic result.

This PR also removes an unused definition which was left over from PR #3427 and reformats a long line which it added.