### PR TITLE
Allow for private CA on the Agent side

### DIFF
--- a/agent/config/pbench-agent-default.cfg
+++ b/agent/config/pbench-agent-default.cfg
@@ -21,6 +21,7 @@ ssh_opts = -o BatchMode=yes -o StrictHostKeyChecking=no
 api_version = 1
 rest_endpoint = api/v%(api_version)s
 server_rest_url = https://%(pbench_web_server)s/%(rest_endpoint)s
+#server_ca =
 
 [pbench/tools]
 light-tool-set = vmstat

--- a/agent/config/pbench-agent.cfg
+++ b/agent/config/pbench-agent.cfg
@@ -6,3 +6,6 @@ pbench_web_server = pbench.example.com
 [config]
 path = %(pbench_install_dir)s/config
 files = pbench-agent-default.cfg
+
+[results]
+#server_ca =

--- a/agent/config/pbench-agent.cfg
+++ b/agent/config/pbench-agent.cfg
@@ -6,6 +6,3 @@ pbench_web_server = pbench.example.com
 [config]
 path = %(pbench_install_dir)s/config
 files = pbench-agent-default.cfg
-
-[results]
-#server_ca =

--- a/agent/containers/images/container_build.sh
+++ b/agent/containers/images/container_build.sh
@@ -4,17 +4,33 @@
 # Pbench Agent containers for a platform specified by the PB_AGENT_DISTRO
 # environment variable, defaulting to fedora-38.
 #
-# This is similar to the commands used in the CI; however, the CI builds the
+# These are the same commands used in the CI; however, the CI builds the
 # RPMs in the common build.sh script while the Jenkins Pipeline.gy builds the
-# CI container on top of that. This encapsulates the "trickery" used to get a
-# functional result so it's easier to use interactively.
+# CI container on top of that. Here we encapsulate the steps used to get a
+# functional result to make this more convenient interactively.
 #
-# For efficiency, we don't use the various "cleanup" Make targets; however
-# instead of needing to remember and execute them separately, you can use
+# WORKSPACE_TMP is assumed to be the root of the work area, and by default will
+# be set to ${HOME}.
+#
+# If you want to clean the make targets for RPM and container builds, use:
+#
 #   agent/containers/images/container_build.sh --clean
-# to insert the cleanup targets when desirable.
 
-opts=$(getopt -q -o ch --longoptions "clean,help" -n "container_build" -- "${@}")
+export PB_AGENT_DISTRO=${PB_AGENT_DISTRO:-fedora-38}
+export WORKSPACE_TMP=${WORKSPACE_TMP:-${HOME}}
+
+function usage {
+    printf "Build a Pbench Agent container for the distribution named by the\n"
+    printf "PB_AGENT_DISTRO environment variable, which defaults to '${PB_AGENT_DISTRO}'.\n"
+    printf "\nThe following options are available:\n"
+    printf "\n"
+    printf -- "\t-c|--clean\n"
+    printf "\t\tRemove old RPM and container image targets before building.\n"
+    printf -- "\t-h|--help\n"
+    printf "\t\tPrint this usage message and terminate.\n"
+}
+
+opts=$(getopt -q -o ch --longoptions "clean,help" -n "${0}" -- "${@}")
 if [[ ${?} -ne 0 ]]; then
     printf -- "%s %s\n\n\tunrecognized option specified\n\n" "${0}" "${*}" >&2
     usage >&2
@@ -22,14 +38,14 @@ if [[ ${?} -ne 0 ]]; then
 fi
 eval set -- "${opts}"
 rpm_clean=
-pod_clean=
+image_clean=
 while true; do
     arg=${1}
     shift
     case "${arg}" in
     -c|--clean)
         rpm_clean=distclean
-        pod_clean=clean
+        image_clean=clean
         ;;
     -h|--help)
         usage
@@ -46,8 +62,6 @@ while true; do
     esac
 done
 
-PB_AGENT_DISTRO=${PB_AGENT_DISTRO:-fedora-38}
-
-WORKSPACE_TMP=${HOME} make -C agent/rpm ${rpm_clean} ${PB_AGENT_DISTRO}-rpm
-CI=1 WORKSPACE_TMP=${HOME} make -C agent/containers/images \
-    CI_RPM_ROOT=${HOME} ${pod_clean} ${PB_AGENT_DISTRO}-everything
+make -C agent/rpm ${rpm_clean} ${PB_AGENT_DISTRO}-rpm
+make -C agent/containers/images CI=1 CI_RPM_ROOT=${WORKSPACE_TMP} \
+    ${image_clean} ${PB_AGENT_DISTRO}-everything

