### PR TITLE
Make `contents` API scale

### DIFF
--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -486,7 +486,7 @@ def report(
 
     try:
         config = config_setup(context)
-        logger = get_pbench_logger("report-generator", config)
+        logger = get_pbench_logger("pbench-report-generator", config)
         if any((all, archive, backup, cache)):
             cache_m = CacheManager(config, logger)
             verifier.status("starting discovery")

--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -491,7 +491,7 @@ def report(
             cache_m = CacheManager(config, logger)
             verifier.status("starting discovery")
             watcher.update("discovering cache")
-            cache_m.full_discovery(full=False)
+            cache_m.full_discovery(search=False)
             watcher.update("processing reports")
             verifier.status("finished discovery")
             if all or archive:

--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -491,7 +491,7 @@ def report(
             cache_m = CacheManager(config, logger)
             verifier.status("starting discovery")
             watcher.update("discovering cache")
-            cache_m.full_discovery()
+            cache_m.full_discovery(full=False)
             watcher.update("processing reports")
             verifier.status("finished discovery")
             if all or archive:

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -80,7 +80,7 @@ def tree_manage(
     logger = None
     try:
         config = config_setup(context)
-        logger = get_pbench_logger("cachemanager", config)
+        logger = get_pbench_logger("pbench-tree-manager", config)
         cache_m = CacheManager(config, logger)
         cache_m.full_discovery()
         if display:

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -815,12 +815,10 @@ class Tarball:
             artifact: Path = self.get_results(lock) / path
             try:
                 # NOTE: os.path.abspath() removes ".." but Path.absolute(),
-                # which means the latter allows a query with path "..", and
-                # we don't want to allow reaching outside of the tarball.
+                # doesn't, meaning the latter allows a query with path "..",
+                # and we don't want to allow reaching outside of the tarball.
                 arel = Path(os.path.abspath(artifact)).relative_to(self.unpacked)
-                self.logger.info("RELATIVE {} -> {}", artifact, arel)
-            except Exception as e:
-                self.logger.error("{} got {}", artifact, e)
+            except Exception:
                 raise CacheExtractError(self.name, path)
             if artifact.is_dir() and not artifact.is_symlink():
                 dir_list = []
@@ -832,8 +830,7 @@ class Tarball:
                         target = f.resolve()
                         try:
                             link = target.relative_to(self.unpacked)
-                        except Exception as e:
-                            self.logger.info("{} is unrelated: {}", target, e)
+                        except Exception:
                             link = f.readlink()
                             uri = f"{origin}/inventory/{relative}"
                             type = CacheType.BROKEN

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -1657,6 +1657,13 @@ class TestCacheManager:
             "uri": f"{root}/contents/",
         }
 
+        assert cm.get_contents(md5, "subdir", root) == {
+            "name": "subdir",
+            "type": "DIRECTORY",
+            "directories": [],
+            "files": [],
+            "uri": f"{root}/contents/subdir",
+        }
         assert cm.get_contents(md5, "dir_link", root) == {
             "name": "dir_link",
             "type": "SYMLINK",
@@ -1685,6 +1692,11 @@ class TestCacheManager:
             "uri": f"{root}/inventory/fifo_link",
             "link": "fifo",
             "link_type": "OTHER",
+        }
+        assert cm.get_contents(md5, "fifo", root) == {
+            "name": "fifo",
+            "type": "OTHER",
+            "uri": f"{root}/inventory/fifo",
         }
 
     def test_find(

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -1577,6 +1577,16 @@ class TestCacheManager:
             ],
         }
 
+        assert cm.get_contents(md5, "metadata.log", root) == {
+            "name": "metadata.log",
+            "type": "FILE",
+            "uri": f"{root}/inventory/metadata.log",
+            "size": 28,
+        }
+
+        with pytest.raises(CacheExtractError):
+            cm.get_contents(md5, "../..", root)
+
         # Now that we have an unpacked directory, manually "enhance" it to test
         # more paths.
 
@@ -1645,6 +1655,36 @@ class TestCacheManager:
                 },
             ],
             "uri": f"{root}/contents/",
