### PR TITLE
Nits and stuff

### DIFF
--- a/agent/containers/images/Makefile
+++ b/agent/containers/images/Makefile
@@ -363,7 +363,7 @@ ifdef CI
 	if [[ -z "${_RPM_PATH}" ]] ; then echo "No RPM found with ID ${_LOCAL_GIT_HASH} for ${_LOCAL_MAJORMINOR} in ${CI_RPM_LOC}" >&2 ; exit 2 ; fi
 	if grep ' ' <<< ${_RPM_PATH} ; then echo "Multiple RPMs found:  ${_RPM_PATH}" >&2 ; exit 2 ; fi
 	printf -- "%s\n" ${_LOCAL_GIT_HASH} > ${@}
-	printf -- "v%s\n" "$(shell grep -Eo '[0-9]+\.[0-9]+\.([0-9]+(-[0-9]+)?)?' <<< "${_RPM_PATH}")" >> ${@}
+	printf -- "v%s\n" "$(shell grep -Eo '[0-9]+\.[0-9]+(\.[0-9]+(-[0-9]+)?)?' <<< "${_RPM_PATH}")" >> ${@}
 	printf -- "v%s-latest v%s-latest\n" ${_LOCAL_MAJOR_VER} ${_LOCAL_MAJORMINOR} >> ${@}
 else
 	./gen-tags-from-rpm "${URL_PREFIX}" "$(subst centos,epel,$*)" "${_ARCH}" "${_PBENCH_REPO_NAME}" > ${@}

--- a/jenkins/run-server-func-tests
+++ b/jenkins/run-server-func-tests
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 export EXTRA_PODMAN_SWITCHES=${EXTRA_PODMAN_SWITCHES:-"--pull=newer"}
-export IMAGE_NAME=${IMAGE_NAME:-pbench-ci-fedora}
-export IMAGE_REPO=${IMAGE_REPO:-"quay.io/pbench"}
 
 export PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-"$(cat jenkins/branch.name)"}
 export PB_POD_NAME=${PB_POD_NAME:-"pbench-in-a-can_${PB_SERVER_IMAGE_TAG}"}

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -82,7 +82,7 @@ class DatasetsInventory(ApiBase):
         # Werkzeug will set the mime type and content encoding based on the
         # download_name suffix.
         #
-        # We link a callback to close the file stream and TarFile object on
+        # We attach a callback to the response to close the file stream on
         # completion.
         stream = file_info["stream"]
         name = Path(file_info["name"]).name


### PR DESCRIPTION
This PR is a small collection of tiny fixes for things which I've hit in various contexts:
- `run-server-func-tests` contains a couple of definitions which appear to be unused.
- `datasets_inventory.py` contains a docstring which was missed when I reworked tar file extraction.
- The regex in the Agent container Makefile used to extract the version number from the RPM file name doesn't work properly if the "revision" number is missing (it requires the second dot which would be omitted when the third number is omitted).

The last issue was causing some misbehavior in the `b0.73` branch build (but Nick is going to fix that by adding the "revision" number).