### PR TITLE
Implement typed sorting on dataset metadata

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -558,12 +558,9 @@ class DatasetsList(ApiBase):
                     # explicitly overridden.
                     sorter = order(c if defaulted_type else c.cast(cast_to))
             if sorter is None:
-                query = query.add_column(
-                    cast(aliases[native_key].value[keys].as_string(), cast_to)
-                )
-                sorter = order(
-                    cast(aliases[native_key].value[keys].as_string(), cast_to)
-                )
+                casted = cast(aliases[native_key].value[keys].as_string(), cast_to)
+                query = query.add_column(casted)
+                sorter = order(casted)
             sorters.append(sorter)
 
         # Apply our list of sort terms

--- a/lib/pbench/test/functional/server/test_datasets.py
+++ b/lib/pbench/test/functional/server/test_datasets.py
@@ -721,8 +721,8 @@ class TestList:
         last_size = None
         for d in datasets:
             s = d.metadata["dataset.metalog.run.raw_size"]
-            assert s is not None or last_size is None
             if s is None:
+                assert last_size is None, "Null value sorted after a non-null"
                 continue
             size = int(s)
             assert last_size is None or size <= last_size
@@ -747,6 +747,7 @@ class TestList:
         for d in datasets:
             s = d.metadata["dataset.metalog.run.start_run"]
             if s is None:
+                assert last_date is None, "Null value sorted after a non-null"
                 continue
             date = dateutil.parser.parse(s)
             assert last_date is None or date <= last_date

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -1050,8 +1050,8 @@ class TestDatasetsList:
                 ["uperf_4", "uperf_3", "uperf_2", "uperf_1", "test", "fio_2", "fio_1"],
             ),
             (
-                # Sort by date timestamp
-                "dataset.uploaded",
+                # Sort by date timestamp (redundantly typing as date)
+                "dataset.uploaded:asc:date",
                 ["test", "fio_1", "uperf_1", "uperf_2", "uperf_3", "uperf_4", "fio_2"],
             ),
             (
@@ -1060,17 +1060,12 @@ class TestDatasetsList:
                 ["fio_2", "uperf_4", "uperf_3", "uperf_2", "uperf_1", "fio_1", "test"],
             ),
             (
-                # Sort by a "dataset.metalog" value
-                "dataset.metalog.run.controller",
-                ["test", "fio_1", "fio_2", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
-            ),
-            (
-                # Sort by a general global metadata value in descending order
-                "global.test.sequence:desc",
+                # Sort by a global metadata value in descending order as int
+                "global.test.sequence:desc:int",
                 ["fio_1", "fio_2", "test", "uperf_1", "uperf_2", "uperf_3", "uperf_4"],
             ),
             (
-                # Sprt by a general global metadata value in ascending order
+                # Sort by a global metadata value in ascending order as string
                 "global.test.sequence",
                 ["uperf_4", "uperf_3", "uperf_2", "uperf_1", "test", "fio_2", "fio_1"],
             ),
@@ -1081,7 +1076,7 @@ class TestDatasetsList:
             ),
             (
                 # Sort two keys across distinct metadata namespaces desc/desc
-                "user.test.odd:desc,dataset.name:desc",
+                "user.test.odd:desc:bool,dataset.name:desc",
                 ["uperf_3", "uperf_1", "fio_2", "uperf_4", "uperf_2", "test", "fio_1"],
             ),
             (
@@ -1098,6 +1093,16 @@ class TestDatasetsList:
                 # Sort by a dataset owner, descending
                 "dataset.owner:desc",
                 ["test", "fio_2", "uperf_1", "uperf_2", "uperf_3", "uperf_4", "fio_1"],
+            ),
+            (
+                # Sort by stringified integer
+                "global.test.mcguffin:asc:str",
+                ["uperf_4", "uperf_2", "uperf_1", "test", "fio_2", "fio_1", "uperf_3"],
+            ),
+            (
+                # Sort by integer
+                "global.test.mcguffin:asc:int",
+                ["uperf_4", "uperf_3", "uperf_2", "uperf_1", "test", "fio_2", "fio_1"],
             ),
         ],
     )
@@ -1119,10 +1124,12 @@ class TestDatasetsList:
         # Assign "sequence numbers" in the inverse order of name
         test = User.query(username="test")
         all = Database.db_session.query(Dataset).order_by(desc(Dataset.name)).all()
+        mover = 1
         for i, d in enumerate(all):
             odd = i & 1
             Metadata.setvalue(d, "global.test.sequence", i)
-            Metadata.setvalue(d, "global.test.mcguffin", 100 - i)
+            Metadata.setvalue(d, "global.test.mcguffin", str(mover))
+            mover += 8
             Metadata.setvalue(d, "user.test.odd", odd, user=test)
         query = {"sort": sort, "metadata": ["dataset.uploaded"]}
         result = query_as(query, "test", HTTPStatus.OK)
@@ -1144,12 +1151,17 @@ class TestDatasetsList:
             (
                 # Specify a sort using bad sort order syntax
                 "dataset.name:desc:",
-                "The sort order 'desc:' for key 'dataset.name' must be 'asc' or 'desc'",
+                "The sort type must be one of bool,date,int,str",
             ),
             (
                 # Specify a sort using a bad metadata namespace
                 "xyzzy.uploaded",
                 "Metadata key 'xyzzy.uploaded' is not supported",
+            ),
+            (
+                # Specify a sort using bad sort order type
+                "dataset.name:desc:foobar",
+                "The sort type must be one of bool,date,int,str",
             ),
         ],
     )

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -1050,7 +1050,7 @@ class TestDatasetsList:
                 ["uperf_4", "uperf_3", "uperf_2", "uperf_1", "test", "fio_2", "fio_1"],
             ),
             (
-                # Sort by date timestamp (redundantly typing as date)
+                # Sort by uploaded timestamp (which is already a date)
                 "dataset.uploaded:asc:date",
                 ["test", "fio_1", "uperf_1", "uperf_2", "uperf_3", "uperf_4", "fio_2"],
             ),
@@ -1124,12 +1124,16 @@ class TestDatasetsList:
         # Assign "sequence numbers" in the inverse order of name
         test = User.query(username="test")
         all = Database.db_session.query(Dataset).order_by(desc(Dataset.name)).all()
-        mover = 1
         for i, d in enumerate(all):
             odd = i & 1
+
+            # A simple integer sequence
             Metadata.setvalue(d, "global.test.sequence", i)
-            Metadata.setvalue(d, "global.test.mcguffin", str(mover))
-            mover += 8
+
+            # A sequence that will sort differently as integer vs string
+            Metadata.setvalue(d, "global.test.mcguffin", str(i * 8 + 1))
+
+            # A simple boolean in the per-user namespace
             Metadata.setvalue(d, "user.test.odd", odd, user=test)
         query = {"sort": sort, "metadata": ["dataset.uploaded"]}
         result = query_as(query, "test", HTTPStatus.OK)


### PR DESCRIPTION
PBENCH-1297

`GET /datasets` supports sorting of the output, but SQL dislikes `order by` on a JSON field value. The solution is to cast the field `.as_string()`, but this PR goes a step further to allow sorting based on converting a field value to `int`, `float`, `bool`, or `date` as well as the default `str`: for example, `GET /datasets?sort=dataset.metalog.run.start_time:desc:date` will produce a list of datasets sorted in descending order by the recorded collection start timestamp in the Pbench Agent `metadata.log` file. (This works even if some datasets lack a `dataset.metalog.run.start_time` file: SQL will return `null` values at the beginning of the list.)