### PR TITLE
Use subdirectories to hold backup files

### DIFF
--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -8,7 +8,7 @@ from logging import Logger
 import os
 from pathlib import Path
 from time import time as _time
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from pbench import PbenchConfig
 from pbench.common.exceptions import BadConfig

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -17,8 +17,8 @@ from pbench.common.exceptions import BadConfig
 # with Python syntax.
 JSONSTRING = str
 JSONNUMBER = Union[int, float]
-JSONARRAY = List["JSONVALUE"]
-JSONOBJECT = Dict[JSONSTRING, "JSONVALUE"]
+JSONARRAY = list["JSONVALUE"]
+JSONOBJECT = dict[JSONSTRING, "JSONVALUE"]
 JSONVALUE = Union[JSONOBJECT, JSONARRAY, JSONSTRING, JSONNUMBER, bool, None]
 JSON = JSONVALUE
 

--- a/lib/pbench/server/__init__.py
+++ b/lib/pbench/server/__init__.py
@@ -17,9 +17,9 @@ from pbench.common.exceptions import BadConfig
 # with Python syntax.
 JSONSTRING = str
 JSONNUMBER = Union[int, float]
-JSONVALUE = Union["JSONOBJECT", "JSONARRAY", JSONSTRING, JSONNUMBER, bool, None]
-JSONARRAY = List[JSONVALUE]
-JSONOBJECT = Dict[JSONSTRING, JSONVALUE]
+JSONARRAY = List["JSONVALUE"]
+JSONOBJECT = Dict[JSONSTRING, "JSONVALUE"]
+JSONVALUE = Union[JSONOBJECT, JSONARRAY, JSONSTRING, JSONNUMBER, bool, None]
 JSON = JSONVALUE
 
 # Define a type hint for "Path-like" parameters, so the cumbersomeness of the

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -127,7 +127,15 @@ class IntakeBase(ApiBase):
         return metadata
 
     def _backup_tarball(self, tarball_path: Path, md5_str: str) -> Path:
-        """Helper function which creates a backup copy of a tarball file"""
+        """Helper function which creates a backup copy of a tarball file
+
+        Args:
+            tarball_path:  the path to the tarball to be backed up
+            md5_str:  the MD5 hash value for the file
+
+        Returns:
+            The Path to the backup file location
+        """
         backup_target = self.backup_dir / md5_str / tarball_path.name
         try:
             backup_target.parent.mkdir(exist_ok=True)
@@ -142,10 +150,15 @@ class IntakeBase(ApiBase):
 
     @staticmethod
     def _remove_backup(backup: Path):
-        """Helper function which encapsulates the removal of a backup tarball
+        """Helper function which encapsulates the removal of a tarball backup
 
-        This is intended to be used during error recovery, so it simply
-        eats any errors and returns nothing.
+        This is intended to be used during error recovery to rewind the steps
+        taken by the _backup_tarball() method, so it simply eats any errors
+        and returns nothing.  Note that it removes the backup tarball file as
+        well as the directory which contains it!
+
+        Args:
+            backup:  the path to the backup file
         """
         shutil.rmtree(backup.parent, ignore_errors=True)
 

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -206,7 +206,7 @@ class IntakeBase(ApiBase):
         pass
 
     def _intake(
-        self, args: ApiParams, request: Request, context: ApiContext
+        self, args: ApiParams, request: Request, _context: ApiContext
     ) -> Response:
         """Common code to assimilate a remote tarball onto the server
 
@@ -238,7 +238,7 @@ class IntakeBase(ApiBase):
                     access: The desired access policy (default is "private")
                     metadata: Metadata key/value pairs to set on dataset
             request: The original Request object containing query parameters
