### PR TITLE
Protect the cache lock better

### DIFF
--- a/lib/pbench/server/api/resources/datasets_compare.py
+++ b/lib/pbench/server/api/resources/datasets_compare.py
@@ -20,7 +20,7 @@ from pbench.server.api.resources import (
     ParamType,
     Schema,
 )
-from pbench.server.cache_manager import CacheManager
+from pbench.server.cache_manager import CacheManager, CacheManagerError
 from pbench.server.database.models.datasets import Dataset, Metadata
 
 
@@ -128,21 +128,27 @@ class DatasetsCompare(ApiBase):
         stream_file = {}
         for dataset in datasets:
             try:
-                info = cache_m.get_inventory(dataset.resource_id, "result.csv")
-                file = info["stream"].read().decode("utf-8")
-                info["stream"].close()
+                file = cache_m.get_inventory_bytes(dataset.resource_id, "result.csv")
+            except CacheManagerError as e:
+                raise APIAbort(
+                    HTTPStatus.BAD_REQUEST,
+                    "unable to extract postprocessed data from {dataset.name}",
+                ) from e
             except Exception as e:
                 raise APIInternalError(
-                    f"{dataset.name} is missing 'result.csv' file"
+                    f"Unexpected error extracting postprocessed data from {dataset.name}"
                 ) from e
             stream_file[dataset.name] = file
 
