### PR TITLE
Operations cleanup

### DIFF
--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -1441,17 +1441,20 @@ class CacheManager:
         if not tarfile_path.is_file():
             raise BadFilename(tarfile_path)
         name = Dataset.stem(tarfile_path)
-        controller_name = ""
+        controller_name = None
         try:
             metadata = Tarball._get_metadata(tarfile_path)
             controller_name = metadata["run"]["controller"]
         except Exception as exc:
             self.logger.warning(
-                "{} has no controller ({!r}): assuming {!r}", name, exc, controller_name
+                "{} metadata.log is missing run.controller: {!r}", name, exc
             )
 
         if not controller_name:
             controller_name = "unknown"
+            self.logger.warning(
+                "{} has no controller name, assuming {!r}", name, controller_name
+            )
 
         if name in self.tarballs:
             raise DuplicateTarball(name)

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -1422,6 +1422,9 @@ class CacheManager:
         controller directory. The controller directory will be created if
         necessary.
 
+        Datasets without an identifiable controller will be assigned to
+        "unknown".
+
         Args:
             tarfile_path: dataset tarball path
 
@@ -1435,20 +1438,21 @@ class CacheManager:
         Returns
             Tarball object
         """
-        try:
-            metadata = Tarball._get_metadata(tarfile_path)
-            if metadata:
-                controller_name = metadata["run"]["controller"]
-            else:
-                controller_name = "unknown"
-        except Exception as exc:
-            raise MetadataError(tarfile_path, exc)
-
-        if not controller_name:
-            raise MetadataError(tarfile_path, ValueError("no controller value"))
         if not tarfile_path.is_file():
             raise BadFilename(tarfile_path)
         name = Dataset.stem(tarfile_path)
+        controller_name = ""
+        try:
+            metadata = Tarball._get_metadata(tarfile_path)
+            controller_name = metadata["run"]["controller"]
+        except Exception as exc:
+            self.logger.warning(
+                "{} has no controller ({!r}): assuming {!r}", name, exc, controller_name
+            )
+
+        if not controller_name:
+            controller_name = "unknown"
+
         if name in self.tarballs:
             raise DuplicateTarball(name)
         if controller_name in self.controllers:

--- a/lib/pbench/server/indexing_tarballs.py
+++ b/lib/pbench/server/indexing_tarballs.py
@@ -95,6 +95,8 @@ class Index:
     was a bash script.
     """
 
+    BATCH_SIZE = 100  # Number of READY datasets to grab at once
+
     error_code = Errors(
         ErrorCode("OK", 0, None, "Successful completion"),
         ErrorCode("OP_ERROR", 1, False, "Operational error while indexing"),
@@ -176,7 +178,7 @@ class Index:
         idxctx = self.idxctx
         error_code = self.error_code
         try:
-            for dataset in self.sync.next():
+            for dataset in self.sync.next(count=self.BATCH_SIZE):
                 tb = Metadata.getvalue(dataset, Metadata.TARBALL_PATH)
                 if not tb:
                     self.sync.error(dataset, "Dataset does not have a tarball-path")

--- a/lib/pbench/server/sync.py
+++ b/lib/pbench/server/sync.py
@@ -41,7 +41,7 @@ class Sync:
     def __str__(self) -> str:
         return f"<Synchronizer for component {self.component.name!r}>"
 
-    def next(self) -> list[Dataset]:
+    def next(self, count: Optional[int] = None) -> list[Dataset]:
         """
         This is a specialized query to return a list of datasets with the READY
         OperationState for the Sync component.
@@ -59,6 +59,9 @@ class Sync:
         transporting only the resource IDs across the barrier and fetching
         new proxy objects using the general session.
 
+        Args:
+            count: Limit the number of returned matches
+
         Returns:
             A list of Dataset objects which have an associated
             Operation object in READY state.
@@ -71,6 +74,8 @@ class Sync:
                     Operation.state == OperationState.READY,
                 )
                 query = query.order_by(Dataset.resource_id)
+                if count:
+                    query = query.limit(count)
                 Database.dump_query(query, self.logger)
                 id_list = [d.resource_id for d in query.all()]
             return [Dataset.query(resource_id=i) for i in id_list]

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -189,16 +189,13 @@ class TestCacheManager:
     ):
         """Test behavior with metadata.log access errors."""
 
-        def fake_metadata(_tar_path):
-            return metadata
-
         # fetching metadata from metadata.log file and key/value not
         # being there should result in assuming an "unknown" controller
         source_tarball, source_md5, md5 = tarball
         cm = CacheManager(server_config, make_logger)
 
         with monkeypatch.context() as m:
-            m.setattr(Tarball, "_get_metadata", fake_metadata)
+            m.setattr(Tarball, "_get_metadata", lambda p: metadata)
             tarball = cm.create(source_tarball)
             assert tarball.controller_name == "unknown"
 

--- a/lib/pbench/test/unit/server/test_indexing_tarballs.py
+++ b/lib/pbench/test/unit/server/test_indexing_tarballs.py
@@ -248,7 +248,7 @@ class FakeSync:
         self.logger = logger
         self.component = component
 
-    def next(self) -> List[Dataset]:
+    def next(self, count: Optional[int] = None) -> List[Dataset]:
         __class__.called.append(f"next-{self.component.name}")
         assert self.component in __class__.tarballs
         return __class__.tarballs[self.component]


### PR DESCRIPTION
This addresses several issues encountered while monitoring the migration of tarballs from the passthrough server backup directories to the new production server.

First, I've seen `PUT /upload` problems more frequently than anticipated, and when transferring thousands of tarballs the error details get easily hidden: I've improved the way they're captured and reported at the end. Also, having observed many of the NGINX `html` format response messages, I decided to try scraping the text for the `<title>` tag text, which seems to contain the real error message, using BeautifulSoup.

Second, I ran into a set of tarballs from 2020 which seem to have `metadata.log` files which don't contain `run.controller` values. These, it turns out, fall into a hole in intake processing. Without a `metadata.log` at all, we just ignore the problem and use a default "controller" of `unknown`, but if the specific value is missing we fail the upload entirely with a poorly worded error message. It makes more sense to treat a missing `run.controller` the same way as a missing `metadata.log`.

Third, I've seen indexing failures on large "batches" (trying to index thousands of datasets in one run of the indexer) blowing up with memory problems that don't reproduce. Although it's not obvious from glancing through the main indexer loop, it seems likely there's a memory leak somewhere that's gradually building up. Since I can't find it (and I'm on vacation, so I didn't look excessively hard), I took another approach I'd considered earlier anyway and rejiggered the `Sync.update` to allow adding a SQL `LIMIT` to the query for `READY` datasets. This shouldn't have much impact on throughput as the indexer is serial and restarts every minute if it's not already/still busy, but it may keep the memory buildup below the danger threshold.

Only the migration utility changes have actually been tested "live", but the tests run.