### PR TITLE
Adapt to Quisby fio support

### DIFF
--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -124,7 +124,9 @@ class EndpointConfig(ApiBase):
             "identification": f"Pbench server {self.server_config.COMMIT_ID}",
             "uri": templates,
             "visualization": {
-                "benchmarks": [m.lower() for m in BenchmarkName.__members__.keys()]
+                "benchmarks": sorted(
+                    m.lower() for m in BenchmarkName.__members__.keys()
+                )
             },
         }
 

--- a/lib/pbench/test/functional/server/test_connect.py
+++ b/lib/pbench/test/functional/server/test_connect.py
@@ -14,7 +14,7 @@ class TestConnect:
         assert endpoints
         assert "identification" in endpoints
         assert "uri" in endpoints
-        assert endpoints["visualization"]["benchmarks"] == ["uperf"]
+        assert sorted(endpoints["visualization"]["benchmarks"]) == ["fio", "uperf"]
 
         # Verify that all expected endpoints are reported
         for a in endpoints["uri"].keys():

--- a/lib/pbench/test/unit/server/test_endpoint_configure.py
+++ b/lib/pbench/test/unit/server/test_endpoint_configure.py
@@ -54,7 +54,7 @@ class TestEndpointConfig:
         uri = urljoin(host, uri_prefix)
         expected_results = {
             "identification": f"Pbench server {server_config.COMMIT_ID}",
-            "visualization": {"benchmarks": ["uperf"]},
+            "visualization": {"benchmarks": ["fio", "uperf"]},
             "uri": {
                 "datasets": {
                     "template": f"{uri}/datasets/{{dataset}}",

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,7 +12,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-pquisby<0.0.13
+pquisby
 psycopg2
 pyesbulk>=2.0.1
 PyJwt[crypto]


### PR DESCRIPTION
PBENCH-1212

(This Jira issue was originally a placeholder in case changes had to be made to the `comparison` or `visualize` APIs for `fio` support. It seemed likely that wouldn't be necessary, and I'm appropriating the Jira to unlock the `pquisby` package version and adjust tests.)

First, unlock the `pquisby` package version to allow consuming the 0.0.17 version with `fio` support added.

Both unit and functional tests validate the set of benchmarked workloads for which Pbench claims support, and needed to be updated for the addition of `fio`. The `endpoints` API was also reporting the workloads in order from Pquisby's ENUM, and to make the tests a bit more supportable I sorted the list we report.