-        quisby_response = QuisbyProcessing().compare_csv_to_json(
-            benchmark_type, InputType.STREAM, stream_file
-        )
-        if quisby_response["status"] != "success":
-            raise APIInternalError(
-                f"Quisby processing failure. Exception: {quisby_response['exception']}"
+        try:
+            quisby_response = QuisbyProcessing().compare_csv_to_json(
+                benchmark_type, InputType.STREAM, stream_file
             )
-        quisby_response["benchmark"] = benchmark
-        return jsonify(quisby_response)
+            if quisby_response["status"] != "success":
+                raise APIInternalError(
+                    f"Comparison processing failure. Exception: {quisby_response['exception']}"
+                )
+            quisby_response["benchmark"] = benchmark
+            return jsonify(quisby_response)
+        except Exception as e:
+            raise APIInternalError(f"Comparison failed with {str(e)!r}")

--- a/lib/pbench/server/api/resources/datasets_compare.py
+++ b/lib/pbench/server/api/resources/datasets_compare.py
@@ -96,6 +96,7 @@ class DatasetsCompare(ApiBase):
 
         datasets = params.query.get("datasets")
         benchmark_choice = None
+        benchmark = None
         for dataset in datasets:
 
             # Check that the user is authorized to read each dataset
@@ -144,11 +145,12 @@ class DatasetsCompare(ApiBase):
             quisby_response = QuisbyProcessing().compare_csv_to_json(
                 benchmark_type, InputType.STREAM, stream_file
             )
-            if quisby_response["status"] != "success":
-                raise APIInternalError(
-                    f"Comparison processing failure. Exception: {quisby_response['exception']}"
-                )
-            quisby_response["benchmark"] = benchmark
-            return jsonify(quisby_response)
         except Exception as e:
             raise APIInternalError(f"Comparison failed with {str(e)!r}")
+
+        if quisby_response["status"] != "success":
+            raise APIInternalError(
+                f"Comparison processing failure. Exception: {quisby_response['exception']}"
+            )
+        quisby_response["benchmark"] = benchmark
+        return jsonify(quisby_response)

--- a/lib/pbench/server/api/resources/datasets_visualize.py
+++ b/lib/pbench/server/api/resources/datasets_visualize.py
@@ -81,12 +81,12 @@ class DatasetsVisualize(ApiBase):
             quisby_response = QuisbyProcessing().extract_data(
                 benchmark_type, dataset.name, InputType.STREAM, file
             )
-
-            if quisby_response["status"] != "success":
-                raise APIInternalError(
-                    f"Visualization processing failure. Exception: {quisby_response['exception']}"
-                )
-            quisby_response["benchmark"] = benchmark
-            return jsonify(quisby_response)
         except Exception as e:
             raise APIInternalError(f"Visualization failed with {str(e)!r}")
+
+        if quisby_response["status"] != "success":
+            raise APIInternalError(
+                f"Visualization processing failure. Exception: {quisby_response['exception']}"
+            )
+        quisby_response["benchmark"] = benchmark
+        return jsonify(quisby_response)

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -56,6 +56,15 @@ class CacheExtractBadPath(CacheManagerError):
         self.path = str(path)
 
 
+class CacheExtractError(CacheManagerError):
+    """Unable to read a cached file"""
+
+    def __init__(self, dataset: str, target: str):
+        super().__init__(f"Unable to read {target} from {dataset}")
+        self.dataset = dataset
+        self.target = target
+
+
 class TarballNotFound(CacheManagerError):
     """The dataset was not found in the ARCHIVE tree."""
 
@@ -1507,6 +1516,16 @@ class CacheManager:
         """
         tarball = self.find_dataset(dataset_id)
         return tarball.get_inventory(target)
+
+    def get_inventory_bytes(self, dataset_id: str, target: str) -> str:
+        tarball = self.find_dataset(dataset_id)
+        info = tarball.get_inventory(target)
+        try:
+            return info["stream"].read().decode("utf-8")
+        except Exception as e:
+            raise CacheExtractError(tarball.name, target) from e
+        finally:
+            info["stream"].close()
 
     def delete(self, dataset_id: str):
         """Delete the dataset as well as unpacked artifacts.

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -60,7 +60,7 @@ class CacheExtractError(CacheManagerError):
     """Unable to read a cached file"""
 
     def __init__(self, dataset: str, target: str):
-        super().__init__(f"Unable to read {target} from {dataset}")
+        super().__init__(f"Unable to read {target!r} from {dataset}")
         self.dataset = dataset
         self.target = target
 

--- a/lib/pbench/test/unit/server/test_datasets_inventory.py
+++ b/lib/pbench/test/unit/server/test_datasets_inventory.py
@@ -159,33 +159,37 @@ class TestDatasetsAccess:
         assert args["download_name"] == "f1.json"
         assert mock_close
 
-    def test_send_fail(self, query_get_as, monkeypatch):
-        mock_close = False
+    @pytest.mark.parametrize("stream", (io.BytesIO(b"file_as_a_byte_stream"), None))
+    def test_send_fail(self, query_get_as, monkeypatch, stream):
+        """Test handling of stream when send_file fails.
+
+        (Note that while the mocking when "stream" is None doesn't really do
+        much, we gain coverage of both `if stream` paths.)
+        """
+        mock_closed = False
 
         def mock_close(*_args):
-            nonlocal mock_close
-            mock_close = True
-
-        exp_stream = io.BytesIO(b"file_as_a_byte_stream")
+            nonlocal mock_closed
+            mock_closed = True
 
         def mock_get_inventory(_s, _d: str, _t: str):
             return {
                 "name": "f1.json",
                 "type": CacheType.FILE,
-                "stream": Inventory(exp_stream),
+                "stream": Inventory(stream) if stream else None,
             }
 
         def mock_send_file(path_or_file, *args, **kwargs):
             raise Exception("I'm failing to succeed")
 
-        monkeypatch.setattr(exp_stream, "close", mock_close)
+        monkeypatch.setattr(Inventory, "close", mock_close)
         monkeypatch.setattr(CacheManager, "get_inventory", mock_get_inventory)
         monkeypatch.setattr(
             "pbench.server.api.resources.datasets_inventory.send_file", mock_send_file
         )
 
         query_get_as("fio_2", "f1.json", HTTPStatus.INTERNAL_SERVER_ERROR)
-        assert mock_close
+        assert mock_closed is bool(stream)
 
     def test_get_inventory(self, query_get_as, monkeypatch):
         exp_stream = io.BytesIO(b"file_as_a_byte_stream")


### PR DESCRIPTION
PBENCH-1317

We found a case where a cache lock could "leak" when an error occurs reading a file in the visualize and compare APIs. The file read has now been repackaged with a `finally` to be sure the stream is closed and unlocked on error.