### PR TITLE
Support benchmark type fallback

### DIFF
--- a/lib/pbench/server/api/resources/datasets_visualize.py
+++ b/lib/pbench/server/api/resources/datasets_visualize.py
@@ -19,8 +19,8 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
+from pbench.server.api.resources.datasets_compare import DatasetsCompare
 from pbench.server.cache_manager import CacheManager
-from pbench.server.database.models.datasets import Metadata
 
 
 class DatasetsVisualize(ApiBase):
@@ -59,8 +59,7 @@ class DatasetsVisualize(ApiBase):
         """
 
         dataset = params.uri["dataset"]
-
-        benchmark = Metadata.getvalue(dataset, Metadata.SERVER_BENCHMARK)
+        benchmark = DatasetsCompare.get_benchmark_name(dataset)
         benchmark_type = BenchmarkName.__members__.get(benchmark.upper())
         if not benchmark_type:
             raise APIAbort(


### PR DESCRIPTION
PBENCH-1229

The intake code ensures that all dataset (even `server.archiveonly` datasets) will have a `server.benchmark` value representing the core benchmark used in the run. The visualization code uses this value to determine compatibility.

However on the staging server, we have pre-existing datasets without the `server.benchmark` metadata, and the "internal server error" failure mode is unpleasant.

To be a bit more friendly, this adds a wrapper that will first check the `server.benchmark` metadata directly, but failing that will check for the normal Pbench Agent `dataset.metalog.pbench.script` metadata so that older `pbench-uperf` runs will be recognized. Failing that, the wrapper falls back to "unknown" so that we'll never have to deal with a `None` value.