### PR TITLE
Track and report unpack performance

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -1,5 +1,127 @@
+import datetime
+from threading import Thread
+import time
+
+import click
+
 from pbench.server import PbenchServerConfig
 from pbench.server.database import init_db
+
+
+class Detail:
+    """Encapsulate generation of additional diagnostics"""
+
+    def __init__(self, detail: bool = False, errors: bool = False):
+        """Initialize the object.
+
+        Args:
+            detail: True if detailed messages should be generated
+            errors: True if individual file errors should be reported
+        """
+        self.detail = detail
+        self.errors = errors
+
+    def __bool__(self) -> bool:
+        """Report whether detailed messages are enabled
+
+        Returns:
+            True if details are enabled
+        """
+        return self.detail
+
+    def error(self, message: str):
+        """Write a message if details are enabled.
+
+        Args:
+            message: Detail string
+        """
+        if self.errors:
+            click.secho(f"|| {message}", fg="red")
+
+    def message(self, message: str):
+        """Write a message if details are enabled.
+
+        Args:
+            message: Detail string
+        """
+        if self.detail:
+            click.echo(f"|| {message}")
+
+
+class Verify:
+    """Encapsulate -v status messages."""
+
+    def __init__(self, verify: bool):
+        """Initialize the object.
+
+        Args:
+            verify: True to write status messages.
+        """
+        self.verify = verify
+
+    def __bool__(self) -> bool:
+        """Report whether verification is enabled.
+
+        Returns:
+            True if verification is enabled.
+        """
+        return self.verify
+
+    def status(self, message: str):
+        """Write a message if verification is enabled.
+
+        Args:
+            message: status string
+        """
+        if self.verify:
+            ts = datetime.datetime.now().astimezone()
+            click.secho(f"({ts:%H:%M:%S}) {message}", fg="green")
+
+
+class Watch:
+    """Encapsulate a periodic status update.
+
+    The active message can be updated at will; a background thread will
+    periodically print the most recent status.
+    """
+
+    def __init__(self, interval: float):
+        """Initialize the object.
+
+        Args:
+            interval: interval in seconds for status updates
+        """
+        self.start = time.time()
+        self.interval = interval
+        self.status = "starting"
+        if interval:
+            self.thread = Thread(target=self.watcher)
+            self.thread.setDaemon(True)
+            self.thread.start()
+
+    def update(self, status: str):
+        """Update status if appropriate.
+
+        Update the message to be printed at the next interval, if progress
+        reporting is enabled.
+
+        Args:
+            status: status string
+        """
+        self.status = status
+
+    def watcher(self):
+        """A worker thread to periodically write status messages."""
+
+        while True:
+            time.sleep(self.interval)
+            now = time.time()
+            delta = int(now - self.start)
+            hours, remainder = divmod(delta, 3600)
+            minutes, seconds = divmod(remainder, 60)
+            click.secho(
+                f"[{hours:02d}:{minutes:02d}:{seconds:02d}] {self.status}", fg="cyan"
+            )
 
 
 def config_setup(context: object) -> PbenchServerConfig:

--- a/lib/pbench/cli/server/options.py
+++ b/lib/pbench/cli/server/options.py
@@ -22,13 +22,15 @@ def _pbench_server_config(f: Callable) -> Callable:
 
     def callback(ctx, param, value):
         clictx = ctx.ensure_object(CliContext)
-        clictx.config = value
+        clictx.config = (
+            value if value else "/opt/pbench-server/lib/config/pbench-server.cfg"
+        )
         return value
 
     return click.option(
         "-C",
         "--config",
-        required=True,
+        required=False,
         envvar="_PBENCH_SERVER_CONFIG",
         type=click.Path(exists=True, readable=True),
         callback=callback,

--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -235,12 +235,12 @@ def report_cache(tree: CacheManager):
             unpacked_count += 1
             unpacked_times += metrics["count"]
             speedcomp.add(dsname, metrics["min"], metrics["max"])
-        if size and metrics:
-            stream_fast = size / metrics["min"] / MEGABYTE_FP
-            stream_slow = size / metrics["max"] / MEGABYTE_FP
-            streamcomp.add(dsname, stream_slow, stream_fast)
-        else:
-            stream_unpack_skipped += 1
+            if size:
+                stream_fast = size / metrics["min"] / MEGABYTE_FP
+                stream_slow = size / metrics["max"] / MEGABYTE_FP
+                streamcomp.add(dsname, stream_slow, stream_fast)
+            else:
+                stream_unpack_skipped += 1
     oldest = datetime.datetime.fromtimestamp(agecomp.min, datetime.timezone.utc)
     newest = datetime.datetime.fromtimestamp(agecomp.max, datetime.timezone.utc)
     click.echo("Cache report:")

--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -39,7 +39,7 @@ class Comparator:
         self.name = name
         self.min = really_big
         self.min_name = None
-        self.max = 0
+        self.max = -really_big
         self.max_name = None
 
     def add(
@@ -49,11 +49,11 @@ class Comparator:
         max: Optional[Union[int, float]] = None,
     ):
         minv = value
-        maxv = max if max else value
+        maxv = max if max is not None else value
         if minv < self.min:
             self.min = minv
             self.min_name = name
-        elif maxv > self.max:
+        if maxv > self.max:
             self.max = maxv
             self.max_name = name
 
@@ -258,7 +258,7 @@ def report_cache(tree: CacheManager):
         )
     if stream_unpack_skipped or verifier.verify:
         click.echo(
-            f"  Missing unpack performance data for {stream_unpack_skipped:,d} datasets"
+            f"  {stream_unpack_skipped:,d} datasets are missing unpack performance data"
         )
 
 

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -1,14 +1,19 @@
 import datetime
