### PR TITLE
Rev-lock the `pquisby` version until its packaging is resolved

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,7 +12,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-pquisby
+pquisby<0.0.13
 psycopg2
 pyesbulk>=2.0.1
 PyJwt[crypto]


### PR DESCRIPTION
`pquisby` version 0.0.13 introduced a packaging problem which breaks the Pbench Server.  This was not resolved in version 0.0.14, so, until it's resolved, we're rev-locking to <0.0.13.

Problem symptom:
```
  File "/var/tmp/jenkins/tox/py39/lib/python3.9/site-packages/pbench/server/api/resources/datasets_compare.py", line 6, in <module>
    from pquisby.lib.post_processing import BenchmarkName, InputType, QuisbyProcessing
  File "/var/tmp/jenkins/tox/py39/lib/python3.9/site-packages/pquisby/lib/post_processing.py", line 4, in <module>
    from src.pquisby.lib.benchmarks.fio.fio import extract_fio_run_data
ModuleNotFoundError: No module named 'src'
```