### PR TITLE
Workaround for UBI9 container setup trouble

### DIFF
--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -8,7 +8,11 @@
 #-
 GITTOP=${GITTOP:-$(git rev-parse --show-toplevel)}
 
-BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
+# FIXME: ubi9 doesn't seem to have rsyslog-mmjsonparse available, so
+# temporarily switch to centos:stream9
+BASE_IMAGE=${BASE_IMAGE:-quay.io/centos/centos:stream9}
+# BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
+
 PB_SERVER_IMAGE_NAME=${PB_SERVER_IMAGE_NAME:-"pbench-server"}
 PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
 RPM_PATH=${RPM_PATH:-/root/sandbox/rpmbuild/RPMS/noarch/pbench-server-*.rpm}


### PR DESCRIPTION
PBENCH-1277

This week the CI (and `runlocal`) builds have started failing because the `ubi9` base image system can't install `rsyslog-mmjsonparse` anymore. It's unclear exactly what changed, and specifying `ubi9.0.0` or `ubi9.1` isn't reverting to the previous behavior, which I think means "something else" I haven't discovered has changed environmentally.

For now, this PR just changes the default `BASE_IMAGE` to centos stream9, which works fine, and will get the CI moving again.

We can revist this investigation later.