### PR TITLE
Correct URL handling for Elasticsearch/OpenSearch

### DIFF
--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -40,10 +40,8 @@ def wait_for_uri(uri: str, timeout: int):
         port = 443
     elif url.scheme == "http":
         port = 80
-    elif not url.scheme:
-        raise BadConfig("URI must include the scheme ('http://' or 'https://')")
     else:
-        raise BadConfig(f"URI contains an unrecognized scheme, {url.scheme!r}")
+        raise BadConfig(f"URI must include a scheme of 'http' or 'https'; found {url.scheme!r}")
     if url.port:
         port = url.port
 

--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -24,6 +24,7 @@ def wait_for_uri(uri: str, timeout: int):
     again.
 
     Args:
+        uri : a URL referencing the service to be waited for
         timeout : integer number of seconds to wait before giving up
                   attempts to connect to the URI
 

--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -17,6 +17,14 @@ class MetadataLog(configparser.ConfigParser):
         super().__init__(*args, **kwargs)
 
 
+# List of supported URI schemas and their default ports
+SUPPORTED_SCHEMAS = {
+    "http": 80,
+    "https": 443,
+    "postgresql": 5432,
+}
+
+
 def wait_for_uri(uri: str, timeout: int):
     """Wait for the given URI to become available.
 
@@ -36,16 +44,11 @@ def wait_for_uri(uri: str, timeout: int):
     url = urlparse(uri)
     if not url.hostname:
         raise BadConfig("URI must contain a host name")
-    if url.scheme == "https":
-        port = 443
-    elif url.scheme == "http":
-        port = 80
-    else:
+    if url.scheme not in SUPPORTED_SCHEMAS:
         raise BadConfig(
-            f"URI must include a scheme of 'http' or 'https'; found {url.scheme!r}"
+            f"URI scheme must be one of {list(SUPPORTED_SCHEMAS)}; found {url.scheme!r}"
         )
-    if url.port:
-        port = url.port
+    port = url.port if url.port else SUPPORTED_SCHEMAS[url.scheme]
 
     end = time() + timeout
     while True:

--- a/lib/pbench/common/__init__.py
+++ b/lib/pbench/common/__init__.py
@@ -41,7 +41,9 @@ def wait_for_uri(uri: str, timeout: int):
     elif url.scheme == "http":
         port = 80
     else:
-        raise BadConfig(f"URI must include a scheme of 'http' or 'https'; found {url.scheme!r}")
+        raise BadConfig(
+            f"URI must include a scheme of 'http' or 'https'; found {url.scheme!r}"
+        )
     if url.port:
         port = url.port
 

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -155,7 +155,7 @@ class UnauthorizedAdminAccess(UnauthorizedAccess):
 class SchemaError(APIAbort):
     """Generic base class for errors in processing a JSON schema."""
 
-    def __init__(self, http_status: int = HTTPStatus.BAD_REQUEST):
+    def __init__(self, http_status: int = HTTPStatus.BAD_REQUEST, **_kwargs):
         super().__init__(http_status=http_status)
 
     def __str__(self) -> str:

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -119,6 +119,7 @@ class ElasticBase(ApiBase):
         super().__init__(config, *schemas)
         self.prefix = config.get("Indexing", "index_prefix")
         self.es_url = config.get("Indexing", "uri")
+        self.ca_bundle = config.get("Indexing", "ca_bundle")
 
     @staticmethod
     def _build_elasticsearch_query(
@@ -405,7 +406,7 @@ class ElasticBase(ApiBase):
 
         try:
             # perform the Elasticsearch query
-            es_response = method(url, **es_request["kwargs"])
+            es_response = method(url, **es_request["kwargs"], verify=self.ca_bundle)
             current_app.logger.debug(
                 "ES query response {}:{}",
                 es_response.reason,
@@ -538,6 +539,7 @@ class ElasticBulkBase(ApiBase):
         api_name = self.__class__.__name__
 
         self.elastic_uri = config.get("Indexing", "uri")
+        self.ca_bundle = config.get("Indexing", "ca_bundle")
         self.config = config
 
         # Look for a parameter of type DATASET. It may be defined in any of the
@@ -827,7 +829,7 @@ class ElasticBulkBase(ApiBase):
             # indexed and we skip the Elasticsearch actions.
             if IndexMap.exists(dataset):
                 # Build an Elasticsearch instance to manage the bulk update
-                elastic = Elasticsearch(self.elastic_uri)
+                elastic = Elasticsearch(self.elastic_uri, ca_certs=self.ca_bundle)
                 doc_map = IndexMap.stream(dataset=dataset)
 
                 # NOTE: because both generate_actions and streaming_bulk return

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -107,8 +107,8 @@ def _sleep_w_backoff(backoff):
 
 
 def _get_es_hosts(config):
-    """
-    Return list of dicts (a single dict for now) - that's what ES is expecting.
+    """Return a list of strings (containing only a single string for now) which
+    are the network locations (i.e., URIs) for the configured Elasticsearch hosts.
     """
     try:
         uri = config.get("Indexing", "uri")

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -137,7 +137,8 @@ def get_es(config):
     logging.getLogger("elasticsearch1").setLevel(logging.FATAL)
 
     timeoutobj = Timeout(total=1200, connect=10, read=_read_timeout)
