### PR TITLE
Quick cache manager

### DIFF
--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -19,6 +19,9 @@ pipeline {
         // otherwise we set it to the branch name (e.g., `main`).
         PB_IMAGE_TAG="${env.CHANGE_ID ?: env.BRANCH_NAME}"
         PB_SERVER_IMAGE_NAME="pbench-server"
+        // FIXME: ubi9 doesn't seem to have rsyslog-mmjsonparse available, so
+        // temporarily switch to centos:stream9
+        BASE_IMAGE="quay.io/centos/centos:stream9"
     }
     stages {
         stage('Agent Python3.6 Check') {

--- a/jenkins/Pipeline.gy
+++ b/jenkins/Pipeline.gy
@@ -19,9 +19,6 @@ pipeline {
         // otherwise we set it to the branch name (e.g., `main`).
         PB_IMAGE_TAG="${env.CHANGE_ID ?: env.BRANCH_NAME}"
         PB_SERVER_IMAGE_NAME="pbench-server"
-        // FIXME: ubi9 doesn't seem to have rsyslog-mmjsonparse available, so
-        // temporarily switch to centos:stream9
-        BASE_IMAGE="quay.io/centos/centos:stream9"
     }
     stages {
         stage('Agent Python3.6 Check') {

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -65,11 +65,8 @@ def reclaim_cache(tree: CacheManager, logger: Logger, lifetime: float = CACHE_LI
                             tarball.name,
                             e,
                         )
-                    try:
-                        tarball.cache_delete()
-                        reclaimed += 1
-                    except Exception as e:
-                        error = e
+                    tarball.cache_delete()
+                    reclaimed += 1
             except OSError as e:
                 if e.errno in (errno.EAGAIN, errno.EACCES):
                     logger.info(

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -1,14 +1,92 @@
+from datetime import datetime, timedelta, timezone
+import errno
+import fcntl
+from logging import Logger
+
 import click
 
 from pbench.cli import pass_cli_context
 from pbench.cli.server import config_setup
 from pbench.cli.server.options import common_options
 from pbench.common.logger import get_pbench_logger
-from pbench.server import BadConfig
+from pbench.server import BadConfig, OperationCode
 from pbench.server.cache_manager import CacheManager
+from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
+
+# Length of time in hours to retain unreferenced cached results data.
+# TODO: this could become a configurable setting?
+CACHE_LIFETIME = 4.0
+
+
+def reclaim_cache(tree: CacheManager, logger: Logger, lifetime: float = CACHE_LIFETIME):
+    """Reclaim unused caches
+
+    Args:
+        tree: the cache manager instance
+        lifetime: number of hours to retain unused cache data
+        logger: a Logger object
+    """
+    window = datetime.now(timezone.utc) - timedelta(hours=lifetime)
+    for tarball in tree.datasets.values():
+        if tarball.unpacked:
+            date = datetime.fromtimestamp(
+                tarball.last_ref.stat().st_mtime, timezone.utc
+            )
+            if date < window:
+                logger.info(
+                    "RECLAIM {}: last_ref {:%Y-%m-%d %H:%M:%S} is older than {:%Y-%m-%d %H:%M:%S}",
+                    tarball.name,
+                    date,
+                    window,
+                )
+                error = None
+                audit = None
+                with tarball.lock.open("wb") as lock:
+                    try:
+                        fcntl.lockf(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                        audit = Audit.create(
+                            name="reclaim",
+                            operation=OperationCode.DELETE,
+                            status=AuditStatus.BEGIN,
+                            user_name=Audit.BACKGROUND_USER,
+                            object_type=AuditType.DATASET,
+                            object_id=tarball.resource_id,
+                            object_name=tarball.name,
+                        )
+                        try:
+                            tarball.cache_delete()
+                        except Exception as e:
+                            error = e
+                        finally:
+                            fcntl.lockf(lock, fcntl.LOCK_UN)
+                    except OSError as e:
+                        if e.errno in (errno.EAGAIN, errno.EACCES):
+                            logger.info(
+                                "RECLAIM {}: skipping because cache is locked",
+                                tarball.name,
+                            )
+                            # If the cache is locked, regardless of age, then
+                            # the last_ref timestamp is about to be updated,
+                            # and we skip the cache for now.
+                            continue
+                        error = e
+                attributes = {"last_ref": f"{date:%Y-%m-%d %H:%M:%S}"}
+                if error:
+                    logger.error("RECLAIM {} failed with '{}'", tarball.name, error)
+                    attributes["error"] = str(error)
+                Audit.create(
+                    root=audit,
+                    status=AuditStatus.FAILURE if error else AuditStatus.SUCCESS,
+                    attributes=attributes,
+                )
 
 
 def print_tree(tree: CacheManager):
+    """Print basic information about the cache
+
+    Args:
+        tree: a cache instance
+    """
     print(f"Tree anchored at {tree.archive_root}\n")
 
     if len(tree.datasets) == 0 and len(tree.controllers) == 0:
@@ -18,14 +96,19 @@ def print_tree(tree: CacheManager):
     print("Tarballs:")
     for tarball in tree.datasets.values():
         print(f"  {tarball.name}")
+        if tarball.unpacked:
+            date = datetime.fromtimestamp(
+                tarball.last_ref.stat().st_mtime, timezone.utc
+            )
+            print(
+                f"    Inventory is cached, last referenced {date:%Y-%m-%d %H:%M:%S}"
+            )
 
     print("\nControllers:")
     for controller in tree.controllers.values():
         print(f"  Controller {controller.name}:")
         for tarball in controller.tarballs.values():
             print(f"    Tarball {tarball.name}")
-            if tarball.unpacked:
-                print(f"      Unpacked in {tarball.unpacked}")
 
 
 @click.command(name="pbench-tree-manager")
@@ -33,19 +116,31 @@ def print_tree(tree: CacheManager):
 @click.option(
     "--display", default=False, is_flag=True, help="Display the full tree on completion"
 )
+@click.option(
+    "--lifetime",
+    default=CACHE_LIFETIME,
+    type=click.FLOAT,
+    help="Specify lifetime of cached data for --reclaim",
+)
+@click.option(
+    "--reclaim", default=False, is_flag=True, help="Reclaim stale cached data"
+)
 @common_options
-def tree_manage(context: object, display: bool):
+def tree_manage(context: object, display: bool, lifetime: int, reclaim: bool):
     """
     Discover, display, and manipulate the on-disk representation of controllers
     and datasets.
 
-    This primarily exposes the CacheManager object hierarchy, and provides a simple
-    hierarchical display of controllers and datasets.
+    This primarily exposes the CacheManager object hierarchy, and provides a
+    hierarchical display of controllers and datasets. This also supports
+    reclaiming cached dataset files that haven't been referenced recently.
     \f
 
     Args:
         context: Click context (contains shared `--config` value)
         display: Print a simplified representation of the hierarchy
+        lifetime: Number of hours to retain unused cache before reclaim
+        reclaim: Reclaim stale cached data
     """
     try:
         config = config_setup(context)
@@ -54,6 +149,8 @@ def tree_manage(context: object, display: bool):
         cache_m.full_discovery()
         if display:
             print_tree(cache_m)
+        if reclaim:
+            reclaim_cache(cache_m, logger, lifetime)
         rv = 0
     except Exception as exc:
         logger.exception("An error occurred discovering the file tree: {}", exc)

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -9,7 +9,7 @@ from pbench.cli.server import config_setup
 from pbench.cli.server.options import common_options
 from pbench.common.logger import get_pbench_logger
 from pbench.server import BadConfig, OperationCode
-from pbench.server.cache_manager import CacheManager, LockRef
+from pbench.server.cache_manager import CacheManager, LockManager
 from pbench.server.database.models.audit import Audit, AuditStatus, AuditType
 
 # Length of time in hours to retain unreferenced cached results data.
@@ -48,7 +48,7 @@ def reclaim_cache(tree: CacheManager, logger: Logger, lifetime: float = CACHE_LI
                 window,
             )
             try:
-                with LockRef(tarball.lock, exclusive=True, wait=False):
+                with LockManager(tarball.lock, exclusive=True, wait=False):
                     try:
                         audit = Audit.create(
                             name="reclaim",

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -19,7 +19,12 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.cache_manager import CacheManager, CacheType, TarballNotFound
+from pbench.server.cache_manager import (
+    CacheExtractBadPath,
+    CacheManager,
+    CacheType,
+    TarballNotFound,
+)
 
 
 class DatasetsInventory(ApiBase):
@@ -63,7 +68,7 @@ class DatasetsInventory(ApiBase):
         cache_m = CacheManager(self.config, current_app.logger)
         try:
             file_info = cache_m.get_inventory(dataset.resource_id, target)
-        except TarballNotFound as e:
+        except (TarballNotFound, CacheExtractBadPath) as e:
             raise APIAbort(HTTPStatus.NOT_FOUND, str(e))
 
         if file_info["type"] != CacheType.FILE:

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -464,9 +464,6 @@ class Index:
                             )
                             tb_res = error_code["OP_ERROR" if failures > 0 else "OK"]
                         finally:
-                            # Remove the unpacked data
-                            if tarobj:
-                                tarobj.uncache()
                             if tb_res.success:
                                 try:
 

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -370,9 +370,8 @@ class Index:
                                 tarobj = self.cache_manager.find_dataset(
                                     dataset.resource_id
                                 )
-                                lock = LockRef(tarobj.lock).acquire(exclusive=True)
-                                tarobj.cache_create()
-                                lock.downgrade()
+                                lock = LockRef(tarobj.lock).acquire()
+                                tarobj.get_results(lock)
                             except Exception as e:
                                 self.sync.error(
                                     dataset,

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -370,7 +370,7 @@ class Index:
                                 tarobj = self.cache_manager.find_dataset(
                                     dataset.resource_id
                                 )
-                                lock = LockRef(tarobj.lock, exclusive=True).acquire()
+                                lock = LockRef(tarobj.lock).acquire(exclusive=True)
                                 tarobj.cache_create()
                                 lock.downgrade()
                             except Exception as e:

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -545,8 +545,6 @@ class TestCacheManager:
             tb = Tarball(
                 tar, "ABC", Controller(Path("/mock/archive"), cache, make_logger)
             )
-            with pytest.raises(TarballUnpackError) as exc:
-                tb.cache_create()
             msg = f"An error occurred while unpacking {tar}: Command 'tar' timed out after 43 seconds"
             with pytest.raises(TarballUnpackError, match=msg):
                 tb.cache_create()
@@ -1018,9 +1016,7 @@ class TestCacheManager:
         with monkeypatch.context() as m:
             m.setattr(Tarball, "__init__", TestCacheManager.MockTarball.__init__)
             m.setattr(Controller, "__init__", TestCacheManager.MockController.__init__)
-            tb = Tarball(
-                tar, "ABC", Controller(archive, cache, make_logger)
-            )
+            tb = Tarball(tar, "ABC", Controller(archive, cache, make_logger))
             m.setattr(Tarball, "cache_create", fake_create)
             if is_unpacked:
                 tb.unpacked = unpacked
@@ -1689,8 +1685,8 @@ class TestCacheManager:
         t2 = cm1[id]
         assert t1.name == t2.name == Dataset.stem(source_tarball)
 
-        t1.unpack()
-        t2.unpack()
+        t1.cache_create()
+        t2.cache_create()
 
         assert t1.unpacked != t2.unpacked
         assert (t1.unpacked / "metadata.log").is_file()

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -545,7 +545,7 @@ class TestCacheManager:
                 tar, "ABC", Controller(Path("/mock/archive"), cache, make_logger)
             )
             with pytest.raises(TarballUnpackError) as exc:
-                tb.unpack()
+                tb.cache_create()
             msg = f"An error occurred while unpacking {tar}: Command 'tar' timed out after 43 seconds"
             assert str(exc.value) == msg
             assert exc.type == TarballUnpackError
@@ -595,7 +595,7 @@ class TestCacheManager:
             )
 
             with pytest.raises(TarballModeChangeError) as exc:
-                tb.unpack()
+                tb.cache_create()
             msg = "An error occurred while changing file permissions of "
             msg += f"{cache / 'ABC'}: Command 'find' timed out after 43 seconds"
             assert str(exc.value) == msg
@@ -643,7 +643,7 @@ class TestCacheManager:
             tb = Tarball(
                 tar, "ABC", Controller(Path("/mock/archive"), cache, make_logger)
             )
-            tb.unpack()
+            tb.cache_create()
             assert call == ["tar", "find"]
             assert tb.unpacked == cache / "ABC" / tb.name
 
@@ -1649,7 +1649,7 @@ class TestCacheManager:
 
         # Remove the unpacked tarball, and confirm that the directory and link
         # are removed.
-        cm.uncache(md5)
+        cm.cache_reclaim(md5)
         assert not cache.exists()
 
         # Now that we have all that setup, delete the dataset

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -1033,11 +1033,7 @@ class TestCacheManager:
         cache = tmp_path / "mock" / ".cache"
         unpacked = cache / "ABC" / "dir_name"
 
-        get_results_called = False
-
         def fake_results(self, lock: LockRef) -> Path:
-            nonlocal get_results_called
-            get_results_called = True
             self.unpacked = unpacked
             return self.unpacked
 

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -102,7 +102,7 @@ class TestDatasetsAccess:
             return {
                 "name": "f1.json",
                 "type": CacheType.FILE,
-                "stream": Inventory(exp_stream, None),
+                "stream": Inventory(exp_stream),
             }
 
         response = Response()
@@ -142,7 +142,7 @@ class TestDatasetsAccess:
             return {
                 "name": "f1.json",
                 "type": CacheType.FILE,
-                "stream": Inventory(exp_stream, None),
+                "stream": Inventory(exp_stream),
             }
 
         def mock_send_file(path_or_file, *args, **kwargs):
@@ -164,7 +164,7 @@ class TestDatasetsAccess:
             return {
                 "name": "f1.json",
                 "type": CacheType.FILE,
-                "stream": Inventory(exp_stream, None),
+                "stream": Inventory(exp_stream),
             }
 
         monkeypatch.setattr(CacheManager, "get_inventory", mock_get_inventory)

--- a/lib/pbench/test/unit/server/test_datasets_visualize.py
+++ b/lib/pbench/test/unit/server/test_datasets_visualize.py
@@ -53,7 +53,7 @@ class TestVisualize:
         return {
             "name": Path(target).name,
             "type": CacheType.FILE,
-            "stream": Inventory(BytesIO(b"CSV_file_as_a_byte_stream"), None),
+            "stream": Inventory(BytesIO(b"CSV_file_as_a_byte_stream")),
         }
 
     @staticmethod

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -5,7 +5,7 @@ from os import stat_result
 from pathlib import Path
 from signal import SIGHUP
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
@@ -16,6 +16,7 @@ from pbench.server import (
     OperationCode,
     PbenchServerConfig,
 )
+from pbench.server.cache_manager import LockManager, LockRef
 from pbench.server.database.models.audit import AuditStatus
 from pbench.server.database.models.datasets import (
     Dataset,
@@ -325,7 +326,7 @@ class FakeTarball:
         self.unpacked = self.cache / self.name
         self.isolator = controller.path / resource_id
 
-    def cache_create(self):
+    def get_results(self, lock: Union[LockRef, LockManager]):
         pass
 
 

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -267,22 +267,25 @@ class FakeSync:
 
 class FakeLockRef:
     def __init__(self, lock: Path):
-        """Initialize a lock reference
-
-        The lock file is opened in "w+" mode, which is "write update": unlike
-        "r+", this creates the file if it doesn't already exist, but still
-        allows lock conversion between LOCK_EX and LOCK_SH.
+        """Initialize a mocked lock reference
 
         Args:
             lock: the path of a lock file
-            exclusive: lock for exclusive access
-            wait: [default] wait for lock
         """
         self.locked = False
         self.exclusive = False
         self.unlock = True
 
     def acquire(self, exclusive: bool = False, wait: bool = True) -> "FakeLockRef":
+        """Acquire the lock
+
+        Args:
+            exclusive: lock for exclusive access
+            wait: [default] wait for lock
+
+        Returns:
+            self reference so acquire can be chained with constructor
+        """
         self.locked = True
         self.exclusive = exclusive
         return self
@@ -293,10 +296,12 @@ class FakeLockRef:
         self.exclusive = False
 
     def upgrade(self):
+        """Upgrade a shared lock to exclusive"""
         if not self.exclusive:
             self.exclusive = True
 
     def downgrade(self):
+        """Downgrade an exclusive lock to shared"""
         if self.exclusive:
             self.exclusive = False
 

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -266,7 +266,7 @@ class FakeSync:
 
 
 class FakeLockRef:
-    def __init__(self, lock: Path, exclusive: bool = False, wait: bool = True):
+    def __init__(self, lock: Path):
         """Initialize a lock reference
 
         The lock file is opened in "w+" mode, which is "write update": unlike
@@ -279,11 +279,12 @@ class FakeLockRef:
             wait: [default] wait for lock
         """
         self.locked = False
-        self.exclusive = exclusive
+        self.exclusive = False
         self.unlock = True
 
-    def acquire(self) -> "FakeLockRef":
+    def acquire(self, exclusive: bool = False, wait: bool = True) -> "FakeLockRef":
         self.locked = True
+        self.exclusive = exclusive
         return self
 
     def release(self):
@@ -298,18 +299,6 @@ class FakeLockRef:
     def downgrade(self):
         if self.exclusive:
             self.exclusive = False
-
-    def keep(self) -> "FakeLockRef":
-        """Tell the context manager not to unlock on exit"""
-        self.unlock = False
-        return self
-
-    def __enter__(self) -> "FakeLockRef":
-        return self.acquire()
-
-    def __exit__(self, *exc):
-        if self.unlock:
-            self.release()
 
 
 class FakeController:

--- a/server/lib/systemd/pbench-reclaim.service
+++ b/server/lib/systemd/pbench-reclaim.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reclaim Pbench Server cache
+Wants=pbench-reclaim.timer
+
+[Service]
+Type = simple
+User = pbench
+Group = pbench
+Environment = _PBENCH_SERVER_CONFIG=/opt/pbench-server/lib/config/pbench-server.cfg
+ExecStart=-/opt/pbench-server/bin/pbench-tree-manage --reclaim
+KillSignal = TERM
+
+[Install]
+WantedBy=pbench-server.service

--- a/server/lib/systemd/pbench-reclaim.timer
+++ b/server/lib/systemd/pbench-reclaim.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Pbench Server cache reclaim timer
+After=pbench-server.service
+Requires=pbench-reclaim.service
+BindsTo=pbench-server.service
+
+[Timer]
+Unit=pbench-reclaim.service
+OnUnitInactiveSec=4h
+
+[Install]
+WantedBy=timers.target

--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -79,12 +79,15 @@ buildah run $container cp \
     ${SERVER_LIB}/systemd/pbench-server.service \
     ${SERVER_LIB}/systemd/pbench-index.service \
     ${SERVER_LIB}/systemd/pbench-index.timer \
+    ${SERVER_LIB}/systemd/pbench-reclaim.service \
+    ${SERVER_LIB}/systemd/pbench-reclaim.timer \
     /etc/systemd/system/
 
 buildah run $container systemctl enable nginx
 buildah run $container systemctl enable rsyslog
 buildah run $container systemctl enable pbench-server
 buildah run $container systemctl enable pbench-index.timer
+buildah run $container systemctl enable pbench-reclaim.timer
 
 # Create the container image.
 buildah commit --rm $container ${PB_CONTAINER_REG}/${PB_SERVER_IMAGE_NAME}:${PB_SERVER_IMAGE_TAG}


### PR DESCRIPTION
PBENCH-1249

On large datasets, our direct tarball extraction method can time out the API call. Unlike on a long intake, there is no persistent artifact so a retry will always time out as well. This applies to any `get_inventory` call, and therefore to the `/inventory`, `/visualize`, and `/compare` APIs; and given the central importance of those APIs for our Server 1.0 story, that's not an acceptable failure mode.

This PR mitigates that problem with a "compromise" partial cache manager, leveraging the existing `unpack` method but adding a file lock to manage shared access. The idea is that any consumer of tarball contents (including the indexer) will unpack the entire tarball, but leave a "last reference" timestamp. A periodic timer service will check the cache unpack timestamps, and delete the unpack directories which aren't currently locked and which haven't been referenced for longer than a set time period.