### PR TITLE
Allow deletion of uploaded relay datasets

### DIFF
--- a/dashboard/src/actions/relayActions.js
+++ b/dashboard/src/actions/relayActions.js
@@ -13,7 +13,7 @@ export const uploadFile = () => async (dispatch, getState) => {
     const endpoints = getState().apiEndpoint.endpoints;
     const fileURI = getState().overview.relayInput;
     const uri = uriTemplate(endpoints, "relay", { uri: fileURI });
-    const response = await API.post(uri, null, null);
+    const response = await API.post(uri, null, { params: { delete: "t" } });
     if (response.status >= 200 && response.status < 300) {
       dispatch(showToast(SUCCESS, response.data.message));
       dispatch(setRelayModalState(false));

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -153,7 +153,7 @@ class IntakeBase(ApiBase):
         """
         raise NotImplementedError()
 
-    def _cleanup(self, args: ApiParams, intake: Intake) -> list[str]:
+    def _cleanup(self, args: ApiParams, intake: Intake, notes: list[str]) -> list[str]:
         """Clean up after a completed upload
 
         Default behavior is to do nothing: each subclass can provide a custom
@@ -162,11 +162,9 @@ class IntakeBase(ApiBase):
         Args:
             intake: The intake object
             args: API parameters
-
-        Returns:
-            A list of error strings if any problems occur
+            notes: A list of error strings to report problems.
         """
-        return []
+        pass
 
     def _intake(
         self, args: ApiParams, request: Request, context: ApiContext
@@ -492,7 +490,7 @@ class IntakeBase(ApiBase):
                 enable_next = [OperationName.INDEX] if should_index else None
                 if not should_index:
                     notes.append("Indexing is disabled by 'archive only' setting.")
-                notes += self._cleanup(args, intake)
+                self._cleanup(args, intake, notes)
                 Sync(current_app.logger, OperationName.UPLOAD).update(
                     dataset=dataset, state=OperationState.OK, enabled=enable_next
                 )

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -153,6 +153,21 @@ class IntakeBase(ApiBase):
         """
         raise NotImplementedError()
 
+    def _cleanup(self, args: ApiParams, intake: Intake) -> list[str]:
+        """Clean up after a completed upload
+
+        Default behavior is to do nothing: each subclass can provide a custom
+        behavior for cleanup after successful transfer.
+
+        Args:
+            intake: The intake object
+            args: API parameters
+
+        Returns:
+            A list of error strings if any problems occur
+        """
+        return []
+
     def _intake(
         self, args: ApiParams, request: Request, context: ApiContext
     ) -> Response:
@@ -477,6 +492,7 @@ class IntakeBase(ApiBase):
                 enable_next = [OperationName.INDEX] if should_index else None
                 if not should_index:
                     notes.append("Indexing is disabled by 'archive only' setting.")
+                notes += self._cleanup(args, intake)
                 Sync(current_app.logger, OperationName.UPLOAD).update(
                     dataset=dataset, state=OperationState.OK, enabled=enable_next
                 )

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -153,7 +153,7 @@ class IntakeBase(ApiBase):
         """
         raise NotImplementedError()
 
-    def _cleanup(self, args: ApiParams, intake: Intake, notes: list[str]) -> list[str]:
+    def _cleanup(self, args: ApiParams, intake: Intake, notes: list[str]):
         """Clean up after a completed upload
 
         Default behavior is to do nothing: each subclass can provide a custom

--- a/lib/pbench/server/api/resources/relay.py
+++ b/lib/pbench/server/api/resources/relay.py
@@ -170,7 +170,7 @@ class Relay(IntakeBase):
             intake: The intake object containing the tarball URI
             notes: A list of error strings to report problems.
         """
-        errors = 0
+        errors = False
         if args.query.get("delete"):
             for uri in (args.uri["uri"], intake.uri):
                 reason = None
@@ -181,7 +181,7 @@ class Relay(IntakeBase):
                 except ConnectionError as e:
                     reason = str(e)
                 if reason:
-                    errors += 1
+                    errors = True
                     msg = f"Unable to remove relay file {uri}: {reason!r}"
                     current_app.logger.warning("INTAKE relay {}: {}", intake.name, msg)
                     notes.append(msg)


### PR DESCRIPTION
PBENCH-1238

As a stopgap for "final" Relay support under the agent, we plan to establish a known project Relay Server (e.g., on our AWS host) for testing. That server has limited storage, and substantial use. To avoid requiring constant manual management of space, our plan is to implement a mechanism to cause the Pbench Server to delete files from the Relay Server after intake, and to change the Pbench Dashboard relay action to always supply that option. Note that this PR adds the `?delete=t` to the dashboard *unconditionally*; in the future we can consider adding a checkbox to allow users to control the behavior, especially when they own a private relay server.