-            context: API context dictionary
+            _context: API context dictionary (not used by this function)
         """
 
         # Used to record what steps have been completed during the upload, and
@@ -246,7 +246,6 @@ class IntakeBase(ApiBase):
         recovery = Cleanup(current_app.logger)
 
         audit: Optional[Audit] = None
-        username: Optional[str] = None
         intake_dir: Optional[Path] = None
         notes = []
 
@@ -259,8 +258,6 @@ class IntakeBase(ApiBase):
                 user_id = authorized_user.id
                 username = authorized_user.username
             except Exception as e:
-                username = None
-                user_id = None
                 raise APIAbort(
                     HTTPStatus.UNAUTHORIZED, "Verifying user_id failed"
                 ) from e

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -14,10 +14,10 @@ import uuid
 
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from flask.wrappers import Response
 from freezegun import freeze_time
 import jwt
 import pytest
-from flask.wrappers import Response
 import responses
 
 from pbench.common import MetadataLog

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from freezegun import freeze_time
 import jwt
 import pytest
-from werkzeug.wrappers.response import Response
+from flask.wrappers import Response
 import responses
 
 from pbench.common import MetadataLog

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -24,6 +24,7 @@ from pbench.common import MetadataLog
 from pbench.common.logger import get_pbench_logger
 from pbench.server import PbenchServerConfig
 from pbench.server.api import create_app
+from pbench.server.api.resources.intake_base import IntakeBase
 import pbench.server.auth.auth as Auth
 from pbench.server.database import init_db
 from pbench.server.database.database import Database
@@ -1078,3 +1079,14 @@ def generate_api_key(
     api_key = APIKey(key=key, user=user, label=label)
     api_key.add()
     return api_key
+
+
+@pytest.fixture()
+def mock_backup(server_config, monkeypatch):
+    def mock_backup_tarball(_self, tarball_path: Path, md5_str: str) -> Path:
+        return server_config.BACKUP / md5_str / tarball_path.name
+
+    with monkeypatch.context() as m:
+        m.setattr(IntakeBase, "_backup_tarball", mock_backup_tarball)
+        m.setattr(IntakeBase, "_remove_backup", lambda *_a, **_k: None)
+        yield

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -17,7 +17,7 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from freezegun import freeze_time
 import jwt
 import pytest
-from requests import Response
+from werkzeug.wrappers.response import Response
 import responses
 
 from pbench.common import MetadataLog
@@ -225,9 +225,10 @@ def capinternal(caplog):
             if r.levelno == logging.ERROR:
                 if internal.match(str(r.msg)):
                     return
-        assert (
-            False
-        ), f"Expected pattern {internal.pattern!r} not logged at level 'ERROR': {[str(r.msg) for r in caplog.get_records('call')]}"
+        assert False, (
+            f"Expected pattern {internal.pattern!r} not logged "
+            f"at level 'ERROR': {[str(r.msg) for r in caplog.get_records('call')]}"
+        )
 
     return compare
 

--- a/lib/pbench/test/unit/server/test_datasets_metadata.py
+++ b/lib/pbench/test/unit/server/test_datasets_metadata.py
@@ -464,7 +464,7 @@ class TestDatasetsMetadataPut(TestDatasetsMetadataGet):
             "user.one": None,
         }
 
-    def test_put_set_errors(self, capinternal, monkeypatch, query_get_as, query_put_as):
+    def test_put_set_errors(self, monkeypatch, query_get_as, query_put_as):
         """Test a partial success. We set a scalar value on a key and then try
         to set a nested value: i.e., with "global.dashboard.nested = False", we
         attempt to set "global.dashboard.nested.dummy". We expect this to fail,

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -100,7 +100,9 @@ class TestRelay:
     @pytest.mark.freeze_time("2023-07-01")
     @pytest.mark.parametrize("delete", ("false", "true", None))
     @responses.activate
