### PR TITLE
Improve client benchmark identification

### DIFF
--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -142,7 +142,9 @@ else
 fi
 
 if [[ ${exit_status} -ne 0 ]]; then
-    dump_journal
+    if (( ${cleanup_flag} )); then
+        dump_journal
+    fi
     printf -- "\nFunctional tests exited with code %s\n" ${exit_status} >&2
 fi
 

--- a/lib/pbench/client/__init__.py
+++ b/lib/pbench/client/__init__.py
@@ -494,14 +494,19 @@ class PbenchServerClient:
         ).json()
 
     def update(
-        self, dataset_id: str, access: Optional[str] = None, owner: Optional[str] = None
-    ) -> JSONOBJECT:
+        self,
+        dataset_id: str,
+        access: Optional[str] = None,
+        owner: Optional[str] = None,
+        **kwargs,
+    ) -> requests.Response:
         """Update the dataset access or owner
 
         Args:
             dataset_id: the resource ID of the targeted dataset
             access: set the access mode of the dataset (private, public)
             owner: set the owning username of the dataset (requires ADMIN)
+            kwargs: additional client options
 
         Returns:
             A JSON document containing the response
@@ -515,7 +520,8 @@ class PbenchServerClient:
             api=API.DATASETS,
             uri_params={"dataset": dataset_id},
             params=params,
-        ).json()
+            **kwargs,
+        )
 
     def get_settings(self, key: str = "") -> JSONOBJECT:
         """Return requested server setting.

--- a/lib/pbench/server/api/resources/datasets_compare.py
+++ b/lib/pbench/server/api/resources/datasets_compare.py
@@ -70,7 +70,7 @@ class DatasetsCompare(ApiBase):
         datasets = params.query.get("datasets")
         benchmark_choice = None
         for dataset in datasets:
-            benchmark = Metadata.getvalue(dataset, "dataset.metalog.pbench.script")
+            benchmark = Metadata.getvalue(dataset, Metadata.SERVER_BENCHMARK)
             # Validate if all the selected datasets is of same benchmark
             if not benchmark_choice:
                 benchmark_choice = benchmark
@@ -116,5 +116,5 @@ class DatasetsCompare(ApiBase):
             raise APIInternalError(
                 f"Quisby processing failure. Exception: {quisby_response['exception']}"
             )
-        quisby_response["benchmark"] = benchmark.lower()
+        quisby_response["benchmark"] = benchmark
         return jsonify(quisby_response)

--- a/lib/pbench/server/api/resources/datasets_visualize.py
+++ b/lib/pbench/server/api/resources/datasets_visualize.py
@@ -60,9 +60,8 @@ class DatasetsVisualize(ApiBase):
 
         dataset = params.uri["dataset"]
 
