### PR TITLE
Fix the SQL constraint violation logic

### DIFF
--- a/lib/pbench/server/database/models/__init__.py
+++ b/lib/pbench/server/database/models/__init__.py
@@ -64,16 +64,16 @@ def decode_sql_error(
 
     """Analyze an exception for a SQL constraint violation
 
-    Currently analyzes SQLAlchemy IntegrityException instances for NOT NULL and
-    UNIQUE KEY constraints, constsructing and returning an appropriate
-    exception. If the exception doesn't match a recognized SQL constraint,
-    construct and return a fallback exception type if specified or the original
-    exception.
+    Analyzes SQLAlchemy IntegrityException instances for NOT NULL and UNIQUE
+    KEY constraints, constructing and returning an appropriate exception
+    instance. If the exception doesn't match a recognized SQL constraint,
+    construct and return a fallback exception instance if specified or the
+    original exception.
 
     Args:
         exception: An exception to decode
         on_null: Exception class to build if null contraint
-        on_duplicate: Exception class to build with if duplicate constraint
+        on_duplicate: Exception class to build if duplicate constraint
         fallback: Exception class to build otherwise
         kwargs: additional arguments passed to exception constructors
 

--- a/lib/pbench/server/database/models/__init__.py
+++ b/lib/pbench/server/database/models/__init__.py
@@ -64,14 +64,17 @@ def decode_sql_error(
 
     """Analyze an exception for a SQL constraint violation
 
-    Return a fallback (defaults to original exception) if no match
+    Currently analyzes SQLAlchemy IntegrityException instances for NOT NULL and
+    UNIQUE KEY constraints, constsructing and returning an appropriate
+    exception. If the exception doesn't match a recognized SQL constraint,
+    construct and return a fallback exception type if specified or the original
+    exception.
 
     Args:
-        exception: An IntegrityError to decode
-        on_null: Constructor to call with (model, exception) if null contraint
-        on_duplicate: Constructor to call with (model, exception) if duplicate
-        fallback: Constructor to call with (model, exception); return original
-            exception if omitted/None
+        exception: An exception to decode
+        on_null: Exception class to build if null contraint
+        on_duplicate: Exception class to build with if duplicate constraint
+        fallback: Exception class to build otherwise
         kwargs: additional arguments passed to exception constructors
 
     Returns:

--- a/lib/pbench/server/database/models/api_keys.py
+++ b/lib/pbench/server/database/models/api_keys.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import relationship
 
 from pbench.server import JSONOBJECT
 from pbench.server.database.database import Database
-from pbench.server.database.models import decode_integrity_error, TZDateTime
+from pbench.server.database.models import decode_sql_error, TZDateTime
 from pbench.server.database.models.users import User
 
 # Module private constants
@@ -17,31 +17,34 @@ _TOKEN_ALG_INT = "HS256"
 class APIKeyError(Exception):
     """A base class for errors reported by the APIKey class."""
 
-    def __init__(self, message):
-        self.message = message
+    pass
 
-    def __str__(self):
-        return repr(self.message)
+
+class APIKeySqlError(APIKeyError):
+    """Report a generic SQL error"""
+
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"API key SQL error: '{cause}' {kwargs}")
+        self.cause = cause
+        self.kwargs = kwargs
 
 
 class DuplicateApiKey(APIKeyError):
     """Attempt to commit a duplicate unique value."""
 
-    def __init__(self, cause: str):
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"API key duplicate key error: '{cause}' {kwargs}")
         self.cause = cause
-
-    def __str__(self) -> str:
-        return f"Duplicate api_key: {self.cause}"
+        self.kwargs = kwargs
 
 
 class NullKey(APIKeyError):
     """Attempt to commit an APIkey row with an empty required column."""
 
-    def __init__(self, cause: str):
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"API key null key error: '{cause}' {kwargs}")
         self.cause = cause
-
-    def __str__(self) -> str:
-        return f"Missing required value: {self.cause}"
+        self.kwargs = kwargs
 
 
 class APIKey(Database.Base):
