### PR TITLE
Add support for Python profiling of Server requests

### DIFF
--- a/lib/pbench/cli/server/shell.py
+++ b/lib/pbench/cli/server/shell.py
@@ -169,6 +169,17 @@ def run_gunicorn(server_config: PbenchServerConfig, logger: Logger) -> int:
         "pbench-server",
     ]
 
+    # If PB_PROFILE_DUMP_FILE is defined, enable profiling of the server's
+    # execution of requests.  If defined to an empty string, profiling
+    # results are dumped to the log; otherwise, the value is treated as the
+    # name of a file to receive the data.  (An excellent choice is
+    # "/srv/pbench/public_html/pbench_server.prof", because this is writable
+    # by the server and easily accessed by the user via the browser by hitting
+    # "https://<server>/pbench_server.prof".)  Note that the file is
+    # overwritten for each request.
+    if os.environ.get("PB_PROFILE_DUMP_FILE") is not None:
+        cmd_line += ["--config", "/opt/pbench-server/lib/pbench/profiling.conf.py"]
+
     # When installed via RPM, the shebang in the gunicorn script includes a -s
     # which prevents Python from implicitly including the user site packages in
     # the sys.path configuration.  (Note that, when installed via Pip, the

--- a/lib/pbench/profiling.conf.py
+++ b/lib/pbench/profiling.conf.py
@@ -32,7 +32,7 @@ def pre_request(worker: base.Worker, req: Request):
     worker object (ain't Python grand!?), and we use the worker's log.)
     """
     worker.profile = cProfile.Profile()
-    worker.log.info(f"PROFILING {worker.pid}: {req.uri}")
+    worker.log.info(f"PROFILING: {req.method} {req.uri}")
     worker.start_time = time.time()
     worker.profile.enable()
 
@@ -50,9 +50,7 @@ def post_request(worker: base.Worker, req: Request, *_args):
     worker.profile.disable()
 
     total_time = time.time() - worker.start_time
-    worker.log.info(
-        f"\n[{worker.pid}] [INFO] [{req.method}] Load Time: {total_time:.3}s URI {req.uri}"
-    )
+    worker.log.info(f"Load Time: {total_time:.3}s {req.method} {req.uri}")
 
     # If PB_PROFILE_DUMP_FILE is defined to a true-y value, assume that it is a
     # file into which to dump the profile data.  (An excellent choice is
@@ -69,4 +67,4 @@ def post_request(worker: base.Worker, req: Request, *_args):
         s = StringIO()
         ps = pstats.Stats(worker.profile, stream=s).sort_stats("cumulative")
         ps.print_stats(30)  # Limit the number of lines output
-        worker.log.info(f"[{worker.pid}] [INFO] {s.getvalue()}")
+        worker.log.info(s.getvalue())

--- a/lib/pbench/profiling.conf.py
+++ b/lib/pbench/profiling.conf.py
@@ -1,0 +1,72 @@
+"""Optional Gunicorn configuration file to enable profiling
+
+This module provides definitions for the pre-request and post-request Gunicorn
+hooks, which allow us to get control before a request begins executing and
+after it completes.  We use these to enable and disable profiling (so that the
+profile reflects only the single method call, with a minimum of extraneous
+execution), and, when the request is complete, we dump the profiling report to
+a file or to the log.
+
+This file is specified via a command line switch on the Gunicorn invocation
+when profiling is requested, and it is read by Gunicorn to set the
+`pre_request` and `post_request` Gunicorn settings to the hook routines
+defined below.
+"""
+
+import cProfile
+from io import StringIO
+import os
+import pstats
+import time
+
+from gunicorn.http import Request
+from gunicorn.workers import base
+
+
+def pre_request(worker: base.Worker, req: Request):
+    """Gunicorn hook function called before a request is executed
+
+    We create a profile context, notify the log that we're profiling (so that
+    no one is surprised), note the current time, and enable Python profiling.
+    (We hang the profile context and time stamp off the existing Gunicorn
+    worker object (ain't Python grand!?), and we use the worker's log.)
+    """
+    worker.profile = cProfile.Profile()
+    worker.log.info(f"PROFILING {worker.pid}: {req.uri}")
+    worker.start_time = time.time()
+    worker.profile.enable()
+
+
+def post_request(worker: base.Worker, req: Request, *_args):
+    """Gunicorn hook function called after a request is executed
+
+    Disable Python profiling; calculate the elapsed time for the request
+    execution and log it; dump the statistics to a file, or create a pstats
+    object which prints its output to a string-stream, sort the stats and print
+    them to the stream, and dump the contents of the stream to the log.  (We
+    pull the profile context and start time from where we hung them off the
+    Gunicorn worker object (ain't Python grand!?), and we use the worker's log.)
+    """
+    worker.profile.disable()
+
+    total_time = time.time() - worker.start_time
+    worker.log.info(
+        f"\n[{worker.pid}] [INFO] [{req.method}] Load Time: {total_time:.3}s URI {req.uri}"
+    )
+
+    # If PB_PROFILE_DUMP_FILE is defined to a true-y value, assume that it is a
+    # file into which to dump the profile data.  (An excellent choice is
+    # "/srv/pbench/public_html/pbench_server.prof", because this is writable
+    # by the server and easily accessed by the user via the browser by hitting
+    # "https://<server>/pbench_server.prof".)  Otherwise, dump the top functions
+    # in the profile to the log.  (Note that, if PB_PROFILE_DUMP_FILE is
+    # undefined, profiling will not have been enabled, and we'll never get here.)
+    dump_file = os.environ.get("PB_PROFILE_DUMP_FILE")
+    if dump_file:
+        # Note that this will overwrite the previous request's data, if any.
+        worker.profile.dump_stats(dump_file)
+    else:
+        s = StringIO()
+        ps = pstats.Stats(worker.profile, stream=s).sort_stats("cumulative")
+        ps.print_stats(30)  # Limit the number of lines output
+        worker.log.info(f"[{worker.pid}] [INFO] {s.getvalue()}")


### PR DESCRIPTION
This PR adds support for performing execution profiling of Pbench Server API requests.

The profiling is performed by the Python Standard Library `cProfile` package.  Profiling is controlled via Gunicorn pre- and post-request hook functions, which are installed via a Gunicorn configuration file (which is actually Python code...pretty cool).

**_How to use it_**:  if the `PB_PROFILE_DUMP_FILE` environment variable is defined when `shell.py` executes, it adds the configuration file to the Gunicorn command line, and everything else is handled automagically.

Profiling data is collected only during a single API request, starting when that request is invoked and ending when the request is complete.  If the environment variable is defined to a file path, then the profile data is dumped to that file when the request completes.  The data from each request overwrites the data from the previous request.

I recommend defining `PB_PROFILE_DUMP_FILE` to `/srv/pbench/public_html/server_profile.prof`:  this results in the profile data being placed where it can easily be fetched by pointing a browser at `https://<server_address>/server_profile.prof`.  Once downloaded, the profile data can be nicely visualized using [SnakeViz](https://jiffyclub.github.io/snakeviz/).

Note that if `PB_PROFILE_DUMP_FILE` is defined instead to an empty string, the top time-consuming functions are dumped to the log, instead.  Unfortunately, the list appears twice in the log -- I don't know why -- but, since it's so easy to use the file dump and so much more effective to use SnakeViz's "icicle graph", I'm not overly concerned about it.

There is no turn-key method at present for setting `PB_PROFILE_DUMP_FILE` in the canned server (the easiest way seems to be editing the `server/lib/systemd/pbench-server.service` file before the container is built or editing `/etc/systemd/system/pbench-server.service` inside the container when it's running).  But, this support was quite valuable in tracking down the issues with upload timeouts, so I figured I would just capture it in its current state, which is quite usable once it is enabled.

PBENCH-1228