### PR TITLE
Raise the Nginx max body size to 100G (`b0.72`)

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -118,7 +118,7 @@ http {
             proxy_set_header         X-Forwarded-For  $proxy_add_x_forwarded_for;
             proxy_set_header         X-Real-IP        $remote_addr;
 
-            client_max_body_size     10G;
+            client_max_body_size     100G;
         }
 
         location /dashboard {


### PR DESCRIPTION
This change raises the Nginx maximum request payload size from 10G to 100G to better accommodate certain individuals' results dataset sizes.

PBENCH-1199