@@ -68,14 +71,14 @@ class APIKey(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't add {} to DB: {}", str(self), str(e))
-            decode_exc = decode_integrity_error(
-                e, on_duplicate=DuplicateApiKey, on_null=NullKey
+            raise decode_sql_error(
+                e,
+                on_duplicate=DuplicateApiKey,
+                on_null=NullKey,
+                fallback=APIKeyError,
+                operation="add",
+                key=self,
             )
-            if decode_exc is e:
-                raise APIKeyError(str(e)) from e
-            else:
-                raise decode_exc from e
 
     @staticmethod
     def query(**kwargs) -> Optional["APIKey"]:
@@ -99,7 +102,7 @@ class APIKey(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            raise APIKeyError(f"Error deleting api_key from db : {e}") from e
+            raise APIKeySqlError(e, operation="delete", key=self) from e
 
     def as_json(self) -> JSONOBJECT:
         """Return a JSON object for this APIkey object.

--- a/lib/pbench/server/database/models/api_keys.py
+++ b/lib/pbench/server/database/models/api_keys.py
@@ -75,10 +75,10 @@ class APIKey(Database.Base):
                 e,
                 on_duplicate=DuplicateApiKey,
                 on_null=NullKey,
-                fallback=APIKeyError,
+                fallback=APIKeySqlError,
                 operation="add",
                 key=self,
-            )
+            ) from e
 
     @staticmethod
     def query(**kwargs) -> Optional["APIKey"]:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -190,7 +190,7 @@ class MetadataMissingParameter(MetadataKeyError):
     """A Metadata required parameter was not specified."""
 
     def __init__(self, what: str):
-        super().__init__(f"Metadata must specify a {self.what}")
+        super().__init__(f"Metadata must specify a {what}")
         self.what = what
 
 
@@ -436,7 +436,7 @@ class Dataset(Database.Base):
                 fallback=DatasetSqlError,
                 operation="add",
                 dataset=self,
-            )
+            ) from e
 
     def update(self):
         """Update the database row with the modified version of the Dataset
@@ -453,7 +453,7 @@ class Dataset(Database.Base):
                 fallback=DatasetSqlError,
                 operation="update",
                 dataset=self,
-            )
+            ) from e
 
     def delete(self):
         """Delete the Dataset from the database."""

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -7,11 +7,11 @@ from typing import Any, Dict, List, Optional, Union
 
 from dateutil import parser as date_parser
 from sqlalchemy import Column, Enum, event, ForeignKey, Integer, JSON, String, Text
-from sqlalchemy.exc import DataError, IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import DataError, SQLAlchemyError
 from sqlalchemy.orm import Query, relationship, validates
 
 from pbench.server.database.database import Database
-from pbench.server.database.models import TZDateTime
+from pbench.server.database.models import decode_sql_error, TZDateTime
 from pbench.server.database.models.server_settings import (
     OPTION_DATASET_LIFETIME,
     ServerSetting,
@@ -25,51 +25,47 @@ class DatasetError(Exception):
     It is never raised directly, but may be used in "except" clauses.
     """
 
+    pass
+
 
 class DatasetBadName(DatasetError):
     """Specified filename does not follow Pbench tarball naming rules."""
 
     def __init__(self, name: Path):
+        super().__init__(
+            f"File name {name!r} does not end in {Dataset.TARBALL_SUFFIX!r}"
+        )
         self.name: str = str(name)
-
-    def __str__(self) -> str:
-        return f"File name {self.name!r} does not end in {Dataset.TARBALL_SUFFIX!r}"
 
 
 class DatasetSqlError(DatasetError):
     """SQLAlchemy errors reported through Dataset operations.
 
     The exception will identify the name of the target dataset, along with the
-    operation being attempted; the __cause__ will specify the original
-    SQLAlchemy exception.
+    operation being attempted; the cause is the original SQLAlchemy exception.
     """
 
-    def __init__(self, operation: str, **kwargs):
-        self.operation = operation
-        self.kwargs = [f"{key}={value}" for key, value in kwargs.items()]
-
-    def __str__(self) -> str:
-        return f"Error {self.operation} dataset {'|'.join(self.kwargs)}"
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"SQL error on {kwargs.get('dataset')}: '{cause}'")
+        self.cause = cause
+        self.kwargs = kwargs
 
 
 class DatasetDuplicate(DatasetError):
     """Attempt to create a Dataset that already exists."""
 
-    def __init__(self, name: str):
-        self.name = name
-
-    def __str__(self):
-        return f"Duplicate dataset {self.name!r}"
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Duplicate dataset {kwargs.get('dataset')}: '{cause}'")
+        self.cause = cause
+        self.kwargs = kwargs
 
 
 class DatasetNotFound(DatasetError):
     """Attempt to locate a Dataset that doesn't exist."""
 
     def __init__(self, **kwargs):
-        self.kwargs = [f"{key}={value}" for key, value in kwargs.items()]
-
-    def __str__(self) -> str:
-        return f"No dataset {'|'.join(self.kwargs)}"
+        super().__init__(f"Dataset not found for {kwargs}")
+        self.kwargs = kwargs
 
 
 class DatasetBadParameterType(DatasetError):
@@ -81,13 +77,13 @@ class DatasetBadParameterType(DatasetError):
     """
 
     def __init__(self, bad_value: Any, expected_type: Any):
-        self.bad_value = bad_value
         self.expected_type = (
             expected_type.__name__ if isinstance(expected_type, type) else expected_type
         )
-
-    def __str__(self) -> str:
-        return f'Value "{self.bad_value}" ({type(self.bad_value)}) is not a {self.expected_type}'
+        super().__init__(
+            f'Value "{bad_value}" ({type(bad_value).__name__}) is not a {self.expected_type}'
+        )
+        self.bad_value = bad_value
 
 
 class MetadataError(DatasetError):
@@ -96,29 +92,21 @@ class MetadataError(DatasetError):
     It is never raised directly, but may be used in "except" clauses.
     """
 
-    def __init__(self, dataset: "Dataset", key: str):
-        self.dataset = dataset
-        self.key = key
-
-    def __str__(self) -> str:
-        return f"Generic error on {self.dataset} key {self.key}"
+    pass
 
 
 class MetadataSqlError(MetadataError):
     """SQLAlchemy errors reported through Metadata operations.
 
     The exception will identify the dataset and the metadata key, along with
-    the operation being attempted; the __cause__ will specify the original
-    SQLAlchemy exception.
+    the operation being attempted; the cause is the original SQLAlchemy
+    exception.
     """
 
-    def __init__(self, operation: str, dataset: "Dataset", key: str):
-        self.operation = operation
-        super().__init__(dataset, key)
-
-    def __str__(self) -> str:
-        ds = str(self.dataset) if self.dataset else "no dataset"
-        return f"Error {self.operation} {ds} key {self.key}"
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Metadata SQL error '{cause}': {kwargs}")
+        self.cause = cause
+        self.kwargs = kwargs
 
 
 class MetadataNotFound(MetadataError):
@@ -129,10 +117,9 @@ class MetadataNotFound(MetadataError):
     """
 
     def __init__(self, dataset: "Dataset", key: str):
-        super().__init__(dataset, key)
-
-    def __str__(self) -> str:
-        return f"No metadata {self.key} for {self.dataset}"
+        super().__init__(f"No metadata {key} for {dataset}")
+        self.dataset = dataset
+        self.key = key
 
 
 class MetadataBadStructure(MetadataError):
@@ -148,11 +135,12 @@ class MetadataBadStructure(MetadataError):
     """
 
     def __init__(self, dataset: "Dataset", path: str, element: str):
-        super().__init__(dataset, path)
+        super().__init__(
+            f"Key {element!r} value for {path!r} in {dataset} is not a JSON object"
+        )
+        self.dataset = dataset
+        self.path = path
         self.element = element
-
-    def __str__(self) -> str:
-        return f"Key {self.element!r} value for {self.key!r} in {self.dataset} is not a JSON object"
 
 
 class MetadataBadValue(MetadataError):
@@ -176,15 +164,16 @@ class MetadataBadValue(MetadataError):
             value: Metadata key value
             expected: The expected metadata value type
         """
-        super().__init__(dataset, key)
+        super().__init__(
+            (
+                f"Metadata key {key!r} value {value!r} for dataset "
+                f"{str(dataset) + ' ' if dataset else ''}must be a {expected}"
+            )
+        )
+        self.dataset = dataset
+        self.key = key
         self.value = value
         self.expected = expected
-
-    def __str__(self) -> str:
-        return (
-            f"Metadata key {self.key!r} value {self.value!r} for dataset"
-            f"{' ' + str(self.dataset) if self.dataset else ''} must be a {self.expected}"
-        )
 
 
 class MetadataKeyError(MetadataError):
@@ -194,15 +183,15 @@ class MetadataKeyError(MetadataError):
     It is never raised directly, but may be used in "except" clauses.
     """
 
+    pass
+
 
 class MetadataMissingParameter(MetadataKeyError):
     """A Metadata required parameter was not specified."""
 
     def __init__(self, what: str):
+        super().__init__(f"Metadata must specify a {self.what}")
         self.what = what
-
-    def __str__(self) -> str:
-        return f"Metadata must specify a {self.what}"
 
 
 class MetadataBadKey(MetadataKeyError):
@@ -212,15 +201,12 @@ class MetadataBadKey(MetadataKeyError):
     """
 
     def __init__(self, key: str):
+        super().__init__(f"Metadata key {key!r} is not supported")
         self.key = key
-
-    def __str__(self) -> str:
-        return f"Metadata key {self.key!r} is not supported"
 
 
 class MetadataProtectedKey(MetadataKeyError):
-    """A metadata key was specified that cannot be modified in the current
-    context.
+    """A metadata key cannot be modified in the current context.
 
     Usually an internally reserved key that was referenced in an external
     client API.
@@ -229,10 +215,8 @@ class MetadataProtectedKey(MetadataKeyError):
     """
 
     def __init__(self, key: str):
+        super().__init__(f"Metadata key {key} cannot be modified by client")
         self.key = key
-
-    def __str__(self) -> str:
-        return f"Metadata key {self.key} cannot be modified by client"
 
 
 class MetadataMissingKeyValue(MetadataKeyError):
@@ -242,10 +226,8 @@ class MetadataMissingKeyValue(MetadataKeyError):
     """
 
     def __init__(self, key: str):
+        super().__init__(f"Metadata key {key} value is required")
         self.key = key
-
-    def __str__(self) -> str:
-        return f"Metadata key {self.key} value is required"
 
 
 class MetadataDuplicateKey(MetadataError):
@@ -256,10 +238,9 @@ class MetadataDuplicateKey(MetadataError):
     """
 
     def __init__(self, dataset: "Dataset", key: str):
-        super().__init__(dataset, key)
-
-    def __str__(self) -> str:
-        return f"{self.dataset} already has metadata key {self.key}"
+        super().__init__(f"{dataset} already has metadata key {key}")
+        self.dataset = dataset
+        self.key = key
 
 
 class Dataset(Database.Base):
@@ -396,7 +377,7 @@ class Dataset(Database.Base):
         try:
             dataset = Database.db_session.query(Dataset).filter_by(**kwargs).first()
         except SQLAlchemyError as e:
-            raise DatasetSqlError("querying", **kwargs) from e
+            raise DatasetSqlError(e, operation="querying", **kwargs) from e
 
         if dataset is None:
             raise DatasetNotFound(**kwargs)
@@ -446,14 +427,16 @@ class Dataset(Database.Base):
         try:
             Database.db_session.add(self)
             Database.db_session.commit()
-        except IntegrityError as e:
-            Database.db_session.rollback()
-            self.logger.warning("Duplicate dataset {}: {}", self.name, e)
-            raise DatasetDuplicate(self.name) from None
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't add {} to DB: {}", str(self), str(e))
-            raise DatasetSqlError("adding", name=self.name) from e
+            raise decode_sql_error(
+                e,
+                on_duplicate=DatasetDuplicate,
+                on_null=DatasetSqlError,
+                fallback=DatasetSqlError,
+                operation="add",
+                dataset=self,
+            )
 
     def update(self):
         """Update the database row with the modified version of the Dataset
@@ -463,8 +446,14 @@ class Dataset(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't update {} in DB: {}", str(self), str(e))
-            raise DatasetSqlError("updating", name=self.name) from e
+            raise decode_sql_error(
+                e,
+                on_duplicate=DatasetDuplicate,
+                on_null=DatasetSqlError,
+                fallback=DatasetSqlError,
+                operation="update",
+                dataset=self,
+            )
 
     def delete(self):
         """Delete the Dataset from the database."""
@@ -473,8 +462,7 @@ class Dataset(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't delete {} in DB: {}", str(self), str(e))
-            raise DatasetSqlError("updating", name=self.name) from e
+            raise DatasetSqlError(e, operation="delete", dataset=self) from e
 
 
 class OperationName(enum.Enum):
@@ -1091,7 +1079,7 @@ class Metadata(Database.Base):
             meta = __class__._query(dataset, key, user).first()
         except SQLAlchemyError as e:
             Metadata.logger.error("Can't get {}>>{} from DB: {}", dataset, key, str(e))
-            raise MetadataSqlError("getting", dataset, key) from e
+            raise MetadataSqlError(e, operation="get", dataset=dataset, key=key) from e
         else:
             if meta is None:
                 raise MetadataNotFound(dataset, key)
@@ -1115,7 +1103,9 @@ class Metadata(Database.Base):
             Metadata.logger.error(
                 "Can't remove {}>>{} from DB: {}", dataset, key, str(e)
             )
-            raise MetadataSqlError("deleting", dataset, key) from e
+            raise MetadataSqlError(
+                e, operation="delete", dataset=dataset, key=key
+            ) from e
 
     def __str__(self) -> str:
         return f"{self.dataset}>>{self.key}"
@@ -1138,9 +1128,10 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't add {}>>{} to DB: {}", dataset, self.key, str(e))
             dataset.metadatas.remove(self)
-            raise MetadataSqlError("adding", dataset, self.key) from e
+            raise MetadataSqlError(
+                e, operation="add", dataset=dataset, key=self.key
+            ) from e
 
     def update(self):
         """Update the database with the modified Metadata."""
@@ -1148,8 +1139,9 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't update {} in DB: {}", self, str(e))
-            raise MetadataSqlError("updating", self.dataset, self.key) from e
+            raise MetadataSqlError(
+                e, operation="update", dataset=self.dataset, key=self.key
+            ) from e
 
     def delete(self):
         """Remove the Metadata from the database."""
@@ -1158,8 +1150,9 @@ class Metadata(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            self.logger.error("Can't delete {} from DB: {}", self, str(e))
-            raise MetadataSqlError("deleting", self.dataset, self.key) from e
+            raise MetadataSqlError(
+                e, operation="delete", dataset=self.dataset, key=self.key
+            ) from e
 
 
 @event.listens_for(Metadata, "init")

--- a/lib/pbench/server/database/models/index_map.py
+++ b/lib/pbench/server/database/models/index_map.py
@@ -29,7 +29,7 @@ class IndexMapSqlError(IndexMapError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(
-            f"Index SQL error {kwargs.get('operation')} "
+            f"Index SQL error on {kwargs.get('operation')} "
             f"{kwargs.get('dataset')}:{kwargs.get('name')}: '{cause}'"
         )
         self.cause = cause
@@ -306,4 +306,4 @@ class IndexMap(Database.Base):
                 operation=operation,
                 dataset=dataset,
                 name="all",
-            )
+            ) from e

--- a/lib/pbench/server/database/models/server_settings.py
+++ b/lib/pbench/server/database/models/server_settings.py
@@ -37,7 +37,7 @@ class ServerSettingSqlError(ServerSettingError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(
-            f"Error {kwargs.get('operation')} index {kwargs.get('key')!r}: '{cause}'"
+            f"Error on {kwargs.get('operation')} index {kwargs.get('key')!r}: '{cause}'"
         )
         self.cause = cause
         self.kwargs = kwargs
@@ -342,7 +342,7 @@ class ServerSetting(Database.Base):
                 fallback=ServerSettingSqlError,
                 operation="add",
                 key=self.key,
-            )
+            ) from e
 
     def update(self):
         """Update the database row with the modified version of the
@@ -359,4 +359,4 @@ class ServerSetting(Database.Base):
                 fallback=ServerSettingSqlError,
                 operation="update",
                 key=self.key,
-            )
+            ) from e

