### PR TITLE
Fix corruption during CONFLICT upload

### DIFF
--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -248,7 +248,7 @@ class Upload(ApiBase):
             try:
                 tmp_dir = self.temporary / md5sum
                 tmp_dir.mkdir()
-            except FileExistsError:
+            except FileExistsError as e:
                 raise CleanupTime(
                     HTTPStatus.CONFLICT,
                     "Dataset is currently being uploaded",

--- a/lib/pbench/server/api/resources/upload_api.py
+++ b/lib/pbench/server/api/resources/upload_api.py
@@ -178,7 +178,7 @@ class Upload(ApiBase):
 
         attributes = {"access": access, "metadata": metadata}
         filename = args.uri["filename"]
-        tmp_dir: Optional[Path] = None
+        intake_dir: Optional[Path] = None
 
         try:
             try:
@@ -251,10 +251,12 @@ class Upload(ApiBase):
             except FileExistsError:
                 raise CleanupTime(
                     HTTPStatus.CONFLICT,
-                    "Temporary upload directory already exists",
-                )
-            tar_full_path = tmp_dir / filename
-            md5_full_path = tmp_dir / f"{filename}.md5"
+                    "Dataset is currently being uploaded",
+                ) from e
+            else:
+                intake_dir = tmp_dir
+            tar_full_path = intake_dir / filename
+            md5_full_path = intake_dir / f"{filename}.md5"
 
             bytes_received = 0
             usage = shutil.disk_usage(tar_full_path.parent)
@@ -523,9 +525,9 @@ class Upload(ApiBase):
             else:
                 raise APIAbort(status, message) from e
         finally:
-            if tmp_dir:
+            if intake_dir:
                 try:
-                    shutil.rmtree(tmp_dir)
+                    shutil.rmtree(intake_dir)
                 except Exception as e:
                     current_app.logger.warning("Error removing {}: {}", tmp_dir, str(e))
 


### PR DESCRIPTION
PBENCH-1219

b0.72 ARCHIVE server version

Large uploads can time out, causing the client (e.g., the 0.69 passthrough server's dispatch) to retry. Eventually, this will result in an `OK` (200) response, which is good. However if we retry before the original operation finishes (it may be still running, despite the client timeout), we catch the already existing "temporary intake directory" as a `CONFLICT` error.

Unfortunately, the cleanup logic doesn't recognize this distinction, and still deleted the intake directory on exit. Timed correctly, this could break the original upload: at best, it results in a noisy termination with complaints that the existed temporary directory no longer exists.

Fix this problem by attempting to delete only when this API instance has successfully created the temporary directory. Modify the `CONFLICT` unit test case to reproduce the situation more accurately and additionally validate that the directory still exists after completion.