### PR TITLE
Add `pytest-timeout` and refactor `requirements.txt` files

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,2 +1,1 @@
-pytest>=6.2.5
 requests

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,10 @@
 [pytest]
 addopts = -s
-log_cli=False
-log_level=INFO
+log_cli = False
+log_level = INFO
 filterwarnings=
   # Issue #557 in `pytest-cov` (currently v4.x) has not moved for a while now,
   # but once a resolution has been adopted we can drop this "ignore".
   # Ref: https://github.com/pytest-dev/pytest-cov/issues/557
   ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
+timeout = 300

--- a/server/test-requirements.txt
+++ b/server/test-requirements.txt
@@ -1,13 +1,3 @@
-coverage
-filelock
-gitpython
-mock>=3.0.5
-pytest>=6.2.5
-pytest-cov>=2.7.1
-pytest-freezegun
-pytest-helpers-namespace==2019.1.8
-pytest-mock
 pytest-dependency  # functional tests
-pytest-xdist
+pytest-freezegun
 requests_mock
-responses

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,5 +6,6 @@ pytest>=6.2.5
 pytest-cov>=2.7.1
 pytest-helpers-namespace==2019.1.8
 pytest-mock
+pytest-timeout
 pytest-xdist
 responses

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,9 @@ setenv =
     SKIP_WRITE_GIT_CHANGELOG = 1
 deps =
     -r{toxinidir}/agent/requirements.txt
-    -r{toxinidir}/agent/test-requirements.txt
     -r{toxinidir}/client/requirements.txt
     -r{toxinidir}/server/requirements.txt
+    -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/server/test-requirements.txt
 commands =
     bash -c "{toxinidir}/exec-tests {envdir} {posargs}"
@@ -43,7 +43,7 @@ basepython = python3.6
 deps =
     -c{toxinidir}/agent/test-constraints-3.6.txt
     -r{toxinidir}/agent/requirements.txt
-    -r{toxinidir}/agent/test-requirements.txt
+    -r{toxinidir}/test-requirements.txt
 
 [testenv:alembic-migration]
 description = Verify alembic migrations cover latest database schema


### PR DESCRIPTION
After some difficulties I had with a hanging test in #3501, I've decided to add a timeout mechanism to the PyTest tests.  This is trivially done simply by adding a requirement for the `pytest-timeout` plugin and setting a timeout value in the `pytest.ini` file.  Once this change is merged, the PyTest tests will henceforth be aborted if they run longer than 300 seconds (5 minutes).  Note that affects only tests run under PyTest, which includes the unit tests and the functional tests but not the Agent "legacy" tests (which, I think, already provide timeouts).  Hopefully 5 minutes is long enough for individual tests; if not, we can easily increase the limit.

In the course of making this change, I noted that we have a bunch of redundancy and similar silliness in our Python requirements files for the Agent, Client, and Server, and the "test" ones are referenced (AFAICT) only from the common `tox.ini` file, so there isn't much need (at the moment, anyway) to maintain strict separation between them since they are always referenced together.

Thus, rather than adding the new `pytest-timeout` dependency in multiple places, this PR adds it once to a new, top-level `test-requirements.txt` which contains all the dependencies of the testing system(s) which are common between the Agent, Client, and Server, and it removes the common requirements from the Client- and Server-specific `test-requirements.txt` files (the Agent-specific `test-requirements.txt` file ended up empty so I removed it, and so Git regards the creation of the new file as a "rename" of the Agent one), and it fixes up the `tox.ini` file to match.

[The PR is in Draft mode pending proof that the tests still work under the new organization.]