--- a/lib/pbench/server/database/models/server_settings.py
+++ b/lib/pbench/server/database/models/server_settings.py
@@ -11,11 +11,12 @@ import re
 from typing import Optional
 
 from sqlalchemy import Column, Integer, String
-from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.sqltypes import JSON
 
 from pbench.server import JSONOBJECT, JSONVALUE
 from pbench.server.database.database import Database
+from pbench.server.database.models import decode_sql_error
 
 
 class ServerSettingError(Exception):
@@ -23,6 +24,8 @@ class ServerSettingError(Exception):
 
     It is never raised directly, but may be used in "except" clauses.
     """
+
+    pass
 
 
 class ServerSettingSqlError(ServerSettingError):
@@ -32,63 +35,56 @@ class ServerSettingSqlError(ServerSettingError):
     key; the cause will specify the original SQLAlchemy exception.
     """
 
-    def __init__(self, operation: str, name: str, cause: str):
-        self.operation = operation
-        self.name = name
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(
+            f"Error {kwargs.get('operation')} index {kwargs.get('key')!r}: '{cause}'"
+        )
         self.cause = cause
-
-    def __str__(self) -> str:
-        return f"Error {self.operation} index {self.name!r}: {self.cause}"
+        self.kwargs = kwargs
 
 
 class ServerSettingDuplicate(ServerSettingError):
     """Attempt to commit a duplicate ServerSetting."""
 
