### PR TITLE
Clean up

### DIFF
--- a/lib/pbench/server/api/resources/datasets_list.py
+++ b/lib/pbench/server/api/resources/datasets_list.py
@@ -5,7 +5,7 @@ from urllib.parse import urlencode, urlparse
 from flask import current_app
 from flask.json import jsonify
 from flask.wrappers import Request, Response
-from sqlalchemy import and_, asc, Boolean, cast, desc, func, Integer, or_, String
+from sqlalchemy import and_, asc, BigInteger, Boolean, cast, desc, func, or_, String
 from sqlalchemy.exc import ProgrammingError, StatementError
 from sqlalchemy.orm import aliased, Query
 from sqlalchemy.sql.expression import Alias, BinaryExpression, ColumnElement
@@ -45,7 +45,7 @@ from pbench.server.database.models.users import User
 TYPES = {
     "bool": Type(Boolean, convert_boolean),
     "date": Type(TZDateTime, convert_date),
-    "int": Type(Integer, convert_int),
+    "int": Type(BigInteger, convert_int),
     "str": Type(String, convert_string),
 }
 

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -909,16 +909,16 @@ class Tarball:
         if not self.dataset:
             return 0
 
-        size = Metadata.getvalue(self.dataset, Metadata.SERVER_UNPACKED)
-        self.logger.info("SIZE unpacked = {}", size)
+        source = Metadata.SERVER_UNPACKED
+        size = Metadata.getvalue(self.dataset, source)
         if not size:
             try:
-                size = int(
-                    Metadata.getvalue(self.dataset, "dataset.metalog.run.raw_size")
-                )
-                self.logger.info("SIZE metalog = {}", size)
+                source = "dataset.metalog.run.raw_size"
+                size = int(Metadata.getvalue(self.dataset, source))
             except (ValueError, TypeError):
+                source = None
                 size = 0
+        self.logger.info("{} unpacked size (from {}) = {}", self.name, source, size)
         self.unpacked_size = size
         return size
 
@@ -1009,6 +1009,7 @@ class Tarball:
                 if process.returncode == 0:
                     size = int(process.stdout.split("\t", maxsplit=1)[0])
                     self.unpacked_size = size
+                    self.logger.info("actual unpacked {} size = {}", self.name, size)
                     Metadata.setvalue(self.dataset, Metadata.SERVER_UNPACKED, size)
             except Exception as e:
                 self.logger.warning("usage check failed: {}", e)

--- a/lib/pbench/test/unit/server/test_datasets_list.py
+++ b/lib/pbench/test/unit/server/test_datasets_list.py
@@ -608,19 +608,19 @@ class TestDatasetsList:
             ),
             (
                 ["global.something.integer:<1:int"],
-                "CAST(dataset_metadata_3.value[['something', 'integer']] AS INTEGER) < 1",
+                "CAST(dataset_metadata_3.value[['something', 'integer']] AS BIGINT) < 1",
             ),
             (
                 ["global.something.integer:>2:int"],
-                "CAST(dataset_metadata_3.value[['something', 'integer']] AS INTEGER) > 2",
+                "CAST(dataset_metadata_3.value[['something', 'integer']] AS BIGINT) > 2",
             ),
             (
                 ["global.something.integer:<=1:int"],
-                "CAST(dataset_metadata_3.value[['something', 'integer']] AS INTEGER) <= 1",
+                "CAST(dataset_metadata_3.value[['something', 'integer']] AS BIGINT) <= 1",
             ),
             (
                 ["global.something.integer:>=2:int"],
-                "CAST(dataset_metadata_3.value[['something', 'integer']] AS INTEGER) >= 2",
+                "CAST(dataset_metadata_3.value[['something', 'integer']] AS BIGINT) >= 2",
             ),
             (
                 ["global.something.boolean:t:bool"],


### PR DESCRIPTION
This combines a few issues: first, I've wanted to filter based on the unpacked tarball size, but some tarballs are beyond the range of the SQL `INTEGER` type and cause SQL cast errors -- change the interpretation of the `int` filter and sort type to `BigInteger`. Also cleans up the logging around retried Sync transaction errors, only logging warnings when it can't determine that the error is a PostgreSQL serialization error. (I hope: this is hard to provoke in casual testing.) Finally, clean up the logging of cached unpacked size by avoiding two separate logs (without dataset name) on unpack, and adding a log of the final unpacked size when we compute it.