### PR TITLE
Return to using a UBI-9 base image for the Server Container

### DIFF
--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -8,11 +8,7 @@
 #-
 GITTOP=${GITTOP:-$(git rev-parse --show-toplevel)}
 
-# FIXME: ubi9 doesn't seem to have rsyslog-mmjsonparse available, so
-# temporarily switch to centos:stream9
-BASE_IMAGE=${BASE_IMAGE:-quay.io/centos/centos:stream9}
-# BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
-
+BASE_IMAGE=${BASE_IMAGE:-registry.access.redhat.com/ubi9:latest}
 PB_SERVER_IMAGE_NAME=${PB_SERVER_IMAGE_NAME:-"pbench-server"}
 PB_SERVER_IMAGE_TAG=${PB_SERVER_IMAGE_TAG:-$(< ${GITTOP}/jenkins/branch.name)}
 RPM_PATH=${RPM_PATH:-/root/sandbox/rpmbuild/RPMS/noarch/pbench-server-*.rpm}


### PR DESCRIPTION
This PR reverts the change made in #3554 which is no longer needed, now that our Subscription Manager subscription has been renewed.  (The subscription is required in order for us to access the `rhel-9-for-x86_64-appstream-rpms` DNF repo which contains a number of packages (such as `rsyslog-mmjsonparse`) that we need for building on a UBI base image.)