### PR TITLE
Implement backup for the Server

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -216,6 +216,12 @@ class PbenchServerConfig(PbenchConfig):
         )
 
     @property
+    def BACKUP(self) -> Path:
+        return self._get_valid_dir_option(
+            "BACKUP", "pbench-server", "pbench-backup-dir"
+        )
+
+    @property
     def CACHE(self) -> Path:
         return self._get_valid_dir_option("CACHE", "pbench-server", "pbench-cache-dir")
 

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -137,7 +137,7 @@ class IntakeBase(ApiBase):
         """Helper function which creates a backup copy of a tarball/md5 file-pair"""
 
         # The type returned by shutil.copy() depends on the types of the inputs;
-        # since we want Path's, coerce them.
+        # since we want Path's, construct them explicitly.
         try:
             md5_backup = Path(shutil.copy(md5_path, self.backup_dir))
         except Exception as e:

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -1,3 +1,4 @@
+import contextlib
 from dataclasses import dataclass
 import datetime
 import errno
@@ -58,6 +59,12 @@ class Access:
     stream: IO[bytes]
 
 
+@dataclass
+class Backup:
+    tarfile: Path
+    md5: Path
+
+
 class IntakeBase(ApiBase):
     """Framework to assimilate a dataset into the Pbench Server.
 
@@ -76,6 +83,7 @@ class IntakeBase(ApiBase):
     def __init__(self, config: PbenchServerConfig, schema: ApiSchema):
         super().__init__(config, schema)
         self.temporary = config.ARCHIVE / CacheManager.TEMPORARY
+        self.backup_dir = config.BACKUP
         self.temporary.mkdir(mode=0o755, parents=True, exist_ok=True)
         method = list(self.schemas.schemas.keys())[0]
         self.name = self.schemas[method].audit_name
@@ -124,6 +132,37 @@ class IntakeBase(ApiBase):
                 errors=errors,
             )
         return metadata
+
+    def _backup_tarball(self, tarball_path: Path, md5_path: Path) -> Backup:
+        """Helper function which creates a backup copy of a tarball/md5 file-pair"""
+
+        # The type returned by shutil.copy() depends on the types of the inputs;
+        # since we want Path's, coerce them.
+        try:
+            md5_backup = Path(shutil.copy(md5_path, self.backup_dir))
+        except Exception as e:
+            raise APIInternalError(f"Failure backing up MD5 file: {e}")
+        try:
+            tb_backup = Path(shutil.copy(tarball_path, self.backup_dir))
+        except Exception as e:
+            # We're already failing, so just ignore any exceptions.
+            with contextlib.suppress(Exception):
+                md5_backup.unlink()
+            raise APIInternalError(f"Failure backing up tarball: {e}")
+        return Backup(tarfile=tb_backup, md5=md5_backup)
+
+    @staticmethod
+    def _remove_backup(backup: Backup):
+        """Helper function which encapsulates the removal of a backup
+        tarball/md5 file-pair
+
+        This is intended to be used during error recovery, so it simply
+        eats any errors and returns nothing.
+        """
+        with contextlib.suppress(Exception):
+            backup.tarfile.unlink(missing_ok=True)
+        with contextlib.suppress(Exception):
+            backup.md5.unlink(missing_ok=True)
 
     def _identify(self, args: ApiParams, request: Request) -> Intake:
         """Identify the tarball to be streamed.
@@ -498,6 +537,9 @@ class IntakeBase(ApiBase):
                     attributes["failures"] = f
             except Exception as e:
                 raise APIInternalError(f"Unable to set metadata: {e!s}") from e
+
+            backup = self._backup_tarball(tarball.tarball_path, tarball.md5_path)
+            recovery.add(lambda: self._remove_backup(backup))
 
             # Finally, update the operational state and Audit success.
             try:

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -83,6 +83,8 @@ def do_setup(tmp_d: Path) -> Path:
     pbench_tmp.mkdir(parents=True, exist_ok=True)
     pbench_cache = srv_pbench / "cache"
     pbench_cache.mkdir(parents=True, exist_ok=True)
