### PR TITLE
Lock pquisby version

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,7 +12,7 @@ flask-restful>=0.3.9
 flask-sqlalchemy
 gunicorn
 humanize
-pquisby
+pquisby==0.0.17
 psycopg2
 pyesbulk>=2.0.1
 PyJwt[crypto]


### PR DESCRIPTION
PBENCH-1260

The pquisby PyPi package has been unstable. Right now the Pbench Server on main supports uperf visualization, which is adequately supported by pquisby 0.0.17. Unless we hit critical bugs in the support, we won't need a higher version until fio support is finalized. Minimize our support overhead in the meantime by locking the package to the version we know works for us.