### PR TITLE
Update the `pbench_demo` script to add `--server`

### DIFF
--- a/contrib/containerized-pbench/pbench_demo
+++ b/contrib/containerized-pbench/pbench_demo
@@ -1,33 +1,51 @@
-#! /bin/bash -xe
+#! /bin/bash -e
 #
 # This script provides a demonstration of the contrib/containerized-pbench/pbench
-# wrapper script.
+# wrapper script, using it to run the FIO workload.  It is not really intended
+# to be a tool unto itself -- it is intended to document the workflow which a
+# user might follow using the containerized Agent.
+#
+# Inputs to this script are provided via environment variables:
+#   PBENCH_AGENT_SERVER_LOC:  the Pbench Server host address, including schema
+#                                 and port (e.g., https://example.com:8443)
+#   PBENCH_API_KEY:  the Pbench Server API Key token value, which is obtained
+#                                 from the Pbench Dashboard profile page
 #
 
 #+
-# Set up a few things to make life simpler.  Typically, these would already be
-# set in the users environment (e.g., the `pbench` command alias would be done
-# by the user's login script; we wouldn't need the `shopt` command if these
-# commands were being run interactively; and, we only need `PB_AGENT_IMAGE_NAME`
-# here because we're not using the default image).
+# Set up a couple of things to make life simpler.  Typically, these would
+# already be set in the users environment (e.g., the `pbench` command alias
+# would be done by the user's login script, and we wouldn't need the `shopt`
+# command if these commands were being run interactively).
 #-
 shopt -s expand_aliases
 alias pbench="$(git rev-parse --show-toplevel)"/contrib/containerized-pbench/pbench
 
-FIOTEST=${PWD}/fiotest
-export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
-export PB_AGENT_IMAGE_NAME=quay.io/pbench/pbench-agent-all-fedora-38:main
-
-mkdir -p "${FIOTEST}"
-
-# Before we run the demo, we need a Pbench API key. The key can be an
-# environment variable of PBENCH_API_KEY or need to be supplied to this
-# script as an argument.
-api_key=${1:-${PBENCH_API_KEY}}
-if [[ -z "${api_key}" ]]; then
-  echo "Pbench API key must be provided, either on the command line or via the PBENCH_API_KEY environment variable"
+#+
+# In order to upload the results of the demo to the Pbench Server, we need a
+# Pbench API key; and, to simplify things, we specify the Pbench Server on the
+# pbench-results-push command line instead of modifying the Agent configuration
+# file.  Make sure that the environment variables for them are set.
+#-
+if [[ -z "${PBENCH_API_KEY}" || ! (${PBENCH_AGENT_SERVER_LOC} =~ ^https?://[a-z0-9.-]+(:[0-9]+)?$) ]]; then
+  echo "Environment variables PBENCH_API_KEY and PBENCH_AGENT_SERVER_LOC must be properly defined"
   exit 2
 fi
+
+#+
+# Echo the rest of the commands as though the user had typed them.
+#-
+set -x
+
+#+
+# The workload that we're going to run requires a directory to run in, so
+# create that directory if it doesn't exist and then arrange for it to be made
+# available at a particular path inside the container where the workload will
+# be run.
+#-
+FIOTEST=${PWD}/fiotest
+mkdir -p "${FIOTEST}"
+export PB_AGENT_PODMAN_OPTIONS="--pull newer -v ${FIOTEST}:/fiotest:z"
 
 #+
 # Run the demo!
@@ -38,4 +56,4 @@ pbench pbench-user-benchmark --config example-workload -- \
     fio --directory=/fiotest --name fio_test_file --direct=1 --rw=randread \
         --bs=16k --size=100M --numjobs=8 --time_based --runtime=5s \
         --group_reporting --norandommap
-pbench pbench-results-move --token=${api_key}
+pbench pbench-results-move --server ${PBENCH_AGENT_SERVER_LOC} --token=${PBENCH_API_KEY}


### PR DESCRIPTION
This PR is a follow-on to #3494, which removed the use of `PB_AGENT_SERVER_LOC` from the containerized Agent `pbench` wrapper script (it turns out that the demo was depending on it...).  Now that we have the `--server` option on `pbench-results-move`, we use that in the demo script (instead of dynamically creating an Agent config file) to specify the server location.

While making the above addition, I also dusted off the demo file:
- I reworked the header comment to clarify the purpose of the file (i.e., it's more _documentation_ than **_tool_**) and to explicitly list the required input environment variables.
- I removed the explicit override of the container image -- that's a feature of the `pbench` script, and if the user wants it s/he can define it in the environment when running the demo -- and reworked the comment which mentions it.
- I removed the feature of specifying the API Key token as a command line argument -- I'm not aware of anyone using it, and it therefore imposes useless complication.  Providing it via the environment is adequate (and can be done as part of the command line anyway, so the difference is just syntactic sugar).
- The script now makes sure during setup that the Server location and API Key environment variables are defined and that the Server location is properly formatted, so that there are fewer surprises after the workload run is complete when we try to upload the result.
- I repositioned the code which creates the FIO work directory and added an explanatory comment for it.
- I changed the script execution to echo only the "interesting" commands, instead of the whole script including the setup.

NOTE:  since @pravins wants this change for use over the weekend, and since this is a change to the `contrib` area, and since there aren't any reviewers around today, I'm going to go ahead and merge this once the tests pass.  If someone has comments, we can iterate on them.