### PR TITLE
Increase Nginx limits for internal responses

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -88,10 +88,12 @@ http {
 
         location = /404.html {
             internal;
+            client_max_body_size     100G;
         }
 
         location = /50x.html {
             internal;
+            client_max_body_size     100G;
         }
 
         location /api {


### PR DESCRIPTION
The recent "Ops Review" revealed a mysterious behavior around the "inner" Nginx proxy:  whenever we had a request timeout, we immediately had a second failure which returned a `413` response to the client.  We initially thought that this was a configuration problem in the "outer" proxy, but that proved to be unfounded.  Then I stumbled onto [this explanation](https://github.com/SpiderLabs/ModSecurity/issues/2170#issuecomment-536553266):  because the `client_max_body_size` is increased only for the Pbench Server API routes, when the request times out and is redirected to the internal `50X.html` page, the maximum request size changes back to the default, and the _redirected_ request fails with a `413` instead of the appropriate `504`.

This PR adds `client_max_body_size` to the two internal routes, to allow them to function properly in the face of large request sizes.  (We don't make the `client_max_body_size` definition global, because there is no reason to tolerate large request sizes for the other routes.)
