### PR TITLE
Allow typed metadata on upload

### DIFF
--- a/contrib/server/operations/pbench-upload-results.py
+++ b/contrib/server/operations/pbench-upload-results.py
@@ -56,7 +56,7 @@ def upload(
     uploaded = datetime.datetime.fromtimestamp(
         tarball.stat().st_mtime, tz=datetime.timezone.utc
     )
-    meta = [f"global.server.legacy.migrated:{uploaded:%Y-%m-%dT%H:%M}"]
+    meta = [f"global.server.legacy.migrated:'{uploaded:%Y-%m-%dT%H:%M}'"]
     if "::" in tarball.parent.name:
         satellite, _ = tarball.parent.name.split("::", 1)
         meta.append(f"server.origin:{satellite}")

--- a/docs/Server/API/V1/metadata.md
+++ b/docs/Server/API/V1/metadata.md
@@ -2,7 +2,8 @@
 
 This API sets or retrieves metadata for the identified dataset. For `GET` you
 specify a list of metadata keys with the `?metadata` query parameter; for `PUT`
-you specify an `application/json` request body to identify
+you specify an `application/json` request body to specify a set of keys and
+values.
 
 ## URI parameters
 
@@ -16,14 +17,35 @@ A list of metadata keys to retrieve. For example, `?metadata=dataset,global,serv
 will retrieve all metadata values, each namespace as a nested JSON object. (This can
 be a lot of data, and is generally not recommended.)
 
-Less radically, `?metadata=dataset.name,dataset.access,server.deletion` will return
+The metadata query string `?metadata=dataset.name,dataset.access,server` will return
 an `application/json` response something like this:
 
 ```json
 {
     "dataset.access": "public",
-    "dataset.name": "pbench-user-benchmark__2022.12.24T15.00.58",
-    "server.deletion": "2025-10-20"
+    "dataset.name": "uperf__2023.08.21T15.09.46",
+    "server": {
+        "benchmark": "uperf",
+        "deletion": "2025-08-21",
+        "tarball-path": "<internal path>"
+    }
+}
+```
+## Request body
+
+For `PUT`, specify the keys and values in an `application/json` request body
+under the `"metadata"` field, like this:
+
+```json
+{
+  "metadata": {
+    "dataset.name": "I shall call you squishie",
+    "server.deletion": "2024-12-13",
+    "global.pbench": {
+      "tag": "ABC",
+      "version": 1.0
+    }
+  }
 }
 ```
 
@@ -52,10 +74,11 @@ See [Access model](../access_model.md)
 Successful request.
 
 `401`   **UNAUTHORIZED** \
-The client is not authenticated.
+The client is not authenticated for a `PUT` call.
 
 `403`   **FORBIDDEN** \
-The authenticated client does not have `UPDATE`` access to the specified dataset.
+The authenticated client does not have `READ` access (for `GET`) or `UPDATE`
+access (for `PUT`) to the specified dataset.
 
 `404`   **NOT FOUND** \
 The `<dataset>` resource ID does not exist.

--- a/docs/Server/API/V1/metadata.md
+++ b/docs/Server/API/V1/metadata.md
@@ -1,0 +1,101 @@
+# `GET|PUT /api/v1/datasets/<dataset>/metadata`
+
+This API sets or retrieves metadata for the identified dataset. For `GET` you
+specify a list of metadata keys with the `?metadata` query parameter; for `PUT`
+you specify an `application/json` request body to identify
+
+## URI parameters
+
+`<dataset>` string \
+The resource ID of a dataset on the Pbench Server.
+
+## Query parameters
+
+`metadata` (`GET` only) \
+A list of metadata keys to retrieve. For example, `?metadata=dataset,global,server,user`
+will retrieve all metadata values, each namespace as a nested JSON object. (This can
+be a lot of data, and is generally not recommended.)
+
+Less radically, `?metadata=dataset.name,dataset.access,server.deletion` will return
+an `application/json` response something like this:
+
+```json
+{
+    "dataset.access": "public",
+    "dataset.name": "pbench-user-benchmark__2022.12.24T15.00.58",
+    "server.deletion": "2025-10-20"
+}
+```
+
+## Request headers
+
+`authorization: bearer` token \
+*Bearer* schema authorization is required to update a dataset.
+E.g., `authorization: bearer <token>`
+
+## Response headers
+
+`content-type: application/json` \
+The return is a serialized JSON object with with the retrieved metadata key and
+value pairs.
+
+## Resource access
+
+* `GET` requires `READ` access to the `<dataset>` resource, while `PUT` requires
+`UPDATE` access to the `<dataset>` resource.
+
+See [Access model](../access_model.md)
+
+## Response status
+
+`200`   **OK** \
+Successful request.
+
+`401`   **UNAUTHORIZED** \
+The client is not authenticated.
+
+`403`   **FORBIDDEN** \
+The authenticated client does not have `UPDATE`` access to the specified dataset.
+
+`404`   **NOT FOUND** \
+The `<dataset>` resource ID does not exist.
+
+`503`   **SERVICE UNAVAILABLE** \
+The server has been disabled using the `server-state` server configuration
+setting in the [server configuration](./server_config.md) API. The response
+body is an `application/json` document describing the current server state,
+a message, and optional JSON data provided by the system administrator.
+
+## Response body
+
+The `application/json` response shows the referenced metadata key values.
+
+For `GET`, these are the keys you specified with the `?metadata`
+query parameter.
+
+For `PUT`, the actual metadata values you set are returned, along with a
+possible map of errors. In general these are exactly what you set, but
+some like `server.archiveonly` and `server.deletion` may be normalized
+during validation. For example, for
+
+```
+PUT /api/v1/datasets/<resource_id>/metadata
+{
+  "metadata": {
+    "server.archiveonly": "true",
+    "server.deletion": "2023-12-25T15:43"
+  }
+}
+```
+
+The response might be:
+
+```json
+{
+    "errors": {},
+    "metadata": {
+        "server.archiveonly": true,
+        "server.deletion": "2023-12-26"
+    }
+}
+```

--- a/docs/Server/API/V1/upload.md
+++ b/docs/Server/API/V1/upload.md
@@ -37,6 +37,34 @@ In particular the client can set any of:
 
 For example, `?metadata=server.archiveonly:true,global.project:oidc`
 
+__Typed metadata__
+
+When you set metadata dynamically using `PUT /datasets/<id>/metadata`, you
+specify a JSON object for each key, so defining typed metadata is implicit in
+the JSON object interpretation.
+
+When using the `?metadata` query parameter, you're limited to writing strings,
+and it's not quite so straightfoward. The string can contain type information
+to compensate for the limitation. Each `?metadata` string is a comma-separated
+list of "metadata expressions" of the form "<key>:<value>[:<type>]". If the
+":<type>" is omitted, type is assumed to be "str". For example, you can specify
+integer metadata values using ":int" (`global.mine.count:1:int`).
+
+Types:
+* `str` (default) The value is a string. If you want to include "," or ":"
+  characters, you can quote the value using matched (and potentially nested)
+  single and double quote characters. For example `<key>:'2023-10-01:10:23':str`
+  will set the specified key to the value `2023-10-01:10:23`.
+* `bool` The value is a (JSON format) boolean, `true` or `false`. For example
+  `<key>:true:bool` will set the specified key to the boolean value `true`.
+* `int` The value is an integer. For example `<key>:1:int` will set the
+  specified key to the integer value 1.
+* `float` The value is a floating point number. For example `<key>:1.0:float`
+  will set the specified key to the floating point value 1.0.
+* `json` The value is a quoted serialized JSON object representation. For
+  example, `<key>:'{"str": "string", "int": 1, "bool": true}':json` will set
+  the specified key to the JSON object `{"str": "string", "int": 1, "bool": true}`
+
 ## Request headers
 
 `authorization: bearer` token \

--- a/docs/Server/API/V1/upload.md
+++ b/docs/Server/API/V1/upload.md
@@ -40,8 +40,8 @@ For example, `?metadata=server.archiveonly:true,global.project:oidc`
 __Typed metadata__
 
 When you set metadata dynamically using `PUT /datasets/<id>/metadata`, you
-specify a JSON object for each key, so defining typed metadata is implicit in
-the JSON object interpretation.
+specify a JSON value for each key, so defining typed metadata is implicit in
+the JSON interpretation.
 
 When using the `?metadata` query parameter, you're limited to writing strings,
 and it's not quite so straightfoward. The string can contain type information
@@ -50,20 +50,13 @@ list of "metadata expressions" of the form "<key>:<value>[:<type>]". If the
 ":<type>" is omitted, type is assumed to be "str". For example, you can specify
 integer metadata values using ":int" (`global.mine.count:1:int`).
 
-Types:
-* `str` (default) The value is a string. If you want to include "," or ":"
-  characters, you can quote the value using matched (and potentially nested)
-  single and double quote characters. For example `<key>:'2023-10-01:10:23':str`
-  will set the specified key to the value `2023-10-01:10:23`.
-* `bool` The value is a (JSON format) boolean, `true` or `false`. For example
-  `<key>:true:bool` will set the specified key to the boolean value `true`.
-* `int` The value is an integer. For example `<key>:1:int` will set the
-  specified key to the integer value 1.
-* `float` The value is a floating point number. For example `<key>:1.0:float`
-  will set the specified key to the floating point value 1.0.
-* `json` The value is a quoted serialized JSON object representation. For
-  example, `<key>:'{"str": "string", "int": 1, "bool": true}':json` will set
-  the specified key to the JSON object `{"str": "string", "int": 1, "bool": true}`
+| Type | Description |
+| ---- | ----------- |
+| `str` | (default) The value is a   string. If you want to include "," or ":" characters, you can quote the value using matched (and potentially nested) single and double quote characters. For example `<key>:'2023-10-01:10:23':str` will set the specified key to the value `2023-10-01:10:23`. |
+| `bool` | The value is a (JSON format) boolean, `true` or `false`. For example `<key>:true:bool` will set the specified key to the boolean value `true`. |
+| `int` | The value is an integer. For example `<key>:1:int` will set the specified key to the integer value 1. |
+| `float` | The value is a floating point number. For example `<key>:1.0:float` will set the specified key to the floating point value 1.0. |
+| `json` | The value is a quoted serialized JSON object representation. For example, `<key>:'{"str": "string", "int": 1, "bool": true}':json` will set the specified key to the JSON object `{"str": "string", "int": 1, "bool": true}` |
 
 ## Request headers
 

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -5,7 +5,7 @@ from http import HTTPStatus
 import json
 from json.decoder import JSONDecodeError
 import re
-from typing import Any, Callable, Dict, NamedTuple, Optional, Union
+from typing import Any, Callable, NamedTuple, Optional, Union
 import uuid
 
 from dateutil import parser as date_parser
@@ -694,7 +694,7 @@ def convert_boolean(value: Any, parameter: "Parameter") -> bool:
 
 
 # A type defined to pass context through API methods.
-ApiContext = Dict[str, Any]
+ApiContext = dict[str, Any]
 
 
 @dataclass
@@ -780,13 +780,13 @@ class Term:
         expression.
 
         The key and value can be quoted to include mixed case and symbols,
-        including the ":" character, by starting and starting and ending the
-        key or value with the "'" or '"' character, e.g.,
-        "'dataset.metalog.tool/iteration:1':'foo:1#bar':str".
+        including the ":" and "," characters, by wrapping the key or value in
+        quotes (single "'" and '"' quotes may be nested), for example,
+        `'dataset.metalog.tool/iteration:1':'foo:"1"#bar':str`
 
-        The "operator" and "type", if omitted, can be defaulted from the object
-        configuration, so that `dataset.name:foo` can have the same effect as
-        `dataset.name:=foo:str`.
+        The "operator" and "type", if omitted, can be defaulted from the Term
+        object configuration, so that with default_operator="=", the expression
+        `dataset.name:foo` has the same effect as `dataset.name:=foo:str`.
 
         Returns:
             self
@@ -845,8 +845,8 @@ class Term:
         prefix = default
         for p in sorted(prefixes, key=lambda k: len(k), reverse=True):
             if self.buffer.startswith(p):
-                prefix = self.buffer[: len(p)]
-                self.buffer = self.buffer[len(p) :]
+                prefix = p
+                self.buffer = self.buffer.removeprefix(p)
                 self.offset += len(p)
                 break
         return prefix
@@ -1337,7 +1337,7 @@ class ApiSchemaSet:
         """
         if not schemas:
             raise RuntimeError("At least one ApiSchema must be provided")
-        self.schemas: Dict[ApiMethod, ApiSchema] = {s.method: s for s in schemas}
+        self.schemas: dict[ApiMethod, ApiSchema] = {s.method: s for s in schemas}
 
     def __getitem__(self, key: ApiMethod):
         return self.schemas.get(key)

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -123,7 +123,7 @@ class IntakeBase(ApiBase):
 
         This supports typed metadata expressions using the syntax key : value
         : type, such as `global.key:1:int`, `global.key:true:bool`, or
-        `global.key:'{"a": true, "b": 1}`:json`.
+        `global.key:'{"a": true, "b": 1}':json`.
 
         NOTE: Multiple metadata expressions may occur in each item in the list,
         separated by unquoted "," characters. We don't rely on the common

--- a/lib/pbench/server/api/resources/relay.py
+++ b/lib/pbench/server/api/resources/relay.py
@@ -35,10 +35,7 @@ class Relay(IntakeBase):
                     Parameter("access", ParamType.ACCESS),
                     Parameter("delete", ParamType.BOOLEAN),
                     Parameter(
-                        "metadata",
-                        ParamType.LIST,
-                        element_type=ParamType.STRING,
-                        string_list=",",
+                        "metadata", ParamType.LIST, element_type=ParamType.STRING
                     ),
                 ),
                 audit_type=AuditType.NONE,

