### PR TITLE
Version lock redis to <5.0.0 -b0.73 branch

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -6,7 +6,7 @@ ifaddr
 jinja2
 python-daemon
 python-pidfile
-redis
+redis<5.0.0
 requests # TODO CVE-2023-32681 (>=2.31)
 sh
 state-signals>=1.0.1


### PR DESCRIPTION
The release of v0.73 of the agent is imminent and for now, this fix is required. A more permanent fix will be made in future releases.

See also PR #3525.

JIRA-1250