### PR TITLE
Handle missing Opensearch indices

### DIFF
--- a/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
+++ b/lib/pbench/server/api/resources/query_apis/datasets/__init__.py
@@ -121,6 +121,7 @@ class IndexMapBase(ElasticBase):
 
         Raises:
             APIAbort(CONFLICT) if indexing was disabled on the target dataset.
+            APIAbort(NOT_FOUND) if the dataset has no matching index data
 
         Returns:
             A string that joins all selected indices with ",", suitable for use
@@ -133,7 +134,13 @@ class IndexMapBase(ElasticBase):
         if Metadata.getvalue(dataset, Metadata.SERVER_ARCHIVE):
             raise APIAbort(HTTPStatus.CONFLICT, "Dataset indexing was disabled")
 
-        index_keys = IndexMap.indices(dataset, root_index_name)
+        index_keys = list(IndexMap.indices(dataset, root_index_name))
+
+        if not index_keys:
+            raise APIAbort(
+                HTTPStatus.NOT_FOUND, f"Dataset has no {root_index_name!r} data"
+            )
+
         indices = ",".join(index_keys)
         return indices
 

--- a/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
+++ b/lib/pbench/test/unit/server/query_apis/test_namespace_and_rows.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 
 import pytest
 
-from pbench.server.api.resources import ApiMethod
+from pbench.server.api.resources import APIAbort, ApiMethod
 from pbench.server.api.resources.query_apis.datasets.namespace_and_rows import (
     SampleNamespace,
     SampleValues,
@@ -774,7 +774,8 @@ class TestSampleValues(Commons):
 
         # The "test" dataset has no index map initially; verify that we get
         # no indices.
-        assert self.cls_obj.get_index(test, "result-data-sample") == ""
+        with pytest.raises(APIAbort, match="Dataset has no 'result-data-sample' data"):
+            self.cls_obj.get_index(test, "result-data-sample")
 
         # Add an index that doesn't have the desired root name, and verify that
         # we still don't find a match.
@@ -786,7 +787,8 @@ class TestSampleValues(Commons):
                 }
             },
         )
-        assert self.cls_obj.get_index(test, "result-data-sample") == ""
+        with pytest.raises(APIAbort, match="Dataset has no 'result-data-sample' data"):
+            self.cls_obj.get_index(test, "result-data-sample")
 
         # Add an index with the expected root, and verify that we get the one
         # matching index name.


### PR DESCRIPTION
PBENCH-1308

An Opensearch-based query like `/api/v1/datasets/{dataset}/values/iterations` requires that the `{dataset}` have at least one `result-data-sample` indexed document. However it doesn't actually check that this is true. This leads to an Opensearch query with a bad URL fragment causing an Opensearch error we report as an internal server error.

This change detects early that the dataset has no indices for the required index root name, and fails with a meaningful message.