### PR TITLE
Redirect DIR `/inventory/path` to `/contents/path`

### DIFF
--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -48,8 +48,14 @@ class DatasetsInventory(ApiBase):
     def _get(
         self, params: ApiParams, request: Request, context: ApiContext
     ) -> Response:
-        """
-        This function returns the contents of the requested file as a byte stream.
+        """Request the contents of a results file.
+
+        This function examines a "target" path within the results tarball of a
+        dataset. If the target path is a regular file, this returns the
+        contents of the requested file as a byte stream. If the target path is
+        a directory, it returns a client redirect (301 status with a new url
+        in the "location" header) to acquire metadata about the directory and
+        its contents. Otherwise, the request fails with a BAD_REQUEST error.
 
         Args:
             params: includes the uri parameters, which provide the dataset and target.
@@ -57,7 +63,7 @@ class DatasetsInventory(ApiBase):
             context: API context dictionary
 
         Raises:
-            APIAbort, reporting either "NOT_FOUND" or "UNSUPPORTED_MEDIA_TYPE"
+            APIAbort, reporting either "NOT_FOUND" or "BAD_REQUEST"
 
         GET /api/v1/datasets/{dataset}/inventory/{target}
         """

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -638,10 +638,11 @@ class Tarball:
             path: relative path of the subdirectory/file
 
         Raises:
-            BadDirpath if the directory/file path is not valid
+            BadDirpath if the directory/file path is not valid or doesn't
+                correspond to an entity within the tarball.
 
         Returns:
-            cache map entry if present
+            cache map entry
         """
         if str(path).startswith("/"):
             raise BadDirpath(
@@ -771,35 +772,26 @@ class Tarball:
             tarball_path, f"Unexpected error from {tar_path}: {error_text!r}"
         )
 
-    def stream(self, path: str) -> Inventory:
-        """Return a cached inventory file as a binary stream
-
-        Args:
-            path: Relative path of a regular file within a tarball.
-
-        On failure, an exception is raised and the cache lock is released; on
-        success, returns an Inventory object which implicitly transfers
-        ownership and management of the cache lock to the caller. When done
-        with the inventory's file stream, the caller must close the Inventory
-        object to release the file stream and the cache lock.
-
-        Raises:
-            CacheExtractBadPath: the path does not match a regular file within
-                the tarball.
-
-        Returns:
-            An Inventory object encapsulating the file stream and the cache
-            lock.
-        """
-
-        with LockManager(self.lock) as lock:
-            artifact: Path = self.get_results(lock) / path
-            if not artifact.is_file():
-                raise CacheExtractBadPath(self.tarball_path, path)
-            return Inventory(artifact.open("rb"), lock=lock.keep())
-
     def get_inventory(self, path: str) -> Optional[JSONOBJECT]:
         """Access the file stream of a tarball member file.
+
+        Returns a JSON description of the entity at "path" within the tarball's
+        directory tree.
+
+        If "path" is a directory, release the cache lock and return the path
+        and type.
+
+        If "path" is a regular file, return an Inventory object, transferring
+        ownership of the cache lock to the caller. When done with the file
+        Inventory stream, the caller must close the Inventory object to release
+        the file stream and the cache lock.
+
+        if "path" is anything else, the cache lock is released and an exception
+        is raised.
+
+        Raises:
+            CacheExtractBadPath: the path does not match a directory or regular
+                file within the tarball.
 
         Args:
             path: relative path within the tarball of a file
@@ -814,8 +806,17 @@ class Tarball:
                 "stream": Inventory(self.tarball_path.open("rb")),
             }
         else:
-            stream = self.stream(path)
-            info = {"name": path, "type": CacheType.FILE, "stream": stream}
+            with LockManager(self.lock) as lock:
+                artifact: Path = self.get_results(lock) / path
+                if artifact.is_dir():
+                    stream = None
+                    type = CacheType.DIRECTORY
+                elif not artifact.is_file():
+                    raise CacheExtractBadPath(self.tarball_path, path)
+                else:
+                    stream = Inventory(artifact.open("rb"), lock=lock.keep())
+                    type = CacheType.FILE
+            info = {"name": path, "type": type, "stream": stream}
 
         return info
 

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -988,7 +988,8 @@ class TestCacheManager:
             ("", True, b"tarball_as_a_byte_stream"),
             (None, True, b"tarball_as_a_byte_stream"),
             ("f1.json", True, b"{'json': 'value'}"),
-            ("subdir1/f12_sym", False, CacheExtractBadPath(Path("a"), "b")),
+            ("subdir1/subdir12/f122_sym", True, CacheExtractBadPath(Path("a"), "b")),
+            ("subdir1/f12_sym", False, None),
         ],
     )
     def test_get_inventory(
@@ -1030,10 +1031,14 @@ class TestCacheManager:
                 assert isinstance(e, type(exp_stream)), e
             else:
                 assert not isinstance(exp_stream, Exception)
-                assert file_info["type"] is CacheType.FILE
-                stream: Inventory = file_info["stream"]
-                assert stream.stream.read() == exp_stream
-                stream.close()
+                if exp_stream:
+                    assert file_info["type"] is CacheType.FILE
+                    stream: Inventory = file_info["stream"]
+                    assert stream.stream.read() == exp_stream
+                    stream.close()
+                else:
+                    assert file_info["type"] is CacheType.DIRECTORY
+                    assert file_info["stream"] is None
 
     def test_cm_inventory(self, monkeypatch, server_config, make_logger):
         """Verify the happy path of the high level get_inventory"""

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -19,6 +19,6 @@ PyJwt[crypto]
 python-dateutil
 requests # TODO CVE-2023-32681 (>=2.31.0)
 sdnotify
-sqlalchemy>=1.4.23
+sqlalchemy>=1.4.23,<2.0.23
 sqlalchemy_utils>=0.37.6
 urllib3


### PR DESCRIPTION
PBENCH-1291

Pbench Agent postprocessing creates `result.html` files, which display a table of result data for each iteration. Each row contains a relative link to the iteration directory, with the intention of linking to the web server directory listing. Because the `result.html` was loaded using the `inventory` API as `/datasets/<id>/inventory/result.html`, the relative path access also routes to the `inventory` API, which doesn't support directories and therefore fails.

It's hard to fix this to work like the old server without some way to interact with the dashboard UI code (ideally it would open the appropriate directory in the TOC view). Nevertheless, this PR implements a change that improves the behavior a bit (it's no longer an error), by handling this request as an HTML `301` (redirect, as "permanently moved") to the appropriate `/contents` URI.

Right now the browser will display the raw `contents` JSON response, which is a bit ugly if not entirely uninformative.

This PR also cleans up the `inventory` code path a bit, collapsing the cache manager `stream` API into `get_inventory` as it's not called anywhere else.