--- a/agent/containers/images/container_build.sh
+++ b/agent/containers/images/container_build.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This is an essentially "trivial" script to interactively build a full set of
+# Pbench Agent containers for a platform specified by the PB_AGENT_DISTRO
+# environment variable, defaulting to fedora-38.
+#
+# This is similar to the commands used in the CI; however, the CI builds the
+# RPMs in the common build.sh script while the Jenkins Pipeline.gy builds the
+# CI container on top of that. This encapsulates the "trickery" used to get a
+# functional result so it's easier to use interactively.
+#
+# For efficiency, we don't use the various "cleanup" Make targets; however
+# instead of needing to remember and execute them separately, you can use
+#   agent/containers/images/container_build.sh --clean
+# to insert the cleanup targets when desirable.
+
+opts=$(getopt -q -o ch --longoptions "clean,help" -n "container_build" -- "${@}")
+if [[ ${?} -ne 0 ]]; then
+    printf -- "%s %s\n\n\tunrecognized option specified\n\n" "${0}" "${*}" >&2
+    usage >&2
+    exit 1
+fi
+eval set -- "${opts}"
+rpm_clean=
+pod_clean=
+while true; do
+    arg=${1}
+    shift
+    case "${arg}" in
+    -c|--clean)
+        rpm_clean=distclean
+        pod_clean=clean
+        ;;
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        break
+        ;;
+    *)
+        printf -- "${0}: unrecognized command line argument, '${arg}'\n" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+done
+
+PB_AGENT_DISTRO=${PB_AGENT_DISTRO:-fedora-38}
+
+WORKSPACE_TMP=${HOME} make -C agent/rpm ${rpm_clean} ${PB_AGENT_DISTRO}-rpm
+CI=1 WORKSPACE_TMP=${HOME} make -C agent/containers/images \
+    CI_RPM_ROOT=${HOME} ${pod_clean} ${PB_AGENT_DISTRO}-everything

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -29,7 +29,11 @@ image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:main}
 config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
 pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
 pbench_server=${PB_AGENT_SERVER_LOC}
-pbench_ca=$(readlink -f ${PB_AGENT_CA:-${REQUESTS_CA_BUNDLE}})
+ca=${PB_AGENT_CA:-${REQUESTS_CA_BUNDLE}}
+if [[ ${ca} ]]; then
+    pbench_ca=$(readlink -f )
+fi
+container_ca=/etc/pki/tls/certs/pbench_CA.crt
 other_options=${PB_AGENT_PODMAN_OPTIONS}
 
 if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
@@ -54,17 +58,21 @@ elif [[ -n "${pbench_server}" ]]; then
 		[config]
 		path = %(pbench_install_dir)s/config
 		files = pbench-agent-default.cfg
-		[results]
-		pbench_ca = ${pbench_ca}
 		EOF
+    if [[ -f "${pbench_ca}" ]] ;then
+        cat >> ${config_file} <<- EOF
+			[results]
+			pbench_ca = ${container_ca}
+			EOF
+    fi
 else
     echo "Warning:  the Pbench Agent config file (e.g., ${config_file}) is missing or inaccessible -- using default configuration." >&2
 fi
 
 mkdir -p ${pbench_run_dir}
 if [[ -f "${pbench_ca}" ]]; then
-    other_options="-v ${pbench_ca}:/etc/pki/tls/certs/pbench_CA.crt:z ${other_options}"
-    other_options="-e REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/pbench_CA.crt ${other_options}"
+    other_options="-v ${pbench_ca}:${container_ca}:z ${other_options}"
+    other_options="-e REQUESTS_CA_BUNDLE=${container_ca} ${other_options}"
 fi
 other_options="-v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
 

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -1,52 +1,42 @@
 #! /bin/bash
 #
 # This script is a wrapper to facilitate the invocation of a Pbench Agent
-# command using a containerized deployment of the Pbench Agent.  Simply prefix
+# command using a containerized deployment of the Pbench Agent. Simply prefix
 # a Pbench Agent command line with the path to this script to run it inside a
 # container, without needing to install the Agent on the host system.
 #
 # Invocation options are provided as environment variables:
 #    PB_AGENT_IMAGE_NAME: the full image name for the containerized Pbench Agent
-#    _PBENCH_AGENT_CONFIG: the location of the Pbench Agent configuration file
 #    PB_AGENT_RUN_DIR: the directory for use as the Pbench Agent "run directory"