-    def __init__(self, name: str, cause: str):
-        self.name = name
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Duplicate server setting {kwargs.get('key')!r}: '{cause}'")
         self.cause = cause
-
-    def __str__(self) -> str:
-        return f"Duplicate server setting {self.name!r}: {self.cause}"
+        self.kwargs = kwargs
 
 
 class ServerSettingNullKey(ServerSettingError):
     """Attempt to commit a ServerSetting with an empty key."""
 
-    def __init__(self, name: str, cause: str):
-        self.name = name
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Missing key value in {kwargs.get('key')!r}: '{cause}'")
         self.cause = cause
-
-    def __str__(self) -> str:
-        return f"Missing key value in {self.name!r}: {self.cause}"
+        self.kwargs = kwargs
 
 
 class ServerSettingMissingKey(ServerSettingError):
     """Attempt to set a ServerSetting with a missing key."""
 
-    def __str__(self) -> str:
-        return "Missing server setting key name"
+    def __init__(self):
+        super().__init__("Missing server setting key name")
 
 
 class ServerSettingBadKey(ServerSettingError):
     """Attempt to commit a ServerSetting with a bad key."""
 
     def __init__(self, key: str):
+        super().__init__(f"Server setting key {key!r} is unknown")
         self.key = key
-
-    def __str__(self) -> str:
-        return f"Server setting key {self.key!r} is unknown"
 
 
 class ServerSettingBadValue(ServerSettingError):
     """Attempt to assign a bad value to a server setting option."""
 
     def __init__(self, key: str, value: JSONVALUE):
