### PR TITLE
Update Dashboard dependency on Axios

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,7 +13,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
-    "axios": "^0.26.1",
+    "axios": "^0.28.0",
     "babel-jest": "^27.5.1",
     "chart.js": "^4.2.1",
     "classnames": "^2.3.1",


### PR DESCRIPTION
After ten months, I finally got tired of [the Dependabot warnings](https://github.com/distributed-system-analysis/pbench/security/dependabot/16), so here's a PR to update the Dashboard's dependency on `axios` to at least the version which addresses [CVE-2023-45857](https://nvd.nist.gov/vuln/detail/CVE-2023-45857).  (See also the [GitHub advisory](https://github.com/advisories/GHSA-wf5p-g6vw-rhxx).)

I assume (boldly) that when we actually build the Dashboard, we pull a safe version of `axios` (since the `package.json` file is specifying only the _minimum_ -- not the "locked" -- version), so I don't think this issue actually affects us (and, even if it did, we run the Dashboard in limited quantities in what I think is a safe environment...), so I didn't bother to actually test this change.  (For me, the definition of "working" will be the absence of Dependabot warnings....)