### PR TITLE
Fixes to ansible roles (fwd port of #3478)

### DIFF
--- a/agent/ansible/ansible-lint.yml
+++ b/agent/ansible/ansible-lint.yml
@@ -1,4 +1,5 @@
 ---
 skip_list:
-  - experimental  # all rules tagged as experimental
-  - no-changed-when  # Commands should not change things if nothing needs doing.
+  - experimental        # all rules tagged as experimental
+  - no-changed-when     # Commands should not change things if nothing needs doing.
+  - package-latest      # Do not complain about using `latest'

--- a/agent/ansible/collection/galaxy.yml
+++ b/agent/ansible/collection/galaxy.yml
@@ -10,7 +10,7 @@ namespace: pbench
 name: agent
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.0.7
+version: 1.0.11
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/agent/ansible/collection/roles/pbench_agent_install/tasks/main.yml
+++ b/agent/ansible/collection/roles/pbench_agent_install/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Install RPMs
   ansible.builtin.package:
-    name: "{{ item }}"
-  with_items:
-    - pbench-agent
-    - pbench-sysstat
+    name:
+      - pbench-agent
+      - pbench-sysstat
+    state: latest

--- a/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/defaults/main.yml
@@ -17,7 +17,7 @@ repos:
 
   - tag: "{{ pbench_aux_repo_name }}"
     user: "{{ fedoraproject_username }}"
-    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/{{distrodir}}"
+    baseurl: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/{{ distrodir }}"
     gpgkey: "{{ pbench_repo_url_prefix }}/{{ pbench_aux_repo_name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: "{{ enable_copr_aux_repo }}"

--- a/agent/ansible/collection/roles/pbench_repo_install/tasks/main.yml
+++ b/agent/ansible/collection/roles/pbench_repo_install/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 # Install pbench.repo
 - name: Assert pbench_repo_name is defined
-  assert:
+  ansible.builtin.assert:
     that:
       - pbench_repo_name is defined
     fail_msg: "Please specify the COPR repository name to use in the `pbench_repo_name` variable"
+    quiet: true
 
 - name: Ensure we have the pbench.repo file properly in place
   ansible.builtin.template:

--- a/agent/ansible/collection/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
+++ b/agent/ansible/collection/roles/pbench_repo_install/templates/etc/yum.repos.d/pbench.repo.j2
@@ -1,7 +1,7 @@
 {% for repo in repos %}
 
-[copr-{{ repo.name }}-{{ repo.user }}]
-name=COPR {{ repo.name }} ({{ repo.user }}) repo
+[copr-{{ repo.tag }}-{{ repo.user }}]
+name=COPR {{ repo.tag }} ({{ repo.user }}) repo
 baseurl={{ repo.baseurl }}
 gpgcheck={{ repo.gpgcheck }}
 gpgkey={{ repo.gpgkey }}


### PR DESCRIPTION
- repo.name -> repo.tag

- assert that `pbench_repo_name' is defined (users have to define it in their inventory)

- use `latest' when installing packages and stop ansible-lint from complaining about it

These fixes are incorporated into the `pbench.agent` collection, v1.0.11, available from Galaxy.

PBENCH-1129