+        super().__init__(
+            f"Unsupported value for server setting key {key!r} ({value!r})"
+        )
         self.key = key
         self.value = value
-
-    def __str__(self) -> str:
-        return f"Unsupported value for server setting key {self.key!r} ({self.value!r})"
 
 
 # Formal timedelta syntax is "[D day[s], ][H]H:MM:SS[.UUUUUU]"; without an
@@ -269,7 +265,7 @@ class ServerSetting(Database.Base):
             if setting is None and use_default:
                 setting = ServerSetting(key=key, value=__class__._default(key))
         except SQLAlchemyError as e:
-            raise ServerSettingSqlError("finding", key, str(e)) from e
+            raise ServerSettingSqlError(e, operation="get", key=key) from e
         return setting
 
     @staticmethod
@@ -332,27 +328,6 @@ class ServerSetting(Database.Base):
         """
         return f"{self.key}: {self.value!r}"
 
-    def _decode(self, exception: IntegrityError) -> Exception:
-        """Decode a SQLAlchemy IntegrityError to look for a recognizable UNIQUE
-        or NOT NULL constraint violation.
-
-        Return the original exception if it doesn't match.
-
-        Args:
-            exception : An IntegrityError to decode
-
-        Returns:
-            a more specific exception, or the original if decoding fails
-        """
-        # Postgres engine returns (code, message) but sqlite3 engine only
-        # returns (message); so always take the last element.
-        cause = exception.orig.args[-1]
-        if cause.find("UNIQUE constraint") != -1:
-            return ServerSettingDuplicate(self.key, cause)
-        elif cause.find("NOT NULL constraint") != -1:
-            return ServerSettingNullKey(self.key, cause)
-        return exception
-
     def add(self):
         """Add the ServerSetting object to the database."""
         try:
@@ -360,9 +335,14 @@ class ServerSetting(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            if isinstance(e, IntegrityError):
-                raise self._decode(e) from e
-            raise ServerSettingSqlError("adding", self.key, str(e)) from e
+            raise decode_sql_error(
+                e,
+                on_duplicate=ServerSettingDuplicate,
+                on_null=ServerSettingNullKey,
+                fallback=ServerSettingSqlError,
+                operation="add",
+                key=self.key,
+            )
 
     def update(self):
         """Update the database row with the modified version of the
@@ -372,6 +352,11 @@ class ServerSetting(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            if isinstance(e, IntegrityError):
-                raise self._decode(e) from e
-            raise ServerSettingSqlError("updating", self.key, str(e)) from e
+            raise decode_sql_error(
+                e,
+                on_duplicate=ServerSettingDuplicate,
+                on_null=ServerSettingNullKey,
+                fallback=ServerSettingSqlError,
+                operation="update",
+                key=self.key,
+            )

--- a/lib/pbench/server/database/models/templates.py
+++ b/lib/pbench/server/database/models/templates.py
@@ -28,7 +28,7 @@ class TemplateSqlError(TemplateError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(
-            f"Error {kwargs.get('operation')} index {kwargs.get('name')!r}: '{cause}'"
+            f"Error on {kwargs.get('operation')} index {kwargs.get('name')!r}: '{cause}'"
         )
         self.cause = cause
         self.kwargs = kwargs
@@ -165,7 +165,7 @@ class Template(Database.Base):
                 fallback=TemplateSqlError,
                 operation="add",
                 name=self.name,
-            )
+            ) from e
 
     def update(self):
         """Update the database row with the modified version of the
@@ -182,7 +182,7 @@ class Template(Database.Base):
                 fallback=TemplateSqlError,
                 operation="update",
                 name=self.name,
-            )
+            ) from e
 
 
 @event.listens_for(Template, "init")

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -2,12 +2,11 @@ import enum
 from typing import Optional
 
 from sqlalchemy import Column, String
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import relationship
 
 from pbench.server import JSONOBJECT
 from pbench.server.database.database import Database
-from pbench.server.database.models import decode_integrity_error
+from pbench.server.database.models import decode_sql_error
 
 
 class Roles(enum.Enum):
@@ -20,6 +19,8 @@ class UserError(Exception):
     It is never raised directly, but may be used in "except" clauses.
     """
 
+    pass
+
 
 class UserSqlError(UserError):
     """SQLAlchemy errors reported through User operations.
@@ -28,33 +29,27 @@ class UserSqlError(UserError):
     key; the cause will specify the original SQLAlchemy exception.
     """
 
-    def __init__(self, operation: str, params: JSONOBJECT, cause: str):
-        super().__init__(
-            f"Error {self.operation} {self.params!r}: {self.cause}",
-            operation,
-            params,
-            cause,
-        )
-        self.operation = operation
-        self.params = params
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"User SQL error: '{cause}'", kwargs)
+        self.kwargs = kwargs
         self.cause = cause
 
 
 class UserDuplicate(UserError):
     """Attempt to commit a duplicate unique value."""
 
-    def __init__(self, user: "User", cause: Exception):
-        super().__init__(f"Duplicate user entry in {user}: {cause}", user, cause)
-        self.user = user
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Duplicate user: '{cause}'", kwargs)
+        self.kwargs = kwargs
         self.cause = cause
 
 
 class UserNullKey(UserError):
     """Attempt to commit a User row with an empty required column."""
 
-    def __init__(self, user: "User", cause: Exception):
-        super().__init__(f"Missing required key in {user}: {cause}", user, cause)
-        self.user = user
+    def __init__(self, cause: Exception, **kwargs):
+        super().__init__(f"Missing required key: '{cause}'", kwargs)
+        self.kwargs = kwargs
         self.cause = cause
 
 