-#    PB_AGENT_SERVER_LOC: the host and port for the Pbench Server
 #    PB_AGENT_CA: a CA bundle to verify Pbench Server PUTs
 #    PB_AGENT_PODMAN_OPTIONS: Additional options to be supplied to Podman run
 #
 # In all cases, reasonable defaults are supplied if the environment variables
 # are not defined.
 #
-# This script checks for the presence of a `~/.ssh` directory, an existing
-# Pbench Agent configuration file, and a Pbench Agent "run directory" and maps
-# them into the container if they exist.  If the configuration file is missing
-# but the location of the Pbench Server is specified with PB_AGENT_SERVER_LOC,
-# then this script will generate the configuration file, and the script creates
-# the run directory if it does not exist.  The script then invokes the Pbench
-# Agent container with these options and any others which the user specifies
-# and passes in the command to be executed.
+# This script manages a persistent host Pbench Agent "run directory", which
+# defaults to /var/tmp/{USER}/pbench-agent/run, and maps that directory into
+# the container so that multiple runs can be generated and uploaded at once.
+#
+# To upload results to a Pbench Server, use this script to execute the
+# pbench-results-move command within the container, specifying either --relay
+# with the address of a Pbench Relay Server, or --server with the address of a
+# Pbench Server and --token to specify a Pbench Server API key for user
+# authentication.
 #
 # To use a server with a certificate signed by the Pbench development CA bundle
-# define the environment variable PB_AGENT_CA. If the script generates a new
-# ~/.config/pbench/pbench-agent.cfg then the "server_ca" variable will be set.
-# However a simple mode of operation is to use the "--server" and PB_AGENT_CA
-# to avoid reliance on a config file, as
+# define the environment variable PB_AGENT_CA to cause the CA to be mapped into
+# the container and defined using REQUESTS_CA_BUNDLE:
 #
 #  PB_AGENT_CA=server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt \
 #    contrib/containerized-pbench/pbench pbench-results-move \
 #      --server https://<server>:8443 --token <api-token>
-#
-# TODO: if you generate a config file (manually or automatically) including
-# [results] server_ca, the local CA file needs to be mapped into the container,
-# and this is not currently done manually. You can work around that by using
-# the PB_AGENT_CA environment variable.
 
 image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:main}
-config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
 pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
-pbench_server=${PB_AGENT_SERVER_LOC}
 ca=${PB_AGENT_CA:-${REQUESTS_CA_BUNDLE}}
 if [[ ${ca} ]]; then
-    pbench_ca=$(readlink -f ${ca})  # expand path outside container
+    pbench_ca=$(realpath ${ca})  # expand path outside container
 fi
 container_ca=/etc/pki/tls/certs/pbench_CA.crt  # path inside container
 other_options=${PB_AGENT_PODMAN_OPTIONS}
@@ -56,42 +46,12 @@ if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
     exit 2
 fi
 
-# TODO: I think we only need this for Server 0.69; not really sure how we
-# want to manage this going forward.
-if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
-    other_options="--security-opt=label=disable -v ${HOME}/.ssh:/root/.ssh ${other_options}"
-fi
-
-if [[ -f "${config_file}" && -r "${config_file}" ]]; then
-    other_options="-v ${config_file}:/opt/pbench-agent/config/pbench-agent.cfg:z ${other_options}"
-elif [[ -n "${pbench_server}" ]]; then
-    echo "Warning:  the Pbench Agent config file is missing; attempting to generate one in ${config_file}" >&2
-    # TODO:  this should be handled by a separate Pbench Agent "configuration wizard".
-    mkdir -p $(dirname ${config_file})
-    cat > ${config_file} <<- EOF
-		[DEFAULT]
-		pbench_install_dir = /opt/pbench-agent
-		pbench_web_server = ${pbench_server}
-		[config]
-		path = %(pbench_install_dir)s/config
-		files = pbench-agent-default.cfg
-		EOF
-    if [[ -f "${pbench_ca}" ]] ;then
-        cat >> ${config_file} <<- EOF
-			[results]
-			pbench_ca = ${container_ca}
-			EOF
-    fi
-else
-    echo "Warning:  the Pbench Agent config file (e.g., ${config_file}) is missing or inaccessible -- using default configuration." >&2
-fi
-
 mkdir -p ${pbench_run_dir}
 if [[ -f "${pbench_ca}" ]]; then
     other_options="-v ${pbench_ca}:${container_ca}:z ${other_options}"
     other_options="-e REQUESTS_CA_BUNDLE=${container_ca} ${other_options}"
 fi
