### PR TITLE
Enable CodeQL runs on release branches going forward

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,12 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'b[0-9].[0-9]+' ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
-  schedule:
-    - cron: '39 1 * * 6'
+    branches: [ main, 'b[0-9].[0-9]+' ]
 
 jobs:
   analyze:


### PR DESCRIPTION
Currently, we only run CodeQL on PRs and pushes to the `main` branch.  This change will trigger it to run on PRs and pushes to any branch which looks like `b0.00` where the zeros are any digit.  This change also removes the time-based trigger, since I don't see any point to running the analysis if we haven't changed anything.