### PR TITLE
Report Server out of space errors via `507` instead of `413`/`500`

### DIFF
--- a/lib/pbench/server/api/__init__.py
+++ b/lib/pbench/server/api/__init__.py
@@ -4,11 +4,13 @@ Provides middleware for remote clients, either the associated Pbench Dashboard
 or any number of pbench agent users.
 """
 
+from http import HTTPStatus
 import os
 
 from flask import Flask
 from flask_cors import CORS
 from flask_restful import Api
+import werkzeug
 
 from pbench.common.exceptions import ConfigFileNotSpecified
 from pbench.common.logger import get_pbench_logger
@@ -229,5 +231,12 @@ def create_app(server_config: PbenchServerConfig) -> Flask:
         raise
 
     app.teardown_appcontext(shutdown_session)
+
+    class InsufficientStorage(werkzeug.exceptions.HTTPException):
+        code = HTTPStatus.INSUFFICIENT_STORAGE.value
+        description = HTTPStatus.INSUFFICIENT_STORAGE.phrase
+
+    # Add an entry for 507/INSUFFICIENT_STORAGE to Werkzeug's list
+    app.aborter.mapping[507] = InsufficientStorage
 
     return app

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -186,11 +186,15 @@ class IntakeBase(ApiBase):
         try:
             backup_target.parent.mkdir(exist_ok=True)
         except Exception as e:
+            if isinstance(e, OSError) and e.errno == errno.ENOSPC:
+                raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE)
             raise APIInternalError(f"Failure creating backup subdirectory: {e}")
         try:
             shutil.copy(tarball_path, backup_target)
         except Exception as e:
             IntakeBase._remove_backup(backup_target)
+            if isinstance(e, OSError) and e.errno == errno.ENOSPC:
+                raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE)
             raise APIInternalError(f"Failure backing up tarball: {e}")
         return backup_target
 

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -446,7 +446,7 @@ class IntakeBase(ApiBase):
                         dataset.name,
                         humanize.naturalsize(stream.length),
                     )
-                    raise APIAbort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Out of space")
+                    raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE, "Out of space")
                 raise APIInternalError(
                     f"Unexpected error encountered during file upload: {str(exc)!r} "
                 ) from exc
@@ -472,7 +472,7 @@ class IntakeBase(ApiBase):
                 md5_full_path.write_text(f"{intake.md5} {filename}\n")
             except OSError as exc:
                 if exc.errno == errno.ENOSPC:
-                    raise APIAbort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Out of space")
+                    raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE, "Out of space")
                 raise APIInternalError(
                     f"Unexpected error encountered during MD5 creation: {str(exc)!r}"
                 ) from exc
@@ -502,7 +502,7 @@ class IntakeBase(ApiBase):
                 ) from exc
             except OSError as exc:
                 if exc.errno == errno.ENOSPC:
-                    raise APIAbort(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Out of space")
+                    raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE, "Out of space")
                 raise APIInternalError(
                     f"Unexpected error encountered during archive: {str(exc)!r}"
                 ) from exc

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -287,11 +287,11 @@ class TestResultsPush:
             (HTTPStatus.NO_CONTENT, {"message": "No content"}, 0),
             (HTTPStatus.NO_CONTENT, "No content", 0),
             (
-                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                HTTPStatus.INSUFFICIENT_STORAGE,
                 {"message": "Request Entity Too Large"},
                 1,
             ),
-            (HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Request Entity Too Large", 1),
+            (HTTPStatus.INSUFFICIENT_STORAGE, "Request Entity Too Large", 1),
             (HTTPStatus.NOT_FOUND, {"message": "Not Found"}, 1),
             (HTTPStatus.NOT_FOUND, "Not Found", 1),
             (None, requests.exceptions.ConnectionError("Oops"), 1),

--- a/lib/pbench/test/unit/agent/task/test_results_push.py
+++ b/lib/pbench/test/unit/agent/task/test_results_push.py
@@ -25,7 +25,7 @@ class TestResultsPush:
     RELAY_SWITCH = "--relay"
     BRIEF_SWITCH = "--brief"
     SRVR_SWITCH = "--server"
-    RELAY_TEXT = "http://relay.example.com"
+    RELAY_TEXT = "https://relay.example.com"
     SRVR_TEXT = "https://pbench.test.example.com"
     URL = "https://pbench.example.com/api/v1"
 
@@ -144,7 +144,7 @@ class TestResultsPush:
         assert result.exit_code == 0
         pattern = (
             "RELAY log.tar.xz: " if not brief else ""
-        ) + r"http://relay.example.com/[a-z0-9]+\n"
+        ) + r"https://relay.example.com/[a-z0-9]+\n"
         assert re.match(pattern, result.stdout)
 
     @staticmethod

--- a/lib/pbench/test/unit/server/test_upload.py
+++ b/lib/pbench/test/unit/server/test_upload.py
@@ -290,7 +290,7 @@ class TestUpload:
     @pytest.mark.parametrize(
         "error,http_status,message",
         (
-            (errno.ENOSPC, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Out of space"),
+            (errno.ENOSPC, HTTPStatus.INSUFFICIENT_STORAGE, "Out of space"),
             (
                 errno.ENFILE,
                 HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -311,7 +311,7 @@ class TestUpload:
     ):
         """Test handling of errors from the intake stream read
 
-        The intake code reports errno.ENOSPC with 413/REQUEST_ENTITY_TOO_LARGE,
+        The intake code reports errno.ENOSPC with 507/INSUFFICIENT_STORAGE,
         but other file create errors are reported as 500/INTERNAL_SERVER_ERROR.
         """
         stream = BytesIO(b"12345")
@@ -341,7 +341,7 @@ class TestUpload:
     @pytest.mark.parametrize(
         "error,http_status,message",
         (
-            (errno.ENOSPC, HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Out of space"),
+            (errno.ENOSPC, HTTPStatus.INSUFFICIENT_STORAGE, "Out of space"),
             (
                 errno.ENFILE,
                 HTTPStatus.INTERNAL_SERVER_ERROR,
@@ -363,7 +363,7 @@ class TestUpload:
     ):
         """Test handling of errors from MD5 file creation.
 
-        The intake code reports errno.ENOSPC with 413/REQUEST_ENTITY_TOO_LARGE,
+        The intake code reports errno.ENOSPC with 507/INSUFFICIENT_STORAGE,
         but other file create errors are reported as 500/INTERNAL_SERVER_ERROR.
         """
         path: Optional[Path] = None
@@ -491,7 +491,7 @@ class TestUpload:
             (DuplicateTarball("x"), HTTPStatus.BAD_REQUEST),
             (
                 OSError(errno.ENOSPC, "The closet is too small!"),
-                HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+                HTTPStatus.INSUFFICIENT_STORAGE,
             ),
             (
                 OSError(errno.EACCES, "Can't get they-ah from he-ah"),


### PR DESCRIPTION
Previously, out-of-storage errors on the Server resulted in a `500`/`INTERNAL_ERROR` driven by a `413`/`REQUEST_ENTITY_TOO_LARGE` HTTP status.  This PR changes that to use a `507`/`INSUFFICIENT_STORAGE` status, which we report directly to the user instead of triggering an `INTERNAL_ERROR`.  This is for the initial upload as well as for the backup.

This gives the end-user a clearer picture of the nature of the failure.

PBENCH-1299