### PR TITLE
Nits and stuff

### DIFF
--- a/agent/containers/images/container_entrypoint
+++ b/agent/containers/images/container_entrypoint
@@ -19,5 +19,5 @@ fi
 # shellcheck disable=SC2093
 exec "${@}"
 rc=${?}
-echo "exec ${@} failed with status ${rc}"
+echo "exec ${*} failed with status ${rc}" >&2
 exit ${rc}

--- a/agent/containers/images/container_entrypoint
+++ b/agent/containers/images/container_entrypoint
@@ -8,4 +8,16 @@
 
 source /opt/pbench-agent/profile
 
+if [[ -z "${*}" ]]; then
+  echo "No command supplied" >&2
+  exit 127
+fi
+
+# If the exec is successful, control won't return to this script, so the
+# commands following it are only for reporting the error (so disable the
+# lint check).
+# shellcheck disable=SC2093
 exec "${@}"
+rc=${?}
+echo "exec ${@} failed with status ${rc}"
+exit ${rc}

--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -8,8 +8,8 @@ from typing import Any, Optional
 import jwt
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 from requests.structures import CaseInsensitiveDict
+from urllib3 import Retry
 
 from pbench.server import JSON, PbenchServerConfig
 

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -1016,7 +1016,7 @@ def generate_api_key(
 
     Args:
         username: username to include in the token payload.
-        name: name or description of the key.
+        label: name or description of the key.
         user: user attributes will be extracted from the user object to include
             in the token payload.
         offset: If True, 10 min will be added to 'current_utc',to avoid duplicate error

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -24,7 +24,6 @@ PBINC_INACAN=${PBINC_SERVER}/pbenchinacan
 # Locations inside the container
 INSTALL_ROOT=/opt/pbench-server
 SERVER_LIB=${INSTALL_ROOT}/lib
-CONF_PATH=${SERVER_LIB}/config/pbench-server.cfg
 
 #+
 # Configuration verification section.

--- a/server/pbenchinacan/deploy-dependencies
+++ b/server/pbenchinacan/deploy-dependencies
@@ -15,9 +15,13 @@
 #   8090 - keycloak authentication server
 #   9200 - Elasticsearch
 
+TMP_DIR=${TMP_DIR:-${WORKSPACE_TMP:-/var/tmp/pbench}}
+PB_DEPLOY_FILES=${PB_DEPLOY_FILES:-${TMP_DIR}/pbench_server_deployment}
+
 # The default container registry to use with the organization name in that
 # registry.  E.g., `quay.io/pbench`.
 PB_CONTAINER_REG=${PB_CONTAINER_REG:-$(<${HOME}/.config/pbench/ci_registry.name)}
+PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-${USER}}
 
 # Default pull policy for all images is to pull the image if the registry has a
 # *different* version (despite the name -- different is assumed to be "newer").

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -29,9 +29,6 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 REALM=${KEYCLOAK_REALM:-"pbench-server"}
 CLIENT=${KEYCLOAK_CLIENT:-"pbench-client"}
 
-TMP_DIR=${TMP_DIR:-${WORKSPACE_TMP:-/var/tmp/pbench}}
-PB_DEPLOY_FILES=${PB_DEPLOY_FILES:-${TMP_DIR}/pbench_server_deployment}
-
 export CURL_CA_BUNDLE=${CURL_CA_BUNDLE:-"${PWD}/server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt"}
 
 end_in_epoch_secs=$(date --date "2 minutes" +%s)

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -21,3 +21,4 @@ requests # TODO CVE-2023-32681 (>=2.31.0)
 sdnotify
 sqlalchemy>=1.4.23
 sqlalchemy_utils>=0.37.6
+urllib3


### PR DESCRIPTION
This PR consists of a bunch of tiny fixes of minimal consequence which I've gradually accumulated over the last month.  They were things which I ran into in the course of making other changes, but, since they had nothing to do with the changes I was making, I kept them on a side branch.  At this point, there are enough of them to warrant putting up a review.

- Remove unused definitions from the Server container build and from `load_keycloak.sh`
- Correct a docstring
- Correct the import of the `urllib3` package and add a requirement for it:  the package is apparently included inside the `requests` package, and we were referencing it there instead of declaring our own dependency on it.
- Add defaults to the `deploy-dependencies` script:  this script is normally invoked by a higher-level script which provides these definitions; if a user wants to run this script independently, then s/he has to "just know" to provide these definitions in the environment; this change provides reasonable default values if the variables are not already defined.
- Try to report errors in the containerized Agent command invocation.  The containerized Agent container images are intended to be invoked with a shell command (typically a Pbench Agent script) to run.  If this is omitted, or if the container invocation command line is formed incorrectly with command options positioned after the image spec, then the `exec` call inside the script which is run as the container entrypoint will fail, and this results in a cryptic response (if any) for the user.  This PR modifies the entry point script script to try to handle these cases better for the user.