### PR TITLE
Re-enable the dev dashboard

### DIFF
--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const axios = require('axios');
+const https = require('https')
 require('dotenv').config()
 
 
@@ -8,7 +9,12 @@ app.get('/api/v1/endpoints', (_req, res) => {
     console.log('Mirror engaged: ', process.env.PBENCH_SERVER)
     axios.get(
             `${process.env.PBENCH_SERVER}/api/v1/endpoints`,
-            { headers: { 'Accept': 'application/json' } })
+        {
+            headers: { 'Accept': 'application/json' },
+            httpsAgent: new https.Agent({
+                rejectUnauthorized: false
+            })
+        })
         .then(endpoints => {
             res.setHeader('Content-Type', 'application/json');
             res.send(endpoints.data);

--- a/dashboard/server/index.js
+++ b/dashboard/server/index.js
@@ -1,27 +1,28 @@
-const express = require('express');
-const axios = require('axios');
-const https = require('https')
-require('dotenv').config()
+const express = require("express");
+const axios = require("axios");
+const https = require("https");
+const fs = require("fs");
+require("dotenv").config();
 
+const app = express();
+app.get("/api/v1/endpoints", (_req, res) => {
+  console.log("Mirror engaged: ", process.env.PBENCH_SERVER);
+  axios
+    .get(`${process.env.PBENCH_SERVER}/api/v1/endpoints`, {
+      headers: { Accept: "application/json" },
+      httpsAgent: new https.Agent({
+        ca: fs.readFileSync(
+          "../server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt"
+          )
+      }),
+    })
+    .then((endpoints) => {
+      res.setHeader("Content-Type", "application/json");
+      res.send(endpoints.data);
+    })
+    .catch((err) => {
+      console.log("Error: ", err.message);
+    });
+});
 
-const app = express()
-app.get('/api/v1/endpoints', (_req, res) => {
-    console.log('Mirror engaged: ', process.env.PBENCH_SERVER)
-    axios.get(
-            `${process.env.PBENCH_SERVER}/api/v1/endpoints`,
-        {
-            headers: { 'Accept': 'application/json' },
-            httpsAgent: new https.Agent({
-                rejectUnauthorized: false
-            })
-        })
-        .then(endpoints => {
-            res.setHeader('Content-Type', 'application/json');
-            res.send(endpoints.data);
-        })
-        .catch(err => {
-            console.log('Error: ', err.message);
-        })
-})
-
-app.listen(3001, () => console.log('Mirror server running on localhost:3001'));
+app.listen(3001, () => console.log("Mirror server running on localhost:3001"));

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -107,9 +107,6 @@ curl -si -f -X POST \
       ]
     }'
 
-echo "Setting redirect [ ${KEYCLOAK_DEV_REDIRECT}, ${KEYCLOAK_REDIRECT_URI} ]"
-
-set -vx
 CLIENT_CONF=$(curl -si -f -X POST \
   "${KEYCLOAK_HOST_PORT}/admin/realms/${REALM}/clients" \
   -H "Authorization: Bearer ${ADMIN_TOKEN}" \
@@ -123,10 +120,7 @@ CLIENT_CONF=$(curl -si -f -X POST \
        "attributes": {"post.logout.redirect.uris": "+"},
        "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'", "'${KEYCLOAK_DEV_REDIRECT}'"]}')
 
-echo "client ${?}, output ${CLIENT_CONF}"
-
 CLIENT_ID=$(grep -o -e 'https://[^[:space:]]*' <<< ${CLIENT_CONF} | sed -e 's|.*/||')
-echo "CLIENT_ID: ${CLIENT_ID}"
 if [[ -z "${CLIENT_ID}" ]]; then
   echo "${CLIENT} id is empty"
   exit 1

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -19,6 +19,7 @@
 
 KEYCLOAK_HOST_PORT=${KEYCLOAK_HOST_PORT:-"https://localhost:8090"}
 KEYCLOAK_REDIRECT_URI=${KEYCLOAK_REDIRECT_URI:-"https://localhost:8443/*"}
+KEYCLOAK_DEV_ORIGIN=${KEYCLOAK_DEV_ORIGIN:-"http://localhost:3000"}
 ADMIN_USERNAME=${ADMIN_USERNAME:-"admin"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 # These values must match the options "realm" and "client in the
@@ -118,7 +119,7 @@ CLIENT_CONF=$(curl -si -f -X POST \
        "serviceAccountsEnabled": true,
        "enabled": true,
        "attributes": {"post.logout.redirect.uris": "'${KEYCLOAK_REDIRECT_URI}'"},
-       "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'"]}')
+       "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'", "'${KEYCLOAK_DEV_ORIGIN}/*'" ]}')
 
 CLIENT_ID=$(grep -o -e 'https://[^[:space:]]*' <<< ${CLIENT_CONF} | sed -e 's|.*/||')
 if [[ -z "${CLIENT_ID}" ]]; then

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -19,7 +19,7 @@
 
 KEYCLOAK_HOST_PORT=${KEYCLOAK_HOST_PORT:-"https://localhost:8090"}
 KEYCLOAK_REDIRECT_URI=${KEYCLOAK_REDIRECT_URI:-"https://localhost:8443/*"}
-KEYCLOAK_DEV_ORIGIN=${KEYCLOAK_DEV_ORIGIN:-"http://localhost:3000"}
+KEYCLOAK_DEV_ORIGIN=${KEYCLOAK_DEV_ORIGIN:-"http://localhost:3000/*"}
 ADMIN_USERNAME=${ADMIN_USERNAME:-"admin"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 # These values must match the options "realm" and "client in the
@@ -118,8 +118,8 @@ CLIENT_CONF=$(curl -si -f -X POST \
        "directAccessGrantsEnabled": true,
        "serviceAccountsEnabled": true,
        "enabled": true,
-       "attributes": {"post.logout.redirect.uris": "'${KEYCLOAK_REDIRECT_URI}'"},
-       "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'", "'${KEYCLOAK_DEV_ORIGIN}/*'" ]}')
+       "attributes": {"post.logout.redirect.uris": ["'${KEYCLOAK_REDIRECT_URI}'", "'${KEYCLOAK_DEV_ORIGIN}'"]},
+       "redirectUris": ["'${KEYCLOAK_REDIRECT_URI}'", "'${KEYCLOAK_DEV_ORIGIN}'" ]}')
 
 CLIENT_ID=$(grep -o -e 'https://[^[:space:]]*' <<< ${CLIENT_CONF} | sed -e 's|.*/||')
 if [[ -z "${CLIENT_ID}" ]]; then


### PR DESCRIPTION
PBENCH-1203

The shift to HTTPS and Keycloak has broken our dashboard local dev mode hack in two ways:

1. The `axios.get` call in the express mirror server needs to either load certificates or disable validation. This adds the CI private CA key.
2. Login requires that the Keycloak be configured with the address of the dashboard code, which in this mode is `http://localhost:3000`. This adds that redirect to the Keycloak configuration