--- a/lib/pbench/server/api/resources/upload.py
+++ b/lib/pbench/server/api/resources/upload.py
@@ -33,10 +33,7 @@ class Upload(IntakeBase):
                 query_schema=Schema(
                     Parameter("access", ParamType.ACCESS),
                     Parameter(
-                        "metadata",
-                        ParamType.LIST,
-                        element_type=ParamType.STRING,
-                        string_list=",",
+                        "metadata", ParamType.LIST, element_type=ParamType.STRING
                     ),
                 ),
                 audit_type=AuditType.NONE,

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -80,8 +80,8 @@ class TestPut:
             a = access[cur_access]
             if a == "public":
                 metadata = (
-                    "server.origin:test,user.pbench.access:public,server.archiveonly:n",
-                    f"server.deletion:{expire_soon:%Y-%m-%d %H:%M%z}",
+                    "server.origin:test,user.pbench.access:public,server.archiveonly:n:bool",
+                    f"server.deletion:'{expire_soon:%Y-%m-%d %H:%M%z}'",
                 )
             else:
                 metadata = None

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -736,17 +736,17 @@ class TestDatasetsList:
             (
                 "global.x=3",
                 HTTPStatus.BAD_REQUEST,
-                "Missing ':' terminator in 'global.x=3'",
+                "Missing ':' terminator after 'global.x=3'",
             ),
             (
                 "'global.x'",
                 HTTPStatus.BAD_REQUEST,
-                "Missing ':' terminator in 'global.x'",
+                "Missing ':' terminator after \"'global.x'\"",
             ),
             (
                 "dataset.x':v",
                 HTTPStatus.BAD_REQUEST,
-                'Metadata key "dataset.x\'" is not supported',
+                'Unterminated quote at "dataset.x[\']:v"',
             ),
             (
                 "dataset.notright:10",
@@ -756,22 +756,22 @@ class TestDatasetsList:
             (
                 "'dataset.name:foo",
                 HTTPStatus.BAD_REQUEST,
-                'Bad quote termination in "\'dataset.name:foo"',
+                'Unterminated quote at "[\']dataset.name:foo"',
             ),
             (
                 "dataset.name:'foo",
                 HTTPStatus.BAD_REQUEST,
-                'Bad quote termination in "dataset.name:\'foo"',
+                'Unterminated quote at "dataset.name:[\']foo"',
             ),
             (
                 "server.deletion:<2023-05-01:time",
                 HTTPStatus.BAD_REQUEST,
-                "The filter type 'time' must be one of bool,date,int,str",
+                "The metadata type 'time' must be one of bool,date,int,str",
             ),
             (
                 "server.deletion:2023-05-01:date:",
                 HTTPStatus.BAD_REQUEST,
-                "The filter type 'date:' must be one of bool,date,int,str",
+                "The metadata type 'date:' must be one of bool,date,int,str",
             ),
         ],
     )


### PR DESCRIPTION
PBENCH-1283

Normally metadata keys are set through `PUT /datasets/<id>/metadata` using an `application/json` request body, allowing the full expressiveness of JSON, specifically to specify sub-objects, integers, floating point numbers, and boolean literals.

I added the `?metadata` query parameter on `PUT /upload/<name>` to allow a client to specify metadata during the upload instead of waiting; however the nature of the HTTP interface constrains these to text strings, which can be limiting.

This PR generalizes the typed "metadata expression" syntax developed to support generalized metadata `?filter` expressions on `GET /datasets` to allow both quoting value strings and typing them. For example, one could now set a JSON value using

```
?metadata=global.legacy.pbench:'{"host":"agent","migrate":true}':json
```

We support `str`, `int`, `float`, `bool`, and `json` types; e.g.,

`?metadata=global.tester.run_id:100:int,global.tester.good:true:bool`

(P.S.: when updating the `upload.md` I noticed that I'd somehow missed ever writing a `metadata.md` for the `/datasets/<id>/metadata` APIs, and I corrected that oversight. I think we're now also missing `visualize` and `compare` API documentation, but that's a bit too far disconnected from this topic.)