### PR TITLE
Add Nginx magic for Dashboard access

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -126,14 +126,14 @@ http {
             client_max_body_size     100G;
         }
 
-        location ~* ^/dashboard {
+        location ~ ^/dashboard$ {
             port_in_redirect off;
 
-            # Make all accesses to /dashboard be case-insensitive, and, if the
-            # URI omits the trailing slash, add it, and reevaluate the location.
-            # Note that this only happens if the URI does _not_ begin with
-            # /dashboard/, as that will match the location below instead.
-            rewrite ^/(?i:dashboard)(/(.*))? /dashboard/$2 permanent;
+            # If the URI omits the trailing slash, add it and reevaluate the
+            # location.  Note that this only happens if the URI does _not_
+            # begin with /dashboard/, as that will match the location below
+            # instead.
+            rewrite ^ /dashboard/ permanent;
         }
 
         location ^~ /dashboard/ {

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -126,7 +126,17 @@ http {
             client_max_body_size     100G;
         }
 
-        location /dashboard {
+        location ~* ^/dashboard {
+            port_in_redirect off;
+
+            # Make all accesses to /dashboard be case-insensitive, and, if the
+            # URI omits the trailing slash, add it, and reevaluate the location.
+            # Note that this only happens if the URI does _not_ begin with
+            # /dashboard/, as that will match the location below instead.
+            rewrite ^/(?i:dashboard)(/(.*))? /dashboard/$2 permanent;
+        }
+
+        location ^~ /dashboard/ {
             # See if the URI exists, as a file or as a directory, under
             # /srv/pbench/public_html and serve that. If it doesn't, just serve
             # /dashboard/index.html.


### PR DESCRIPTION
Currently, attempts to load the Pbench Dashboard (e.g., from the Staging server) via requests like
```
GET /Dashboard/
```
or
```
GET /dashboard
```
will each fail (with a `404` and a blank page, respectively).

To improve the user experience, this PR adds a `location` directive which rewrites the URI, down-casing the "dashboard" and adding the trailing slash if it is missing.  This returns a `301`/`Moved Permanently` response to the browser which causes it to retry at the correct location (which then gets routed properly).

This change also changes the existing Dashboard `location` to require the trailing slash and makes the match preferred over the regex matches, to avoid recursive rewrites.

(BTW, this change has already been deployed on the current Staging Pbench Server instance, if you want to kick the tires.)