-other_options="-v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
+other_options="--security-opt=label=disable -v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
 
 podman run \
     -it \

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -19,11 +19,26 @@
 # This script checks for the presence of a `~/.ssh` directory, an existing
 # Pbench Agent configuration file, and a Pbench Agent "run directory" and maps
 # them into the container if they exist.  If the configuration file is missing
-# but the location of the Pbench Server is available, then this script will
-# generate the configuration file, and the script creates the run directory if
-# it does not exist.  The script then invokes the Pbench Agent container with
-# these options and any others which the user has specified and passes in the
-# command to be executed.
+# but the location of the Pbench Server is specified with PB_AGENT_SERVER_LOC,
+# then this script will generate the configuration file, and the script creates
+# the run directory if it does not exist.  The script then invokes the Pbench
+# Agent container with these options and any others which the user specifies
+# and passes in the command to be executed.
+#
+# To use a server with a certificate signed by the Pbench development CA bundle
+# define the environment variable PB_AGENT_CA. If the script generates a new
+# ~/.config/pbench/pbench-agent.cfg then the "server_ca" variable will be set.
+# However a simple mode of operation is to use the "--server" and PB_AGENT_CA
+# to avoid reliance on a config file, as
+#
+#  PB_AGENT_CA=server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt \
+#    contrib/containerized-pbench/pbench pbench-results-move \
+#      --server https://<server>:8443 --token <api-token>
+#
+# TODO: if you generate a config file (manually or automatically) including
+# [results] server_ca, the local CA file needs to be mapped into the container,
+# and this is not currently done manually. You can work around that by using
+# the PB_AGENT_CA environment variable.
 
 image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:main}
 config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
@@ -31,9 +46,9 @@ pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
 pbench_server=${PB_AGENT_SERVER_LOC}
 ca=${PB_AGENT_CA:-${REQUESTS_CA_BUNDLE}}
 if [[ ${ca} ]]; then
-    pbench_ca=$(readlink -f )
+    pbench_ca=$(readlink -f ${ca})  # expand path outside container
 fi
-container_ca=/etc/pki/tls/certs/pbench_CA.crt
+container_ca=/etc/pki/tls/certs/pbench_CA.crt  # path inside container
 other_options=${PB_AGENT_PODMAN_OPTIONS}
 
 if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
@@ -41,6 +56,8 @@ if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
     exit 2
 fi
 
+# TODO: I think we only need this for Server 0.69; not really sure how we
+# want to manage this going forward.
 if [[ -d "${HOME}/.ssh" && -r "${HOME}/.ssh" ]]; then
     other_options="--security-opt=label=disable -v ${HOME}/.ssh:/root/.ssh ${other_options}"
 fi

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -48,15 +48,15 @@ fi
 
 mkdir -p ${pbench_run_dir}
 if [[ -f "${pbench_ca}" ]]; then
-    other_options="-v ${pbench_ca}:${container_ca}:z ${other_options}"
+    other_options="-v ${pbench_ca}:${container_ca}:Z ${other_options}"
     other_options="-e REQUESTS_CA_BUNDLE=${container_ca} ${other_options}"
 fi
-other_options="--security-opt=label=disable -v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
 
 podman run \
     -it \
     --rm \
     --network host \
     --name pbench-agent \
+    -v ${pbench_run_dir}:/var/lib/pbench-agent:Z \
     ${other_options} \
     ${image_name} "${@}"

--- a/contrib/containerized-pbench/pbench
+++ b/contrib/containerized-pbench/pbench
@@ -6,11 +6,12 @@
 # container, without needing to install the Agent on the host system.
 #
 # Invocation options are provided as environment variables:
-#    PB_AGENT_IMAGE_NAME:  the full image name for the containerized Pbench Agent
-#    _PBENCH_AGENT_CONFIG:  the location of the Pbench Agent configuration file
-#    PB_AGENT_RUN_DIR:  the directory for use as the Pbench Agent "run directory"
-#    PB_AGENT_SERVER_LOC:  the host and port for the Pbench Server
-#    PB_AGENT_PODMAN_OPTIONS:  Additional options to be supplied to Podman run
+#    PB_AGENT_IMAGE_NAME: the full image name for the containerized Pbench Agent
+#    _PBENCH_AGENT_CONFIG: the location of the Pbench Agent configuration file
+#    PB_AGENT_RUN_DIR: the directory for use as the Pbench Agent "run directory"
+#    PB_AGENT_SERVER_LOC: the host and port for the Pbench Server
+#    PB_AGENT_CA: a CA bundle to verify Pbench Server PUTs
+#    PB_AGENT_PODMAN_OPTIONS: Additional options to be supplied to Podman run
 #
 # In all cases, reasonable defaults are supplied if the environment variables
 # are not defined.
