### PR TITLE
Correct COPR repo file generation in Agent container builds (`b0.73`)

### DIFF
--- a/agent/containers/images/repo.yml.j2
+++ b/agent/containers/images/repo.yml.j2
@@ -1,12 +1,12 @@
 ---
 repos:
-  - name: {{ name }}
+  - tag: {{ name }}
     user: {{ user }}
     baseurl: "{{ url_prefix }}/{{ name }}/{{ distro }}-$basearch"
     gpgkey: "{{ url_prefix }}/{{ name }}/pubkey.gpg"
     gpgcheck: 1
     enabled: 1
-  - name: pbench
+  - tag: pbench
     user: {{ user }}
     baseurl: "{{ url_prefix }}/pbench/{{ distro }}-$basearch"
     gpgkey: "{{ url_prefix }}/pbench/pubkey.gpg"


### PR DESCRIPTION
The build used to produce Agent container images for releases uses RPMs pulled from DNF repositories on COPR.  The build generates a `.repo` file which allows DNF to access the appropriate Agent RPM.  The `.repo` file is constructed by the build from a template.  The parameters for the template are provided by a `.yml` file which the build also generates.

In #3479, the `.repo` template was modified, and one of the parameters names was changed from `name` to `tag`.  However, that PR was aimed at Ansible functionality, and the requirements for the Agent release container build were overlooked.

The `.repo` file is generated with two entries, and, without the related change, both entries end up with the same label.  This results in the second entry superseding the first entry, such that the RPM search doesn't reach the `Pbench-0.73` repository, and so it doesn't find the Pbench Agent v0.73 RPM.  Ideally, this would have resulted in an obvious failure, but, as it happens, the version-independent `Pbench` repository (which contains RPMs for things like `pbench-sysstat`, etc.) contains the RPM for Pbench Agent v0.71, and DNF installs that.  And, so the result is a "successful" build of the Agent container but it contains the wrong version of the Pbench Agent.

This PR corrects the template for the generation of the `.yml` file.  As a result, the `.repo` file is generated correctly, which allows DNF to find the correct version of the Pbench Agent RPM, which results in a correctly constructed container image.