### PR TITLE
Add report of Pbench Agent version statistics

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,6 +13,7 @@ flask-sqlalchemy
 gunicorn
 humanfriendly
 humanize
+numpy<2.0 # Indirect: elasticsearch
 pquisby
 psycopg2
 pyesbulk>=2.0.1


### PR DESCRIPTION
Add a new `--agent` option and generator to report on the Pbench Agent versions present on the server. By default we report on the "main" versions, like "0.50" and "0.73"; by adding `--detail` it'll report the much longer list of full agent versions ("v0.73-2g6da0cfc8d") as well as "nonsense" version metadata like "system".

This also recognizes the `--since` and `--until` options to report on agent versions that appear within a specific time range.

The report is sorted by the last date a given version was seen, which makes it a bit easier to see that only 0.73 has been used since March 08 2024.

```console
Dataset statistics by Pbench Agent version:
    Count            Version            First       Last    
  ---------- ----------------------- ----------- -----------
           1          0.37           Apr 13 2012 Apr 13 2012
          68          0.44           Jan 04 2018 Feb 06 2018
          84          0.46           Jan 03 2018 Mar 09 2018
       1,341          0.47           Jan 02 2018 Apr 03 2018
       2,197          0.49           Mar 21 2018 Aug 04 2018
       1,388          0.48           Feb 06 2018 Aug 14 2018
         171          0.51           Aug 10 2018 Aug 31 2018
       4,962          0.50           May 11 2018 Sep 25 2018
         494          0.52           Aug 24 2018 Jan 02 2019
       1,942          0.53           Sep 13 2018 May 29 2019
         898          0.58           Apr 08 2019 May 30 2019
         246          0.55           Jan 28 2019 Jun 06 2019
       1,205          0.54           Nov 27 2018 Jul 01 2019
           1          0.61           Jul 08 2019 Jul 08 2019
         532          0.57           Mar 15 2019 Aug 28 2019
         382          0.62           Jul 17 2019 Sep 10 2019
       1,426          0.56           Feb 11 2019 Oct 16 2019
       1,067          0.59           Apr 30 2019 Nov 12 2019
       1,454          0.63           Jul 31 2019 Dec 18 2019
       2,151          0.65           Sep 27 2019 Feb 21 2020
       1,342          0.64           Aug 27 2019 Mar 26 2020
       1,587          0.60           May 25 2019 May 22 2020
       5,255          0.66           Nov 07 2019 Jul 10 2020
       4,596          0.67           Jan 16 2020 Nov 30 2020
          33          0.70           Nov 18 2020 Jan 12 2021
       7,427          0.68           Apr 01 2020 Apr 27 2021
      54,179          0.69           Jun 25 2020 Mar 08 2023
      44,870          0.71           Oct 17 2020      Feb 28
       7,073          0.72           Jun 24 2022      Mar 08
       4,025          0.73           Aug 14 2023       today
```

I won't capture the full list here (it's much longer), but the "nonsense" version report is currently:

```console
Datasets with nonsensical version metadata:
    Count            Version            First       Last    
  ---------- ----------------------- ----------- -----------
          37        'system'         Mar 30 2019 Apr 01 2019
          54       'plugins:'        Jan 26 2018 Apr 27 2021
           5           ''            Oct 02 2018 Dec 20 2021
           3 'v(unknown)-g(unknown)' Dec 14 2020 Sep 30 2022
```