-    def test_relay(self, client, server_config, pbench_drb_token, tarball, delete):
+    def test_relay(
+        self, client, mock_backup, server_config, pbench_drb_token, tarball, delete
+    ):
         """Verify the success path
 
         Ensure successful completion when the primary relay URI returns a valid
@@ -438,6 +440,7 @@ class TestRelay:
     def test_delete_failures(
         self,
         client,
+        mock_backup,
         server_config,
         pbench_drb_token,
         tarball,

--- a/lib/pbench/test/unit/server/test_relay.py
+++ b/lib/pbench/test/unit/server/test_relay.py
@@ -1,3 +1,4 @@
+import hashlib
 from http import HTTPStatus
 from logging import Logger
 from pathlib import Path
@@ -54,6 +55,13 @@ class TestRelay:
                 self.md5_path = path.with_suffix(".xz.md5")
                 self.name = Dataset.stem(path)
                 self.metadata = None
+                # Note that, while this resource ID -is- a real MD5 hash and
+                # that it -is- unique to this file _path_, it won't match the
+                # actual hash of the file _contents_ (i.e., it won't match the
+                # value from the `tarball` fixture).
+                self.resource_id = hashlib.md5(
+                    str(path).encode(errors="ignore")
+                ).hexdigest()
 
             def delete(self):
                 TestRelay.tarball_deleted = self.name

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -1,4 +1,5 @@
 import errno
+import hashlib
 from http import HTTPStatus
 from io import BytesIO
 from logging import Logger
@@ -10,7 +11,7 @@ import pytest
 
 from pbench.server import OperationCode, PathLike, PbenchServerConfig
 from pbench.server.api.resources import APIInternalError, ApiMethod, ApiSchema
-from pbench.server.api.resources.intake_base import Access, Backup, IntakeBase
+from pbench.server.api.resources.intake_base import Access, IntakeBase
 from pbench.server.api.resources.upload import Upload
 from pbench.server.cache_manager import CacheManager, DuplicateTarball
 from pbench.server.database.models.audit import (
@@ -62,6 +63,13 @@ class TestUpload:
                 self.md5_path = path.with_suffix(".xz.md5")
                 self.name = Dataset.stem(path)
                 self.metadata = None
+                # Note that, while this resource ID -is- a real MD5 hash and
+                # that it -is- unique to this file _path_, it won't match the
+                # actual hash of the file _contents_ (i.e., it won't match the
+                # value from the `tarball` fixture).
+                self.resource_id = hashlib.md5(
+                    str(path).encode(errors="ignore")
+                ).hexdigest()
 
             def delete(self):
                 TestUpload.tarball_deleted = self.name
@@ -107,11 +115,8 @@ class TestUpload:
 
     @staticmethod
     def mock_out_backup(server_config, monkeypatch):
-        def mock_backup_tarball(_self, tarball_path: Path, md5_path: Path) -> Backup:
-            return Backup(
-                tarfile=server_config.BACKUP / tarball_path.name,
-                md5=server_config.BACKUP / md5_path.name,
-            )
+        def mock_backup_tarball(_self, tarball_path: Path, md5_str: str) -> Path:
+            return server_config.BACKUP / md5_str / tarball_path.name
 
         monkeypatch.setattr(IntakeBase, "_backup_tarball", mock_backup_tarball)
         monkeypatch.setattr(IntakeBase, "_remove_backup", lambda *_a, **_k: None)
@@ -552,16 +557,17 @@ class TestUpload:
         """
         datafile, _, md5 = tarball
         name = Dataset.stem(datafile)
-        backup_file = server_config.BACKUP / datafile.name
-        backup: Optional[Backup] = None
+        backup_target = server_config.BACKUP / md5 / datafile.name
+        backup_created = False
         backup_removed = False
 
-        def mock_backup_tarball(_self, tarball_path: Path, md5_path: Path) -> Backup:
-            nonlocal backup
-            dst_tbp = server_config.BACKUP / tarball_path.name
-            dst_md5 = server_config.BACKUP / md5_path.name
-            backup = Backup(tarfile=dst_tbp, md5=dst_md5)
-            return backup
+        def mock_backup_tarball(_self, tarball_path: Path, dataset_id: str) -> Path:
+            # Note that the `dataset_id` here comes from a `FakeTarball`
+            # instance, and it probably doesn't match the MD5 hash from the
+            # `tarball` fixture in `md5`....
+            nonlocal backup_created
+            backup_created = True
+            return server_config.BACKUP / dataset_id / tarball_path.name
 
         def mock_remove_backup(*_args, **_kwargs):
             nonlocal backup_removed
@@ -608,15 +614,13 @@ class TestUpload:
         assert dataset.name in self.cachemanager_created
         assert self.cachemanager_create_path
 
-        assert backup.tarfile == backup_file
-        assert backup.md5 == backup_file.with_suffix(".xz.md5")
+        assert backup_created
         assert not backup_removed
 
         # The test mocks the actual creation of these files, so they should not exist.
         assert not self.cachemanager_create_path.exists()
         assert not self.cachemanager_create_path.with_suffix(".xz.md5").exists()
-        assert not backup_file.exists()
-        assert not backup_file.with_suffix(".xz.md5").exists()
+        assert not backup_target.exists()
 
         audit = Audit.query()
         assert len(audit) == 2
