### PR TITLE
Nits and stuff

### DIFF
--- a/lib/pbench/agent/base.py
+++ b/lib/pbench/agent/base.py
@@ -81,7 +81,7 @@ class BaseCommand(metaclass=abc.ABCMeta):
         self.date_suffix = now.strftime("%Y.%m.%dT%H.%M.%S")
 
     @abc.abstractmethod
-    def execute(self):
+    def execute(self, **kwargs):
         """
         This is the main method of the application
         """

--- a/lib/pbench/server/api/resources/__init__.py
+++ b/lib/pbench/server/api/resources/__init__.py
@@ -2091,14 +2091,14 @@ class ApiBase(Resource):
             )
         return response
 
-    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _get(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested GET operation, and handle any exceptions.
 
         ABSTRACT METHOD: override in subclass to perform operation.
 
         Args:
             args : Type-normalized client argument sets
-            request : Original incoming Request object
+            req : Original incoming Request object
             context : API context dictionary
 
         Returns:
@@ -2108,14 +2108,14 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _get method"
         )
 
-    def _head(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _head(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested HEAD operation, and handle any exceptions.
 
         ABSTRACT METHOD: override in subclass to perform operation.
 
         Args:
             args : Type-normalized client argument sets
-            request : Original incoming Request object
+            req : Original incoming Request object
             context : API context dictionary
 
         Returns:
@@ -2125,14 +2125,14 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _head method"
         )
 
-    def _post(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _post(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested POST operation, and handle any exceptions.
 
         ABSTRACT METHOD: override in subclass to perform operation.
 
         Args:
             args : Type-normalized client argument sets
-            request : Original incoming Request object
+            req : Original incoming Request object
             context : API context dictionary
 
         Returns:
@@ -2142,14 +2142,14 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _post method"
         )
 
-    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _put(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested PUT operation, and handle any exceptions.
 
         ABSTRACT METHOD: override in subclass to perform operation.
 
         Args:
             args : Type-normalized client argument sets
-            request : Original incoming Request object
+            req : Original incoming Request object
             context : API context dictionary
 
         Returns:
@@ -2159,16 +2159,14 @@ class ApiBase(Resource):
             f"Class {self.__class__.__name__} doesn't override abstract _put method"
         )
 
-    def _delete(
-        self, args: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _delete(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested DELETE operation, and handle any exceptions.
 
         ABSTRACT METHOD: override in subclass to perform operation.
 
         Args:
             args : Type-normalized client argument sets
-            request : Original incoming Request object
+            req : Original incoming Request object
             context : API context dictionary
 
         Returns:

--- a/lib/pbench/server/api/resources/api_key.py
+++ b/lib/pbench/server/api/resources/api_key.py
@@ -56,9 +56,7 @@ class APIKeyManage(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Get a list of API keys associated with the user.
 
         GET /api/v1/key
@@ -89,9 +87,7 @@ class APIKeyManage(ApiBase):
                 raise APIAbort(HTTPStatus.NOT_FOUND, "Requested key not found")
             return key[0].as_json()
 
-    def _post(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _post(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Post request for generating a new persistent API key.
 
@@ -138,9 +134,7 @@ class APIKeyManage(ApiBase):
         response.status_code = status
         return response
 
-    def _delete(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _delete(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Delete the requested key.
 
         DELETE /api/v1/key/{key}

--- a/lib/pbench/server/api/resources/datasets_compare.py
+++ b/lib/pbench/server/api/resources/datasets_compare.py
@@ -77,15 +77,13 @@ class DatasetsCompare(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         This function is using Quisby to compare results into a form that supports visualization
 
         Args:
             params: includes the uri parameters, which provide the list of dataset.
-            request: Original incoming Request object
+            req: Original incoming Request object
             context: API context dictionary
 
         Raises:

--- a/lib/pbench/server/api/resources/datasets_contents.py
+++ b/lib/pbench/server/api/resources/datasets_contents.py
@@ -48,15 +48,13 @@ class DatasetsContents(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Returns metadata about the target file path within a tarball.
 
         Args:
             params: includes the uri parameters, which provide the dataset and target.
-            request: Original incoming Request object
+            req: Original incoming Request object
             context: API context dictionary
 
         Raises:
@@ -79,7 +77,7 @@ class DatasetsContents(ApiBase):
 
         prefix = current_app.server_config.rest_uri
         origin = (
-            f"{self._get_uri_base(request).host}{prefix}/datasets/{dataset.resource_id}"
+            f"{self._get_uri_base(req).host}{prefix}/datasets/{dataset.resource_id}"
         )
 
         details: CacheObject = info["details"]

--- a/lib/pbench/server/api/resources/datasets_inventory.py
+++ b/lib/pbench/server/api/resources/datasets_inventory.py
@@ -45,9 +45,7 @@ class DatasetsInventory(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Request the contents of a results file.
 
         This function examines a "target" path within the results tarball of a
@@ -59,7 +57,7 @@ class DatasetsInventory(ApiBase):
 
         Args:
             params: includes the uri parameters, which provide the dataset and target.
-            request: Original incoming Request object
+            req: Original incoming Request object
             context: API context dictionary
 
         Raises:
@@ -79,7 +77,7 @@ class DatasetsInventory(ApiBase):
         if file_info["type"] is CacheType.DIRECTORY:
             prefix = current_app.server_config.rest_uri
             uri = (
-                f"{self._get_uri_base(request).host}{prefix}/datasets/"
+                f"{self._get_uri_base(req).host}{prefix}/datasets/"
                 f"{dataset.resource_id}/contents/"
             )
             uri += target if target else ""

--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -598,9 +598,7 @@ class DatasetsList(ApiBase):
         paginated_result["results"] = response
         return paginated_result
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Get a list of datasets matching a set of criteria.
 
         GET /api/v1/datasets/list?start=1970-01-01&end=2040-12-31&owner=fred&metadata=dashboard.seen,server.deletion
@@ -610,7 +608,7 @@ class DatasetsList(ApiBase):
 
         Args:
             params : API parameters
-            request : The original Request object
+            req : The original Request object
             context : API context dictionary
 
         Returns:
@@ -719,5 +717,5 @@ class DatasetsList(ApiBase):
             result.update(self.daterange(query))
             done = True
         if not done:
-            result = self.datasets(request, aliases, json, context["raw_params"], query)
+            result = self.datasets(req, aliases, json, context["raw_params"], query)
         return jsonify(result)

--- a/lib/pbench/server/api/resources/datasets_metadata.py
+++ b/lib/pbench/server/api/resources/datasets_metadata.py
@@ -74,15 +74,13 @@ class DatasetsMetadata(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Get the values of client-accessible dataset metadata keys.
 
         Args:
             params: API parameters
-            request: The original Request object containing query parameters
+            req: The original Request object containing query parameters
             context: API context dictionary
 
         GET /api/v1/datasets/metadata?name=dname&metadata=global.seen,server.deletion
@@ -98,15 +96,13 @@ class DatasetsMetadata(ApiBase):
 
         return jsonify(metadata)
 
-    def _put(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _put(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Set or modify the values of client-accessible dataset metadata keys.
 
         Args:
             params: API parameters
-            request: The original Request object containing query parameters
+            req: The original Request object containing query parameters
             context: API context dictionary
 
         PUT /api/v1/datasets/metadata

--- a/lib/pbench/server/api/resources/datasets_visualize.py
+++ b/lib/pbench/server/api/resources/datasets_visualize.py
@@ -41,15 +41,13 @@ class DatasetsVisualize(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         This function is using Quisby to process results into a form that supports visualization
 
         Args:
             params: includes the uri parameters, which provide the dataset.
-            request: Original incoming Request object
+            req: Original incoming Request object
             context: API context dictionary
 
         Raises:

--- a/lib/pbench/server/api/resources/endpoint_configure.py
+++ b/lib/pbench/server/api/resources/endpoint_configure.py
@@ -47,7 +47,7 @@ class EndpointConfig(ApiBase):
         super().__init__(config, ApiSchema(ApiMethod.GET, OperationCode.READ))
         self.server_config = config
 
-    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _get(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Return server configuration information required by web clients
         including the Pbench dashboard UI. This includes:
@@ -79,7 +79,7 @@ class EndpointConfig(ApiBase):
 
             template.replace('{target_username}', 'value')
         """
-        origin = self._get_uri_base(request)
+        origin = self._get_uri_base(req)
         current_app.logger.info(
             "Advertising endpoints at {} relative to {} ({})",
             origin.host,

--- a/lib/pbench/server/api/resources/query_apis/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/__init__.py
@@ -455,7 +455,7 @@ class ElasticBase(ApiBase):
         except Exception as e:
             raise APIInternalError(f"Unexpected backend exception '{e}'") from e
 
-    def _post(self, params: ApiParams, request: Request, context: ApiContext) -> JSON:
+    def _post(self, params: ApiParams, req: Request, context: ApiContext) -> JSON:
         """Handle a Pbench server POST operation involving Elasticsearch
 
         The assembly and post-processing of the Elasticsearch query are
@@ -465,13 +465,13 @@ class ElasticBase(ApiBase):
 
         Args:
             params: The API HTTP method parameters
-            request: The flask Request object containing payload and headers
+            req: The flask Request object containing payload and headers
             context: The API context dictionary
         """
-        context["request"] = request
+        context["request"] = req
         return self._call(requests.post, params, context)
 
-    def _get(self, params: ApiParams, request: Request, context: ApiContext) -> JSON:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> JSON:
         """Handle a GET operation involving a call to Elasticsearch
 
         The post-processing of the Elasticsearch query is handled by the
@@ -479,10 +479,10 @@ class ElasticBase(ApiBase):
 
         Args:
             params: The API HTTP method parameters
-            request: The flask Request object containing payload and headers
+            req: The flask Request object containing payload and headers
             context: The API context dictionary
         """
-        context["request"] = request
+        context["request"] = req
         return self._call(requests.get, params, context)
 
 
@@ -725,9 +725,7 @@ class ElasticBulkBase(ApiBase):
             report[status][index] += 1
         return BulkResults(errors=errors, count=count, report=report)
 
-    def _post(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _post(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested POST operation, and handle any exceptions.
 
         This is called by the ApiBase post() method through its dispatch
@@ -740,18 +738,16 @@ class ElasticBulkBase(ApiBase):
 
         Args:
             params: Type-normalized client parameters
-            request: Original incoming Request object (not used)
+            req: Original incoming Request object (not used)
             context: API context
 
         Returns:
             Response to return to client
         """
 
-        return self._bulk_dispatch(params, request, context)
+        return self._bulk_dispatch(params, req, context)
 
-    def _delete(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _delete(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """Perform the requested DELETE operation, and handle any exceptions.
 
         This is called by the ApiBase delete() method through its dispatch
@@ -764,13 +760,13 @@ class ElasticBulkBase(ApiBase):
 
         Args:
             params: Type-normalized client parameters
-            request: Original incoming Request object (not used)
+            req: Original incoming Request object (not used)
             context: API context
 
         Returns:
             Response to return to client
         """
-        return self._bulk_dispatch(params, request, context)
+        return self._bulk_dispatch(params, req, context)
 
     def _bulk_dispatch(
         self, params: ApiParams, _request: Request, context: ApiContext

--- a/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/datasets_mappings.py
@@ -83,9 +83,7 @@ class DatasetsMappings(ApiBase):
             ),
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Return mapping properties of the document specified by the dataset view
         specified in the URI parameter (supported dataset views are defined in

--- a/lib/pbench/server/api/resources/relay.py
+++ b/lib/pbench/server/api/resources/relay.py
@@ -185,6 +185,6 @@ class Relay(IntakeBase):
             if not errors:
                 notes.append("Relay files were successfully removed.")
 
-    def _post(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _post(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Launch the Relay operation from an HTTP POST"""
-        return self._intake(args, request, context)
+        return self._intake(args, req, context)

--- a/lib/pbench/server/api/resources/server_audit.py
+++ b/lib/pbench/server/api/resources/server_audit.py
@@ -55,9 +55,7 @@ class ServerAudit(ApiBase):
             always_enabled=True,
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Retrieve audit trail records. Each operation that affects a resource
         (create, update, delete) generates two audit records, a BEGIN and
@@ -76,7 +74,7 @@ class ServerAudit(ApiBase):
 
         Args:
             params: API parameters
-            request: The original Request object containing query parameters
+            req: The original Request object containing query parameters
             context: API context dictionary
 
         Returns:

--- a/lib/pbench/server/api/resources/server_settings.py
+++ b/lib/pbench/server/api/resources/server_settings.py
@@ -71,9 +71,7 @@ class ServerSettings(ApiBase):
             always_enabled=True,
         )
 
-    def _get(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _get(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Get the values of server settings.
 
@@ -87,7 +85,7 @@ class ServerSettings(ApiBase):
 
         Args:
             params: API parameters
-            request: The original Request object containing query parameters
+            req: The original Request object containing query parameters
             context: API context dictionary
 
         Returns:
@@ -205,9 +203,7 @@ class ServerSettings(ApiBase):
             raise APIAbort(HTTPStatus.BAD_REQUEST, message=", ".join(failures))
         return jsonify(response)
 
-    def _put(
-        self, params: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _put(self, params: ApiParams, req: Request, context: ApiContext) -> Response:
         """
         Set or modify the values of server setting keys.
 
@@ -226,7 +222,7 @@ class ServerSettings(ApiBase):
 
         Args:
             params: API parameters
-            request: The original Request object containing query parameters
+            req: The original Request object containing query parameters
             context: API context dictionary
 
         Returns:

--- a/lib/pbench/server/api/resources/upload.py
+++ b/lib/pbench/server/api/resources/upload.py
@@ -114,6 +114,6 @@ class Upload(IntakeBase):
             raise APIAbort(HTTPStatus.LENGTH_REQUIRED, msg)
         return Access(content_length, request.stream)
 
-    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _put(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         """Launch the upload operation from an HTTP PUT"""
-        return self._intake(args, request, context)
+        return self._intake(args, req, context)

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -14,7 +14,7 @@ from pbench.server.database.models.users import Roles, User, UserDuplicate
 
 # Module public
 token_auth = HTTPTokenAuth("Bearer")
-oidc_client: OpenIDClient = None
+oidc_client: Optional[OpenIDClient] = None
 
 
 def setup_app(app: Flask, server_config: PbenchServerConfig):
@@ -28,6 +28,7 @@ def setup_app(app: Flask, server_config: PbenchServerConfig):
     verification if the configuration is provided.
 
     Args:
+        app : the Flask application object
         server_config : Parsed Pbench server configuration
     """
     app.secret_key = server_config.get("flask-app", "secret-key")

--- a/lib/pbench/server/auth/auth.py
+++ b/lib/pbench/server/auth/auth.py
@@ -128,7 +128,7 @@ def verify_auth_api_key(api_key: str) -> Optional[User]:
 
     """
     key = APIKey.query(key=api_key)
-    return key[0].user if key and len(key) == 1 else None
+    return key[0].user if key else None
 
 
 def verify_auth_oidc(auth_token: str) -> Optional[User]:

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -908,9 +908,9 @@ class ResultData(PbenchData):
             except Exception as e:
                 self.logger.warning(
                     "result-data-indexing: encountered invalid JSON file,"
-                    " {}: {str(e)!r} ({})",
+                    " {}: {!r} ({})",
                     result_json,
-                    e,
+                    str(e),
                     self.ptb._tbctx,
                 )
                 self.counters["not_valid_json_file"] += 1
@@ -920,8 +920,8 @@ class ResultData(PbenchData):
             # to see if that is true.
             if not isinstance(results, list):
                 self.logger.warning(
-                    "result-data-indexing: encountered unexpected"
-                    " JSON file format, {} ({})",
+                    "result-data-indexing: encountered unexpected JSON file format,"
+                    " {} ({})",
                     result_json,
                     self.ptb._tbctx,
                 )

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -908,7 +908,7 @@ class ResultData(PbenchData):
             except Exception as e:
                 self.logger.warning(
                     "result-data-indexing: encountered invalid JSON file,"
-                    " {}: {str(e)!s} ({})",
+                    " {}: {str(e)!r} ({})",
                     result_json,
                     e,
                     self.ptb._tbctx,
@@ -2216,7 +2216,7 @@ class ToolData(PbenchData):
         for csvf in self.files:
             assert (
                 csvf["header"][0] == "timestamp_ms"
-            ), f"Unexpected time stamp header, \"{csvf['header'][0]}\""
+            ), f"Unexpected time stamp header, '{csvf['header'][0]}'"
             header = csvf["header"]
             handler_rec = csvf["handler_rec"]
             klass = handler_rec["class"]

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -188,11 +188,9 @@ class PbenchData:
     """
 
     def __init__(self, ptb):
-        self.year, self.month, self.day = (
-            "{:04d}".format(ptb.start_run_ts.year),
-            "{:02d}".format(ptb.start_run_ts.month),
-            "{:02d}".format(ptb.start_run_ts.day),
-        )
+        self.year = f"{ptb.start_run_ts.year:04d}"
+        self.month = f"{ptb.start_run_ts.month:02d}"
+        self.day = f"{ptb.start_run_ts.day:02d}"
         self.ptb = ptb
         self.logger = ptb.idxctx.logger
         self.idxctx = ptb.idxctx
@@ -240,8 +238,8 @@ class PbenchData:
         except Exception as e:
             self.counters["ts_not_epoch_millis_float"] += 1
             raise BadDate(
-                "{!r} is not a float in milliseconds since the"
-                " epoch: {}".format(orig_ts, e)
+                "{!r} is not a float in milliseconds since the epoch: "
+                "{}".format(orig_ts, e)
             )
         ts_float = orig_ts_float / 1000
         try:
@@ -249,8 +247,8 @@ class PbenchData:
         except Exception as e:
             self.counters["ts_not_epoch_float"] += 1
             raise BadDate(
-                "{:f} ({!r}) is not a proper float in seconds since"
-                " the epoch: {}".format(ts_float, orig_ts, e)
+                "{:f} ({!r}) is not a proper float in seconds since the epoch: "
+                "{}".format(ts_float, orig_ts, e)
             )
         if ts < self.ptb.start_run_ts:
             # The calculated timestamp, `ts`, is earlier that the timestamp of
@@ -278,25 +276,25 @@ class PbenchData:
             except Exception as e:
                 self.counters["ts_calc_not_epoch_millis_float"] += 1
                 raise BadDate(
-                    "{:f} ({!r}) is not a proper float in"
-                    " milliseconds since the epoch: {}".format(
-                        orig_ts_float, orig_ts, e
-                    )
+                    "{:f} ({!r}) is not a proper float in milliseconds since the epoch:"
+                    " {}".format(orig_ts_float, orig_ts, e)
                 )
             newts = self.ptb.start_run_ts + d
             if newts > self.ptb.end_run_ts:
                 self.counters["ts_before_start_run_ts"] += 1
                 raise BadDate(
-                    "{} ({!r}) is before the start of the"
-                    " run ({})".format(ts, orig_ts, self.ptb.start_run_ts)
+                    "{} ({!r}) is before the start of the run ({})".format(
+                        ts, orig_ts, self.ptb.start_run_ts
+                    )
                 )
             else:
                 ts = newts
         elif ts > self.ptb.end_run_ts:
             self.counters["ts_after_end_run_ts"] += 1
             raise BadDate(
-                "{} ({!r}) is after the end of the"
-                " run ({})".format(ts, orig_ts, self.ptb.end_run_ts)
+                "{} ({!r}) is after the end of the run ({})".format(
+                    ts, orig_ts, self.ptb.end_run_ts
+                )
             )
         return ts.strftime(_STD_DATETIME_FMT)
 
@@ -1381,15 +1379,11 @@ class ResultData(PbenchData):
                             orig_ts = res["date"]
                             del res["date"]
                             ts = cvt_ts(orig_ts)
-                            if prev_ts is not None:
-                                assert (
-                                    prev_ts <= ts
-                                ), "prev_ts (%r, %r) > ts (%r, %r)" % (
-                                    prev_ts,
-                                    prev_orig_ts,
-                                    ts,
-                                    orig_ts,
-                                )
+                            assert (
+                                prev_ts is None or prev_ts <= ts
+                            ), "prev_ts ({!r}, {!r}) > ts ({!r}, {!r})".format(
+                                prev_ts, prev_orig_ts, ts, orig_ts
+                            )
                             prev_orig_ts = orig_ts
                             prev_ts = ts
                             # Now we can emit the actual timeseries value
@@ -1823,7 +1817,7 @@ class ToolData(PbenchData):
         self.idxctx.opctx.append(
             _dict_const(
                 tbname=ptb.tbname,
-                object="ToolData-%s-%s-%s-%s" % (iteration, sample, host, tool),
+                object=f"ToolData-{iteration}-{sample}-{host}-{tool}",
                 counters=self.counters,
             )
         )
@@ -2152,15 +2146,11 @@ class ToolData(PbenchData):
             # to a floating point value in seconds, and then formatted as a
             # string.
             ts_val = self.mk_abs_timestamp_millis(first)
-            if prev_ts_val is not None:
-                assert (
-                    prev_ts_val <= ts_val
-                ), "prev_ts_val (%r, %r) > first (%r, %r)" % (
-                    prev_ts_val,
-                    prev_first,
-                    ts_val,
-                    first,
-                )
+            assert (
+                prev_ts_val is None or prev_ts_val <= ts_val
+            ), "prev_ts_val ({!r}, {!r}) > first ({!r}, {!r})".format(
+                prev_ts_val, prev_first, ts_val, first
+            )
             prev_first = first
             prev_ts_val = ts_val
             datum = _dict_const()
@@ -2230,7 +2220,7 @@ class ToolData(PbenchData):
         for csvf in self.files:
             assert (
                 csvf["header"][0] == "timestamp_ms"
-            ), "Unexpected time stamp header, '{}'".format(csvf["header"][0])
+            ), f"Unexpected time stamp header, \"{csvf['header'][0]}\""
             header = csvf["header"]
             handler_rec = csvf["handler_rec"]
             klass = handler_rec["class"]
@@ -2267,15 +2257,11 @@ class ToolData(PbenchData):
                     # The timestamp column is index zero.
                     if col == 0:
                         ts_val = self.mk_abs_timestamp_millis(val)
-                        if prev_ts_val is not None:
-                            assert (
-                                prev_ts_val <= ts_val
-                            ), "prev_ts_val (%r, %r) > ts_val (%r, %r)" % (
-                                prev_ts_val,
-                                prev_val,
-                                ts_val,
-                                val,
-                            )
+                        assert (
+                            prev_ts_val is None or prev_ts_val <= ts_val
+                        ), "prev_ts_val ({!r}, {!r}) > first ({!r}, {!r})".format(
+                            prev_ts_val, prev_val, ts_val, val
+                        )
                         prev_val = val
                         prev_ts_val = ts_val
                         datum = _dict_const()
@@ -2400,11 +2386,9 @@ class ToolData(PbenchData):
                 # *seconds* since the epoch, and then convert to millis
                 # since the epoch.
                 ts_orig = float(line.split(":")[1])
-                if prev_ts_orig is not None:
-                    assert prev_ts_orig <= ts_orig, "prev_ts_orig %r > ts_orig %r" % (
-                        prev_ts_orig,
-                        ts_orig,
-                    )
+                assert (
+                    prev_ts_orig is None or prev_ts_orig <= ts_orig
+                ), f"prev_ts_orig {prev_ts_orig!r} > ts_orig {ts_orig!r}"
                 ts_str = self.mk_abs_timestamp_millis(ts_orig * 1000)
                 record = _dict_const()
                 record["@timestamp"] = ts_str
@@ -2494,11 +2478,9 @@ class ToolData(PbenchData):
                 # *seconds* since the epoch, and then convert to millis
                 # since the epoch.
                 ts_orig = float(line.split(":")[1])
-                if prev_ts_orig is not None:
-                    assert prev_ts_orig <= ts_orig, "prev_ts_orig %r > ts_orig %r" % (
-                        prev_ts_orig,
-                        ts_orig,
-                    )
+                assert (
+                    prev_ts_orig is None or prev_ts_orig <= ts_orig
+                ), f"prev_ts_orig {prev_ts_orig!r} > ts_orig {ts_orig!r}"
                 ts_str = self.mk_abs_timestamp_millis(ts_orig * 1000)
                 # The next line is assumed to be the header, so instead of
                 # looping to get to it, we just pull it out and process it
@@ -2851,7 +2833,7 @@ class ToolData(PbenchData):
                 handler, basepath, toolsgroup, tool, ptb
             )
         else:
-            raise Exception("Logic error! %s" % (handler["@prospectus"]["handling"]))
+            raise Exception(f"Logic error! {handler['@prospectus']['handling']}")
         datafiles.sort(key=itemgetter("path", "basename"))
         return datafiles
 
@@ -3245,7 +3227,7 @@ class PbenchTarBall:
         #
         # ... while we are at it, we verify we have a metadata.log file in the
         # tar ball before we start extracting.
-        metadata_log_path = "%s/metadata.log" % (self.dirname)
+        metadata_log_path = self.dirname + "/metadata.log"
         metadata_log_found = False
         self.members = self.tb.getmembers()
         for m in self.members:
@@ -4044,7 +4026,7 @@ class PbenchTarBall:
             assert doc_type in (
                 "sample",
                 "res",
-            ), "Invalid result data document type, {}".format(doc_type)
+            ), f"Invalid result data document type, {doc_type}"
             idx = "result-data" if doc_type == "res" else "result-data-sample"
             try:
                 idx_name = rd.generate_index_name(idx, source)

--- a/lib/pbench/test/unit/server/query_apis/conftest.py
+++ b/lib/pbench/test/unit/server/query_apis/conftest.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import pytest
 import requests
@@ -34,7 +34,7 @@ def query_api(client, server_config, provide_metadata):
         payload: Dict[str, Any],
         expected_index: str,
         expected_status: str,
-        headers: dict = {},
+        headers: Optional[dict] = None,
         request_method=ApiMethod.POST,
         query_params: JSON = None,
         **kwargs,
@@ -66,7 +66,7 @@ def query_api(client, server_config, provide_metadata):
                 rsp.add(es_method, es_url, **kwargs)
             response = client_method(
                 f"{server_config.rest_uri}{pbench_uri}",
-                headers=headers,
+                headers=headers if headers else {},
                 json=payload,
                 query_string=query_params,
             )

--- a/lib/pbench/test/unit/server/test_api_base.py
+++ b/lib/pbench/test/unit/server/test_api_base.py
@@ -20,7 +20,7 @@ class OnlyGet(ApiBase):
     def __init__(self, server_config):
         super().__init__(server_config, ApiSchema(ApiMethod.GET, OperationCode.READ))
 
-    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> str:
+    def _get(self, args: ApiParams, req: Request, context: ApiContext) -> str:
         return "OK - Only GET"
 
 
@@ -32,7 +32,7 @@ class Always(ApiBase):
             always_enabled=True,
         )
 
-    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _get(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - Always GET"
 
 
@@ -47,21 +47,19 @@ class All(ApiBase):
             ApiSchema(ApiMethod.DELETE, OperationCode.DELETE),
         )
 
-    def _get(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _get(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - All GET"
 
-    def _head(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _head(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - All HEAD"
 
-    def _post(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _post(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - All POST"
 
-    def _put(self, args: ApiParams, request: Request, context: ApiContext) -> Response:
+    def _put(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - All PUT"
 
-    def _delete(
-        self, args: ApiParams, request: Request, context: ApiContext
-    ) -> Response:
+    def _delete(self, args: ApiParams, req: Request, context: ApiContext) -> Response:
         return "OK - All DELETE"
 
 

--- a/server/lib/config/pbench-server-default.cfg
+++ b/server/lib/config/pbench-server-default.cfg
@@ -94,7 +94,7 @@ wait_timeout = 120
 
 [flask-app]
 # Secret key for use by the Pbench Server API Flask sub-system for security
-# related tasks.
+# related tasks, e.g., generating API keys.
 #secret-key = <replace with a secret>
 
 [openid]


### PR DESCRIPTION
This is the latest round of nits and stuff that I've accumulated.  It is broken into separate commits to make it easier to review.

- Most of the changes are picking lint:
  - in particular renaming variables to avoid using keywords or shadowing variables and other names already defined in an outer scope (particularly `request`, throughout the `ApiBase` hierarchy)
  - converting methods to `@staticmethod` where appropriate
  - adding variable initializations to quiet use-before-initialization warnings
  - fixing typos, missing comments, etc.
- Some small code-quality and comment improvements
- Replacing Python V2-style string interpolation with V3 "f-strings" or `str.format()` calls; rewrapping certain long strings at more logical break-points
- Fixing a couple of logging statements in the indexer which result in errors due to their formatting