-    return Elasticsearch(hosts, max_retries=0, timeout=timeoutobj)
+    ca_bundle = config.get("Indexing", "ca_bundle")
+    return Elasticsearch(hosts, max_retries=0, timeout=timeoutobj, ca_certs=ca_bundle)
 
 
 # Always use "create" operations, as we also ensure each JSON document being

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -106,7 +106,7 @@ def _sleep_w_backoff(backoff):
     _sleep(_calc_backoff_sleep(backoff))
 
 
-def _get_es_hosts(config, logger):
+def _get_es_hosts(config):
     """
     Return list of dicts (a single dict for now) - that's what ES is expecting.
     """
@@ -125,12 +125,13 @@ def _get_es_hosts(config, logger):
     ]
 
 
-def get_es(config, logger):
+
+def get_es(config):
     """Return an Elasticsearch() object derived from the given configuration.
     If the configuration does not provide the necessary data, we return None
     instead.
     """
-    hosts = _get_es_hosts(config, logger)
+    hosts = _get_es_hosts(config)
     if hosts is None:
         return None
     # FIXME: we should just change these two loggers to write to a
@@ -4100,7 +4101,7 @@ class IdxContext:
         self.getuid = os.getuid
         self.TS = self.config.TS
 
-        self.es = get_es(self.config, self.logger)
+        self.es = get_es(self.config)
         self.templates = PbenchTemplates(
             self.config.LIBDIR,
             self.idx_prefix,

--- a/lib/pbench/server/report.py
+++ b/lib/pbench/server/report.py
@@ -75,7 +75,7 @@ class Report:
         else:
             if es is None:
                 try:
-                    self.es = get_es(config, self.logger)
+                    self.es = get_es(config)
                 except Exception:
                     self.logger.exception(
                         "Unexpected failure fetching" " Elasticsearch configuration"

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -1,6 +1,7 @@
 """Test wait_for_uri() module method"""
 from contextlib import contextmanager
 import socket
+from typing import Tuple
 
 import pytest
 
@@ -8,11 +9,11 @@ import pbench.common
 from pbench.common.exceptions import BadConfig
 
 
-def test_wait_for_uri_succ(monkeypatch):
-    called = [None]
+def test_wait_for_uri_success(monkeypatch):
+    called = [(("wrong_node", -1),)]
 
     @contextmanager
-    def success(*args, **kwargs):
+    def success(*args: Tuple[str, int], **_kwargs):
         called[0] = args
         yield None
 
@@ -33,7 +34,7 @@ def test_wait_for_uri_bad():
 
 
 def setup_conn_ref(monkeypatch):
-    """Setup a mock'd up environment for socket.create_connection to drive
+    """Set up a mock'd up environment for socket.create_connection to drive
     ConnectionRefusedError behaviors.
 
     The `wait_for_uri()` method invokes `socket.create_connection()`,
@@ -66,13 +67,13 @@ def setup_conn_ref(monkeypatch):
     called = []
 
     @contextmanager
-    def conn_ref(*args, **kwargs):
+    def conn_ref(*_args, **_kwargs):
         called.append(f"conn_ref [{clock[0]}]")
         if clock[0] < 3:
             raise ConnectionRefusedError()
         yield None
 
-    def sleep(*args, **kwargs):
+    def sleep(*_args, **_kwargs):
         called.append("sleep")
 
     def time() -> int:
@@ -87,7 +88,7 @@ def setup_conn_ref(monkeypatch):
     return called
 
 
-def test_wait_for_uri_conn_ref_succ(monkeypatch):
+def test_wait_for_uri_conn_ref_success(monkeypatch):
     """Verify connection attempts initially fail, but then ultimately succeed
     before the timeout period.
     """

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -11,11 +11,13 @@ from pbench.common.exceptions import BadConfig
 
 @pytest.mark.parametrize(
     ("uri", "arg0", "arg1"),
-    ("http://localhost:42", "localhost", 42),
-    ("http://host1.example.com", "host1.example.com", 80),
-    ("https://host2.example.com", "host2.example.com", 443),
-    ("https://user@host3.example.com", "host3.example.com", 443),
-    ("https://user:password@host4.example.com", "host4.example.com", 443),
+    (
+        ("http://localhost:42", "localhost", 42),
+        ("http://host1.example.com", "host1.example.com", 80),
+        ("https://host2.example.com", "host2.example.com", 443),
+        ("https://user@host3.example.com", "host3.example.com", 443),
+        ("https://user:password@host4.example.com", "host4.example.com", 443),
+    ),
 )
 def test_wait_for_uri_success(uri: str, arg0: str, arg1: int, monkeypatch):
     called = [(("wrong_node", -1),)]

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -17,6 +17,7 @@ from pbench.common.exceptions import BadConfig
         ("https://host2.example.com", "host2.example.com", 443),
         ("https://user@host3.example.com", "host3.example.com", 443),
         ("https://user:password@host4.example.com", "host4.example.com", 443),
+        ("postgresql://user:password@host5.example.com", "host5.example.com", 5432),
     ),
 )
 def test_wait_for_uri_success(uri: str, arg0: str, arg1: int, monkeypatch):
