### PR TITLE
Fix content-disposition filename for tarball

### DIFF
--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -657,7 +657,7 @@ class Tarball:
         """
         if not path:
             info = {
-                "name": self.name,
+                "name": self.tarball_path.name,
                 "type": CacheType.FILE,
                 "stream": Inventory(self.tarball_path.open("rb"), None),
             }

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -775,7 +775,9 @@ class TestInventory:
 
             # Werkzeug quotes filenames it thinks might be "suspect"; rather
             # than try to reverse engineer the logic, check it piecemeal.
-            assert response.headers["content-disposition"].startswith("attachment; filename=")
+            assert response.headers["content-disposition"].startswith(
+                "attachment; filename="
+            )
             assert f"{dataset.name}.tar.xz" in response.headers["content-disposition"]
 
 

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -766,6 +766,18 @@ class TestInventory:
             meta = read_metadata(response)
             assert meta == dataset.metadata["dataset.metalog"]
 
+            # Test that the content-disposition header has the proper full
+            # filename for the tarball itself.
+            response = server_client.get(
+                API.DATASETS_INVENTORY,
+                {"dataset": dataset.resource_id, "target": ""},
+            )
+
+            # Werkzeug quotes filenames it thinks might be "suspect"; rather
+            # than try to reverse engineer the logic, check it piecemeal.
+            assert response.headers["content-disposition"].startswith("attachment; filename=")
+            assert f"{dataset.name}.tar.xz" in response.headers["content-disposition"]
+
 
 class TestUpdate:
     @pytest.mark.dependency(name="publish", depends=["index"], scope="session")


### PR DESCRIPTION
PBENCH-1268

The content-disposition filename for the tarball was generated using the base dataset name without the canonical ".tar.xz" suffix. Fix it, and validate the expected response header in the functional test.