### PR TITLE
"Note" non-fatal INTAKE behaviors

### DIFF
--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -21,7 +21,27 @@ SHORT_EXPIRATION_DAYS = 10
 
 
 def utc_from_str(date: str) -> datetime:
+    """Convert a date string to a UTC datetime
+
+    Args:
+        date: date/time string
+
+    Returns:
+        UTC datetime object
+    """
     return dateutil.parser.parse(date).replace(tzinfo=timezone.utc)
+
+
+def expiration() -> str:
+    """Calculate a datetime for dataset deletion from "now".
+
+    Returns:
+        A "YYYY-MM-DD" string representing the day when a dataset uploaded
+        "now" would be deleted.
+    """
+    retention = timedelta(days=730)
+    d = datetime.now(timezone.utc) + retention
+    return f"{d:%Y-%m-%d}"
 
 
 @dataclass
@@ -72,16 +92,15 @@ class TestPut:
             assert (
                 response.status_code == HTTPStatus.CREATED
             ), f"upload returned unexpected status {response.status_code}, {response.text} ({t})"
-            benchmark = server_client.get_metadata(md5, ["server.benchmark"])[
-                "server.benchmark"
-            ]
+            metabench = server_client.get_metadata(md5, ["server.benchmark"])
+            benchmark = metabench["server.benchmark"]
             assert response.json() == {
                 "message": "File successfully uploaded",
                 "name": name,
                 "resource_id": md5,
                 "notes": [
-                    f"Identified benchmark workload {benchmark!r}",
-                    "Expected expiration date is 2025-07-31",
+                    f"Identified benchmark workload {benchmark!r}.",
+                    f"Expected expiration date is {expiration()}.",
                 ],
             }
             assert response.headers["location"] == server_client._uri(
@@ -186,8 +205,9 @@ class TestPut:
             "name": name,
             "resource_id": md5,
             "notes": [
-                "Identified benchmark workload 'fio'",
-                "Expected expiration date is 2025-07-31",
+                "Identified benchmark workload 'fio'.",
+                f"Expected expiration date is {expiration()}.",
+                "Indexing is disabled by 'archive only' setting.",
             ],
         }
         assert response.headers["location"] == server_client._uri(
@@ -227,14 +247,16 @@ class TestPut:
         assert (
             response.status_code == HTTPStatus.CREATED
         ), f"upload {name} returned unexpected status {response.status_code}, {response.text}"
+
         assert response.json() == {
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
             "notes": [
-                "Results archive is missing 'nometadata/metadata.log'",
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 2025-07-31",
+                "Results archive is missing 'nometadata/metadata.log'.",
+                "Identified benchmark workload 'unknown'.",
+                f"Expected expiration date is {expiration()}.",
+                "Indexing is disabled by 'archive only' setting.",
             ],
         }
         assert response.headers["location"] == server_client._uri(

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -72,10 +72,17 @@ class TestPut:
             assert (
                 response.status_code == HTTPStatus.CREATED
             ), f"upload returned unexpected status {response.status_code}, {response.text} ({t})"
+            benchmark = server_client.get_metadata(md5, ["server.benchmark"])[
+                "server.benchmark"
+            ]
             assert response.json() == {
                 "message": "File successfully uploaded",
                 "name": name,
                 "resource_id": md5,
+                "notes": [
+                    f"Identified benchmark workload {benchmark!r}",
+                    "Expected expiration date is 2025-07-31",
+                ],
             }
             assert response.headers["location"] == server_client._uri(
                 API.DATASETS_INVENTORY, {"dataset": md5, "target": ""}
@@ -178,6 +185,10 @@ class TestPut:
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
+            "notes": [
+                "Identified benchmark workload 'fio'",
+                "Expected expiration date is 2025-07-31",
+            ],
         }
         assert response.headers["location"] == server_client._uri(
             API.DATASETS_INVENTORY, {"dataset": md5, "target": ""}
@@ -220,6 +231,11 @@ class TestPut:
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
+            "notes": [
+                "Results archive is missing 'nometadata/metadata.log'",
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 2025-07-31",
+            ],
         }
         assert response.headers["location"] == server_client._uri(
             API.DATASETS_INVENTORY, {"dataset": md5, "target": ""}

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -88,6 +88,7 @@ class TestRelay:
         assert not self.cachemanager_created
 
     @responses.activate
+    @pytest.mark.freeze_time("2023-07-01")
     def test_relay(self, client, server_config, pbench_drb_token, tarball):
         """Verify the success path
 
@@ -128,8 +129,8 @@ class TestRelay:
             "name": name,
             "resource_id": md5,
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 2025-07-31",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 2025-06-30.",
             ],
         }
         assert (
@@ -169,8 +170,8 @@ class TestRelay:
             "access": "private",
             "metadata": {"global.pbench.test": "data"},
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 2025-07-31",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 2025-06-30.",
             ],
         }
 

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -127,6 +127,10 @@ class TestRelay:
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 2025-07-31",
+            ],
         }
         assert (
             response.headers["location"]
@@ -164,6 +168,10 @@ class TestRelay:
         assert audit[1].attributes == {
             "access": "private",
             "metadata": {"global.pbench.test": "data"},
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 2025-07-31",
+            ],
         }
 
     @responses.activate

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -440,6 +440,10 @@ class TestUpload:
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 1972-01-01",
+            ],
         }
         assert (
             response.headers["location"]
@@ -491,6 +495,10 @@ class TestUpload:
         assert audit[1].attributes == {
             "access": "private",
             "metadata": {"global.pbench.test": "data"},
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 1972-01-01",
+            ],
         }
 
     @pytest.mark.freeze_time("1970-01-01")
@@ -540,6 +548,10 @@ class TestUpload:
             "message": "File successfully uploaded",
             "name": Dataset.stem(datafile),
             "resource_id": md5,
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 2025-07-31",
+            ],
         }
         assert (
             response.headers["location"]
@@ -694,6 +706,10 @@ class TestUpload:
         assert audit[1].attributes == {
             "access": "private",
             "metadata": {"server.archiveonly": True, "server.origin": "test"},
+            "notes": [
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 1972-01-01",
+            ],
         }
 
     @pytest.mark.freeze_time("1970-01-01")
@@ -715,6 +731,11 @@ class TestUpload:
             "message": "File successfully uploaded",
             "name": name,
             "resource_id": md5,
+            "notes": [
+                f"Results archive is missing '{name}/metadata.log'",
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 1972-01-01",
+            ],
         }
         assert (
             response.headers["location"]
@@ -771,4 +792,9 @@ class TestUpload:
             "access": "private",
             "metadata": {"server.archiveonly": True, "server.origin": "test"},
             "missing_metadata": True,
+            "notes": [
+                f"Results archive is missing '{name}/metadata.log'",
+                "Identified benchmark workload 'unknown'",
+                "Expected expiration date is 1972-01-01",
+            ],
         }

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -441,8 +441,8 @@ class TestUpload:
             "name": name,
             "resource_id": md5,
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 1972-01-01",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 1972-01-01.",
             ],
         }
         assert (
@@ -496,8 +496,8 @@ class TestUpload:
             "access": "private",
             "metadata": {"global.pbench.test": "data"},
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 1972-01-01",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 1972-01-01.",
             ],
         }
 
@@ -534,6 +534,7 @@ class TestUpload:
             ],
         }
 
+    @pytest.mark.freeze_time("2023-07-01")
     def test_upload_duplicate(self, client, server_config, pbench_drb_token, tarball):
         datafile, _, md5 = tarball
         with datafile.open("rb") as data_fp:
@@ -549,8 +550,8 @@ class TestUpload:
             "name": Dataset.stem(datafile),
             "resource_id": md5,
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 2025-07-31",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 2025-06-30.",
             ],
         }
         assert (
@@ -707,8 +708,9 @@ class TestUpload:
             "access": "private",
             "metadata": {"server.archiveonly": True, "server.origin": "test"},
             "notes": [
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 1972-01-01",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 1972-01-01.",
+                "Indexing is disabled by 'archive only' setting.",
             ],
         }
 
@@ -732,9 +734,10 @@ class TestUpload:
             "name": name,
             "resource_id": md5,
             "notes": [
-                f"Results archive is missing '{name}/metadata.log'",
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 1972-01-01",
+                f"Results archive is missing '{name}/metadata.log'.",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 1972-01-01.",
+                "Indexing is disabled by 'archive only' setting.",
             ],
         }
         assert (
@@ -793,8 +796,9 @@ class TestUpload:
             "metadata": {"server.archiveonly": True, "server.origin": "test"},
             "missing_metadata": True,
             "notes": [
-                f"Results archive is missing '{name}/metadata.log'",
-                "Identified benchmark workload 'unknown'",
-                "Expected expiration date is 1972-01-01",
+                f"Results archive is missing '{name}/metadata.log'.",
+                "Identified benchmark workload 'unknown'.",
+                "Expected expiration date is 1972-01-01.",
+                "Indexing is disabled by 'archive only' setting.",
             ],
         }


### PR DESCRIPTION
PBENCH-1231

After accidentally observing an uploaded dataset that was marked "archiveonly" not indexed (because the file name didn't match the result directory name), we decided that the intake process should make the reasons more obvious.

I've handled this by adding "notes", which are recorded both in the successful JSON response payload and in the finalized audit record. While I was at it, I exposed our decisions regarding the canonical benchmarked workload name and the computed expiration date.

While doing this, I stripped the rather prolific logging of `INTAKE` to just two, a "pre" log identifying the file and user, and a "post" log providing the summary file system status (adding the size of the tarball).

I debated logging the "notes", but didn't. On one hand, it would make the info more easily visible; on another it restores verbosity, and the notes strings are going to be unwieldy in the log. I've also several times considered that we might log every audit record, which would include attributes... but might be hard to read in the linear log format.

In any case, it's easy enough to do an Audit query on the dataset resource_id even when the client doesn't capture the "notes".