### PR TITLE
Update containerized Agent build for PCP and CA

### DIFF
--- a/agent/containers/images/Dockerfile.base.j2
+++ b/agent/containers/images/Dockerfile.base.j2
@@ -4,6 +4,15 @@
 # {{ distro_name }} pbench-agent base image
 FROM {{ image_repo }}/{{ image_name }}:{{ image_tag }}
 
+# Since the Pbench Server requires TLS access and it is hosted on an internal
+# Red Hat host, we need the Red Hat CA certificates in order to validate the
+# connection to it when we upload results.
+ADD \
+    https://certs.corp.redhat.com/certs/2015-IT-Root-CA.pem \
+    https://certs.corp.redhat.com/certs/2022-IT-Root-CA.pem \
+    /etc/pki/ca-trust/source/anchors/
+RUN update-ca-trust
+
 # Install the appropriate pbench repository file for {{ distro_name }}.
 COPY ./{{ pbench_repo_file }} /etc/yum.repos.d/pbench.repo
 

--- a/agent/containers/images/Dockerfile.layered.j2
+++ b/agent/containers/images/Dockerfile.layered.j2
@@ -7,11 +7,8 @@ ENTRYPOINT ["/container_entrypoint"]
 {% endif %}
 
 {% if kind in ('tools', 'all') %}
-{% if distro.startswith('fedora') or distro == 'centos-7' or distro == 'centos-8' %}
-COPY ./{{ distro }}-pcp.repo /etc/yum.repos.d/pcp.repo
-{% if distro.startswith('centos') %}
+{% if distro == 'centos-7' or distro == 'centos-8' %}
 COPY ./{{ distro }}-prometheus.repo /etc/yum.repos.d/prometheus.repo
-{% endif %}
 {% endif %}
 {% endif %}
 

--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -238,10 +238,8 @@ repofix: $(_DEFAULT_DISTROS:%=%-repofix)
 	./apply-tags pbench-agent-tools-$* $*-tags.lis
 
 # CentOS 7 & 8 (but not 9) require an additional .repo file for Prometheus for
-# the tools container; analogously, they as well as Fedora require an additional
-# .repo file for PCP.
+# the tools container.
 centos-7-tools centos-8-tools: centos-%-tools: centos-%-prometheus.repo
-$(_ALL_fedora_VERSIONS:%=%-tools) centos-7-tools centos-8-tools: %-tools: %-pcp.repo
 
 %-tools: %-base-tagged %-tools.Dockerfile %-tags.lis
 	./build-image tools $* $*-tags.lis
@@ -397,9 +395,6 @@ all-tags: pkgmgr-clean $(_DEFAULT_DISTROS:%=%-tags.lis)
 	jinja2 repo.yml.j2 -D name=${_PBENCH_REPO_NAME} -D user=${COPR_USER} \
         -D distro=$(if $(filter centos,${DIST_NAME}),$(subst centos,epel,$*),$*) \
         -D url_prefix=${URL_PREFIX} -o $@
-
-%-pcp.repo: pcp.repo.j2
-	jinja2 pcp.repo.j2 -D distro=${DIST_NAME} -D version=${DIST_VERSION} -o $@
 
 %-prometheus.repo:
 	curl -sSf "${_PROMETHEUS_REPO_URL}" > $@

--- a/agent/containers/images/pcp.repo.j2
+++ b/agent/containers/images/pcp.repo.j2
@@ -1,7 +1,0 @@
-[pcp-rpm-release]
-name=pcp-rpm-release
-baseurl=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ distro }}/{{ version }}/x86_64
-enabled=1
-gpgcheck=0
-gpgkey=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ distro }}/{{ version }}/x86_64/repodata/repomd.xml.key
-repo_gpgcheck=1


### PR DESCRIPTION
Previously, we pulled the PCP RPM from their upstream repository; unfortunately, that repo no longer exists.  Instead, we will now pull the RPM from the distro which corresponds to the base image that we're building on.  This means that we won't be providing the latest-and-greatest PCP, and it means that the different versions of the containerized Agent may provide different versions of PCP (e.g., the RHEL-7-based image will provide PCP v4 while the CentOS Stream 9 image will provide PCP v6).  Hopefully, this won't result in any surprise or disappointment.  (If it does, people can use an Agent container built from a different base image, or they are free to build their own container image using ours as base images and install whatever version of PCP they want in their own layer.)  This PR removes the special handling for the PCP RPM, and these dependencies are now satisfied in the normal way.

In preparation for the deployment of Pbench Server 1.0, which will require TLS access, this PR also adds the Red Hat Certificate Authority certificates required to validate the Agent's connection to the Pbench Server (e.g., for `pbench-results-push`).