### PR TITLE
A small reporting hack

### DIFF
--- a/lib/pbench/cli/server/__init__.py
+++ b/lib/pbench/cli/server/__init__.py
@@ -23,13 +23,16 @@ class DateParser(ParamType):
     def convert(
         self, value: Any, param: Optional[Parameter], ctx: Optional[Context]
     ) -> Any:
-        if isinstance(value, datetime.datetime):
-            return value
-
-        try:
-            return parser.parse(value)
-        except Exception as e:
-            self.fail(f"{value!r} cannot be converted to a datetime: {str(e)!r}")
+        if isinstance(value, str):
+            try:
+                value = parser.parse(value)
+            except Exception as e:
+                self.fail(f"{value!r} cannot be converted to a datetime: {str(e)!r}")
+        if not isinstance(value, datetime.datetime):
+            self.fail(f"{value!r} ({type(value).__name__}) is unsupported.")
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return value
 
 
 class Detail:


### PR DESCRIPTION
I'd considered some way to report dataset create/upload statistics based on a date range, but never got around to it. Today, writing up the draft report for April, I of course didn't have a report "for April", and pasted in one from April 25...

And then thought, well, how hard would it be to add `--since` and `--until` to set the range?

It's not perfect, but it's a potentially useful twist. If you like it, we can merge it; if not, maybe some evening or weekend I'll get around to working on it some more.

```
$ pbench-report-generator --statistics=creation --since 2024-04-01 --until 2024-05-01
Dataset statistics by creation date:
  540 since 2024-04-01 00:00 until 2024-05-01 00:00
    540 in year 2024
    540 in month April 2024
    131 in week April 23 to April 30
    8 on 30 April 2024
 Total by year:
    2024:      540
 Total by month of year:
    Apr:      540
 Total by day of month:
    02:       25    03:       26    04:        2    06:        9
    07:        9    08:        3    09:       28    10:       29
    11:        9    12:       23    13:       47    14:       29
    15:       33    16:       24    17:       31    18:        6
    19:        2    20:       38    21:       36    23:       31
    24:       30    25:       11    26:        4    27:       23
    28:       23    29:        1    30:        8
 Total by day of week:
    Mon:       37    Tue:      116    Wed:      116    Thu:       28
    Fri:       29    Sat:      117    Sun:       97
 Total by hour of day:
    00:       24    01:       12    02:       10    03:       14
    04:       32    05:       51    06:       34    07:       14
    08:       26    09:       31    10:       30    11:       29
    12:       31    13:       38    14:       19    15:       26
    16:       17    17:       17    18:       17    19:       13
    20:       11    21:       19    22:       12    23:       13
```