### PR TITLE
Fix OIDC access to verify TLS connection

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -205,10 +205,10 @@ class OpenIDClient:
         try:
             oidc_server = server_config.get("openid", "server_url")
             oidc_realm = server_config.get("openid", "realm")
-            # Get a custom cert location to verify Keycloak ssl if its define
-            # in the config file. Otherwise, we default to using system-wide
-            # certificates.
-            cert = server_config.get("openid", "cert_location", fallback=True)
+            # Look for a custom CA to use in the verification of the TLS
+            # connection to the OIDC server.  If it is undefined, the value of
+            # True will result in using the default TLS verification.
+            ca_cert = server_config.get("openid", "tls_ca_file", fallback=True)
         except (NoOptionError, NoSectionError) as exc:
             raise OpenIDClient.NotConfigured() from exc
 
@@ -238,7 +238,7 @@ class OpenIDClient:
             try:
                 response = session.get(
                     f"{oidc_server}/realms/{oidc_realm}/.well-known/openid-configuration",
-                    verify=cert,
+                    verify=ca_cert,
                 )
                 response.raise_for_status()
             except Exception as exc:
@@ -270,6 +270,10 @@ class OpenIDClient:
             server_url = server_config.get("openid", "server_url")
             client = server_config.get("openid", "client")
             realm = server_config.get("openid", "realm")
+            # Look for a custom CA to use in the verification of the TLS
+            # connection to the OIDC server.  If it is undefined, the value of
+            # True will result in using the default TLS verification.
+            ca_cert = server_config.get("openid", "tls_ca_file", fallback=True)
         except (NoOptionError, NoSectionError) as exc:
             raise OpenIDClient.NotConfigured() from exc
 
@@ -277,7 +281,7 @@ class OpenIDClient:
             server_url=server_url,
             client_id=client,
             realm_name=realm,
-            verify=False,
+            verify=ca_cert
         )
         oidc_client.set_oidc_public_key()
         return oidc_client

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -240,7 +240,7 @@ class OpenIDClient:
                 )
                 response.raise_for_status()
             except Exception as exc:
-                raise OpenIDClient.ServerConnectionError() from exc
+                raise OpenIDClient.ServerConnectionError(str(exc)) from exc
             if response.json().get("issuer") == f"{oidc_server}/realms/{oidc_realm}":
                 logger.debug("OIDC server connection verified")
                 connected = True

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -224,6 +224,8 @@ class OpenIDClient:
         # https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry
         retry = Retry(
             total=8,
+            connect=0,
+            other=0,
             backoff_factor=2,
             status_forcelist=tuple(int(x) for x in HTTPStatus if x != 200),
         )

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -278,10 +278,7 @@ class OpenIDClient:
             raise OpenIDClient.NotConfigured() from exc
 
         oidc_client = cls(
-            server_url=server_url,
-            client_id=client,
-            realm_name=realm,
-            verify=ca_cert
+            server_url=server_url, client_id=client, realm_name=realm, verify=ca_cert
         )
         oidc_client.set_oidc_public_key()
         return oidc_client

--- a/lib/pbench/test/unit/server/auth/test_auth.py
+++ b/lib/pbench/test/unit/server/auth/test_auth.py
@@ -300,7 +300,7 @@ class TestOpenIDClient:
         config["openid"] = {
             "server_url": "https://example.com",
             "realm": "realm",
-            "cert_location": "/ca.crt",
+            "tls_ca_file": "/ca.crt",
         }
 
         # Keycloak well-known endpoint without any response
@@ -338,7 +338,7 @@ class TestOpenIDClient:
         config["openid"] = {
             "server_url": "https://example.com",
             "realm": "realm",
-            "cert_location": "/ca.crt",
+            "tls_ca_file": "/ca.crt",
         }
 
         # Keycloak well-known endpoint returning response with valid issuer

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -107,9 +107,9 @@ realm = pbench-server
 # Client entity name requesting OIDC to authenticate a user.
 client = pbench-client
 
-# Cert location for connecting to the OIDC client
-# If you want to use a custom CA then its location path should be recorded.
-#cert_location = /path/CA
+# Custom CA for verifying the TLS connection to the OIDC client.
+# If omitted, TLS verification will use the system's trusted CA list.
+#tls_ca_file = /path/to/CA/file
 
 [logging]
 logger_type = devlog

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -27,9 +27,8 @@ secret-key = "pbench-in-a-can secret shhh"
 [openid]
 server_url = https://localhost:8090
 
-# Override the default cert value to use for pbenchinacan Keycloak container
-# connection.
-cert_location = /etc/pki/tls/certs/pbench_CA.crt
+# Provide a CA cert for the pbenchinacan Keycloak server connection.
+tls_ca_file = /etc/pki/tls/certs/pbench_CA.crt
 
 ###########################################################################
 # The rest will come from the default config file.


### PR DESCRIPTION
In the course of recovering from our latest challenges with the Staging server, we noticed warnings triggered by the Pbench Server accesses to the OIDC server indicating that TLS verification was disabled...which, in fact, it was...which is undesirable.  It turns out that there are two places in the Pbench Server code where it connects to the OIDC server -- once during startup to make sure that the service is available and once somewhat later to fetch the public key for token decryption -- and the first was performing TLS verification but the second wasn't.

This PR provides a common mechanism for both sets of accesses to use to determine whether and how to use TLS verification.  Both relevant places in the code now pull the path to the CA from the Pbench Server configuration; if the path is not provided, they use `True` to trigger default TLS verification using the system's trusted CA store.

This change also renames the configuration option and wordsmiths some of the relevant code comments.