+        }
+
+        assert cm.get_contents(md5, "dir_link", root) == {
+            "name": "dir_link",
+            "type": "SYMLINK",
+            "uri": f"{root}/contents/subdir",
+            "link": "subdir",
+            "link_type": "DIRECTORY",
+        }
+        assert cm.get_contents(md5, "file_link", root) == {
+            "name": "file_link",
+            "type": "SYMLINK",
+            "uri": f"{root}/inventory/metadata.log",
+            "link": "metadata.log",
+            "link_type": "FILE",
+            "size": 28,
+        }
+        assert cm.get_contents(md5, "bad_link", root) == {
+            "name": "bad_link",
+            "type": "SYMLINK",
+            "uri": f"{root}/inventory/bad_link",
+            "link": "/etc/passwd",
+            "link_type": "BROKEN",
+        }
+        assert cm.get_contents(md5, "fifo_link", root) == {
+            "name": "fifo_link",
+            "type": "SYMLINK",
+            "uri": f"{root}/inventory/fifo_link",
+            "link": "fifo",
+            "link_type": "OTHER",
         }
 
     def test_find(

--- a/lib/pbench/test/unit/server/test_cache_manager.py
+++ b/lib/pbench/test/unit/server/test_cache_manager.py
@@ -2016,7 +2016,7 @@ class TestCacheManager:
         ds = Dataset(name=name, resource_id=md5, owner=drb, access="public")
         ds.add()
         Metadata.setvalue(ds, Metadata.TARBALL_PATH, path)
-        cm2 = CacheManager(server_config, make_logger).full_discovery(full=False)
+        cm2 = CacheManager(server_config, make_logger).full_discovery(search=False)
         assert cm2[md5].name == name
 
     def test_lockref(self, monkeypatch):

--- a/lib/pbench/test/unit/server/test_datasets_contents.py
+++ b/lib/pbench/test/unit/server/test_datasets_contents.py
@@ -63,6 +63,23 @@ class TestDatasetsContents:
             "message": "User drb is not authorized to READ a resource owned by test with private access"
         }
 
+    def test_contents_error(self, monkeypatch, query_get_as):
+        """This fails with an internal error from get_contents"""
+
+        def mock_contents(_s, _d, _p, _o):
+            raise Exception("Nobody expected me")
+
+        monkeypatch.setattr(CacheManager, "get_contents", mock_contents)
+        query_get_as("drb", "metadata.log", HTTPStatus.INTERNAL_SERVER_ERROR)
+
+    def test_jsonify_error(self, monkeypatch, query_get_as):
+        """This fails with an internal error from jsonifying bad data"""
+
+        monkeypatch.setattr(
+            CacheManager, "get_contents", lambda _s, _d, _p, _o: {1: 0, Path("."): "a"}
+        )
+        query_get_as("drb", "metadata.log", HTTPStatus.INTERNAL_SERVER_ERROR)
+
     @pytest.mark.parametrize("key", ("", ".", "subdir1"))
     def test_path_is_directory(self, query_get_as, monkeypatch, key):
         """Mock a directory cache node to check that data is passed through"""


### PR DESCRIPTION
PBENCH-1321

The `/datasets/{id}/contents` API includes into several unexpectedly expensive steps:

1. Finding the tarball (by MD5 value) within the `ARCHIVE` tree using a `glob`
2. Fully discovering all tarballs within the controller directory
3. Unpacking the tarball into a cache directory using `tar`
4. Building a "map" of the contents of the unpacked tarball subtree

This PR includes mitigations for all but the `tar` unpack step:

1. Use the `server.tarball-path` metadata instead of searching the disk
2. Only discover the target tarball rather than the entire controller
3. Skip the "map" and evaluate the actual target path within the cache

Finding a tarball within our 30Tb `ARCHIVE` tree can take many minutes, while identifying the controller directory from the tarball path takes a fraction of a second.

Depending on the number of tarballs within a controller (some have many), full controller discovery has been observed to take half a minute; while populating only the target tarball takes a fraction of a second.

Building the map for a large tarball tree can take minutes, whereas discovery of the actual relative file path within the cache runs at native (Python) file system speeds.