### PR TITLE
Fix possible use-before-assign bug

### DIFF
--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -150,8 +150,8 @@ def make_cache_object(dir_path: Path, path: Path) -> CacheObject:
 
     if path.is_symlink():
         ftype = CacheType.SYMLINK
+        link_path = path.readlink()
         try:
-            link_path = path.readlink()
             if link_path.is_absolute():
                 raise ValueError("symlink path is absolute")
             r_path = path.resolve(strict=True)


### PR DESCRIPTION
In the Cache Manager `make_cache_object()` function there is a possible use-before-assignment hazard.  This PR addresses that by ensuring that, in the unlikely event that the assignment fails, we won't execute the use.

(This was a part of #3501, but I decided to pull it out into its own PR.)