### PR TITLE
Attempt to improve upload performance

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -5,6 +5,7 @@ from configparser import NoOptionError, NoSectionError
 from datetime import datetime, timedelta, tzinfo
 from enum import auto, Enum
 from logging import Logger
+import os
 from pathlib import Path
 from time import time as _time
 from typing import Dict, List, Optional, Union
@@ -20,6 +21,10 @@ JSONVALUE = Union["JSONOBJECT", "JSONARRAY", JSONSTRING, JSONNUMBER, bool, None]
 JSONARRAY = List[JSONVALUE]
 JSONOBJECT = Dict[JSONSTRING, JSONVALUE]
 JSON = JSONVALUE
+
+# Define a type hint for "Path-like" parameters, so the cumbersomeness of the
+# type won't discourage us from using it where it is warranted.
+PathLike = Union[str, bytes, os.PathLike]
 
 
 class OperationCode(Enum):

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -600,6 +600,10 @@ class Tarball:
 
             elapsed = time.time() - start
             if elapsed > Tarball.TAR_EXEC_TIMEOUT:
+                # No signs of life from the subprocess.  Kill it to ensure that
+                # the Python runtime can clean it up after we leave, and report
+                # the failure.
+                tarproc.kill()
                 raise subprocess.TimeoutExpired(
                     cmd=tar_command,
                     timeout=elapsed,

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -976,6 +976,8 @@ class TestCacheManager:
             ),
             # Unexpected failure
             ("/usr/bin/tar", False, 0, b"", 1, 1, b"mock-tar: bolt out of the blue!"),
+            # Hang, never returning output nor an exit code
+            ("/usr/bin/tar", False, 0, b"", None, None, b""),
         ),
     )
     def test_tarfile_extract(
@@ -1057,6 +1059,12 @@ class TestCacheManager:
                 assert tar_path
                 assert not popen_fail
                 assert str(exc) == f"Unable to extract {path} from {tar.name}"
+            except subprocess.TimeoutExpired as exc:
+                assert tar_path
+                assert not popen_fail
+                assert (
+                    not peek_return and not poll_return
+                ), f"Unexpected test timeout: {exc}"
             except TarballUnpackError as exc:
                 if tar_path is None:
                     msg = "External 'tar' executable not found"

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -1029,9 +1029,7 @@ class TestCacheManager:
                 return poll_return
 
             def kill(self) -> None:
-                raise AssertionError(
-                    "This test doesn't expect the stream to be closed."
-                )
+                pass
 
         def mock_shutil_which(
             cmd: str, _mode: int = os.F_OK | os.X_OK, _path: Optional[str] = None
@@ -1042,6 +1040,7 @@ class TestCacheManager:
         with monkeypatch.context() as m:
             m.setattr(shutil, "which", mock_shutil_which)
             m.setattr(subprocess, "Popen", MockPopen)
+            m.setattr(Inventory, "close", MockBufferedReader.close)
 
             try:
                 got = Tarball.extract(tar, path)


### PR DESCRIPTION
The recent "Ops Review" session revealed that upload requests time out if the file approaches 7Gb in size.  Profiling the execution indicates that the bulk of the time is spent extracting the `metadata.log` file from the results tarball.  This is due to a "feature" of tar archives:  the same file may appear more than once, and so an extraction has to search the entire archive to ensure that the member being extracted is the most up-to-date (i.e., last) one, and this is punishing as the archive size grows.  (Also, the Python Standard library `tarfile` package is not as performant as the standalone `tar(1)` utility, and this costs additional time.)

This PR changes the Server to spawn a subprocess to run the `tar(1)` utility, which allows us to specify the `--occurrence` option which allows us to abort the search after the first instance of the member is found.  Since Pbench owns the construction of the archive, we know that each member occurs only once, so there is no need to search for other instances of it.  Also, since the `metadata.log` file occurs near the beginning of the archive, by aborting the search when we find the first instance of the member, we are able to reduce the overall search time from multiple minutes to a fraction of a second.

This PR consists of a series of commits.  Two of them are the changes to the cache manager module to add the subprocess execution and the changes to the corresponding unit tests.  Two of them are passes over the cache manager module and the corresponding tests to "pick lint".  The others are iteration on the respective changes to the code and the tests.