### PR TITLE
count only currently cached datasets in cache size

### DIFF
--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -215,6 +215,8 @@ def report_cache(tree: CacheManager):
         cache = Path(tree.cache_root / rid)
         if (cache / tarname).exists():
             cached_count += 1
+            if isinstance(size, int):
+                cached_size += size
             try:
                 referenced = (cache / "last_ref").stat().st_mtime
             except Exception as e:
@@ -233,7 +235,6 @@ def report_cache(tree: CacheManager):
             bad_size += 1
         else:
             sizecomp.add(dsname, size)
-            cached_size += size
 
             # Check compression ratios
             if tarball:


### PR DESCRIPTION
We were counting aggregate cache size for all datasets but reporting that value as if it were "currently cached"; count only currently cached datasets.