### PR TITLE
Some logging cleanup

### DIFF
--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -2043,7 +2043,9 @@ class ApiBase(Resource):
             current_app.logger.exception("{} {}", api_name, e.details)
             abort(e.http_status, message=str(e))
         except APIAbort as e:
-            current_app.logger.warning("{} {}", api_name, e)
+            current_app.logger.warning(
+                "{} client error {}: '{}'", api_name, e.http_status, e
+            )
             if auditing["finalize"]:
                 attr = auditing.get("attributes", {"message": str(e)})
                 try:

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -441,7 +441,7 @@ class ElasticBase(ApiBase):
         except requests.exceptions.InvalidURL as e:
             raise APIInternalError(f"Invalid Elasticsearch URL {url}") from e
         except Exception as e:
-            raise APIInternalError("Unexpected backend error") from e
+            raise APIInternalError(f"Unexpected backend error '{e}'") from e
 
         try:
             # postprocess Elasticsearch response
@@ -451,7 +451,7 @@ class ElasticBase(ApiBase):
             current_app.logger.error("{}", msg)
             raise APIAbort(e.status, msg)
         except Exception as e:
-            raise APIInternalError("Unexpected backend exception") from e
+            raise APIInternalError(f"Unexpected backend exception '{e}'") from e
 
     def _post(
         self, params: ApiParams, request: Request, context: ApiContext
@@ -847,7 +847,7 @@ class ElasticBulkBase(ApiBase):
                 except APIAbort:
                     raise
                 except Exception as e:
-                    raise APIInternalError("Unexpected backend error '{e}'") from e
+                    raise APIInternalError(f"Unexpected backend error '{e}'") from e
             elif context["attributes"].require_map and self.expect_index(dataset):
                 # If the dataset has no index map, the bulk operation requires one,
                 # and we expect one to appear, fail rather than risking abandoning

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -4,6 +4,7 @@ from typing import Optional
 from flask import current_app, Flask, request
 from flask_httpauth import HTTPTokenAuth
 from flask_restful import abort
+from jwt import ExpiredSignatureError
 from werkzeug.exceptions import Unauthorized
 
 from pbench.server import PbenchServerConfig
@@ -103,6 +104,9 @@ def verify_auth(auth_token: str) -> Optional[User]:
         user = verify_auth_oidc(auth_token)
     except Unauthorized:
         raise
+    except ExpiredSignatureError:
+        # This is expected periodically, and of no interest operationally
+        pass
     except Exception as e:
         current_app.logger.exception(
             "Unexpected exception occurred while verifying the auth token {!r}: {}",


### PR DESCRIPTION
PBENCH-1303

This adds an `except` clause to explicitly ignore an expired OIDC token: it was being reported with a stack trace, which is disruptive and unnecessary as it's a normal and expected periodic event. (Tokens are supposed to expire, and can be refreshed by the client.)

Also, to make it easier to attach the server's client API error `WARNING` messages to the associated NGINX messages, report the HTTP status.

We'll now see client API errors reported like this:

```
Upload client error 400: 'File extension not supported, must be .tar.xz'
```

I nearly made a similar change to the server internal error before deciding it would be redundant (and broke `caplog` fixture tests which weren't worth changing), but in tracking down the initial attempt I found some lint warnings about redeclaring `json`, corrected a weird attempt to verify a faked internal server error log message, and fixed some internal server
error f-strings.