### PR TITLE
Minor logging cleanup

### DIFF
--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -2,7 +2,6 @@ import datetime
 
 import click
 import humanfriendly
-import humanize
 
 from pbench.cli import pass_cli_context
 from pbench.cli.server import config_setup
@@ -90,12 +89,7 @@ def tree_manage(
         if reclaim_percent or reclaim_size:
             target_size = humanfriendly.parse_size(reclaim_size) if reclaim_size else 0
             target_pct = reclaim_percent if reclaim_percent else 20.0
-            click.echo(
-                f"Reclaiming {target_pct}% or {humanize.naturalsize(target_size)}"
-            )
             outcome = cache_m.reclaim_cache(goal_pct=target_pct, goal_bytes=target_size)
-            un = "" if outcome else "un"
-            click.echo(f"The cache manager was {un}able to free the requested space")
             rv = 0 if outcome else 1
     except Exception as exc:
         if logger:

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -1651,11 +1651,11 @@ class CacheManager:
         goal_check = reached_goal()
         free_pct = goal_check.usage.free * 100.0 / goal_check.usage.total
         self.logger.info(
-            "RECLAIM (goal {}%, {}) {}: {} datasets, "
+            "RECLAIM {} (goal {}%, {}): {} datasets, "
             "{} had cache: {} reclaimed and {} errors: {:.1f}% free",
+            "achieved" if goal_check.reached else "partial",
             goal_pct,
             humanize.naturalsize(goal_bytes),
-            "achieved" if goal_check.reached else "failed",
             total_count,
             has_cache,
             reclaimed,

--- a/lib/pbench/server/indexer.py
+++ b/lib/pbench/server/indexer.py
@@ -637,7 +637,7 @@ class ResultData(PbenchData):
                     # The csv_reader encountered the end-of-file on the first
                     # iteration (i.e., the file was empty), so skip it.
                     self.ptb.idxctx.logger.warning(
-                        "CSV file {csv_name!r} is empty ({self.ptb._tbctx})"
+                        "CSV file {!r} is empty ({})", csv_name, self.ptb._tbctx
                     )
                     continue
                 except OSError as exc:


### PR DESCRIPTION
Minimize cache logging: details were useful when cache management first went in, but are now disruptive during ops review.