### PR TITLE
Increase Nginx limits for internal responses on b0.72

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -86,10 +86,12 @@ http {
 
         location = /404.html {
             internal;
+            client_max_body_size     100G;
         }
 
         location = /50x.html {
             internal;
+            client_max_body_size     100G;
         }
 
         location /api {


### PR DESCRIPTION
This is a backport of #3504 which addresses a problem where a timed-out upload request returns a `413` instead of a `504`.