@@ -750,14 +754,17 @@ class TestUpload:
         handling.
         """
         datafile, _, md5 = tarball
-        backup_file = server_config.BACKUP / datafile.name
-        backup: Optional[Backup] = None
+        backup_target = server_config.BACKUP / md5 / datafile.name
+        backup_created = False
         backup_removed = False
 
-        def mock_backup_tarball(*_args, **_kwargs) -> Backup:
-            nonlocal backup
-            backup = Backup(tarfile=backup_file, md5=backup_file.with_suffix(".xz.md5"))
-            return backup
+        def mock_backup_tarball(_self, tarball_path: Path, dataset_id: str) -> Path:
+            # Note that the `dataset_id` here comes from a `FakeTarball`
+            # instance, and it probably doesn't match the MD5 hash from the
+            # `tarball` fixture in `md5`....
+            nonlocal backup_created
+            backup_created = True
+            return server_config.BACKUP / dataset_id / tarball_path.name
 
         def mock_remove_backup(*_args, **_kwargs):
             nonlocal backup_removed
@@ -787,9 +794,8 @@ class TestUpload:
         assert not self.cachemanager_create_path.exists()
         assert not self.cachemanager_create_path.with_suffix(".xz.md5").exists()
         assert self.tarball_deleted == Dataset.stem(datafile)
-        assert not backup_file.exists()
-        assert not backup_file.with_suffix(".xz.md5").exists()
-        assert backup
+        assert not backup_target.exists()
+        assert backup_created
         assert backup_removed
 
         audit = Audit.query()
@@ -1021,31 +1027,29 @@ class TestUpload:
         }
 
     @pytest.mark.parametrize(
-        ("copy_err", "unlink_err", "exc_expected", "expected_ops"),
+        ("mkdir_err", "copy_err", "exc_expected", "expected_ops"),
         (
             (  # Success
-                None,
-                None,
                 False,
-                [["copy", "md5", "bdir"], ["copy", "tbp", "bdir"]],
+                False,
+                False,
+                [["mkdir", "parent"], ["copy", "tbp", "target"]],
             ),
-            (  # MD5 file copy fails
+            (  # mkdir() fails
                 True,
                 None,
                 True,
-                [["copy", "md5", "bdir"]],
+                [["mkdir", "parent"]],
             ),
-            (  # MD5 file copy doesn't fail, tarball file copy fails, unlink works
-                False,
-                False,
-                True,
-                [["copy", "md5", "bdir"], ["copy", "tbp", "bdir"], ["unlink", "bmd5"]],
-            ),
-            (  # MD5 file copy doesn't fail, tarball file copy fails, unlink fails
+            (  # mkdir() doesn't fail, tarball file copy fails
                 False,
                 True,
                 True,
-                [["copy", "md5", "bdir"], ["copy", "tbp", "bdir"], ["unlink", "bmd5"]],
+                [
+                    ["mkdir", "parent"],
+                    ["copy", "tbp", "target"],
+                    ["_remove_backup", "target"],
+                ],
             ),
         ),
     )
@@ -1054,43 +1058,55 @@ class TestUpload:
         server_config,
         tarball,
         monkeypatch,
+        mkdir_err: bool,
         copy_err: Optional[bool],
-        unlink_err: Optional[bool],
         exc_expected: bool,
         expected_ops: list[list[str]],
     ):
         """Test the tarball backup function
 
