### PR TITLE
Identify benchmark type

### DIFF
--- a/lib/pbench/server/api/resources/datasets_compare.py
+++ b/lib/pbench/server/api/resources/datasets_compare.py
@@ -109,11 +109,12 @@ class DatasetsCompare(ApiBase):
                 ) from e
             stream_file[dataset.name] = file
 
-        get_quisby_data = QuisbyProcessing().compare_csv_to_json(
+        quisby_response = QuisbyProcessing().compare_csv_to_json(
             benchmark_type, InputType.STREAM, stream_file
         )
-        if get_quisby_data["status"] != "success":
+        if quisby_response["status"] != "success":
             raise APIInternalError(
-                f"Quisby processing failure. Exception: {get_quisby_data['exception']}"
+                f"Quisby processing failure. Exception: {quisby_response['exception']}"
             )
-        return jsonify(get_quisby_data)
+        quisby_response["benchmark"] = benchmark.lower()
+        return jsonify(quisby_response)

--- a/lib/pbench/server/api/resources/datasets_visualize.py
+++ b/lib/pbench/server/api/resources/datasets_visualize.py
@@ -76,12 +76,13 @@ class DatasetsVisualize(ApiBase):
         except Exception as e:
             raise APIInternalError(str(e)) from e
 
-        get_quisby_data = QuisbyProcessing().extract_data(
+        quisby_response = QuisbyProcessing().extract_data(
             benchmark_type, dataset.name, InputType.STREAM, file
         )
 
-        if get_quisby_data["status"] != "success":
+        if quisby_response["status"] != "success":
             raise APIInternalError(
-                f"Quisby processing failure. Exception: {get_quisby_data['exception']}"
+                f"Quisby processing failure. Exception: {quisby_response['exception']}"
             )
-        return jsonify(get_quisby_data)
+        quisby_response["benchmark"] = benchmark.lower()
+        return jsonify(quisby_response)

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -610,6 +610,7 @@ class TestInventory:
             ), f"VISUALIZE {dataset.name} failed {response.status_code}:{response.json()['message']}"
             json = response.json()
             assert json["status"] == "success"
+            assert json["benchmark"] == "uperf"
             assert "csv_data" in json
             assert json["json_data"]["dataset_name"] == dataset.name
             assert isinstance(json["json_data"]["data"], list)
@@ -643,6 +644,7 @@ class TestInventory:
             response.ok
         ), f"COMPARE {candidates[:2]} failed {response.status_code}:{json['message']}"
         assert json["status"] == "success"
+        assert json["benchmark"] == "uperf"
         assert isinstance(json["json_data"]["data"], list)
 
     @pytest.mark.dependency(name="inventory", depends=["upload"], scope="session")

--- a/lib/pbench/test/unit/server/test_datasets_compare.py
+++ b/lib/pbench/test/unit/server/test_datasets_compare.py
@@ -143,6 +143,7 @@ class TestCompareDatasets:
         response = query_get_as(datasets, user, exp_status)
         if exp_status == HTTPStatus.OK:
             assert response.json["status"] == "success"
+            assert response.json["benchmark"] == "uperf"
             assert response.json["json_data"] == "quisby_data"
         else:
             assert response.json["message"] == exp_message

--- a/lib/pbench/test/unit/server/test_datasets_visualize.py
+++ b/lib/pbench/test/unit/server/test_datasets_visualize.py
@@ -96,6 +96,7 @@ class TestVisualize:
 
         response = query_get_as("uperf_1", "test", HTTPStatus.OK)
         assert response.json["status"] == "success"
+        assert response.json["benchmark"] == "uperf"
         assert response.json["json_data"] == "quisby_data"
 
     def test_unsuccessful_get_with_incorrect_data(self, query_get_as, monkeypatch):


### PR DESCRIPTION
PBENCH-1210

Right now we only support visualizing and comparing `uperf` benchmark data with Quisby. However as we expand that support within the server, the UI code will need to be able to identify the schema of the output data, which depends on the benchmark.

As a simple solution, add a `"benchmark"` field to the response data which the client can read.