@@ -82,7 +77,7 @@ class User(Database.Base):
         try:
             self._roles = ";".join(value)
         except Exception as e:
-            raise UserSqlError("Setting role", value, str(e)) from e
+            raise UserSqlError(e, user=self, operation="setrole", role=value) from e
 
     def __str__(self):
         return f"User, id: {self.id}, username: {self.username}"
@@ -94,30 +89,6 @@ class User(Database.Base):
             A JSONOBJECT with all the object fields mapped to appropriate names.
         """
         return {"username": self.username, "id": self.id, "roles": self.roles}
-
-    def _decode(
-        self, exception: IntegrityError, operation: Optional[str] = ""
-    ) -> Exception:
-        """Decode a SQLAlchemy IntegrityError to look for a recognizable UNIQUE
-        or NOT NULL constraint violation.
-
-        Return the original exception if it doesn't match.
-
-        Args:
-            exception : An IntegrityError to decode
-
-        Returns:
-            a more specific exception, or the original if decoding fails
-        """
-        # Postgres engine returns (code, message) but sqlite3 engine only
-        # returns (message); so always take the last element.
-        cause = exception.orig.args[-1]
-        if "UNIQUE constraint" in cause:
-            return UserDuplicate(self, cause)
-        elif "NOT NULL constraint" in cause:
-            return UserNullKey(self, cause)
-        else:
-            return UserSqlError(operation, self.get_json(), str(exception))
 
     @staticmethod
     def query(id: str = None, username: str = None) -> Optional["User"]:
@@ -149,12 +120,13 @@ class User(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            raise decode_integrity_error(
-                self,
+            raise decode_sql_error(
                 e,
                 on_duplicate=UserDuplicate,
                 on_null=UserNullKey,
                 fallback=UserSqlError,
+                user=self,
+                operation="add",
             ) from e
 
     def update(self, **kwargs):
@@ -165,12 +137,13 @@ class User(Database.Base):
             Database.db_session.commit()
         except Exception as e:
             Database.db_session.rollback()
-            raise decode_integrity_error(
-                self,
+            raise decode_sql_error(
                 e,
                 on_duplicate=UserDuplicate,
                 on_null=UserNullKey,
                 fallback=UserSqlError,
+                user=self,
+                operation="update",
             ) from e
 
     def is_admin(self) -> bool:

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -31,8 +31,8 @@ class UserSqlError(UserError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(f"User SQL error: '{cause}'", kwargs)
-        self.kwargs = kwargs
         self.cause = cause
+        self.kwargs = kwargs
 
 
 class UserDuplicate(UserError):
@@ -40,8 +40,8 @@ class UserDuplicate(UserError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(f"Duplicate user: '{cause}'", kwargs)
-        self.kwargs = kwargs
         self.cause = cause
+        self.kwargs = kwargs
 
 
 class UserNullKey(UserError):
@@ -49,8 +49,8 @@ class UserNullKey(UserError):
 
     def __init__(self, cause: Exception, **kwargs):
         super().__init__(f"Missing required key: '{cause}'", kwargs)
-        self.kwargs = kwargs
         self.cause = cause
+        self.kwargs = kwargs
 
 
 class User(Database.Base):

--- a/lib/pbench/test/unit/server/database/test_audit_db.py
+++ b/lib/pbench/test/unit/server/database/test_audit_db.py
@@ -59,9 +59,9 @@ class TestAudit:
     def test_construct_null(self, fake_db):
         """Test handling of Audit record null value error"""
         self.session.raise_on_commit = IntegrityError(
-            statement="", params="", orig=FakeDBOrig("NOT NULL constraint")
+            statement="", params="", orig=FakeDBOrig("not null constraint")
         )
-        with pytest.raises(AuditNullKey, match="'operation': 'CREATE'"):
+        with pytest.raises(AuditNullKey):
             Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 
@@ -70,7 +70,7 @@ class TestAudit:
         self.session.raise_on_commit = IntegrityError(
             statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
         )
-        with pytest.raises(AuditDuplicate, match="'id': 1"):
+        with pytest.raises(AuditDuplicate):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 
@@ -79,7 +79,7 @@ class TestAudit:
         self.session.raise_on_commit = DatabaseError(
             statement="", params="", orig=FakeDBOrig("something else")
         )
-        with pytest.raises(AuditSqlError, match="'id': 1"):
+        with pytest.raises(AuditSqlError):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 
@@ -139,10 +139,7 @@ class TestAudit:
 
     def test_exceptional_query(self, fake_db):
         FakeSession.throw_query = True
-        with pytest.raises(
-            AuditSqlError,
-            match=r"Error finding {'user_name': 'imme'}: \('test', 'because'\)",
-        ):
+        with pytest.raises(AuditSqlError):
             Audit.query(user_name="imme")
         self.session.reset_context()
 

--- a/lib/pbench/test/unit/server/database/test_audit_db.py
+++ b/lib/pbench/test/unit/server/database/test_audit_db.py
@@ -61,7 +61,9 @@ class TestAudit:
         self.session.raise_on_commit = IntegrityError(
             statement="", params="", orig=FakeDBOrig("not null constraint")
         )
-        with pytest.raises(AuditNullKey):
+        with pytest.raises(
+            AuditNullKey, match=r"Missing required key.*'operation': 'add'"
+        ):
             Audit.create(operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 
@@ -70,7 +72,9 @@ class TestAudit:
         self.session.raise_on_commit = IntegrityError(
             statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
         )
-        with pytest.raises(AuditDuplicate):
+        with pytest.raises(
+            AuditDuplicate, match=r"Duplicate key in.*'operation': 'add'"
+        ):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 
@@ -79,7 +83,7 @@ class TestAudit:
         self.session.raise_on_commit = DatabaseError(
             statement="", params="", orig=FakeDBOrig("something else")
         )
-        with pytest.raises(AuditSqlError):
+        with pytest.raises(AuditSqlError, match=r"SQL error on.*'operation': 'add'"):
             Audit.create(id=1, operation=OperationCode.CREATE, status=AuditStatus.BEGIN)
         self.session.check_session(rolledback=1)
 

--- a/lib/pbench/test/unit/server/database/test_audit_db.py
+++ b/lib/pbench/test/unit/server/database/test_audit_db.py
@@ -143,7 +143,7 @@ class TestAudit:
 
     def test_exceptional_query(self, fake_db):
         FakeSession.throw_query = True
-        with pytest.raises(AuditSqlError):
+        with pytest.raises(AuditSqlError, match=r"SQL error on.+'operation': 'query'"):
             Audit.query(user_name="imme")
         self.session.reset_context()
 

--- a/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
+++ b/lib/pbench/test/unit/server/database/test_datasets_metadata_db.py
@@ -256,7 +256,7 @@ class TestMetadataNamespace:
         with pytest.raises(MetadataBadStructure) as exc:
             Metadata.getvalue(ds, "global.contact.email")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "global.contact.email"
+        assert exc.value.path == "global.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)
@@ -272,7 +272,7 @@ class TestMetadataNamespace:
         with pytest.raises(MetadataBadStructure) as exc:
             Metadata.setvalue(ds, "global.contact.email", "me@example.com")
         assert exc.type == MetadataBadStructure
-        assert exc.value.key == "global.contact.email"
+        assert exc.value.path == "global.contact.email"
         assert exc.value.element == "contact"
         assert (
             str(exc.value)

--- a/lib/pbench/test/unit/server/database/test_index_map_db.py
+++ b/lib/pbench/test/unit/server/database/test_index_map_db.py
@@ -140,21 +140,25 @@ class TestIndexMapDB:
                     statement="", params="", orig=BaseException("UNIQUE constraint")
                 ),
                 IndexMapDuplicate,
-                "Duplicate index map 'any'",
+                "Duplicate index map ",
             ),
             (
                 IntegrityError(
                     statement="", params="", orig=BaseException("NOT NULL constraint")
                 ),
                 IndexMapMissingParameter,
-                "Missing required parameters in 'any'",
+                "Missing required parameters ",
             ),
             (
                 IntegrityError(statement="", params="", orig=BaseException("JUNK")),
-                IntegrityError,
-                "(builtins.BaseException) JUNK",
+                IndexMapSqlError,
+                "Index SQL error create (drb)|drb:all: '(builtins.BaseException) JUNK",
             ),
-            (Exception("Not me"), IndexMapSqlError, "Error create index drb:any"),
+            (
+                Exception("Not me"),
+                IndexMapSqlError,
+                "Index SQL error create (drb)|drb:all",
+            ),
         ),
     )
     def test_commit_error(
@@ -211,7 +215,10 @@ class TestIndexMapDB:
         drb = Dataset.query(name="drb")
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.create(drb, {"root": {"idx": ["id"]}})
-        assert str(e.value) == "Error add_all index drb:all: Yeah, that didn't work"
+        assert (
+            str(e.value)
+            == "Index SQL error create (drb)|drb:all: 'Yeah, that didn't work'"
+        )
 
     def test_merge_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index map creation failure"""
