### PR TITLE
Move nginx cache into /srv/pbench

### DIFF
--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -117,6 +117,7 @@ http {
             proxy_buffers            512 4k;
             proxy_request_buffering  on;
             proxy_http_version       1.1;
+            proxy_temp_path          /srv/pbench/nginx 1 2;
 
             proxy_set_header         Host              $http_host;
             proxy_set_header         X-Forwarded-For   $proxy_add_x_forwarded_for;

--- a/server/lib/config/nginx.conf
+++ b/server/lib/config/nginx.conf
@@ -117,13 +117,13 @@ http {
             proxy_buffers            512 4k;
             proxy_request_buffering  on;
             proxy_http_version       1.1;
-            proxy_temp_path          /srv/pbench/nginx 1 2;
 
             proxy_set_header         Host              $http_host;
             proxy_set_header         X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header         X-Real-IP         $remote_addr;
             proxy_set_header         X-Forwarded-Proto $scheme;
 
+            client_body_temp_path    /srv/pbench/nginx 1 2;
             client_max_body_size     100G;
         }
 

--- a/server/pbenchinacan/run-pbench-in-a-can
+++ b/server/pbenchinacan/run-pbench-in-a-can
@@ -99,10 +99,11 @@ sed -Ei \
 podman unshare rm -rf ${SRV_PBENCH}/*
 mkdir -p -m 0755  \
     ${SRV_PBENCH}/archive/fs-version-001 \
-    ${SRV_PBENCH}/public_html/dashboard \
-    ${SRV_PBENCH}/tmp \
     ${SRV_PBENCH}/backup \
-    ${SRV_PBENCH}/cache
+    ${SRV_PBENCH}/cache \
+    ${SRV_PBENCH}/nginx \
+    ${SRV_PBENCH}/public_html/dashboard \
+    ${SRV_PBENCH}/tmp
 
 # Set up the static fallback pages for Nginx.
 #


### PR DESCRIPTION
PBENCH-1316

Our deployed containerized server maps `/var/lib` (the default NGINX cache location) to `/home`, which has only 26Gb free. Instead, map NGINX cache to our large Pbench volume at `/srv/pbench/nginx` in order to be able to transfer larger datasets.