### PR TITLE
Partial backport of #3469 (agent side only) to b0.72

### DIFF
--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -5,7 +5,6 @@ import tempfile
 from typing import List
 
 import click
-import requests
 
 from pbench.agent.base import BaseCommand
 from pbench.agent.results import CopyResultTb, MakeResultTb
@@ -111,7 +110,7 @@ class MoveResults(BaseCommand):
                     if not res.ok:
                         try:
                             msg = res.json()["message"]
-                        except requests.exceptions.JSONDecodeError:
+                        except Exception:
                             msg = res.text if res.text else res.reason
                         raise CopyResultTb.FileUploadError(msg)
                 except Exception as exc:

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import List
 
 import click
-import requests
 
 from pbench.agent.base import BaseCommand
 from pbench.agent.results import CopyResultTb
@@ -36,7 +35,7 @@ class ResultsPush(BaseCommand):
 
         try:
             msg = res.json()["message"]
-        except requests.exceptions.JSONDecodeError:
+        except Exception:
             msg = res.text if res.text else res.reason
 
         # dup or other unexpected but non-error status


### PR DESCRIPTION
Replace `requests.exceptions.JSONDecodeError` by generic `Exception`.

See #3469 for some details. The upstream issue is

   https://github.com/psf/requests/issues/5794

and the PR is

   https://github.com/psf/requests/pull/5856

but we are running older versions of `requests' in various places.