@@ -224,7 +231,7 @@ class TestIndexMapDB:
         drb = Dataset.query(name="drb")
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.merge(drb, {"root": {"idx": ["id"]}})
-        assert str(e.value) == "Error merge index drb:all: That was easy"
+        assert str(e.value) == "Index SQL error merge (drb)|drb:all: 'That was easy'"
 
     def test_indices_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index list failure"""
@@ -237,7 +244,7 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.indices(drb, "idx")
-        assert str(e.value) == "Error finding index drb:idx: That was easy"
+        assert str(e.value) == "Index SQL error indices (drb)|drb:idx: 'That was easy'"
 
     def test_exists_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index existence check failure"""
@@ -250,7 +257,7 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.exists(drb)
-        assert str(e.value) == "Error checkexist index drb:any: That was easy"
+        assert str(e.value) == "Index SQL error exists (drb)|drb:any: 'That was easy'"
 
     def test_stream_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index stream failure"""
@@ -263,4 +270,4 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             list(IndexMap.stream(drb))
-        assert str(e.value) == "Error streaming index drb:all: That was easy"
+        assert str(e.value) == "Index SQL error stream (drb)|drb:all: 'That was easy'"

--- a/lib/pbench/test/unit/server/database/test_index_map_db.py
+++ b/lib/pbench/test/unit/server/database/test_index_map_db.py
@@ -152,12 +152,12 @@ class TestIndexMapDB:
             (
                 IntegrityError(statement="", params="", orig=BaseException("JUNK")),
                 IndexMapSqlError,
-                "Index SQL error create (drb)|drb:all: '(builtins.BaseException) JUNK",
+                "Index SQL error on create (drb)|drb:all: '(builtins.BaseException) JUNK",
             ),
             (
                 Exception("Not me"),
                 IndexMapSqlError,
-                "Index SQL error create (drb)|drb:all",
+                "Index SQL error on create (drb)|drb:all",
             ),
         ),
     )
@@ -217,7 +217,7 @@ class TestIndexMapDB:
             IndexMap.create(drb, {"root": {"idx": ["id"]}})
         assert (
             str(e.value)
-            == "Index SQL error create (drb)|drb:all: 'Yeah, that didn't work'"
+            == "Index SQL error on create (drb)|drb:all: 'Yeah, that didn't work'"
         )
 
     def test_merge_fail(self, monkeypatch, db_session, attach_dataset):
@@ -231,7 +231,7 @@ class TestIndexMapDB:
         drb = Dataset.query(name="drb")
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.merge(drb, {"root": {"idx": ["id"]}})
-        assert str(e.value) == "Index SQL error merge (drb)|drb:all: 'That was easy'"
+        assert str(e.value) == "Index SQL error on merge (drb)|drb:all: 'That was easy'"
 
     def test_indices_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index list failure"""
