### PR TITLE
Fix server tests on b0.73 branch

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,7 +12,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-pquisby
+pquisby<0.0.13
 psycopg2
 pyesbulk>=2.0.1
 PyJwt[crypto]


### PR DESCRIPTION
PBENCH-1256

The b0.73 branch code branched after Quisby `uperf` visualization support, but the `pquisby` 0.0.17 package adds `fio`, breaking a few tests that expect only `uperf`. We don't intend to support the server on the b0.73 branch, so it seems most appropriate to lock the `pquisby` package to 0.0.12 which exposes only `uperf` and matches the tests on that branch.