### PR TITLE
Increase the TM SIGNAL_RESPONSE_TIMEOUT

### DIFF
--- a/lib/pbench/agent/tool_meister_client.py
+++ b/lib/pbench/agent/tool_meister_client.py
@@ -25,7 +25,7 @@ from pbench.agent.constants import cli_tm_allowed_actions, tm_allowed_actions
 from pbench.agent.tool_group import ToolGroup
 from pbench.agent.utils import RedisServerCommon
 
-SIGNAL_RESPONSE_TIMEOUT = 100
+SIGNAL_RESPONSE_TIMEOUT = 300
 
 
 class Client:


### PR DESCRIPTION
the 100s timeout is too short for some systems (reported on slightly outdated aarch64).

Note I tested it with 200s which was still failing. With 300s it succeeded 5/5.