### PR TITLE
Version lock redis to <5.0.0

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -6,7 +6,7 @@ ifaddr
 jinja2
 python-daemon
 python-pidfile
-redis
+redis<5.0.0
 requests
 sh
 state-signals>=1.0.1


### PR DESCRIPTION
Temporary fix to unblock v0.72 users.

See also PR #3526.

JIRA-1250