### PR TITLE
Sweep one missed piece of crontab fluff

### DIFF
--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -11,7 +11,6 @@ environment = container
 realhost = pbenchinacan
 maximum-dataset-retention-days = 36500
 default-dataset-retention-days = 730
-roles = pbench-results
 admin-role = ##ADMIN_NAMES##
 
 [Indexing]


### PR DESCRIPTION
PBENCH-1206

Webb noticed a crontab "roles" definition in the canned cfg file, which never belonged there.