### PR TITLE
Support "brief" URL output on move/push

### DIFF
--- a/agent/util-scripts/gold/pbench-results-move/test-23.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-23.txt
@@ -6,6 +6,7 @@ Usage: pbench-results-move [OPTIONS]
 Options:
   -a, --access [public|private]  pbench tarball access permission  [default:
                                  private]
+  -b, --brief                    Output bare relay manifest URIs
   -C, --config PATH              Path to a pbench-agent configuration file
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]

--- a/agent/util-scripts/gold/pbench-results-move/test-35.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-35.txt
@@ -1,4 +1,4 @@
-+++ Running test-35 pbench-results-move 
++++ Running test-35 pbench-results-move
 Usage: pbench-results-move [OPTIONS]
 Try 'pbench-results-move --help' for help.
 

--- a/agent/util-scripts/gold/pbench-results-move/test-35.txt
+++ b/agent/util-scripts/gold/pbench-results-move/test-35.txt
@@ -1,4 +1,4 @@
-+++ Running test-35 pbench-results-move
++++ Running test-35 pbench-results-move 
 Usage: pbench-results-move [OPTIONS]
 Try 'pbench-results-move --help' for help.
 

--- a/agent/util-scripts/gold/pbench-results-push/test-24.txt
+++ b/agent/util-scripts/gold/pbench-results-push/test-24.txt
@@ -8,6 +8,7 @@ Usage: pbench-results-push [OPTIONS] RESULT_TB_NAME
 Options:
   -a, --access [public|private]  pbench tarball access permission  [default:
                                  private]
+  -b, --brief                    Output bare relay manifest URIs
   -C, --config PATH              Path to a pbench-agent configuration file
                                  (defaults to the '_PBENCH_AGENT_CONFIG'
                                  environment variable, if defined)  [required]

--- a/exec-tests
+++ b/exec-tests
@@ -69,7 +69,7 @@ function run_legacy {
     shift
 
     printf -- "\n\n\nRunning %s/%s legacy unit tests\n\n" "${_major}" "${_subtst}"
-    _time ${_major}/${_subtst}/unittests ${@}
+    COLUMNS=80 _time ${_major}/${_subtst}/unittests ${@}
     _rc=${?}
     if [[ ${_rc} -ne 0 ]]; then
         printf -- "\n%s %s legacy unit tests failed with '%s'\n\n" "${_major^}" "${_subtst}" "${_rc}"

--- a/lib/pbench/cli/agent/commands/results/move.py
+++ b/lib/pbench/cli/agent/commands/results/move.py
@@ -106,7 +106,10 @@ class MoveResults(BaseCommand):
                             msg = res.text if res.text else res.reason
                         raise CopyResult.FileUploadError(msg)
                     if self.context.relay:
-                        click.echo(f"RELAY {result_tb_name.name}: {res.url}")
+                        if self.context.brief:
+                            click.echo(res.url)
+                        else:
+                            click.echo(f"RELAY {result_tb_name.name}: {res.url}")
                 except Exception as exc:
                     if isinstance(exc, (CopyResult.FileUploadError, RuntimeError)):
                         msg = "Error uploading file"
@@ -164,12 +167,13 @@ class MoveResults(BaseCommand):
                         # problems.
                         break
 
-        action = "moved" if delete else "copied"
-        click.echo(
-            f"Status: total # of result directories considered {no_of_tb:d},"
-            f" successfully {action} {runs_copied:d}, encountered"
-            f" {failures:d} failures"
-        )
+        if not self.context.brief:
+            action = "moved" if delete else "copied"
+            click.echo(
+                f"Status: total # of result directories considered {no_of_tb:d},"
+                f" successfully {action} {runs_copied:d}, encountered"
+                f" {failures:d} failures"
+            )
 
         return 0 if failures == 0 else 1
 
@@ -200,6 +204,7 @@ class MoveResults(BaseCommand):
 @pass_cli_context
 def main(
     context: CliContext,
+    brief: bool,
     controller: str,
     access: str,
     token: str,
@@ -235,6 +240,7 @@ def main(
         click.echo(f"Controller, {controller!r}, is not a valid host name")
         clk_ctx.exit(1)
 
+    context.brief = brief
     context.controller = controller
     context.access = access
     context.token = token

--- a/lib/pbench/cli/agent/commands/results/push.py
+++ b/lib/pbench/cli/agent/commands/results/push.py
@@ -23,7 +23,10 @@ class ResultsPush(BaseCommand):
         res = crt.push(tarball, tarball_md5)
 
         if res.ok and self.context.relay:
-            click.echo(f"RELAY {tarball.name}: {res.url}")
+            if self.context.brief:
+                click.echo(res.url)
+            else:
+                click.echo(f"RELAY {tarball.name}: {res.url}")
 
         # success
         if res.status_code == HTTPStatus.CREATED:
@@ -67,6 +70,7 @@ def main(
     result_tb_name: str,
     token: str,
     access: str,
+    brief: bool,
     metadata: List,
     server: str,
     relay: str,
@@ -85,6 +89,7 @@ def main(
     context.result_tb_name = result_tb_name
     context.token = token
     context.access = access
+    context.brief = brief
     context.metadata = metadata
     context.server = server
     context.relay = relay

--- a/lib/pbench/cli/agent/commands/results/results_options.py
+++ b/lib/pbench/cli/agent/commands/results/results_options.py
@@ -23,6 +23,13 @@ def results_common_options(f):
             help="pbench tarball access permission",
         ),
         click.option(
+            "-b",
+            "--brief",
+            is_flag=True,
+            default=False,
+            help="Output bare relay manifest URIs",
+        ),
+        click.option(
             "-m",
             "--metadata",
             multiple=True,

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -381,7 +381,7 @@ class TestResultsMove:
         assert (
             result.exit_code == 0
         ), f"Expected a successful operation, exit_code = {result.exit_code:d}, stderr: {result.stderr}, stdout: {result.stdout}"
-        pattern = r"http://relay.example.com/[a-z0-9]+\n"
+        pattern = r"http://relay\.example\.com/[a-z0-9]+\n"
         if not brief:
             pattern = (
                 "RELAY pbench-user-benchmark_test-results-move_YYYY.MM.DDTHH.MM.SS.tar.xz: "

--- a/lib/pbench/test/unit/agent/task/test_results_move.py
+++ b/lib/pbench/test/unit/agent/task/test_results_move.py
@@ -364,10 +364,7 @@ class TestResultsMove:
             arg_list.append(TestResultsMove.BRIEF_SWITCH)
 
         # Test --no-delete
-        result = runner.invoke(
-            main,
-            args=arg_list,
-        )
+        result = runner.invoke(main, args=arg_list)
 
         # We expect two PUT calls using the relay base URI: first the tarball
         # itself, and then a JSON manifest file. The manifest JSON must contain

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -145,7 +145,7 @@ class TestResultsPush:
         pattern = (
             "RELAY log.tar.xz: " if not brief else ""
         ) + r"http://relay.example.com/[a-z0-9]+\n"
-        assert re.match((pattern), result.stdout)
+        assert re.match(pattern, result.stdout)
 
     @staticmethod
     @responses.activate


### PR DESCRIPTION
PBENCH-1272

When an automated tool chain uses `pbench-results-move --relay` (or, less commonly, `pbench-results-push --relay`), the command offers a "helpful" message on `stdout` identifying each dataset name and the associated relay URI. This would require automated tooling to parse each line of output.

This adds `--brief` which will print only the raw URIs, one per line, allowing tooling to easily process the data.