+    pbench_backup = srv_pbench / "backup"
+    pbench_backup.mkdir(parents=True, exist_ok=True)
 
     opt_pbench = tmp_d / "opt" / "pbench-server"
     pbench_bin = opt_pbench / "bin"

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -313,6 +313,7 @@ class FakeTarball:
     def __init__(self, path: Path, resource_id: str, controller: FakeController):
         self.name = path.name
         self.tarball_path = path
+        self.md5_path = path.with_suffix(".xz.md5")
         self.controller = controller
         self.cache = controller.cache / "ABC"
         self.lock = self.cache / "lock"

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -51,6 +51,7 @@ class TestRelay:
         class FakeTarball:
             def __init__(self, path: Path):
                 self.tarball_path = path
+                self.md5_path = path.with_suffix(".xz.md5")
                 self.name = Dataset.stem(path)
                 self.metadata = None
 

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -1041,9 +1041,17 @@ class TestUpload:
         copy_err: Optional[bool],
         unlink_err: Optional[bool],
         exc_expected: bool,
-        expected_ops: List,
+        expected_ops: list[list[str]],
     ):
-        """Test the tarball backup function"""
+        """Test the tarball backup function
+
+        When the `copy_err` or `unlink_err` flags are `None`, there is no
+        exception raised by the corresponding mock (in the case where
+        `unlink_err` is `None`, the mock should not even be called).  When
+        `copy_err` is not `None`, the mock raises an exception for one of the
+        two files, depending on the value.  When `unlink_err` is `True`, the
+        mock raises an exception; otherwise, the function "succeeds".
+        """
         tbp, md5, _ = tarball
         ops = []
 

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from logging import Logger
 from pathlib import Path
 import shutil
-from typing import List, Optional
+from typing import Optional
 
 import pytest
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -48,6 +48,13 @@ default-dataset-retention-days = 730
 pbench-archive-version = 001
 pbench-archive-dir = %(pbench-top-dir)s/archive/fs-version-%(pbench-archive-version)s
 
+# Specify where to store backups of the result tar files. By default this is
+# `/srv/pbench/backup` if `pbench-top-dir` is `/srv/pbench`; however, for
+# reliability, this directory should be on a file system different from the
+# archive directory (which can be accomplished either by overriding this value
+# or by mounting another file system over this directory).
+pbench-backup-dir = %(pbench-top-dir)s/backup
+
 # Specify where to store temporary cache manager files. By default this is
 # /srv/pbench/cache if pbench-top-dir is /srv/pbench
 pbench-cache-dir = %(pbench-top-dir)s/cache

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -99,6 +99,7 @@ mkdir -p -m 0755  \
     ${SRV_PBENCH}/archive/fs-version-001 \
     ${SRV_PBENCH}/public_html/dashboard \
     ${SRV_PBENCH}/tmp \
+    ${SRV_PBENCH}/backup \
     ${SRV_PBENCH}/cache
 
 # Set up the static fallback pages for Nginx.


### PR DESCRIPTION
Lost in the v0.69 -> v1.0 transition was the mechanism for making backup copies of result tarballs loaded on to the Server.  This gap is currently covered by the fact that the "pass-through" server is v0.69-based and so it makes a backup of the result before pushing it to the "index" server.  As things stand, once we upgrade the "index" server to a full-blown v1.0 and have users push results to it directly, we won't have any provision for creating backups.  This PR closes that gap.

This change adds a `pbench-backup-dir` configuration option which points to a directory to receive copies of result tarballs.  (This directory should be placed on a file system different from the archive directory (preferably on different hardware), although this can easily be effected via a mount point.)  This change adds two functions to the `IntakeBase` class which encapsulate the details of creating a backup copy and of removing it in the event of an upload failure.  Beyond that, the change is just to call the backup function and to declare the removal function as a cleanup handler during the intake process.  The rest of the changes are revisions to the unit tests for the impact of the configuration and backup changes along with two new unit tests for the two new functions.

The PR is structured as a series of commits for your reviewing pleasure:
- the changes to the Server code and configuration
- changes to address linter complaints in the relevant unit test code
- tweaks to `FakeCacheManager` to make it slightly less fake
- the changes to the unit test code for the new backup support

PBENCH-1259