### PR TITLE
Remove working containers when commiting a container image

### DIFF
--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -82,7 +82,7 @@ ${_DISTROS:%=image-rpmbuild-%}: image-rpmbuild-%:
 		buildah run $$container ${PKGMGR} install -y ${RPMBUILD_PACKAGES} && \
 		buildah run $$container ${PKGMGR} clean all && \
 		buildah run $$container python3 -m pip install jinja2-cli && \
-		buildah commit $$container ${PB_CONTAINER_REG}/pbench-rpmbuild:${*}
+		buildah commit --rm $$container ${PB_CONTAINER_REG}/pbench-rpmbuild:${*}
 
 ci.fedora.Dockerfile: ci.Dockerfile.j2
 	jinja2 ci.Dockerfile.j2 \

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -130,6 +130,7 @@ pipeline {
                     | sort -u \
                     | xargs podman image rm -f \
                     || true'
+            sh 'buildah rm --all'
         }
     }
 }

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -84,4 +84,4 @@ buildah run $container systemctl enable pbench-server
 buildah run $container systemctl enable pbench-index.timer
 
 # Create the container image.
-buildah commit $container ${PB_CONTAINER_REG}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}
+buildah commit --rm $container ${PB_CONTAINER_REG}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}


### PR DESCRIPTION
It turns out that the default when committing a container build to a saved image is to retain the working container.  This is never reused and just ends up taking up disk space.

This PR adds the `--rm` switch to the `commit` command to our `buildah`-based container builds to ensure that the working container is removed when the container image is created.

It also adds a `buildah rm --all` command to the CI pipeline cleanup step to ensure that we don't have an unsightly buildup of containers on the Jenkins executors.