### PR TITLE
Correct OIDC URL generation and raise max payload size

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -8,8 +8,8 @@ from typing import Any, Optional
 import jwt
 import requests
 from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 from requests.structures import CaseInsensitiveDict
-from urllib3.util.retry import Retry
 
 from pbench.server import JSON, PbenchServerConfig
 
@@ -53,7 +53,7 @@ class Connection:
 
         Args:
             method : The API HTTP method
-            path : Path for the request.
+            path : Path for the request (must begin with a slash).
             data : Form data to send with the request in case of the POST
             json : JSON data to send with the request in case of the POST
             kwargs : Additional keyword args
@@ -64,7 +64,7 @@ class Connection:
         final_headers = self.headers.copy()
         if headers is not None:
             final_headers.update(headers)
-        url = self.server_url + "/" + path
+        url = self.server_url + path
         request_dict = dict(
             params=kwargs,
             data=data,
@@ -321,7 +321,7 @@ class OpenIDClient:
         )
 
     def set_oidc_public_key(self):
-        realm_public_key_uri = f"realms/{self._realm_name}"
+        realm_public_key_uri = f"/realms/{self._realm_name}"
         response_json = self._connection.get(realm_public_key_uri).json()
         public_key = response_json["public_key"]
         pem_public_key = "-----BEGIN PUBLIC KEY-----\n"

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -4,13 +4,12 @@ from configparser import NoOptionError, NoSectionError
 from http import HTTPStatus
 import logging
 from typing import Any, Optional
-from urllib.parse import urljoin
 
 import jwt
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from requests.structures import CaseInsensitiveDict
+from urllib3.util.retry import Retry
 
 from pbench.server import JSON, PbenchServerConfig
 

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -65,7 +65,7 @@ class Connection:
         final_headers = self.headers.copy()
         if headers is not None:
             final_headers.update(headers)
-        url = urljoin(self.server_url, path)
+        url = self.server_url + "/" + path
         request_dict = dict(
             params=kwargs,
             data=data,

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -10,7 +10,6 @@ import shutil
 from stat import ST_MTIME
 import tarfile
 from typing import Dict, Optional
-from urllib.parse import urljoin
 import uuid
 
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -165,7 +164,7 @@ def add_auth_connection_mock(server_config, rsa_keys):
     with responses.RequestsMock() as mock:
         oidc_server = server_config.get("openid", "server_url")
         oidc_realm = server_config.get("openid", "realm")
-        url = urljoin(oidc_server, f"realms/{oidc_realm}")
+        url = oidc_server + "/realms/" + oidc_realm
 
         mock.add(
             responses.GET,

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -121,7 +121,7 @@ http {
             proxy_set_header         X-Real-IP         $remote_addr;
             proxy_set_header         X-Forwarded-Proto $scheme;
 
-            client_max_body_size     10G;
+            client_max_body_size     100G;
         }
 
         location /dashboard {


### PR DESCRIPTION
This PR provides two small changes identified during Pbench Server "Ops review" sessions.

The first change raises the max request payload size to 100Gb.  The existing limit of 10Gb is too small for certain users' requests.

The other changes is a follow-on to #3427.  This PR replaces a couple of `urljoin()` calls with simple string concatenation, since that function doesn't behave as expected when the configured OIDC server URL contains a partial path.