@@ -28,6 +29,7 @@ image_name=${PB_AGENT_IMAGE_NAME:-quay.io/pbench/pbench-agent-all-centos-8:main}
 config_file=${_PBENCH_AGENT_CONFIG:-${HOME}/.config/pbench/pbench-agent.cfg}
 pbench_run_dir=${PB_AGENT_RUN_DIR:-/var/tmp/${USER}/pbench-agent/run}
 pbench_server=${PB_AGENT_SERVER_LOC}
+pbench_ca=$(readlink -f ${PB_AGENT_CA:-${REQUESTS_CA_BUNDLE}})
 other_options=${PB_AGENT_PODMAN_OPTIONS}
 
 if [[ $# == 0 || $1 == "help" || $1 == "-h" || $1 == "--help" ]]; then
@@ -52,12 +54,18 @@ elif [[ -n "${pbench_server}" ]]; then
 		[config]
 		path = %(pbench_install_dir)s/config
 		files = pbench-agent-default.cfg
+		[results]
+		pbench_ca = ${pbench_ca}
 		EOF
 else
     echo "Warning:  the Pbench Agent config file (e.g., ${config_file}) is missing or inaccessible -- using default configuration." >&2
 fi
 
 mkdir -p ${pbench_run_dir}
+if [[ -f "${pbench_ca}" ]]; then
+    other_options="-v ${pbench_ca}:/etc/pki/tls/certs/pbench_CA.crt:z ${other_options}"
+    other_options="-e REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/pbench_CA.crt ${other_options}"
+fi
 other_options="-v ${pbench_run_dir}:/var/lib/pbench-agent:z ${other_options}"
 
 podman run \

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -411,8 +411,8 @@ class CopyResultToServer(CopyResult):
             uri = config.get("results", "server_rest_url")
 
             # If the "server_ca" config variable isn't defined, we expect to verify
-            # using a registered CA or via REQUESTS_CA_BUNDLE environment variable.
-            self.ca = config.get("results", "server_ca", fallback=True)
+            # using a registered CA.
+            self.ca = config.get("results", "server_ca", fallback=None)
         self.uri = f"{uri}/upload/{{name}}"
         self.headers.update({"Authorization": f"Bearer {token}"})
 

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -406,7 +406,7 @@ class CopyResultToServer(CopyResult):
         if server:
             path = config.get("results", "rest_endpoint")
             uri = f"{server}/{path}"
-            self.ca = True
+            self.ca = None
         else:
             uri = config.get("results", "server_rest_url")
 

--- a/lib/pbench/agent/results.py
+++ b/lib/pbench/agent/results.py
@@ -406,8 +406,13 @@ class CopyResultToServer(CopyResult):
         if server:
             path = config.get("results", "rest_endpoint")
             uri = f"{server}/{path}"
+            self.ca = True
         else:
             uri = config.get("results", "server_rest_url")
+
+            # If the "server_ca" config variable isn't defined, we expect to verify
+            # using a registered CA or via REQUESTS_CA_BUNDLE environment variable.
+            self.ca = config.get("results", "server_ca", fallback=True)
         self.uri = f"{uri}/upload/{{name}}"
         self.headers.update({"Authorization": f"Bearer {token}"})
 
@@ -430,7 +435,11 @@ class CopyResultToServer(CopyResult):
         tar_uri = self.uri.format(name=tarball.name)
         with tarball.open("rb") as f:
             return requests.put(
-                tar_uri, data=f, headers=self.headers, params=self.params
+                tar_uri,
+                data=f,
+                headers=self.headers,
+                params=self.params,
+                verify=self.ca,
             )
 
 


### PR DESCRIPTION
PBENCH-1209

The staging server and local development servers now use HTTPS with certs signed by a private pbench CA. An HTTPS connection can't be validated without a reference to this CA.

The primary change here is in the `contrib/containerized-pbench/pbench` script which now looks for a private CA definition, maps the CA bundle file into the container, and defines `REQUESTS_CA_BUNDLE` within the container.

In an attempt to handle RPM installs, there's also logic to support a new `[results]` section `pbench_ca` configuration variable to define a CA path that will be used to verify the `PUT` to a server.

Note, this isn't being used for the `--relay` path, as that's currently not using `https` and we'll need to figure out how we want to configure this in the future.