+from typing import Optional
 
 import click
 import humanfriendly
 
 from pbench.cli import pass_cli_context
-from pbench.cli.server import config_setup
+from pbench.cli.server import config_setup, Detail, Verify, Watch
 from pbench.cli.server.options import common_options
 from pbench.common.logger import get_pbench_logger
 from pbench.server import BadConfig
 from pbench.server.cache_manager import CacheManager
+
+detailer: Optional[Detail] = None
+watcher: Optional[Watch] = None
+verifier: Optional[Verify] = None
 
 
 def print_tree(tree: CacheManager):
@@ -42,7 +47,17 @@ def print_tree(tree: CacheManager):
 @click.command(name="pbench-tree-manager")
 @pass_cli_context
 @click.option(
+    "--detail",
+    "-d",
+    default=False,
+    is_flag=True,
+    help="Provide extra diagnostic information",
+)
+@click.option(
     "--display", default=False, is_flag=True, help="Display the full tree on completion"
+)
+@click.option(
+    "--progress", "-p", type=float, default=0.0, help="Show periodic progress messages"
 )
 @click.option(
     "--reclaim-percent",
@@ -62,13 +77,19 @@ def print_tree(tree: CacheManager):
     is_flag=True,
     help="Do an exhaustive search of ARCHIVE tree rather than using SQL",
 )
+@click.option(
+    "--verify", "-v", default=False, is_flag=True, help="Display intermediate messages"
+)
 @common_options
 def tree_manage(
     context: object,
+    detail: bool,
     display: bool,
+    progress: float,
     reclaim_percent: float,
     reclaim_size: str,
     search: bool,
+    verify: bool,
 ):
     """
     Discover, display, and manipulate the on-disk representation of controllers
@@ -88,18 +109,33 @@ def tree_manage(
         search: Discover cache with a full disk search
     """
     logger = None
+
+    global detailer, verifier, watcher
+    detailer = Detail(detail, False)
+    verifier = Verify(verify)
+    watcher = Watch(progress)
+
     try:
         config = config_setup(context)
         logger = get_pbench_logger("pbench-tree-manager", config)
         cache_m = CacheManager(config, logger)
         if display:
+            verifier.status("starting discovery")
+            watcher.update("discovering cache")
             cache_m.full_discovery(search=search)
+            verifier.status("finished discovery")
+            watcher.update("building report")
             print_tree(cache_m)
             rv = 0
         if reclaim_percent or reclaim_size:
+            verifier.status("starting reclaim")
+            watcher.update("reclaiming")
             target_size = humanfriendly.parse_size(reclaim_size) if reclaim_size else 0
             target_pct = reclaim_percent if reclaim_percent else 20.0
             outcome = cache_m.reclaim_cache(goal_pct=target_pct, goal_bytes=target_size)
+            verifier.status(
+                f"finished reclaiming: goal {''if outcome else 'not '}achieved"
+            )
             rv = 0 if outcome else 1
     except Exception as exc:
         if logger:

--- a/lib/pbench/cli/server/tree_manage.py
+++ b/lib/pbench/cli/server/tree_manage.py
@@ -57,9 +57,18 @@ def print_tree(tree: CacheManager):
     is_flag=False,
     help="Reclaim cached data to maintain specified free space",
 )
+@click.option(
+    "--search",
+    is_flag=True,
+    help="Do an exhaustive search of ARCHIVE tree rather than using SQL",
+)
 @common_options
 def tree_manage(
-    context: object, display: bool, reclaim_percent: float, reclaim_size: str
+    context: object,
+    display: bool,
+    reclaim_percent: float,
+    reclaim_size: str,
+    search: bool,
 ):
     """
     Discover, display, and manipulate the on-disk representation of controllers
@@ -76,14 +85,15 @@ def tree_manage(
         lifetime: Number of hours to retain unused cache before reclaim
         reclaim-percent: Reclaim cached data to free specified % on drive
         reclaim-size: Reclame cached data to free specified size on drive
+        search: Discover cache with a full disk search
     """
     logger = None
     try:
         config = config_setup(context)
         logger = get_pbench_logger("pbench-tree-manager", config)
         cache_m = CacheManager(config, logger)
-        cache_m.full_discovery()
         if display:
+            cache_m.full_discovery(search=search)
             print_tree(cache_m)
             rv = 0
         if reclaim_percent or reclaim_size:

--- a/lib/pbench/server/api/resources/intake_base.py
+++ b/lib/pbench/server/api/resources/intake_base.py
@@ -396,7 +396,7 @@ class IntakeBase(ApiBase):
             except APIAbort:
                 raise  # Propagate an APIAbort exception to the outer block
             except Exception as e:
