### PR TITLE
All means "all"

### DIFF
--- a/lib/pbench/cli/server/report.py
+++ b/lib/pbench/cli/server/report.py
@@ -779,8 +779,8 @@ def report(context: object, **kwargs):
         if kwargs.get("all") or kwargs.get("cache"):
             report_cache(cache_m)
         stats = kwargs.get("statistics")
-        if stats:
-            if stats == "creation":
+        if stats or kwargs.get("all"):
+            if stats == "creation" or stats is None:
                 report_creation(kwargs)
             elif stats == "upload":
                 report_uploads(kwargs)


### PR DESCRIPTION
When I added a keyword to select "upload" or "creation" time statistics, I omitted "statistics" from the effect of `--all`, but I've come to regret that minor inconvenience. This PR makes `--all` include `--statistics=creation` by default.