### PR TITLE
Separate `audience` from `client`

### DIFF
--- a/lib/pbench/server/auth/__init__.py
+++ b/lib/pbench/server/auth/__init__.py
@@ -263,7 +263,7 @@ class OpenIDClient:
         OpenIDClient.
 
         Args:
-            server_config: a server configuration objects
+            server_config: a server configuration object
 
         Raises:
             OpenIDClient.NotConfigured : when the openid-connect section is

--- a/lib/pbench/server/database/models/users.py
+++ b/lib/pbench/server/database/models/users.py
@@ -80,7 +80,7 @@ class User(Database.Base):
             raise UserSqlError(e, user=self, operation="setrole", role=value) from e
 
     def __str__(self):
-        return f"User, id: {self.id}, username: {self.username}"
+        return f"User, id: {self.id}, username: {self.username}, roles {self._roles}"
 
     def get_json(self) -> JSONOBJECT:
         """Return a JSON object for this User object.

--- a/lib/pbench/test/unit/server/conftest.py
+++ b/lib/pbench/test/unit/server/conftest.py
@@ -796,6 +796,7 @@ def pbench_admin_token(client, server_config, create_admin_user, rsa_keys):
         user=create_admin_user,
         private_key=rsa_keys["private_key"],
         client_id=server_config.get("openid", "client"),
+        audience=server_config.get("openid", "audience"),
         username=admin_username,
         pbench_client_roles=["ADMIN"],
     )
@@ -807,6 +808,7 @@ def pbench_drb_token(client, server_config, create_drb_user, rsa_keys):
     return generate_token(
         username="drb",
         client_id=server_config.get("openid", "client"),
+        audience=server_config.get("openid", "audience"),
         private_key=rsa_keys["private_key"],
         user=create_drb_user,
     )
@@ -819,6 +821,7 @@ def pbench_drb_token_invalid(client, server_config, create_drb_user, rsa_keys):
         username="drb",
         private_key=rsa_keys["private_key"],
         client_id=server_config.get("openid", "client"),
+        audience=server_config.get("openid", "audience"),
         user=create_drb_user,
         valid=False,
     )
@@ -842,6 +845,7 @@ def get_token_func(pbench_admin_token, server_config, rsa_keys):
             username=user,
             private_key=rsa_keys["private_key"],
             client_id=server_config.get("openid", "client"),
+            audience=server_config.get("openid", "audience"),
         )
     )
 
@@ -874,6 +878,7 @@ def generate_token(
     username: str,
     private_key: str,
     client_id: str,
+    audience: str,
     user: Optional[User] = None,
     pbench_client_roles: Optional[list[str]] = None,
     valid: bool = True,
@@ -889,6 +894,7 @@ def generate_token(
         username: username to include in the token payload
         private_key: RS256 private key to encode the jwt token
         client_id: OIDC client id to include in the encoded string.
+        audience: OIDC client audience to encode
         user: user attributes will be extracted from the user object to include
             in the token payload.
         pbench_client_roles: Any OIDC client specifc roles we want to include
@@ -911,7 +917,7 @@ def generate_token(
         "iat": current_utc,
         "exp": exp,
         "sub": user.id,
-        "aud": client_id,
+        "aud": audience,
         "azp": client_id,
         "resource_access": {},
         "scope": "openid profile email",
@@ -919,7 +925,7 @@ def generate_token(
         "preferred_username": username,
     }
     if pbench_client_roles:
-        payload["resource_access"].update({client_id: {"roles": pbench_client_roles}})
+        payload["resource_access"].update({audience: {"roles": pbench_client_roles}})
     token_str = jwt.encode(payload, private_key, algorithm="RS256")
     return token_str
 

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -400,7 +400,7 @@ class TestUpload:
         assert response.json.get("message").startswith(message)
 
     def test_invalid_authorization_upload(
-        self, client, caplog, server_config, pbench_drb_token_invalid
+        self, client, server_config, pbench_drb_token_invalid
     ):
         # Upload with invalid token
         response = client.put(
@@ -408,8 +408,6 @@ class TestUpload:
             headers=self.gen_headers(pbench_drb_token_invalid, "md5sum"),
         )
         assert response.status_code == HTTPStatus.UNAUTHORIZED
-        for record in caplog.records:
-            assert record.levelname in ["DEBUG", "INFO", "WARNING"]
         assert not self.cachemanager_created
 
     def test_empty_upload(

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -111,6 +111,10 @@ realm = pbench-server
 # Client entity name requesting OIDC to authenticate a user.
 client = pbench-client
 
+# Audience we expect to find in keycloak auth tokens. This is part of the
+# Keycloak client configuration.
+audience = pbench-server
+
 # Custom CA for verifying the TLS connection to the OIDC client.
 # If omitted, TLS verification will use the system's trusted CA list.
 #tls_ca_file = /path/to/CA/file

--- a/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
+++ b/server/pbenchinacan/etc/pbench-server/pbench-server.cfg
@@ -27,6 +27,7 @@ secret-key = "pbench-in-a-can secret shhh"
 server_url = ##KEYCLOAK_SERVER_URL##
 realm = ##KEYCLOAK_REALM##
 client = ##KEYCLOAK_CLIENT##
+audience = ##KEYCLOAK_AUDIENCE##
 
 # Provide a CA cert for the pbenchinacan Keycloak server connection.
 tls_ca_file = /etc/pki/tls/certs/pbench_CA.crt

--- a/server/pbenchinacan/load_keycloak.sh
+++ b/server/pbenchinacan/load_keycloak.sh
@@ -28,6 +28,7 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-"admin"}
 # "openid" section of the pbench server configuration file.
 REALM=${KEYCLOAK_REALM:-"pbench-server"}
 CLIENT=${KEYCLOAK_CLIENT:-"pbench-client"}
+AUDIENCE=${KEYCLOAK_AUDIENCE:="pbench-server"}
 
 export CURL_CA_BUNDLE=${CURL_CA_BUNDLE:-"${PWD}/server/pbenchinacan/etc/pki/tls/certs/pbench_CA.crt"}
 
@@ -108,7 +109,7 @@ curl -si -f -X POST \
           "protocolMapper": "oidc-audience-mapper",
           "consentRequired": false,
           "config": {
-            "included.client.audience": "'"${CLIENT}"'",
+            "included.client.audience": "'"${AUDIENCE}"'",
             "id.token.claim": "false",
             "access.token.claim": "true"
           }

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -28,6 +28,7 @@ export PB_DASHBOARD_DIR="${PB_DASHBOARD_DIR:-${PWD}/dashboard/build/}"
 # the pbench-server.cfg file.
 export KEYCLOAK_REALM=${KEYCLOAK_REALM:-"pbench-server"}
 export KEYCLOAK_CLIENT=${KEYCLOAK_CLIENT:-"pbench-client"}
+export KEYCLOAK_AUDIENCE=${KEYCLOAK_AUDIENCE:-"pbench-server"}
 
 # Name or IP address to be used by the client to access the Pbench Server, to
 # load the Dashboard, and to interface with the canned Keycloak server
@@ -90,6 +91,7 @@ sed -Ei \
     -e "s|##KEYCLOAK_SERVER_URL##|https://${host_name}:8090|" \
     -e "s/##KEYCLOAK_REALM##/${KEYCLOAK_REALM}/" \
     -e "s/##KEYCLOAK_CLIENT##/${KEYCLOAK_CLIENT}/" \
+    -e "s/##KEYCLOAK_AUDIENCE##/${KEYCLOAK_AUDIENCE}/" \
     -e "s/##ADMIN_NAMES##/${PB_ADMIN_NAMES}/" \
     ${PB_DEPLOY_FILES}/pbench-server.cfg
 


### PR DESCRIPTION
PBENCH-1296

We've discovered that the configuration of our `auth.redhat.com` Keycloak client does not give us the `client` name as an id in the decoded JWT token's `aud` claim, which was causing the server to reject apparently valid tokens.

This appears to violate the OIDC specification, but for flexibility (and expediency) this PR separates the configuration of "OIDC client name" and "expected `aud` claim" so that we can accommodate either behavior without further code changes. (That is, the openid `client` and `audience` values could be identical if we know the OIDC server follows the specification.)