-        When the `copy_err` or `unlink_err` flags are `None`, there is no
-        exception raised by the corresponding mock (in the case where
-        `unlink_err` is `None`, the mock should not even be called).  When
-        `copy_err` is not `None`, the mock raises an exception for one of the
-        two files, depending on the value.  When `unlink_err` is `True`, the
-        mock raises an exception; otherwise, the function "succeeds".
+        When the `unlink_err` or `copy_err` flags are `True`, an exception is
+        raised by the corresponding mock.  (When their value is `None`, the
+        mock should not be called).
         """
-        tbp, md5, _ = tarball
+        tbp, _, md5 = tarball
+        expected_target = server_config.BACKUP / md5 / tbp.name
         ops = []
 
+        def mock_mkdir(path, *args, **kwargs):
+            """Mock for Path.mkdir()
+
+            Note that mkdir() is called multiple times during the upload
+            processing; we handle the one that we're looking for specially,
+            and the rest we pass off to the real mkdir().
+            """
+            if path == expected_target.parent:
+                ops.append(["mkdir", path])
+                if mkdir_err:
+                    raise RuntimeError("mock_mkdir: mock-failure")
+            else:
+                return path.real_mkdir(*args, **kwargs)
+
         def mock_copy(src, dst, **_kwargs) -> PathLike:
-            if dst == server_config.BACKUP:
+            if dst == expected_target:
                 op = ["copy", src, dst]
-                ret = Path(dst) / Path(src).name
+                ret = expected_target
             else:
                 op = ["Unexpected 'dst' value in copy:", dst]
                 ret = dst
             ops.append(op)
-            if copy_err is not None and src == (md5 if copy_err else tbp):
+            if copy_err:
                 raise RuntimeError("mock_copy: mock-failure")
             return ret
 
-        def mock_unlink(path, **_kwargs):
-            ops.append(["unlink", path])
-            if unlink_err:
-                raise RuntimeError("mock_unlink: mock-failure")
+        def mock_remove_backup(backup: Path):
+            ops.append(["_remove_backup", backup])
 
         with monkeypatch.context() as m:
+            m.setattr(Path, "real_mkdir", Path.mkdir, raising=False)
+            m.setattr(Path, "mkdir", mock_mkdir)
             m.setattr(shutil, "copy", mock_copy)
-            m.setattr(Path, "unlink", mock_unlink)
+            m.setattr(IntakeBase, "_remove_backup", mock_remove_backup)
 
             dummy_schema = ApiSchema(ApiMethod.GET, OperationCode.READ)
             ib = IntakeBase(server_config, dummy_schema)
@@ -1099,46 +1115,28 @@ class TestUpload:
             except APIInternalError:
                 assert exc_expected, "Unexpected APIInternalError exception received"
             else:
-                assert result == Backup(
-                    tarfile=server_config.BACKUP / tbp.name,
-                    md5=server_config.BACKUP / md5.name,
-                )
+                assert result == expected_target
 
             # Replace the placeholders in the expected ops with the actual
             # values, which are hard to obtain in parametrization context, and
             # then compare the result to the actual operations and arguments.
             ph = {
                 "tbp": tbp,
-                "md5": md5,
-                "bdir": server_config.BACKUP,
-                "bmd5": server_config.BACKUP / md5.name,
+                "target": expected_target,
+                "parent": expected_target.parent,
             }
             eo = [[ph.get(o[i], o[i]) for i in range(len(o))] for o in expected_ops]
             assert ops == eo
 
-    @pytest.mark.parametrize(
-        ("tb_err", "md5_err"),
-        (
-            (False, False),  # Both work
-            (False, True),  # tarball unlink works, MD5 unlink fails
-            (True, False),  # tarball unlink fails, MD5 unlink works
-            (True, True),  # Both fail
-        ),
-    )
-    def test_intake_backup_remove(self, server_config, monkeypatch, tb_err, md5_err):
+    def test_intake_backup_remove(self, server_config, monkeypatch):
         """Test the tarball backup removal function"""
-        backup = Backup(
-            tarfile=Path("the_backup_dir/mytb.tar.xz"),
-            md5=Path("the_backup_dir/mytb.md5"),
-        )
+        backup = Path("the_backup_dir/id/mytb.tar.xz")
         ops = []
 
-        def mock_unlink(path, **_kwargs):
-            ops.append(("unlink", path))
-            if tb_err and path == backup.tarfile or md5_err and path == backup.md5:
-                raise RuntimeError("mock_unlink: mock-failure")
+        def mock_rmtree(path, **_kwargs):
+            ops.append(("rmtree", path))
 
         with monkeypatch.context() as m:
-            m.setattr(Path, "unlink", mock_unlink)
+            m.setattr(shutil, "rmtree", mock_rmtree)
             IntakeBase._remove_backup(backup)
-            assert ops == [("unlink", backup.tarfile), ("unlink", backup.md5)]
+            assert ops == [("rmtree", backup.parent)]


### PR DESCRIPTION
This is a follow-on to #3553:  that places all the backup files in a single directory using the original dataset names.  Unfortunately, we have no guarantee that dataset names are unique, and so this could lead to conflicts and overwritten files.  This PR modifies the previous to place each backup in a subdirectory named using the dataset resource ID.  Since each resource ID is unique to its dataset, this ensures that there are no conflicts.  This also has the side-effect that we no longer need to store the `*.md5` files, since the hash value is now embedded in the file path.

This PR consists of two commits.  The second is described above; the first is a few small changes to appease the linter.

PBENCH-1259
