### PR TITLE
Remove directory from disposition header

### DIFF
--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from pathlib import Path
 from urllib.request import Request
 
 from flask import current_app, send_file
@@ -84,10 +85,9 @@ class DatasetsInventory(ApiBase):
         # We link a callback to close the file stream and TarFile object on
         # completion.
         stream = file_info["stream"]
+        name = Path(file_info["name"]).name
         try:
-            resp = send_file(
-                stream, as_attachment=target is None, download_name=file_info["name"]
-            )
+            resp = send_file(stream, as_attachment=target is None, download_name=name)
         except Exception as e:
             if stream:
                 stream.close()

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -751,6 +751,15 @@ class TestInventory:
                 API.DATASETS_INVENTORY,
                 {"dataset": dataset.resource_id, "target": "metadata.log"},
             )
+
+            # Note that Werkzeug doesn't understand anything special about the
+            # ".log" filetype, but will apply a better content-type header for
+            # file types it understands like ".json".
+            assert response.headers["content-type"] == "application/octet-stream"
+            assert (
+                response.headers["content-disposition"]
+                == "inline; filename=metadata.log"
+            )
             assert (
                 response.ok
             ), f"INVENTORY {dataset.name} failed {response.status_code}:{response.json()['message']}"


### PR DESCRIPTION
PBENCH-1240

Now that the dashboard supports download of tarball inventory, I observed that the generated filename included a dataset-name prefix. This is because the content disposition header allows only a name, not a path, and the browser is trying to be "helpful" by converting the `<dataset-name>/<filename>` string, replacing the disallowed `/` with `_`. The result is ugly and unexpected.

NOTE: although the Mozilla guidelines try to suggest that the filename must be enclosed in quotes, this conflicts with the RFC, and Werkzeug's `send_file` is "reluctant" to include quotes (plus it's ugly to construct). Therefore, this doesn't attempt to insert the (presumably unnecessary) quotes. (And note also that, despite the ugly name, the current TOC download works without a quoted filename in Chrome.)

Instead, report only the name of the file. Add unit and functional test validation.