### PR TITLE
End time column update

### DIFF
--- a/dashboard/src/modules/components/OverviewComponent/NewRunsComponent.jsx
+++ b/dashboard/src/modules/components/OverviewComponent/NewRunsComponent.jsx
@@ -64,7 +64,7 @@ const NewRunsComponent = () => {
   );
   const columnNames = {
     result: "Result",
-    endtime: "Endtime",
+    endtime: "Scheduled for deletion on",
   };
 
   /* Selecting */

--- a/dashboard/src/modules/components/OverviewComponent/NewRunsComponent.jsx
+++ b/dashboard/src/modules/components/OverviewComponent/NewRunsComponent.jsx
@@ -64,7 +64,7 @@ const NewRunsComponent = () => {
   );
   const columnNames = {
     result: "Result",
-    endtime: "Scheduled for deletion on",
+    endtime: "Expiration Date",
   };
 
   /* Selecting */

--- a/dashboard/src/modules/components/OverviewComponent/common-component.jsx
+++ b/dashboard/src/modules/components/OverviewComponent/common-component.jsx
@@ -295,7 +295,7 @@ export const NewRunsRow = (props) => {
             onDateSelect={props.onDateSelect}
           />
         ) : (
-          formatDateTime(item.metadata.server.deletion)
+          item.metadata.server.deletion
         )}
       </Td>
       <Td
@@ -373,7 +373,7 @@ export const SavedRunsRow = (props) => {
             onDateSelect={props.onDateSelect}
           />
         ) : (
-          formatDateTime(item.metadata.server.deletion)
+          item.metadata.server.deletion
         )}
       </Td>
       <Td className="access">{item.metadata.dataset.access}</Td>


### PR DESCRIPTION
PBENCH-1307

End time column update

Server deletion date is obtained as string in the format `YYYY-MM-DD` from the response, removed the formatting.

Edit feature is available for Server deletion column so it would be better to maintain the column. 