### PR TITLE
Lock dependency on Bottle

### DIFF
--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,4 +1,4 @@
-bottle
+bottle<0.13.0
 cffi
 click>=8.0
 hiredis


### PR DESCRIPTION
In Bottle 0.13.0 they made a change which prevents us from adding attributes to the `bottle` object, and this breaks our code.

This problem doesn't look difficult to address (they provide an API which yields similar support), but, as an immediate workaround, this PR locks our dependency on Bottle to pre-0.13.0.