### PR TITLE
Fix some problems with archive-only behavior 

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -398,6 +398,8 @@ class ElasticBase(ApiBase):
                 es_request.get("kwargs").get("json"),
             )
         except Exception as e:
+            if isinstance(e, APIAbort):
+                raise
             raise APIInternalError("Elasticsearch assembly error") from e
 
         try:

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -122,12 +122,14 @@ class IndexMapBase(ElasticBase):
             index_map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
         except MetadataError as exc:
             if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
-                raise APIAbort(HTTPStatus.CONFLICT, "Dataset is not indexed")
+                raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
             raise APIInternalError(
                 f"Required metadata {Metadata.INDEX_MAP} missing"
             ) from exc
 
         if index_map is None:
+            if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
+                raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
             raise APIInternalError(
                 f"Required metadata {Metadata.INDEX_MAP} has no value"
             )

--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -118,18 +118,21 @@ class IndexMapBase(ElasticBase):
         """Retrieve the list of ES indices from the metadata table based on a
         given root_index_name.
         """
+
+        # Datasets marked "archiveonly" aren't indexed, and can't be referenced
+        # in APIs that rely on Elasticsearch. Instead, we'll raise a CONFLICT
+        # error.
+        if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
+            raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
+
         try:
             index_map = Metadata.getvalue(dataset=dataset, key=Metadata.INDEX_MAP)
         except MetadataError as exc:
-            if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
-                raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
             raise APIInternalError(
                 f"Required metadata {Metadata.INDEX_MAP} missing"
             ) from exc
 
         if index_map is None:
-            if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
-                raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
             raise APIInternalError(
                 f"Required metadata {Metadata.INDEX_MAP} has no value"
             )

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -35,6 +35,7 @@ class Tarball:
 def all_tarballs() -> list[Path]:
     return list(TARBALL_DIR.glob("*.tar.xz")) + list(SPECIAL_DIR.glob("*.tar.xz"))
 
+
 class TestPut:
     """Test success and failure cases of PUT dataset upload"""
 
@@ -393,7 +394,9 @@ class TestIndexing:
                     == detail["runMetadata"]["script"]
                 )
             else:
-                assert response.status_code == HTTPStatus.CONFLICT, f"Unexpected {response.json()['message']}"
+                assert (
+                    response.status_code == HTTPStatus.CONFLICT
+                ), f"Unexpected {response.json()['message']}"
                 print(f"\t\t... {d.name} is archiveonly")
 
 
@@ -584,7 +587,9 @@ class TestInventory:
             )
             archive = dataset.metadata["server.archiveonly"]
             if archive:
-                assert response.status_code == HTTPStatus.CONFLICT, f"Unexpected {response.json()['message']}"
+                assert (
+                    response.status_code == HTTPStatus.CONFLICT
+                ), f"Unexpected {response.json()['message']}"
                 assert response.json()["message"] == "Dataset indexing was disabled"
                 without_toc = True
                 continue


### PR DESCRIPTION
PBENCH-1215

Webb pointed out a broken functional test in #3496. Once it was testing what I had wanted it to test, I realized that it wasn't quite working. This contains some server and functional test changes to make archive-only dataset queries work correctly and to be sure that's adequately tested in the functional test cases.