### PR TITLE
Fix index-map migration tool

### DIFF
--- a/server/bin/move-index.py
+++ b/server/bin/move-index.py
@@ -48,20 +48,23 @@ def main(options, name):
     indices = 0
     documents = 0
     for m in idx:
-        datasets.add(m.dataset)
-        for i, d in m.value["index-map"].items():
-            indices += 1
-            match = pattern.match(i)
-            root = match.group(1) if match else "<unknown>"
-            roots.add(root)
-            documents += len(d)
-            ids = d[:4]
-            if (len(d) - 4) > 0:
-                ids.append(f"...{len(d) - 4}")
-            im = IndexMap(dataset=m.dataset, root=root, index=i, documents=ids)
-            new_maps.append(im)
-            if options.verify:
-                print(f"IndexMap({im.dataset}, {im.root}, {im.index}, {im.documents})")
+        if m.value.get("index-map"):
+            datasets.add(m.dataset)
+            for i, d in m.value["index-map"].items():
+                indices += 1
+                match = pattern.match(i)
+                root = match.group(1) if match else "<unknown>"
+                roots.add(root)
+                documents += len(d)
+                ids = d[:4]
+                if (len(d) - 4) > 0:
+                    ids.append(f"...{len(d) - 4}")
+                im = IndexMap(dataset=m.dataset, root=root, index=i, documents=ids)
+                new_maps.append(im)
+                if options.verify:
+                    print(
+                        f"IndexMap({im.dataset}, {im.root}, {im.index}, {im.documents})"
+                    )
     if options.verify:
         print(
             f"{len(datasets)} datasets have {len(roots)} index roots "

--- a/server/bin/move-index.py
+++ b/server/bin/move-index.py
@@ -58,7 +58,7 @@ def main(options, name):
             ids = d[:4]
             if (len(d) - 4) > 0:
                 ids.append(f"...{len(d) - 4}")
-            im = IndexMap(m.dataset, root, i, ids)
+            im = IndexMap(dataset=m.dataset, root=root, index=i, documents=ids)
             new_maps.append(im)
             if options.verify:
                 print(f"IndexMap({im.dataset}, {im.root}, {im.index}, {im.documents})")


### PR DESCRIPTION
PBENCH-1252

Fix the `IndexMap` model constructor call to use `kwargs` since SQLAlchemy's declarative base model doesn't support positional parameters.

_NOTE_: this tool has been run on the staging server, and worked. We'll use it again when we upgrade the current b0.72 "archive server" instance to a true 1.0 server.