-        metadata = Metadata.getvalue(dataset, "dataset.metalog.pbench.script")
-        benchmark = metadata.upper()
-        benchmark_type = BenchmarkName.__members__.get(benchmark)
+        benchmark = Metadata.getvalue(dataset, Metadata.SERVER_BENCHMARK)
+        benchmark_type = BenchmarkName.__members__.get(benchmark.upper())
         if not benchmark_type:
             raise APIAbort(
                 HTTPStatus.BAD_REQUEST, f"Unsupported Benchmark: {benchmark}"
@@ -84,5 +83,5 @@ class DatasetsVisualize(ApiBase):
             raise APIInternalError(
                 f"Quisby processing failure. Exception: {quisby_response['exception']}"
             )
-        quisby_response["benchmark"] = benchmark.lower()
+        quisby_response["benchmark"] = benchmark
         return jsonify(quisby_response)

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -2,6 +2,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 from flask import current_app, jsonify, Request, Response
+from pquisby.lib.post_processing import BenchmarkName
 
 from pbench.server import OperationCode, PbenchServerConfig
 from pbench.server.api.resources import (
@@ -122,6 +123,9 @@ class EndpointConfig(ApiBase):
         endpoints = {
             "identification": f"Pbench server {self.server_config.COMMIT_ID}",
             "uri": templates,
+            "visualization": {
+                "benchmarks": [m.lower() for m in BenchmarkName.__members__.keys()]
+            },
         }
 
         client = self.server_config.get("openid", "client")

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -612,6 +612,13 @@ class Metadata(Database.Base):
     METALOG = "metalog"
     NATIVE_KEYS = [GLOBAL, METALOG, SERVER, USER]
 
+    # BENCHMARK provides a simple identification of the native benchmark where
+    # one can be identified. At the simplest for Pbench Agent tarballs this is
+    # just "dataset.metalog.pbench.script" but will be expanded in the future
+    # for example to identify a "pbench-user-benchmark -- fio" as "fio".
+    SERVER_BENCHMARK = "server.benchmark"
+    SERVER_BENCHMARK_UNKNOWN = "unknown"
+
     # DELETION timestamp for dataset based on user settings and system
     # settings when the dataset is created.
     #

--- a/lib/pbench/test/functional/server/test_connect.py
+++ b/lib/pbench/test/functional/server/test_connect.py
@@ -14,6 +14,7 @@ class TestConnect:
         assert endpoints
         assert "identification" in endpoints
         assert "uri" in endpoints
+        assert endpoints["visualization"]["benchmarks"] == ["uperf"]
 
         # Verify that all expected endpoints are reported
         for a in endpoints["uri"].keys():

--- a/lib/pbench/test/unit/server/test_datasets_visualize.py
+++ b/lib/pbench/test/unit/server/test_datasets_visualize.py
@@ -130,5 +130,5 @@ class TestVisualize:
         monkeypatch.setattr(Metadata, "getvalue", mock_get_metadata)
         monkeypatch.setattr(QuisbyProcessing, "extract_data", mock_extract_data)
         response = query_get_as("uperf_1", "test", HTTPStatus.BAD_REQUEST)
-        assert response.json["message"] == "Unsupported Benchmark: HAMMERDB"
+        assert response.json["message"] == "Unsupported Benchmark: hammerDB"
         assert extract_not_called

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -54,6 +54,7 @@ class TestEndpointConfig:
         uri = urljoin(host, uri_prefix)
         expected_results = {
             "identification": f"Pbench server {server_config.COMMIT_ID}",
+            "visualization": {"benchmarks": ["uperf"]},
             "uri": {
                 "datasets": {
                     "template": f"{uri}/datasets/{{dataset}}",

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -638,6 +638,7 @@ class TestUpload:
         assert dataset.name == name
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
         assert Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE) is True
+        assert Metadata.getvalue(dataset, Metadata.SERVER_BENCHMARK) == "unknown"
         assert Metadata.getvalue(dataset, Metadata.SERVER_ORIGIN) == "test"
         assert Metadata.getvalue(dataset, Metadata.SERVER_DELETION) == "1972-01-02"
         assert Metadata.getvalue(dataset, "dataset.operations") == {
@@ -710,13 +711,14 @@ class TestUpload:
         assert dataset.name == name
         assert dataset.uploaded.isoformat() == "1970-01-01T00:00:00+00:00"
         assert Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE) is True
+        assert Metadata.getvalue(dataset, Metadata.SERVER_BENCHMARK) == "unknown"
         assert Metadata.getvalue(dataset, Metadata.SERVER_ORIGIN) == "test"
         assert Metadata.getvalue(dataset, Metadata.SERVER_DELETION) == "1972-01-02"
         assert Metadata.getvalue(dataset, "dataset.operations") == {
             "UPLOAD": {"state": "OK", "message": None}
         }
         assert Metadata.getvalue(dataset, "dataset.metalog") == {
-            "pbench": {"script": "Foreign"}
+            "pbench": {"name": name, "script": "unknown"}
         }
         assert self.cachemanager_created
         assert dataset.name in self.cachemanager_created


### PR DESCRIPTION
PBENCH-1186
PBENCH-1187

A bit of a catch-all. First, this simplifies and standardizes the dashboard's need to identify a benchmark. Eventually we'll be "smart enough" to go beyond the Pbench benchmark wrapper (as we intend to move away from relying on them) and `dataset.metalog.pbench.script` will become unreliable. This adds a new `server.benchmark`, which right now is the same but can be extended beyond that in the future.

The dashboard would also like to be able to identify which benchmark types the current server can support, in advance, and we'd like to avoid hardcoding that knowledge in the dashboard. For this purpose, I've added a "visualization" key in the endpoints response to indicate the benchmark types supported by the current server's `datasets_visualize` and `datasets_compare` APIs.

For some reason, minor consolidation of metadata setting code in the intake API base resulted in weird unit test and functional test failures. The odd part is that these should have been failing earlier, as they're cases where a dataset doesn't have `server.index-map` but the API requires it (for example in `datasets_detail` and `datasets_contents`). I twizzled the code a bit to fail with a `CONFLICT` error (which had already been used elsewhere) rather than a server internal error when the dataset is `server.archiveonly`, and adjusted the tests to match.