@@ -41,11 +42,11 @@ def test_wait_for_uri_bad():
 
     with pytest.raises(BadConfig) as exc:
         pbench.common.wait_for_uri("//example.com", 142)
-    assert "URI must include a scheme" in str(exc.value)
+    assert "URI scheme must be one of" in str(exc.value)
 
     with pytest.raises(BadConfig) as exc:
-        pbench.common.wait_for_uri("postgres://example.com", 142)
-    assert "URI must include a scheme" in str(exc.value)
+        pbench.common.wait_for_uri("badscheme://example.com", 142)
+    assert "URI scheme must be one of" in str(exc.value)
 
 
 def setup_conn_ref(monkeypatch):

--- a/lib/pbench/test/unit/common/test_wait_for_uri.py
+++ b/lib/pbench/test/unit/common/test_wait_for_uri.py
@@ -18,9 +18,18 @@ def test_wait_for_uri_success(monkeypatch):
         yield None
 
     monkeypatch.setattr(socket, "create_connection", success)
+
     pbench.common.wait_for_uri("http://localhost:42", 142)
     first_arg = called[0][0]
     assert first_arg[0] == "localhost" and first_arg[1] == 42, f"{called[0]!r}"
+
+    pbench.common.wait_for_uri("http://host1.example.com", 143)
+    first_arg = called[0][0]
+    assert first_arg[0] == "host1.example.com" and first_arg[1] == 80, f"{called[0]!r}"
+
+    pbench.common.wait_for_uri("https://host2.example.com", 144)
+    first_arg = called[0][0]
+    assert first_arg[0] == "host2.example.com" and first_arg[1] == 443, f"{called[0]!r}"
 
 
 def test_wait_for_uri_bad():
@@ -29,8 +38,12 @@ def test_wait_for_uri_bad():
     assert str(exc.value).endswith("host name")
 
     with pytest.raises(BadConfig) as exc:
-        pbench.common.wait_for_uri("http://example.com", 142)
-    assert str(exc.value).endswith("port number")
+        pbench.common.wait_for_uri("example.com", 142)
+    assert "URI must include the scheme" in str(exc.value)
+
+    with pytest.raises(BadConfig) as exc:
+        pbench.common.wait_for_uri("postgres://example.com", 142)
+    assert "URI contains an unrecognized scheme" in str(exc.value)
 
 
 def setup_conn_ref(monkeypatch):

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -86,6 +86,7 @@ worker_timeout = 9000
 #uri = https://indexer.example.com:9000
 wait_timeout = 120
 #index_prefix =
+ca_bundle = /etc/pki/tls/certs/ca-bundle.crt
 
 [database]
 #uri = driver://user:password@hostname/dbname


### PR DESCRIPTION
Now that we are deploying on an OpenSearch service which requires a username/password, remove assumptions around the contents of the ES URL configuration in the Server code.

- Remove the check for a port from `wait_for_uri()`; add defaulting for the port number if it is omitted.
- Rework `_get_es_hosts()` to return the whole URL instead of the decomposed dict; move the specification of the timeout value to its caller.
- Add a `ca_bundle` configuration option to the `Indexing` configuration section and pointed the default value for it to `/etc/pki/tls/certs/ca-bundle.crt`.
- Provide the `ca_bundle` value to the instantiations of the `Elasticsearch` client and to the `Requests` methods which target Elasticsearch/OpenSearch services.
- Remove the unused `logger` parameter from `get_es()` and `_get_es_hosts()`.
- Clear some lint.

PBENCH-1302