-                raise APIInternalError("Unable to create dataset") from e
+                raise APIInternalError(f"Unable to create dataset: {str(e)!r}") from e
 
             recovery.add(dataset.delete)
 
@@ -452,11 +452,11 @@ class IntakeBase(ApiBase):
                     )
                     raise APIAbort(HTTPStatus.INSUFFICIENT_STORAGE, "Out of space")
                 raise APIInternalError(
-                    f"Unexpected error encountered during file upload: {str(exc)!r} "
+                    f"Unexpected error encountered during file upload: {str(exc)!r}"
                 ) from exc
             except Exception as e:
                 raise APIInternalError(
-                    "Unexpected error encountered during file upload: {str(e)!r}"
+                    f"Unexpected error encountered during file upload: {str(e)!r}"
                 ) from e
 
             if bytes_received != stream.length:

--- a/lib/pbench/server/cache_manager.py
+++ b/lib/pbench/server/cache_manager.py
@@ -1573,7 +1573,6 @@ class CacheManager:
                 and_(Dataset.id == Metadata.dataset_ref, Metadata.key == "server"),
             )
             .yield_per(1000)
-            .all()
         )
 
         for name, resource_id, path in rows:

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -674,7 +674,7 @@ class Metadata(Database.Base):
     # UNPACKED records the size of the unpacked directory tree.
     SERVER_UNPACKED = "server.unpacked-size"
 
-    # UNPACK performance: {"best": <seconds>, "worst": <seconds>, "count": <n>}
+    # UNPACK performance: {"min": <seconds>, "max": <seconds>, "count": <n>}
     SERVER_UNPACK_PERF = "server.unpack-perf"
 
     # TARBALL_PATH access path of the dataset tarball. (E.g., we could use this

--- a/lib/pbench/server/database/models/datasets.py
+++ b/lib/pbench/server/database/models/datasets.py
@@ -674,6 +674,9 @@ class Metadata(Database.Base):
     # UNPACKED records the size of the unpacked directory tree.
     SERVER_UNPACKED = "server.unpacked-size"
 
+    # UNPACK performance: {"best": <seconds>, "worst": <seconds>, "count": <n>}
+    SERVER_UNPACK_PERF = "server.unpack-perf"
+
     # TARBALL_PATH access path of the dataset tarball. (E.g., we could use this
     # to record an S3 object store key.) NOT YET USED.
     #


### PR DESCRIPTION
I added a simple `server.unpack-perf` metadata, which is a JSON block like `{"min": <seconds>, "max": <seconds>, "count": <unpack_count>}`, and then played with the report generator to get some statistics.

I also wrote a report of the `Audit` table contents to summarize the operations, statuses, and users involved in the Pbench Server.

The sample below is for a `runlocal`, with a few small-ish tarballs. The big catch in deploying this would be that none of the existing datasets will have `server.unpack-perf` until they're unpacked again, which somewhat reduces the value of the statistics until they get unpacked again (e.g., for TOC or visualize).

Nevertheless, I figured I might as well post it for consideration. Some of the statistics (and how they're calculated and/or represented) are no doubt arguable; but I enjoyed seeing the numbers anyway. 😆 

```
Cache report:
  7 datasets currently unpacked, consuming 51.7 MB
  7 datasets have been unpacked a total of 7 times
  The least recently used cache was referenced today, fio_rw_2018.02.01T22.40.57
  The most recently used cache was referenced today, trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38
  The smallest cache is 307.2 kB, linpack_mock_2020.02.28T19.10.55
  The biggest cache is 19.6 MB, trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38
  The worst compression ratio is 22.156%, uperf_rhel8.1_4.18.0-107.el8_snap4_25gb_virt_2019.06.21T01.28.57
  The best compression ratio is 96.834%, pbench-user-benchmark_example-vmstat_2018.10.24T14.38.18
  The fastest cache unpack is 0.014 seconds, linpack_mock_2020.02.28T19.10.55
  The slowest cache unpack is 0.084 seconds, trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38
  The fastest cache unpack streaming rate is 233.226 Mb/second, trafficgen_basic-forwarding-example_tg:trex-profile_pf:forwarding_test.json_ml:5_tt:bs__2019-08-27T14:58:38
  The slowest cache unpack streaming rate is 22.228 Mb/second, linpack_mock_2020.02.28T19.10.55
  1 datasets have no unpacked size, 1 are missing reference timestamps, 0 have bad size metadata
  1 datasets are missing unpack metric data, 0 have bad unpack metric data
  1 datasets are missing unpack performance data
Audit logs:
  138 audit log rows for 69 events
  0 unterminated root rows, 0 unmatched terminators
  Status summary:
                   BEGIN         69
                 SUCCESS         68
                 FAILURE          1
  Operation summary:
                template         36
                  upload          9
                   cache          7
                   index          6
                  apikey          1
                  update         10
  Object type summary:
                TEMPLATE         36
                 DATASET         32
                 API_KEY          1
  Users summary:
              BACKGROUND         49
                  tester         18
               testadmin          2
```