### PR TITLE
Fix server RPM builds on Fedora (b0.69)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,30 @@
 ---
-# black complains loudly that fio-histo-log-pctile.py is not a python file
-# because it isn't, so ignore it.
-exclude: (agent/bench-scripts/test-bin/fio-histo-log-pctiles.py|agent/stockpile/roles|web-server)
+# `black` complains loudly that fio-histo-log-pctile.py is not a python file,
+# which it isn't, and also complains about the long forgotten demo.py file, so
+# we ignore them both.
+#
+# We must duplicate these excludes also listed in pyproject.toml because the
+# commands below are explicitly invoked on the files added or changed.  This
+# exclude prevents those checks being run.
+exclude: (agent/bench-scripts/test-bin/fio-histo-log-pctiles\.py|web-server/v0\.3/demo\.py)
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
-     - id: flake8
-       additional_dependencies: [flake8-typing-imports==1.6.0]
+      - id: flake8
+        name: flake8 (python3)
+        language_version: python3
   - repo: https://github.com/python/black.git
-    rev: 19.10b0
+    rev: 22.12.0
     hooks:
-        - id: black
-          language_version: python3
-          args: ["--check"]
+      - id: black
+        name: black (python3)
+        language_version: python3
+        args: ["--check"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python3)
+        language_version: python3
+        args: ["--check"]

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -22,6 +22,10 @@ Requires: python39 python39-six python39-urllib3
 # running RHEL 8.
 BuildRequires: python3-rpm-macros python3-devel
 
+%if 0%{?fedora} >= 37
+BuildRequires: python3.9
+%endif
+
 %define __python3  /usr/bin/python3.9
 
 # policycoreutils for semanage and restorecon - used in pbench-server-activate-create-results-dir


### PR DESCRIPTION
python3.9 is needed as a build requirement. That may be required in b0.72 and main as well, but we'll cross that bridge when/if we need to.

pre-commit was failing with weird errors. After clearing the cache, I was asked to login to gitlab: the config was different from main and was trying to get flake8 from gitlab. I copied the config from main (which is using github for both flake8 and black) into the b0.69 branch and that seems to work.