@@ -244,7 +244,9 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.indices(drb, "idx")
-        assert str(e.value) == "Index SQL error indices (drb)|drb:idx: 'That was easy'"
+        assert (
+            str(e.value) == "Index SQL error on indices (drb)|drb:idx: 'That was easy'"
+        )
 
     def test_exists_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index existence check failure"""
@@ -257,7 +259,9 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             IndexMap.exists(drb)
-        assert str(e.value) == "Index SQL error exists (drb)|drb:any: 'That was easy'"
+        assert (
+            str(e.value) == "Index SQL error on exists (drb)|drb:any: 'That was easy'"
+        )
 
     def test_stream_fail(self, monkeypatch, db_session, attach_dataset):
         """Test index stream failure"""
@@ -270,4 +274,6 @@ class TestIndexMapDB:
 
         with pytest.raises(IndexMapSqlError) as e:
             list(IndexMap.stream(drb))
-        assert str(e.value) == "Index SQL error stream (drb)|drb:all: 'That was easy'"
+        assert (
+            str(e.value) == "Index SQL error on stream (drb)|drb:all: 'That was easy'"
+        )

--- a/lib/pbench/test/unit/server/database/test_server_settings.py
+++ b/lib/pbench/test/unit/server/database/test_server_settings.py
@@ -69,7 +69,7 @@ class TestServerSetting:
                 statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
             )
             ServerSetting.create(key="dataset-lifetime", value=2)
-        assert str(e).find("dataset-lifetime") != -1
+        assert "dataset-lifetime" in str(e)
         self.session.check_session(
             committed=[
                 FakeRow(cls=ServerSetting, id=1, key="dataset-lifetime", value="1")

--- a/lib/pbench/test/unit/server/database/test_template_db.py
+++ b/lib/pbench/test/unit/server/database/test_template_db.py
@@ -151,5 +151,4 @@ class TestTemplate:
         template.idxname = None
         with pytest.raises(TemplateMissingParameter) as e:
             template.update()
-        assert str(e).find("run") != -1
-        assert str(e).find("idxname") != -1
+        assert str(e.value).startswith("Missing required parameters in 'run'")

--- a/lib/pbench/test/unit/server/database/test_users_db.py
+++ b/lib/pbench/test/unit/server/database/test_users_db.py
@@ -73,11 +73,11 @@ class TestUsers:
     def test_construct_duplicate(self, fake_db):
         """Test handling of User record duplicate value error"""
         self.session.raise_on_commit = IntegrityError(
-            statement="", params="", orig=FakeDBOrig("UNIQUE constraint")
+            statement="", params="", orig=FakeDBOrig("unique constraint")
         )
         with pytest.raises(
             UserDuplicate,
-            match="Duplicate user entry in {'username': 'dummy', 'id': [^,]+, 'roles': \\[]}: UNIQUE constraint",
+            match="Duplicate user entry",
         ):
             self.add_dummy_user(fake_db)
         self.session.check_session(rolledback=1)

--- a/lib/pbench/test/unit/server/database/test_users_db.py
+++ b/lib/pbench/test/unit/server/database/test_users_db.py
@@ -72,14 +72,19 @@ class TestUsers:
 
     def test_construct_duplicate(self, fake_db):
         """Test handling of User record duplicate value error"""
-        self.session.raise_on_commit = IntegrityError(
+        exception = IntegrityError(
             statement="", params="", orig=FakeDBOrig("unique constraint")
         )
+        self.session.raise_on_commit = exception
         with pytest.raises(
             UserDuplicate,
-            match="Duplicate user entry",
-        ):
+            match="Duplicate user",
+        ) as exc:
             self.add_dummy_user(fake_db)
+        assert len(exc.value.args) == 2
+        assert exc.value.args[0] == f"Duplicate user: '{exception}'"
+        assert exc.value.args[1]["operation"] == "add"
+        assert exc.value.args[1]["user"].username == "dummy"
         self.session.check_session(rolledback=1)
         self.session.reset_context()
 

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -745,7 +745,9 @@ class TestUpload:
         def setvalue(
             dataset: Dataset, key: str, value: Any, user: Optional[User] = None
         ):
-            raise MetadataSqlError("test", dataset, key)
+            raise MetadataSqlError(
+                Exception("fake"), operation="test", dataset=dataset, key=key
+            )
 
         monkeypatch.setattr(Metadata, "setvalue", setvalue)
 
@@ -761,7 +763,7 @@ class TestUpload:
         assert len(audit) == 2
         fails = audit[1].attributes["failures"]
         assert isinstance(fails, dict)
-        assert fails["server.benchmark"].startswith("Error test ")
+        assert fails["server.benchmark"].startswith("Metadata SQL error 'fake': ")
 
     @pytest.mark.freeze_time("1970-01-01")
     def test_upload_archive(self, client, pbench_drb_token, server_config, tarball):


### PR DESCRIPTION
PBENCH-1251

This is mostly a fix for the ops review problem discovered today, that our carefully unit-tested logic to decode SQLAlchemy `IntegrityError` instances to identify the specific violated constraint (specifically, duplicate vs null) doesn't work in a production environment.

The root problem is that the text strings reported differ between the unit test environment (`sqlite3` engine) and the production environment (`postgresql` engine). Take this opportunity to consolidate into a centralized decoder, which requires making the "SQL related" exception constructors consistent across all of our SQLAlchemy model classes.

And while I did briefly consider consolidating a single set of "SQL related" exceptions, I like having the per-class exception hierarchy to lean on even though there are few contexts where an `except <class>` might have to deal with more than one model's "duplicate" report.