### PR TITLE
Gracefully report duplicate usernames

### DIFF
--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -9,11 +9,13 @@ import pytest
 import requests
 from requests.structures import CaseInsensitiveDict
 import responses
+from werkzeug.exceptions import Unauthorized
 
 from pbench.server import JSON, PbenchServerConfig
 import pbench.server.auth
 from pbench.server.auth import Connection, OpenIDClient, OpenIDClientError
 import pbench.server.auth.auth as Auth
+from pbench.server.database.models.users import User
 from pbench.test.unit.server import DRB_USER_ID
 from pbench.test.unit.server.conftest import jwt_secret
 
@@ -711,6 +713,37 @@ class TestAuthModule:
         assert user.id == "12345"
         assert user.roles == ["ROLE", "ADMIN"]
         assert user.username == "friend"
+
+    def test_verify_auth_oidc_user_duplicate(
+        self, monkeypatch, server_config, db_session, rsa_keys, make_logger
+    ):
+        """Verify behavior when an OIDC username already exists with a
+        different UUID."""
+        client_id = "us"
+        token, expected_payload = gen_rsa_token(client_id, rsa_keys["private_key"])
+
+        # Mock the Connection object and generate an OpenIDClient object,
+        # installing it as Auth module's OIDC client.
+        config = mock_connection(
+            monkeypatch, client_id, public_key=rsa_keys["public_key"]
+        )
+        oidc_client = OpenIDClient.construct_oidc_client(config)
+        monkeypatch.setattr(Auth, "oidc_client", oidc_client)
+
+        app = Flask("test-verify-auth-oidc-user-dup")
+        app.logger = make_logger
+        app.server_config = server_config
+
+        assert not User.query(id="12345")
+        User(username="dummy", id="abcde").add()
+        orig = User.query(id="12345")
+        copy = User.query(id="abcde")
+        assert orig != copy, f"{orig} == {copy}"
+        with app.app_context():
+            with pytest.raises(
+                Unauthorized, match="The username 'dummy' already exists"
+            ):
+                Auth.verify_auth(token)
 
     def test_verify_auth_oidc_invalid(
         self, monkeypatch, server_config, rsa_keys, make_logger


### PR DESCRIPTION
PBENCH-1198

With the move from a private Keycloak ID provider to Red Hat SSO, we find that several user UUID values (from the old and new ID provider) are attempting to claim the same username. The current user "cache" doesn't allow for this, nor in general does it seem we really want to be casually mapping multiple "users" across ID providers into the same "Pbench identity" just because they share a username.

Instead, diagnose this problem with an authorization failure and an explicit error message instead of letting the Auth module hide the error and silently treat the client connection as unauthenticated.

Note that we can manually fix this by renaming the old user entry in SQL, which will allow the server to recognize the new SSO login. We can then reassign any existing datasets from the old user to the new user.