### PR TITLE
Add support for UBI 8 base image to Pbench Server container image build

### DIFF
--- a/server/pbenchinacan/container-build.sh
+++ b/server/pbenchinacan/container-build.sh
@@ -52,6 +52,9 @@ buildah run $container dnf update -y
 if [[ "${BASE_IMAGE}" == *"ubi9:"* || "${BASE_IMAGE}" == *"centos:stream9" ]]; then
     buildah run $container dnf install -y --nodocs \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+elif [[ "${BASE_IMAGE}" == *"ubi8:"* || "${BASE_IMAGE}" == *"centos:stream8" ]]; then
+    buildah run $container dnf install -y --nodocs \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 fi
 buildah run $container dnf install -y --nodocs \
     /tmp/pbench-server.rpm less nginx openssl rsyslog rsyslog-mmjsonparse

--- a/server/rpm/pbench-server.spec.j2
+++ b/server/rpm/pbench-server.spec.j2
@@ -8,7 +8,7 @@ URL:            http://github.com/distributed-systems-analysis/pbench
 Source0:        pbench-server-%{version}.tar.gz
 Buildarch:      noarch
 
-Requires: python3 python3-devel tar xz util-linux-core hostname
+Requires: python3 python3-devel tar xz hostname
 
 # policycoreutils for semanage and restorecon
 Requires:       policycoreutils


### PR DESCRIPTION
During a side trip trying to get the Pbench 1.0 Server deployed on RHEL 8.9, we tried to build the Server container image on a UBI 8 base instead of the usual UBI 9 one and ran into troubles.  This PR makes the build work.

It turns out that -8 uses a different version of EPEL from what -9 uses, so this changes the `container-build.sh` script to add the necessary logic to support that.

Also, we tumbled to the fact that the Server no longer depends on `util-linux-core` (which we couldn't locate easily in the -8 EPEL), so this change removes that dependency from the RPM spec file.

For the record, this change received only the lightest testing:  it passes the CI but mostly because the changes are unused in normal operation.  If someone actually tries to use a UBI 8-based Server, they will run into problems because the version of SSL is too old to produce the TLS certificates in the conventional way and the version of Python is 3.6 which is too old to run the Server code.